### PR TITLE
feat: Obsidian vault path (CLAWQL_OBSIDIAN_VAULT_PATH) and vault utils (#5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,11 @@
 # Optional: pregenerated introspection JSON (skips live introspection for execute field names).
 # CLAWQL_INTROSPECTION_PATH=./introspection.json
 
+# ─── Obsidian vault (memory tools) ───────────────────────────────────
+# When set, the server checks that the path exists and is readable/writable at startup.
+# Docker images default to /vault (see docker/Dockerfile). Omit locally to skip the check.
+# CLAWQL_OBSIDIAN_VAULT_PATH=/vault
+
 # ─── Workflow test toggles ─────────────────────────────────────────────
 # Multi-provider workflow: default to dry-run (show request details, do not POST).
 WORKFLOW_PREVIEW_JIRA_REQUEST=1

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ available via **`CLAWQL_PROVIDER`** (see [`providers/README.md`](providers/READM
 
 **Repo vs npm:** GitHub **`ClawQL`** — published package **`clawql-mcp`**.
 
+**Enterprise agent stack:** **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** is the local-first Docker platform (LangGraph, Obsidian knowledge graph, optional Cloudflare Sandboxes, Langfuse) that uses **this repo** as the MCP **API engine** — token-efficient **`search` / `execute`** over OpenAPI/Discovery. The agent README’s unified tool story (`code()` / `sandbox_exec()`, `memory_ingest()`, `memory_recall()`) is the **parity target** for ClawQL; shipped tools and env wiring are tracked in-repo (see **[#11 — Parity milestone](https://github.com/danielsmithdevelopment/ClawQL/issues/11)**). Optional **`CLAWQL_OBSIDIAN_VAULT_PATH`** configures a shared Obsidian vault path for that roadmap (validated at startup when set; Docker/K8s default **`/vault`** — see [Obsidian vault](#obsidian-vault-optional)).
+
 ## First 5 minutes
 
 1. Install: `npm install clawql-mcp` (or use `npx -p clawql-mcp` as below; expect **~90 MB** on disk, see [Install](#install-npm--yarn--bun)).
@@ -349,6 +351,7 @@ If Stage 1 does **not** apply, one document is loaded in this order:
 | `CLAWQL_PROVIDER` | **Merged** preset in Stage 1, or **single** bundled vendor in Stage 2 — see [Configure the API spec](#configure-the-api-spec) (not both at once) |
 | `CLAWQL_INTROSPECTION_PATH` | Pregenerated GraphQL introspection JSON (optional; speeds MCP `execute` field matching) |
 | `CLAWQL_API_BASE_URL` | Override REST base URL (if spec has no `servers` or you need a different host) |
+| `CLAWQL_OBSIDIAN_VAULT_PATH` | Absolute path to an Obsidian Markdown vault (shared volume/NFS). When set, the server **checks** the path exists and is readable/writable at startup. Omit locally to skip the check; container images default to **`/vault`** (see [Docker](docker/README.md)). Used with **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** and future memory tools. |
 
 **GCP multi-service:** use **`CLAWQL_GOOGLE_TOP50_SPECS=1`**, **`CLAWQL_PROVIDER=google-top50`**, or **`CLAWQL_SPEC_PATHS`** so `search` / `execute` see every merged API in one server; `execute` uses REST in that mode. For **every bundled vendor** (Google top50 + Jira, Bitbucket, Cloudflare, GitHub, Slack, Sentry, n8n), use **`CLAWQL_PROVIDER=all-providers`**. See [`docs/workflow-gcp-multi-service.md`](docs/workflow-gcp-multi-service.md).  
 **Integration check:** `npm run workflow:gcp-multi` runs **`tools/call` → `search`** over real MCP stdio and writes `docs/workflow-gcp-multi-latest.json` (full `CallToolResult` + parsed body). `npm run workflow:gcp-multi:direct` is a faster in-process-only variant for debugging rankers. One-page results summary: [`docs/gcp-multi-mcp-test-summary.md`](docs/gcp-multi-mcp-test-summary.md). Detailed experiment write-up (queries, APIs, token heuristic, MCP samples): [`docs/experiment-gcp-multi-mcp-workflow.md`](docs/experiment-gcp-multi-mcp-workflow.md); `npm run report:gcp-multi-experiment` refreshes [`docs/experiment-gcp-multi-mcp-stats.json`](docs/experiment-gcp-multi-mcp-stats.json).
@@ -375,6 +378,10 @@ Live Jira issue-create instructions are currently omitted — see [`docs/workflo
 **Same scenario via real MCP (`search`, dry run by default):** `npm run workflow:complex-release-stack:mcp` runs **`search`** only (no **`execute`** → no upstream REST). Spawns the stdio server, or set **`CLAWQL_MCP_URL`** (e.g. `http://127.0.0.1:8080/mcp`) for an HTTP server that must use **`all-providers`**. For optional **`execute`** smoke tests with placeholder args: **`WORKFLOW_MCP_EXECUTE=1`** or **`npm run workflow:complex-release-stack:mcp:live`**. Writes [`docs/workflow-complex-release-stack-mcp-latest.json`](docs/workflow-complex-release-stack-mcp-latest.json).
 
 See `.env.example` for a full list.
+
+### Obsidian vault (optional)
+
+Set **`CLAWQL_OBSIDIAN_VAULT_PATH`** when you mount a directory for **Obsidian**-compatible Markdown (e.g. alongside **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** or a future **`memory_ingest` / `memory_recall`** MCP surface). If unset or empty, no vault check runs. If set, startup fails fast when the path is missing, not a directory, or not readable/writable. Implementation helpers live in **`src/vault-config.ts`** and **`src/vault-utils.ts`** (safe paths + cooperative write lock under the vault root).
 
 **Large / vendor OpenAPI docs:** The design goal is **the full spec** — token
 efficiency comes from **search + selective `execute`**, not from trimming the
@@ -447,6 +454,8 @@ In multi-spec mode, ClawQL keeps one merged operation index for discovery and ex
 ---
 
 ## Tools
+
+**Shipped today:** **`search`** and **`execute`** (see [Architecture](#architecture)). **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** layers orchestration, long-term memory, and optional sandboxes on top; additional first-class MCP tools are part of **[parity milestone #11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)**.
 
 | Tool | Description |
 |---|---|
@@ -595,9 +604,9 @@ See [`docs/deploy-k8s.md`](docs/deploy-k8s.md).
 
 ## Extending the server
 
-The default surface is **two tools** (`search`, `execute`). To add more MCP tools
-(e.g. convenience wrappers), register them in `src/tools.ts` the same way
-(`server.tool(...)`).
+The default MCP surface is **`search`** and **`execute`**. To add more tools
+(e.g. `memory_*`, `code()` — see **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** / [#11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)), register them in `src/tools.ts` the same way
+(`server.tool(...)`). Vault path configuration and filesystem helpers for Obsidian-backed tools are in **`src/vault-config.ts`** and **`src/vault-utils.ts`**.
 
 GraphQL field names are **auto-resolved** in `execute` via schema introspection
 (candidates include run-style names, legacy path-derived names, and response-type

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,6 +18,9 @@ RUN npm run build && npm prune --omit=dev
 COPY providers ./providers
 COPY bin ./bin
 
+# Writable Obsidian vault mount (memory tools); nonroot must own the tree.
+RUN mkdir -p /vault && chown 65532:65532 /vault
+
 # Distroless Node: no shell; only Node + minimal libc / CA bundle for HTTPS fetches.
 FROM gcr.io/distroless/nodejs22-debian12 AS runtime
 WORKDIR /app
@@ -25,12 +28,14 @@ WORKDIR /app
 ENV NODE_ENV=production
 # Prefer bundled files on disk; avoids surprise network fetches when a spec is missing.
 ENV CLAWQL_BUNDLED_OFFLINE=1
+ENV CLAWQL_OBSIDIAN_VAULT_PATH=/vault
 
 COPY --from=builder --chown=nonroot:nonroot /app/node_modules ./node_modules
 COPY --from=builder --chown=nonroot:nonroot /app/dist ./dist
 COPY --from=builder --chown=nonroot:nonroot /app/bin ./bin
 COPY --from=builder --chown=nonroot:nonroot /app/providers ./providers
 COPY --from=builder --chown=nonroot:nonroot /app/package.json ./package.json
+COPY --from=builder --chown=nonroot:nonroot /vault /vault
 
 USER nonroot:nonroot
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -32,6 +32,8 @@ docker run --rm -p 8080:8080 -e CLAWQL_PROVIDER=github clawql-mcp
 
 Single-spec `execute` uses a GraphQL proxy at `GRAPHQL_URL` (default `http://localhost:4000/graphql`). Point it at a reachable proxy or use multi-spec presets (REST execution) when you do not run the proxy beside the container.
 
+**Obsidian vault:** The image sets **`CLAWQL_OBSIDIAN_VAULT_PATH=/vault`** and includes a writable **`/vault`** directory for **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** / future memory tooling. Compose mounts a named volume at `/vault`; override the path or mount your host Obsidian folder as needed. See the main [README](../README.md#obsidian-vault-optional).
+
 ## Run (stdio, optional)
 
 If you specifically want stdio mode in a container:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,10 @@ services:
     environment:
       GRAPHQL_URL: http://clawql-graphql:4000/graphql
       CLAWQL_PROVIDER: google-top50
+      CLAWQL_OBSIDIAN_VAULT_PATH: /vault
       PORT: 8080
+    volumes:
+      - clawql-obsidian-vault:/vault
     ports:
       - "8080:8080"
     depends_on:
@@ -25,3 +28,6 @@ services:
       GRAPHQL_PORT: 4000
     ports:
       - "4000:4000"
+
+volumes:
+  clawql-obsidian-vault:

--- a/docker/kustomize/base/deployment-mcp-http.yaml
+++ b/docker/kustomize/base/deployment-mcp-http.yaml
@@ -24,6 +24,8 @@ spec:
           env:
             - name: CLAWQL_PROVIDER
               value: google-top50
+            - name: CLAWQL_OBSIDIAN_VAULT_PATH
+              value: /vault
             - name: GRAPHQL_URL
               value: http://clawql-graphql:4000/graphql
             - name: PORT
@@ -63,3 +65,9 @@ spec:
             limits:
               cpu: "2"
               memory: "2Gi"
+          volumeMounts:
+            - name: obsidian-vault
+              mountPath: /vault
+      volumes:
+        - name: obsidian-vault
+          emptyDir: {}

--- a/src/server-http.ts
+++ b/src/server-http.ts
@@ -13,6 +13,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { loadSpec } from "./spec-loader.js";
 import { preloadSchemaFieldCacheFromDisk, registerTools } from "./tools.js";
+import { validateObsidianVaultAtStartup } from "./vault-config.js";
 
 const PORT = Number.parseInt(process.env.PORT ?? process.env.MCP_PORT ?? "8080", 10);
 const DEFAULT_MCP_PATH = "/mcp";
@@ -86,6 +87,7 @@ export async function createMcpHttpApp(options: CreateMcpHttpAppOptions = {}): P
   if (!options.skipSpecPreload) {
     await loadSpec();
     await preloadSchemaFieldCacheFromDisk();
+    await validateObsidianVaultAtStartup();
   }
 
   const mcpPath =

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -3,6 +3,8 @@
  * `npm test` runs `pretest` → `build` so the entry exists.
  */
 
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -45,6 +47,7 @@ describe("server (stdio)", () => {
     async () => {
       const childEnv = { ...process.env };
       childEnv.CLAWQL_SPEC_PATH = minimalSpec;
+      childEnv.CLAWQL_OBSIDIAN_VAULT_PATH = mkdtempSync(join(tmpdir(), "clawql-vault-"));
       delete childEnv.CLAWQL_PROVIDER;
       delete childEnv.CLAWQL_SPEC_PATHS;
       delete childEnv.CLAWQL_API_BASE_URL;

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,12 +16,14 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { loadSpec } from "./spec-loader.js";
 import { preloadSchemaFieldCacheFromDisk, registerTools } from "./tools.js";
+import { validateObsidianVaultAtStartup } from "./vault-config.js";
 
 async function main() {
   // Pre-warm the spec cache on startup so the first search call is fast
   await loadSpec();
   // Prefer pregenerated introspection.json (bundled or CLAWQL_INTROSPECTION_PATH) over live proxy introspection
   await preloadSchemaFieldCacheFromDisk();
+  await validateObsidianVaultAtStartup();
 
   const server = new McpServer({
     name: "cloudrun-mcp",

--- a/src/vault-config.test.ts
+++ b/src/vault-config.test.ts
@@ -1,0 +1,61 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  getObsidianVaultPath,
+  validateObsidianVaultAtStartup,
+} from "./vault-config.js";
+
+describe("vault-config", () => {
+  const saved: Record<string, string | undefined> = {};
+  const dirs: string[] = [];
+
+  beforeEach(() => {
+    saved.CLAWQL_OBSIDIAN_VAULT_PATH = process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+    delete process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+  });
+
+  afterEach(async () => {
+    for (const key of Object.keys(saved)) {
+      const v = saved[key as keyof typeof saved];
+      if (v === undefined) delete process.env[key];
+      else process.env[key] = v;
+    }
+    for (const d of dirs.splice(0)) {
+      await rm(d, { recursive: true, force: true });
+    }
+  });
+
+  it("getObsidianVaultPath returns null when unset", () => {
+    expect(getObsidianVaultPath()).toBeNull();
+  });
+
+  it("getObsidianVaultPath resolves when set", async () => {
+    const d = await mkdtemp(join(tmpdir(), "clawql-vault-"));
+    dirs.push(d);
+    process.env.CLAWQL_OBSIDIAN_VAULT_PATH = d;
+    expect(getObsidianVaultPath()).toBe(resolve(d));
+  });
+
+  it("validateObsidianVaultAtStartup passes for writable directory", async () => {
+    const d = await mkdtemp(join(tmpdir(), "clawql-vault-"));
+    dirs.push(d);
+    process.env.CLAWQL_OBSIDIAN_VAULT_PATH = d;
+    await expect(validateObsidianVaultAtStartup()).resolves.toBeUndefined();
+  });
+
+  it("validateObsidianVaultAtStartup rejects missing path", async () => {
+    process.env.CLAWQL_OBSIDIAN_VAULT_PATH = join(tmpdir(), "definitely-missing-vault-xyz");
+    await expect(validateObsidianVaultAtStartup()).rejects.toThrow(/does not exist/);
+  });
+
+  it("validateObsidianVaultAtStartup rejects file", async () => {
+    const d = await mkdtemp(join(tmpdir(), "clawql-vault-"));
+    dirs.push(d);
+    const f = join(d, "not-a-dir");
+    await writeFile(f, "x", "utf8");
+    process.env.CLAWQL_OBSIDIAN_VAULT_PATH = f;
+    await expect(validateObsidianVaultAtStartup()).rejects.toThrow(/not a directory/);
+  });
+});

--- a/src/vault-config.ts
+++ b/src/vault-config.ts
@@ -1,0 +1,55 @@
+/**
+ * Obsidian vault path from CLAWQL_OBSIDIAN_VAULT_PATH (optional).
+ * When set, the MCP server validates the path at startup.
+ */
+
+import { constants } from "node:fs";
+import { access, stat } from "node:fs/promises";
+import { resolve } from "node:path";
+
+/** Default mount path in Docker / NAS deployments. */
+export const DEFAULT_OBSIDIAN_VAULT_PATH = "/vault";
+
+/**
+ * Resolved Obsidian vault directory, or `null` if vault integration is disabled
+ * (`CLAWQL_OBSIDIAN_VAULT_PATH` unset or empty).
+ */
+export function getObsidianVaultPath(): string | null {
+  const raw = process.env.CLAWQL_OBSIDIAN_VAULT_PATH?.trim();
+  if (raw === undefined || raw === "") {
+    return null;
+  }
+  return resolve(raw);
+}
+
+/**
+ * Ensures the vault path exists, is a directory, and is readable + writable.
+ * No-op when vault is not configured.
+ */
+export async function validateObsidianVaultAtStartup(): Promise<void> {
+  const vault = getObsidianVaultPath();
+  if (vault === null) {
+    return;
+  }
+  let st;
+  try {
+    st = await stat(vault);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(
+      `CLAWQL_OBSIDIAN_VAULT_PATH: path does not exist or is inaccessible: ${vault} (${msg})`
+    );
+  }
+  if (!st.isDirectory()) {
+    throw new Error(`CLAWQL_OBSIDIAN_VAULT_PATH: not a directory: ${vault}`);
+  }
+  try {
+    await access(vault, constants.R_OK | constants.W_OK);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(
+      `CLAWQL_OBSIDIAN_VAULT_PATH: not readable/writable: ${vault} (${msg})`
+    );
+  }
+  console.error(`[clawql-mcp] Obsidian vault: ${vault}`);
+}

--- a/src/vault-utils.test.ts
+++ b/src/vault-utils.test.ts
@@ -1,0 +1,61 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  readVaultTextFile,
+  resolveVaultPath,
+  withVaultWriteLock,
+  writeVaultTextFileAtomic,
+} from "./vault-utils.js";
+
+describe("vault-utils", () => {
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    for (const d of dirs.splice(0)) {
+      await rm(d, { recursive: true, force: true });
+    }
+  });
+
+  async function freshVault(): Promise<string> {
+    const d = await mkdtemp(join(tmpdir(), "clawql-vault-"));
+    dirs.push(d);
+    return d;
+  }
+
+  it("resolveVaultPath rejects path traversal", async () => {
+    const root = await freshVault();
+    expect(() => resolveVaultPath(root, "../etc/passwd")).toThrow(/Invalid vault relative path/);
+  });
+
+  it("writeVaultTextFileAtomic and readVaultTextFile round-trip", async () => {
+    const root = await freshVault();
+    await writeVaultTextFileAtomic(root, "notes/hello.md", "# hi\n");
+    const text = await readVaultTextFile(root, "notes/hello.md");
+    expect(text).toBe("# hi\n");
+    const disk = await readFile(join(root, "notes", "hello.md"), "utf8");
+    expect(disk).toBe("# hi\n");
+  });
+
+  it("withVaultWriteLock allows only one writer at a time", async () => {
+    const root = await freshVault();
+    let concurrent = 0;
+    let max = 0;
+    await Promise.all([
+      withVaultWriteLock(root, async () => {
+        concurrent++;
+        max = Math.max(max, concurrent);
+        await new Promise((r) => setTimeout(r, 40));
+        concurrent--;
+      }),
+      withVaultWriteLock(root, async () => {
+        concurrent++;
+        max = Math.max(max, concurrent);
+        await new Promise((r) => setTimeout(r, 40));
+        concurrent--;
+      }),
+    ]);
+    expect(max).toBe(1);
+  });
+});

--- a/src/vault-utils.ts
+++ b/src/vault-utils.ts
@@ -1,0 +1,86 @@
+/**
+ * Safe read/write under an Obsidian vault root with cooperative write locking.
+ * Intended for memory_ingest / memory_recall and related tools.
+ */
+
+import { open, mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname, relative, resolve } from "node:path";
+
+const LOCK_NAME = ".clawql-vault-write.lock";
+const LOCK_POLL_MS = 100;
+const LOCK_MAX_ATTEMPTS = 100;
+
+function assertInsideVault(vaultRoot: string, absolutePath: string): void {
+  const root = resolve(vaultRoot);
+  const target = resolve(absolutePath);
+  if (target === root) {
+    return;
+  }
+  const rel = relative(root, target);
+  if (rel.startsWith("..") || rel === "..") {
+    throw new Error(`Path escapes vault root: ${absolutePath}`);
+  }
+}
+
+/**
+ * Resolve a path relative to the vault root; rejects `..` segments.
+ */
+export function resolveVaultPath(vaultRoot: string, relativePath: string): string {
+  const root = resolve(vaultRoot);
+  const cleaned = relativePath.replace(/\\/g, "/").replace(/^\/+/, "");
+  if (!cleaned || cleaned.split("/").some((p) => p === "..")) {
+    throw new Error(`Invalid vault relative path: ${relativePath}`);
+  }
+  const full = resolve(root, cleaned);
+  assertInsideVault(root, full);
+  return full;
+}
+
+/**
+ * Exclusive cooperative lock for vault writes (retry with backoff).
+ */
+export async function withVaultWriteLock<T>(vaultRoot: string, fn: () => Promise<T>): Promise<T> {
+  const lockPath = resolveVaultPath(vaultRoot, LOCK_NAME);
+  let handle: Awaited<ReturnType<typeof open>> | null = null;
+  for (let i = 0; i < LOCK_MAX_ATTEMPTS; i++) {
+    try {
+      handle = await open(lockPath, "wx");
+      break;
+    } catch {
+      await new Promise((r) => setTimeout(r, LOCK_POLL_MS));
+    }
+  }
+  if (!handle) {
+    throw new Error(
+      `Vault write lock timeout after ${LOCK_MAX_ATTEMPTS * LOCK_POLL_MS}ms: ${lockPath}`
+    );
+  }
+  try {
+    return await fn();
+  } finally {
+    await handle.close();
+    try {
+      await unlink(lockPath);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+export async function readVaultTextFile(vaultRoot: string, relativePath: string): Promise<string> {
+  const p = resolveVaultPath(vaultRoot, relativePath);
+  return readFile(p, "utf8");
+}
+
+/** Write UTF-8 text; creates parent directories; atomic rename over the final path. */
+export async function writeVaultTextFileAtomic(
+  vaultRoot: string,
+  relativePath: string,
+  content: string
+): Promise<void> {
+  const p = resolveVaultPath(vaultRoot, relativePath);
+  await mkdir(dirname(p), { recursive: true });
+  const tmp = `${p}.${process.pid}.tmp`;
+  await writeFile(tmp, content, "utf8");
+  await rename(tmp, p);
+}


### PR DESCRIPTION
## Summary
Implements [issue #5](https://github.com/danielsmithdevelopment/ClawQL/issues/5): configuration for an Obsidian vault path shared with future `memory_ingest` / `memory_recall` tooling and [ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent) deployments.

## Changes
- **`CLAWQL_OBSIDIAN_VAULT_PATH`**: when set, validate at MCP startup (directory exists, readable/writable); omit to skip checks locally.
- **`src/vault-utils.ts`**: path confinement, cooperative `.clawql-vault-write.lock`, atomic text writes.
- **Docker**: create `/vault` in image, `ENV CLAWQL_OBSIDIAN_VAULT_PATH=/vault`; Compose named volume; K8s `emptyDir` + mount.
- **Docs**: README + `docker/README.md`, `.env.example`; cross-links to ClawQL-Agent and parity [#11](https://github.com/danielsmithdevelopment/ClawQL/issues/11).

## Testing
`npm test` (68 tests).

Fixes #5