### PR TITLE
feat: sandbox code tools (#4), lean default bundle + auth headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,16 @@
 # Docker images default to /vault (see docker/Dockerfile). Omit locally to skip the check.
 # CLAWQL_OBSIDIAN_VAULT_PATH=/vault
 
+# ─── Cloudflare Sandbox (code / sandbox_exec MCP tools) ───────────────
+# The Sandbox SDK runs in a Worker; MCP calls this bridge over HTTPS.
+# Deploy: cloudflare/sandbox-bridge/ — set BRIDGE_SECRET to match the token below.
+# CLAWQL_SANDBOX_BRIDGE_URL=https://clawql-sandbox-bridge.your-subdomain.workers.dev
+# CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN=
+# CLAWQL_CLOUDFLARE_ACCOUNT_ID=
+# CLAWQL_SANDBOX_PERSISTENCE_MODE=session
+# CLAWQL_SANDBOX_TIMEOUT_MS=120000
+# CLAWQL_SANDBOX_TIMEOUT_MS_MAX=300000
+
 # ─── Workflow test toggles ─────────────────────────────────────────────
 # Multi-provider workflow: default to dry-run (show request details, do not POST).
 WORKFLOW_PREVIEW_JIRA_REQUEST=1

--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@
 #   2) CLAWQL_PROVIDER = merged preset (google-top50, default-multi-provider, all-providers, atlassian, …)
 #   3) CLAWQL_GOOGLE_TOP50_SPECS=1  (if #2 did not already pick multi-spec)
 #   4) Else if SPEC_PATHS / PATH / URL / DISCOVERY / CLAWQL_PROVIDER / GOOGLE_TOP50 are all unset →
-#      built-in default merge (google top50 + cloudflare + jira)
+#      built-in default merge (github + cloudflare)
 #
 # Stage 2 — Single spec (if Stage 1 does not apply), first match wins:
 #   CLAWQL_SPEC_PATH > CLAWQL_SPEC_URL > CLAWQL_DISCOVERY_URL > CLAWQL_PROVIDER (single vendor)
@@ -34,6 +34,16 @@
 
 # Base URL for REST calls (overrides servers[0].url in the spec if set).
 # CLAWQL_API_BASE_URL=https://api.example.com
+
+# ─── Upstream API auth (execute / GraphQL proxy) ─────────────────────
+# Multi-spec default (github + cloudflare): set both so each vendor gets the right Bearer token.
+# CLAWQL_GITHUB_TOKEN=ghp_…
+# CLAWQL_CLOUDFLARE_API_TOKEN=…
+# Optional fallback for other merged APIs or single-vendor mode:
+# CLAWQL_BEARER_TOKEN=…
+# Override headers entirely (JSON object; wins over bearer selection):
+# CLAWQL_HTTP_HEADERS={"Authorization":"Bearer …"}
+
 
 # ─── GraphQL proxy (MCP execute tool) ────────────────────────────────
 # GRAPHQL_URL=http://localhost:4000/graphql

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ manager). Deployments (Docker/K8s/Cloud Run) wire both for you.
 
 **Bring your own OpenAPI 3** (JSON/YAML file or URL), or use **Swagger 2**
 (converted automatically), or a **Google Discovery** document URL. If no spec
-env is set, ClawQL defaults to a bundled **multi-provider** merge (**Google top50 +
-Cloudflare + Jira**). Single-provider **`cloudflare`** and other presets are
+env is set, ClawQL defaults to a bundled **multi-provider** merge (**GitHub +
+Cloudflare**). Single-provider **`cloudflare`** and other presets are
 available via **`CLAWQL_PROVIDER`** (see [`providers/README.md`](providers/README.md)).
 
 **Repo vs npm:** GitHub **`ClawQL`** — published package **`clawql-mcp`**.
@@ -322,7 +322,7 @@ Used when any of the following applies (checked in this order):
 1. **`CLAWQL_SPEC_PATHS`** — merge these local files (comma, semicolon, or newline separated).
 2. **`CLAWQL_PROVIDER`** — if it names a **merged preset** (`google-top50`, `default-multi-provider`, `all-providers`, `atlassian`, …), load that bundle.
 3. **`CLAWQL_GOOGLE_TOP50_SPECS`** (`1` / `true` / `yes`) — merge curated **google-top50** if #1–2 did not already select multi-spec.
-4. **Built-in default merge** — only if **`CLAWQL_SPEC_PATHS`**, **`CLAWQL_SPEC_PATH`**, **`CLAWQL_SPEC_URL`**, **`CLAWQL_DISCOVERY_URL`**, **`CLAWQL_PROVIDER`**, and **`CLAWQL_GOOGLE_TOP50_SPECS`** are all unset: **google top50 + Cloudflare + Jira** (`default-multi-provider`).
+4. **Built-in default merge** — only if **`CLAWQL_SPEC_PATHS`**, **`CLAWQL_SPEC_PATH`**, **`CLAWQL_SPEC_URL`**, **`CLAWQL_DISCOVERY_URL`**, **`CLAWQL_PROVIDER`**, and **`CLAWQL_GOOGLE_TOP50_SPECS`** are all unset: **GitHub + Cloudflare** (`default-multi-provider`).
 
 If Stage 1 runs, you get one merged **search** index; **`execute`** uses **REST** per spec (see server logs: GraphQL is not used for multi-spec execute).
 
@@ -354,11 +354,14 @@ If Stage 1 does **not** apply, one document is loaded in this order:
 | `CLAWQL_CLOUDFLARE_ACCOUNT_ID` | Optional; sent as `CF-Account-ID` on bridge requests. |
 | `CLAWQL_SANDBOX_PERSISTENCE_MODE` | Default `session` / `ephemeral` / `persistent` for sandbox tool calls (overridable per call). |
 | `CLAWQL_SANDBOX_TIMEOUT_MS` | Max wait for each bridge request (default `120000`). |
+| `CLAWQL_GITHUB_TOKEN` | GitHub PAT / fine-grained token for **`execute`** when the operation is from the **github** spec (or `CLAWQL_PROVIDER=github`). Also accepts **`GITHUB_TOKEN`** / **`GH_TOKEN`**. |
+| `CLAWQL_CLOUDFLARE_API_TOKEN` | Cloudflare API token for **`execute`** when the operation is from the **cloudflare** spec (or `CLAWQL_PROVIDER=cloudflare`). Also accepts **`CLOUDFLARE_API_TOKEN`**. |
+| `CLAWQL_BEARER_TOKEN` | Fallback bearer when a provider-specific token is not set; also used for Google and other merged labels. |
 
 **GCP multi-service:** use **`CLAWQL_GOOGLE_TOP50_SPECS=1`**, **`CLAWQL_PROVIDER=google-top50`**, or **`CLAWQL_SPEC_PATHS`** so `search` / `execute` see every merged API in one server; `execute` uses REST in that mode. For **every bundled vendor** (Google top50 + Jira, Bitbucket, Cloudflare, GitHub, Slack, Sentry, n8n), use **`CLAWQL_PROVIDER=all-providers`**. See [`docs/workflow-gcp-multi-service.md`](docs/workflow-gcp-multi-service.md).  
 **Integration check:** `npm run workflow:gcp-multi` runs **`tools/call` → `search`** over real MCP stdio and writes `docs/workflow-gcp-multi-latest.json` (full `CallToolResult` + parsed body). `npm run workflow:gcp-multi:direct` is a faster in-process-only variant for debugging rankers. One-page results summary: [`docs/gcp-multi-mcp-test-summary.md`](docs/gcp-multi-mcp-test-summary.md). Detailed experiment write-up (queries, APIs, token heuristic, MCP samples): [`docs/experiment-gcp-multi-mcp-workflow.md`](docs/experiment-gcp-multi-mcp-workflow.md); `npm run report:gcp-multi-experiment` refreshes [`docs/experiment-gcp-multi-mcp-stats.json`](docs/experiment-gcp-multi-mcp-stats.json).
 
-The default **first-run** bundle is **Stage 1 #4** above. To use another bundled spec or merged preset, set **`CLAWQL_PROVIDER`** — e.g. **`google`**,
+The default **first-run** bundle is **Stage 1 #4** above (**GitHub + Cloudflare**). Set **`CLAWQL_GITHUB_TOKEN`** and **`CLAWQL_CLOUDFLARE_API_TOKEN`** together so **`execute`** can call both APIs. To use another bundled spec or merged preset, set **`CLAWQL_PROVIDER`** — e.g. **`google`**,
 **`atlassian`**, **`cloudflare`**, **`github`**, **`slack`**, **`sentry`**, or **`n8n`**
 (see `providers/README.md`; **`all-providers`** = top50 + all other bundled vendors).  
 Compatibility aliases currently also exist for **`jira`** and **`bitbucket`**.  
@@ -590,7 +593,7 @@ Run **MCP Streamable HTTP** and **clawql-graphql** in a local cluster so clients
    This builds **`clawql-mcp:latest`**, applies **`docker/kustomize/overlays/local`**, and waits for rollouts. The script uses the **`docker-desktop`** kubectl context when present.
 
 3. **Health:** `curl -s http://localhost:8080/healthz` should return `{"status":"ok",...}` before connecting the client.
-4. **GitHub / bearer auth:** `bash scripts/k8s-docker-desktop-set-github-token.sh` (or set `CLAWQL_BEARER_TOKEN` via a Secret) — see [`docker/README.md`](docker/README.md).
+4. **GitHub + Cloudflare auth:** `bash scripts/k8s-docker-desktop-set-github-token.sh` (optional `CLAWQL_CLOUDFLARE_API_TOKEN` in the environment for the same run). See [`docker/README.md`](docker/README.md).
 
 **Teardown:** `kubectl --context docker-desktop delete namespace clawql`
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 # ClawQL
 
-MCP server with **two tools** (`search`, `execute`), an internal **GraphQL**
-layer for lean responses, and **spec-driven discovery** so agents don’t load
-full OpenAPI definitions into context.
+MCP server with **`search`** and **`execute`** (OpenAPI/Discovery), plus optional **`code`** / **`sandbox_exec`** (isolated execution via a [Cloudflare Sandbox](https://developers.cloudflare.com/sandbox/) **bridge Worker**). An internal **GraphQL** layer keeps **`execute`** responses lean; **spec-driven discovery** means agents don’t load full OpenAPI definitions into context.
 
 **What is MCP?** [Model Context Protocol](https://modelcontextprotocol.io) is how
 clients such as [Cursor](https://cursor.com/docs/context/mcp) or Claude Desktop
-run this server over **stdio** or **HTTP** and expose `search` / `execute` as
-tools to the model.
+run this server over **stdio** or **HTTP** and expose **`search`**, **`execute`**, and (when configured) **`code`** / **`sandbox_exec`** to the model.
 
 **Why two processes?** `search` runs inside the MCP process. The **`execute`**
 tool calls a **local GraphQL proxy** (`clawql-graphql`, default
@@ -352,6 +349,11 @@ If Stage 1 does **not** apply, one document is loaded in this order:
 | `CLAWQL_INTROSPECTION_PATH` | Pregenerated GraphQL introspection JSON (optional; speeds MCP `execute` field matching) |
 | `CLAWQL_API_BASE_URL` | Override REST base URL (if spec has no `servers` or you need a different host) |
 | `CLAWQL_OBSIDIAN_VAULT_PATH` | Absolute path to an Obsidian Markdown vault (shared volume/NFS). When set, the server **checks** the path exists and is readable/writable at startup. Omit locally to skip the check; container images default to **`/vault`** (see [Docker](docker/README.md)). Used with **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** and future memory tools. |
+| `CLAWQL_SANDBOX_BRIDGE_URL` | Origin of the [sandbox bridge Worker](cloudflare/sandbox-bridge/README.md) (e.g. `https://….workers.dev`). Required for **`code`** / **`sandbox_exec`**. |
+| `CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN` | Bearer token for **`POST /exec`**; must match the Worker `BRIDGE_SECRET`. |
+| `CLAWQL_CLOUDFLARE_ACCOUNT_ID` | Optional; sent as `CF-Account-ID` on bridge requests. |
+| `CLAWQL_SANDBOX_PERSISTENCE_MODE` | Default `session` / `ephemeral` / `persistent` for sandbox tool calls (overridable per call). |
+| `CLAWQL_SANDBOX_TIMEOUT_MS` | Max wait for each bridge request (default `120000`). |
 
 **GCP multi-service:** use **`CLAWQL_GOOGLE_TOP50_SPECS=1`**, **`CLAWQL_PROVIDER=google-top50`**, or **`CLAWQL_SPEC_PATHS`** so `search` / `execute` see every merged API in one server; `execute` uses REST in that mode. For **every bundled vendor** (Google top50 + Jira, Bitbucket, Cloudflare, GitHub, Slack, Sentry, n8n), use **`CLAWQL_PROVIDER=all-providers`**. See [`docs/workflow-gcp-multi-service.md`](docs/workflow-gcp-multi-service.md).  
 **Integration check:** `npm run workflow:gcp-multi` runs **`tools/call` → `search`** over real MCP stdio and writes `docs/workflow-gcp-multi-latest.json` (full `CallToolResult` + parsed body). `npm run workflow:gcp-multi:direct` is a faster in-process-only variant for debugging rankers. One-page results summary: [`docs/gcp-multi-mcp-test-summary.md`](docs/gcp-multi-mcp-test-summary.md). Detailed experiment write-up (queries, APIs, token heuristic, MCP samples): [`docs/experiment-gcp-multi-mcp-workflow.md`](docs/experiment-gcp-multi-mcp-workflow.md); `npm run report:gcp-multi-experiment` refreshes [`docs/experiment-gcp-multi-mcp-stats.json`](docs/experiment-gcp-multi-mcp-stats.json).
@@ -455,12 +457,14 @@ In multi-spec mode, ClawQL keeps one merged operation index for discovery and ex
 
 ## Tools
 
-**Shipped today:** **`search`** and **`execute`** (see [Architecture](#architecture)). **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** layers orchestration, long-term memory, and optional sandboxes on top; additional first-class MCP tools are part of **[parity milestone #11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)**.
+**Core tools:** **`search`** and **`execute`** (see [Architecture](#architecture)). **`code`** and **`sandbox_exec`** are the same tool under two names; they run snippets in **Cloudflare Sandboxes** through the HTTP bridge in [`cloudflare/sandbox-bridge/`](cloudflare/sandbox-bridge/README.md) (set **`CLAWQL_SANDBOX_BRIDGE_URL`** and **`CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN`** — see `.env.example`). **`memory_ingest` / `memory_recall`** remain on **[parity milestone #11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)**.
 
 | Tool | Description |
 |---|---|
 | `search` | Search the active OpenAPI/Discovery spec by natural language intent |
 | `execute` | Run a discovered operation by `operationId`, with optional GraphQL field selection |
+| `code` | Run `code` + `language` in an isolated sandbox (alias: `sandbox_exec`) |
+| `sandbox_exec` | Same as `code` — use one name consistently in agent prompts |
 
 ### Agent workflow example
 
@@ -604,9 +608,8 @@ See [`docs/deploy-k8s.md`](docs/deploy-k8s.md).
 
 ## Extending the server
 
-The default MCP surface is **`search`** and **`execute`**. To add more tools
-(e.g. `memory_*`, `code()` — see **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** / [#11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)), register them in `src/tools.ts` the same way
-(`server.tool(...)`). Vault path configuration and filesystem helpers for Obsidian-backed tools are in **`src/vault-config.ts`** and **`src/vault-utils.ts`**.
+The default API surface is **`search`** and **`execute`**; **`code`** / **`sandbox_exec`** are registered in the same module and call **`src/sandbox-bridge-client.ts`**. To add more tools
+(e.g. `memory_*` — see **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** / [#11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)), register them in `src/tools.ts` the same way (`server.tool(...)`). Vault path configuration and filesystem helpers for Obsidian-backed tools are in **`src/vault-config.ts`** and **`src/vault-utils.ts`**.
 
 GraphQL field names are **auto-resolved** in `execute` via schema introspection
 (candidates include run-style names, legacy path-derived names, and response-type

--- a/cloudflare/sandbox-bridge/Dockerfile
+++ b/cloudflare/sandbox-bridge/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.io/cloudflare/sandbox:0.8.10
+
+EXPOSE 8080

--- a/cloudflare/sandbox-bridge/README.md
+++ b/cloudflare/sandbox-bridge/README.md
@@ -1,0 +1,57 @@
+# ClawQL sandbox bridge (Cloudflare Worker)
+
+The [Sandbox SDK](https://developers.cloudflare.com/sandbox/) runs **inside Workers** with a container binding. The Node-based `clawql-mcp` server cannot load `@cloudflare/sandbox` directly, so this Worker exposes a small **POST `/exec`** API that the MCP tools **`code`** and **`sandbox_exec`** call using HTTP.
+
+## Deploy
+
+1. Install deps (Docker must be running for `wrangler deploy`):
+
+   ```bash
+   cd cloudflare/sandbox-bridge
+   npm install
+   ```
+
+2. Set the shared secret (use the same value as **`CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN`** on the machine running ClawQL MCP):
+
+   ```bash
+   npx wrangler secret put BRIDGE_SECRET
+   ```
+
+3. Deploy:
+
+   ```bash
+   npm run deploy
+   ```
+
+4. Copy the **`*.workers.dev`** origin and set on the MCP host:
+
+   - **`CLAWQL_SANDBOX_BRIDGE_URL`** — e.g. `https://clawql-sandbox-bridge.<your-subdomain>.workers.dev`
+   - **`CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN`** — same string as `BRIDGE_SECRET`
+
+Optional:
+
+- **`CLAWQL_CLOUDFLARE_ACCOUNT_ID`** — sent as `CF-Account-ID` on bridge requests (logging / future use).
+- **`CLAWQL_SANDBOX_PERSISTENCE_MODE`** — default `session` | `ephemeral` | `persistent` for MCP calls.
+
+## Request shape
+
+`POST /exec` with `Authorization: Bearer <BRIDGE_SECRET>` and JSON body:
+
+```json
+{
+  "code": "print(2+2)",
+  "language": "python",
+  "sessionId": "my-thread",
+  "persistenceMode": "session"
+}
+```
+
+`language`: `python` | `javascript` | `shell`. Code is written under `/workspace` and executed with `python3`, `node`, or `sh`.
+
+## Local dev
+
+```bash
+npm run dev
+```
+
+Use `wrangler` vars for `BRIDGE_SECRET` during development (do not commit secrets). First container build can take a few minutes.

--- a/cloudflare/sandbox-bridge/package.json
+++ b/cloudflare/sandbox-bridge/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "clawql-sandbox-bridge",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Worker bridge: ClawQL MCP (Node) -> Cloudflare Sandbox SDK",
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev",
+    "cf-typegen": "wrangler types"
+  },
+  "devDependencies": {
+    "@cloudflare/sandbox": "^0.8.10",
+    "typescript": "^5.9.3",
+    "wrangler": "^4.76.0"
+  },
+  "license": "Apache-2.0"
+}

--- a/cloudflare/sandbox-bridge/src/index.ts
+++ b/cloudflare/sandbox-bridge/src/index.ts
@@ -1,0 +1,101 @@
+import { getSandbox, type Sandbox } from "@cloudflare/sandbox";
+
+export { Sandbox } from "@cloudflare/sandbox";
+
+type Env = {
+  Sandbox: DurableObjectNamespace<Sandbox>;
+  BRIDGE_SECRET: string;
+};
+
+function resolveSandboxId(
+  mode: "ephemeral" | "session" | "persistent",
+  sessionId: string | undefined
+): string {
+  if (mode === "ephemeral") {
+    return `ephemeral-${crypto.randomUUID()}`;
+  }
+  if (mode === "persistent") {
+    return "clawql-persistent";
+  }
+  const sid = sessionId?.trim() || "default";
+  return `session-${sid}`;
+}
+
+function buildPaths(
+  language: "python" | "javascript" | "shell",
+  workspace: string
+): { rel: string; cmd: string } {
+  switch (language) {
+    case "python":
+      return { rel: "clawql_snippet.py", cmd: `python3 ${workspace}/clawql_snippet.py` };
+    case "javascript":
+      return { rel: "clawql_snippet.mjs", cmd: `node ${workspace}/clawql_snippet.mjs` };
+    case "shell":
+      return { rel: "clawql_snippet.sh", cmd: `sh ${workspace}/clawql_snippet.sh` };
+    default:
+      throw new Error(`unsupported language: ${language}`);
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname !== "/exec") {
+      return new Response("Not found", { status: 404 });
+    }
+    if (request.method !== "POST") {
+      return new Response("Method not allowed", { status: 405 });
+    }
+
+    const auth = request.headers.get("Authorization") ?? "";
+    const expected = `Bearer ${env.BRIDGE_SECRET}`;
+    if (!env.BRIDGE_SECRET || auth !== expected) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    let body: {
+      code?: string;
+      language?: "python" | "javascript" | "shell";
+      sessionId?: string;
+      persistenceMode?: "ephemeral" | "session" | "persistent";
+    };
+    try {
+      body = (await request.json()) as typeof body;
+    } catch {
+      return Response.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    if (!body.code || typeof body.code !== "string") {
+      return Response.json({ error: "Missing code" }, { status: 400 });
+    }
+    const language = body.language ?? "python";
+    if (language !== "python" && language !== "javascript" && language !== "shell") {
+      return Response.json({ error: "Invalid language" }, { status: 400 });
+    }
+
+    const persistenceMode = body.persistenceMode ?? "session";
+    if (
+      persistenceMode !== "ephemeral" &&
+      persistenceMode !== "session" &&
+      persistenceMode !== "persistent"
+    ) {
+      return Response.json({ error: "Invalid persistenceMode" }, { status: 400 });
+    }
+
+    const sandboxId = resolveSandboxId(persistenceMode, body.sessionId);
+    const sandbox = getSandbox(env.Sandbox, sandboxId);
+    const workspace = "/workspace";
+    const { rel, cmd } = buildPaths(language, workspace);
+    const path = `${workspace}/${rel}`;
+    await sandbox.writeFile(path, body.code);
+    const result = await sandbox.exec(cmd);
+
+    return Response.json({
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+      success: result.success,
+      sandboxId,
+    });
+  },
+};

--- a/cloudflare/sandbox-bridge/wrangler.jsonc
+++ b/cloudflare/sandbox-bridge/wrangler.jsonc
@@ -1,0 +1,19 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "clawql-sandbox-bridge",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-05-06",
+  "compatibility_flags": ["nodejs_compat"],
+  "containers": [
+    {
+      "class_name": "Sandbox",
+      "image": "./Dockerfile",
+      "instance_type": "lite",
+      "max_instances": 4
+    }
+  ],
+  "durable_objects": {
+    "bindings": [{ "class_name": "Sandbox", "name": "Sandbox" }]
+  },
+  "migrations": [{ "new_sqlite_classes": ["Sandbox"], "tag": "v1" }]
+}

--- a/docker/README.md
+++ b/docker/README.md
@@ -86,16 +86,16 @@ make local-k8s-up
 
 This tags **`clawql-mcp:latest`** (same daemon as Docker Desktop; no registry push). The overlay lives at `docker/kustomize/overlays/local`.
 
-- **`CLAWQL_PROVIDER`:** The **local** overlay sets **`github`** only (lighter RAM on a laptop). Edit `docker/kustomize/overlays/local/patch-local-provider-env.yaml` to **`all-providers`** when you need the full merge for multi-vendor MCP or **`workflow:complex-release-stack:mcp`** over HTTP. The **base** manifest defaults to **`google-top50`** when no overlay patch applies.
+- **`CLAWQL_PROVIDER`:** The **local** overlay sets **`default-multi-provider`** (GitHub + Cloudflare, same as bare `npx clawql-mcp`). Edit `docker/kustomize/overlays/local/patch-local-provider-env.yaml` to **`all-providers`** when you need the full merge for multi-vendor MCP or **`workflow:complex-release-stack:mcp`** over HTTP. The **base** manifest defaults to **`google-top50`** when no overlay patch applies.
 - **`kubectl` context:** The script targets **`docker-desktop`** when that context exists (so your default context can stay on EKS or another cluster).
 - **Restart behavior:** Deployments keep **`replicas: 1`** and Kubernetes **restarts failed containers** automatically (Pod `restartPolicy` is `Always`).
 - **MCP URL:** `http://localhost:8080/mcp` once `kubectl -n clawql get svc clawql-mcp-http` shows an external address (often `localhost` on Docker Desktop).
 - **Cold start:** The MCP container loads every bundled spec before `listen()`; hitting `:8080` too early can produce `fetch failed` / “other side closed” in Node. Wait until `curl http://localhost:8080/healthz` returns `{"status":"ok"…}` or the pod is **Ready** (the MCP Deployment includes `/healthz` startup/readiness probes). The `workflow:complex-release-stack:mcp` script polls `/healthz` when `CLAWQL_MCP_URL` is set.
 - **Teardown:** `kubectl delete namespace clawql` (or `kubectl --context docker-desktop delete namespace clawql`)
 
-### GitHub API auth (`CLAWQL_BEARER_TOKEN`) on Docker Desktop K8s
+### GitHub + Cloudflare API auth on Docker Desktop K8s
 
-ClawQL adds `Authorization: Bearer …` from **`CLAWQL_BEARER_TOKEN`** (see `src/rest-operation.ts`). For **`issues/create`** and other GitHub `execute` calls, set it in the cluster:
+Merged **`execute`** calls pick the bearer per vendor (`specLabel`): **`CLAWQL_GITHUB_TOKEN`** / **`GITHUB_TOKEN`** for GitHub operations and **`CLAWQL_CLOUDFLARE_API_TOKEN`** / **`CLOUDFLARE_API_TOKEN`** for Cloudflare (see `src/auth-headers.ts`). **`CLAWQL_BEARER_TOKEN`** remains a fallback. For the default **GitHub + Cloudflare** bundle, set both tokens in the cluster.
 
 1. **One-shot (recommended):** from the ClawQL repo root, with `gh` logged in:
 
@@ -103,18 +103,19 @@ ClawQL adds `Authorization: Bearer …` from **`CLAWQL_BEARER_TOKEN`** (see `src
    bash scripts/k8s-docker-desktop-set-github-token.sh
    ```
 
-   This creates/updates Secret **`clawql-github-auth`** in namespace **`clawql`**, attaches **`CLAWQL_BEARER_TOKEN`** to **`deployment/clawql-mcp-http`**, and **`rollout restart`**s it.
+   Optional: `export CLAWQL_CLOUDFLARE_API_TOKEN=…` in the same shell so the script stores **both** keys in Secret **`clawql-github-auth`** and attaches **`CLAWQL_GITHUB_TOKEN`** (and **`CLAWQL_CLOUDFLARE_API_TOKEN`** when set) to **`deployment/clawql-mcp-http`**, then **`rollout restart`**s it.
 
-   You can also pipe a PAT: `gh auth token | bash scripts/k8s-docker-desktop-set-github-token.sh`, or `export CLAWQL_BEARER_TOKEN=…` before the script.
+   You can also pipe a PAT: `gh auth token | bash scripts/k8s-docker-desktop-set-github-token.sh`, or `export CLAWQL_GITHUB_TOKEN=…` / `CLAWQL_BEARER_TOKEN=…` before the script.
 
 2. **Manual:**
 
    ```bash
    kubectl create secret generic clawql-github-auth -n clawql \
-     --from-literal=CLAWQL_BEARER_TOKEN="$(gh auth token)" \
+     --from-literal=CLAWQL_GITHUB_TOKEN="$(gh auth token)" \
+     --from-literal=CLAWQL_CLOUDFLARE_API_TOKEN="YOUR_CF_TOKEN" \
      --dry-run=client -o yaml | kubectl apply -f -
    kubectl -n clawql set env deployment/clawql-mcp-http \
-     --from=secret/clawql-github-auth --keys=CLAWQL_BEARER_TOKEN --overwrite
+     --from=secret/clawql-github-auth --keys=CLAWQL_GITHUB_TOKEN,CLAWQL_CLOUDFLARE_API_TOKEN --overwrite
    kubectl -n clawql rollout restart deployment/clawql-mcp-http
    ```
 

--- a/docker/kustomize/overlays/local/patch-local-provider-env.yaml
+++ b/docker/kustomize/overlays/local/patch-local-provider-env.yaml
@@ -1,5 +1,5 @@
-# Local Docker Desktop: single bundled spec (lighter than all-providers merge).
-# Switch value to all-providers (or another CLAWQL_PROVIDER) when you need multi-vendor again.
+# Local Docker Desktop: same default merge as bare npm (GitHub + Cloudflare).
+# Pin github, cloudflare, google-top50, or all-providers if you prefer.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -11,7 +11,7 @@ spec:
         - name: clawql-mcp-http
           env:
             - name: CLAWQL_PROVIDER
-              value: github
+              value: default-multi-provider
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -24,4 +24,4 @@ spec:
         - name: clawql-graphql
           env:
             - name: CLAWQL_PROVIDER
-              value: github
+              value: default-multi-provider

--- a/providers/README.md
+++ b/providers/README.md
@@ -12,10 +12,10 @@ start avoids downloading multi‑MB specs.
 | `slack` | `slack/openapi.json` | Official Web API spec from [api.slack.com/specs](https://api.slack.com/specs) (OpenAPI 2; loader upgrades). |
 | `sentry` | `sentry/openapi.json` | Dereferenced public API from [getsentry/sentry-api-schema](https://github.com/getsentry/sentry-api-schema) (`openapi-derefed.json`). |
 | `n8n` | `n8n/openapi.json` | n8n Public API (bundled JSON; refresh via `npm run fetch-n8n-openapi` against a running instance). |
-| `jira` | `atlassian/jira/openapi.yaml` | Jira Cloud REST (alias of single-spec mode; also part of `atlassian` / default merge). |
+| `jira` | `atlassian/jira/openapi.yaml` | Jira Cloud REST (alias of single-spec mode; also part of `atlassian` / `all-providers`). |
 | `bitbucket` | `atlassian/bitbucket/openapi.yaml` | Bitbucket Cloud REST (alias; also part of `atlassian` / `all-providers`). |
 | `google-top50` | *(merged preset)* | Curated [`google-top50-apis.json`](google/google-top50-apis.json) only (~50 Discovery specs). |
-| `default-multi-provider` | *(merged preset)* | Same as **no spec env**: top50 + Cloudflare + Jira. |
+| `default-multi-provider` | *(merged preset)* | Same as **no spec env**: GitHub + Cloudflare. |
 | `all-providers` | *(merged preset)* | Top50 + **every** other `BUNDLED_PROVIDERS` vendor (adds Bitbucket, GitHub, Slack, Sentry, n8n, …). |
 
 Compatibility aliases for merged groups: `atlassian` = Jira + Bitbucket together.
@@ -24,7 +24,7 @@ Compatibility aliases for merged groups: `atlassian` = Jira + Bitbucket together
 
 **Google “top 50” offline bundle:** Pinned Discovery JSON (and optional `introspection.json` / `schema.graphql`) for common GCP services — under [`google/apis/`](google/apis/README.md). Manifest: `google/google-top50-apis.json`. Refresh: `npm run fetch-google-top50` then `npm run build && npm run pregenerate-google-top50-graphql`, or `npm run refresh-google-top50`.
 
-**Default no-config mode:** when no spec env vars are set, ClawQL loads a bundled multi-provider set (`google-top50` + `cloudflare` + `jira`) so complex cross-provider search works on first install.
+**Default no-config mode:** when no spec env vars are set, ClawQL loads a bundled multi-provider set (**GitHub + Cloudflare**) so agents can **`search`** / **`execute`** both APIs in one process. Set **`CLAWQL_GITHUB_TOKEN`** and **`CLAWQL_CLOUDFLARE_API_TOKEN`** (or **`GITHUB_TOKEN`** / **`CLOUDFLARE_API_TOKEN`**) together for live calls — see `src/auth-headers.ts`.
 
 **All-providers merged preset:** set **`CLAWQL_PROVIDER=all-providers`** to load **Google top50 + every other bundled vendor** (Jira, Bitbucket, Cloudflare, GitHub, Slack, Sentry, n8n) in one merged operation index. This wins over **`CLAWQL_GOOGLE_TOP50_SPECS`** when both are set. Adding a new entry under `BUNDLED_PROVIDERS` automatically includes it here.
 

--- a/scripts/k8s-docker-desktop-set-github-token.sh
+++ b/scripts/k8s-docker-desktop-set-github-token.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-# Create/update a Kubernetes Secret with CLAWQL_BEARER_TOKEN (from gh or stdin),
-# wire it into clawql-mcp-http, set CORS for browser/Gallery clients, and restart.
+# Create/update a Kubernetes Secret with GitHub + optional Cloudflare API tokens,
+# wire them into clawql-mcp-http, set CORS for browser/Gallery clients, and restart.
+#
+# For the default merged bundle (GitHub + Cloudflare), set both:
+#   CLAWQL_GITHUB_TOKEN / CLAWQL_CLOUDFLARE_API_TOKEN
+# (see src/auth-headers.ts). CLAWQL_BEARER_TOKEN still works for single-vendor or as a fallback.
 #
 # Prerequisites:
 #   - Docker Desktop Kubernetes running; context docker-desktop (or docker-for-desktop)
@@ -10,7 +14,8 @@
 # Usage:
 #   bash scripts/k8s-docker-desktop-set-github-token.sh
 #   gh auth token | bash scripts/k8s-docker-desktop-set-github-token.sh
-#   CLAWQL_BEARER_TOKEN=ghp_xxx bash scripts/k8s-docker-desktop-set-github-token.sh
+#   CLAWQL_GITHUB_TOKEN=ghp_xxx bash scripts/k8s-docker-desktop-set-github-token.sh
+#   CLAWQL_CLOUDFLARE_API_TOKEN=… CLAWQL_GITHUB_TOKEN=… bash scripts/k8s-docker-desktop-set-github-token.sh
 #
 # CORS (CLAWQL_CORS_ALLOW_ORIGIN on clawql-mcp-http — see server-http.ts):
 #   Default: *  (Gallery / iPhone webview, Cloudflare Tunnel, etc.)
@@ -42,11 +47,11 @@ if ! kc get ns "$NAMESPACE" >/dev/null 2>&1; then
   exit 1
 fi
 
-TOKEN="${CLAWQL_BEARER_TOKEN:-}"
+TOKEN="${CLAWQL_GITHUB_TOKEN:-${CLAWQL_BEARER_TOKEN:-}}"
 if [[ -z "$TOKEN" ]]; then
   if [[ -t 0 ]]; then
     if ! command -v gh >/dev/null 2>&1; then
-      echo "ERROR: No CLAWQL_BEARER_TOKEN and gh not on PATH. Install gh or export CLAWQL_BEARER_TOKEN."
+      echo "ERROR: No CLAWQL_GITHUB_TOKEN/CLAWQL_BEARER_TOKEN and gh not on PATH. Install gh or export a token."
       exit 1
     fi
     TOKEN="$(gh auth token)"
@@ -56,19 +61,33 @@ if [[ -z "$TOKEN" ]]; then
 fi
 
 if [[ -z "${TOKEN// }" ]]; then
-  echo "ERROR: empty token"
+  echo "ERROR: empty GitHub token"
   exit 1
 fi
 
-echo "==> Creating/updating secret $SECRET_NAME in namespace $NAMESPACE"
-kc -n "$NAMESPACE" create secret generic "$SECRET_NAME" \
-  --from-literal=CLAWQL_BEARER_TOKEN="$TOKEN" \
-  --dry-run=client -o yaml | kc apply -f -
+CF_TOKEN="${CLAWQL_CLOUDFLARE_API_TOKEN:-}"
 
-echo "==> Attaching secret env to deployment/$DEPLOY (CLAWQL_BEARER_TOKEN)"
+echo "==> Creating/updating secret $SECRET_NAME in namespace $NAMESPACE"
+if [[ -n "${CF_TOKEN// }" ]]; then
+  kc -n "$NAMESPACE" create secret generic "$SECRET_NAME" \
+    --from-literal=CLAWQL_GITHUB_TOKEN="$TOKEN" \
+    --from-literal=CLAWQL_CLOUDFLARE_API_TOKEN="$CF_TOKEN" \
+    --dry-run=client -o yaml | kc apply -f -
+else
+  kc -n "$NAMESPACE" create secret generic "$SECRET_NAME" \
+    --from-literal=CLAWQL_GITHUB_TOKEN="$TOKEN" \
+    --dry-run=client -o yaml | kc apply -f -
+fi
+
+ENV_KEYS="CLAWQL_GITHUB_TOKEN"
+if [[ -n "${CF_TOKEN// }" ]]; then
+  ENV_KEYS="CLAWQL_GITHUB_TOKEN,CLAWQL_CLOUDFLARE_API_TOKEN"
+fi
+
+echo "==> Attaching secret env to deployment/$DEPLOY ($ENV_KEYS)"
 kc -n "$NAMESPACE" set env "deployment/$DEPLOY" \
   --from="secret/${SECRET_NAME}" \
-  --keys=CLAWQL_BEARER_TOKEN \
+  --keys="$ENV_KEYS" \
   --overwrite
 
 if [[ "${CLAWQL_SKIP_CORS:-}" == "1" ]]; then

--- a/src/auth-headers.ts
+++ b/src/auth-headers.ts
@@ -1,0 +1,69 @@
+/**
+ * REST / GraphQL→REST upstream headers: `CLAWQL_HTTP_HEADERS` JSON plus bearer
+ * selection by merged `specLabel` (multi-spec) or `CLAWQL_PROVIDER` (single-spec).
+ */
+
+function trimEnv(...keys: string[]): string | undefined {
+  for (const k of keys) {
+    const v = process.env[k]?.trim();
+    if (v) return v;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve `Authorization: Bearer …` for an operation.
+ * - When `specLabel` is set (multi-spec merge), it selects GitHub vs Cloudflare tokens.
+ * - When unset, `CLAWQL_PROVIDER` selects the same for single-vendor mode.
+ * - Falls back to `CLAWQL_BEARER_TOKEN` / `GOOGLE_ACCESS_TOKEN`.
+ */
+export function mergedAuthHeaders(specLabel?: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const raw = process.env.CLAWQL_HTTP_HEADERS;
+  if (raw) {
+    try {
+      Object.assign(out, JSON.parse(raw) as Record<string, string>);
+    } catch {
+      console.error(
+        "[auth-headers] Invalid CLAWQL_HTTP_HEADERS (expected JSON object)"
+      );
+    }
+  }
+  if (out.Authorization || out.authorization) {
+    return out;
+  }
+
+  const label = specLabel?.trim().toLowerCase();
+  const prov = process.env.CLAWQL_PROVIDER?.trim().toLowerCase();
+  const effective = label || prov;
+
+  let bearer: string | undefined;
+  if (effective === "github") {
+    bearer = trimEnv(
+      "CLAWQL_GITHUB_TOKEN",
+      "GITHUB_TOKEN",
+      "GH_TOKEN",
+      "CLAWQL_BEARER_TOKEN",
+      "GOOGLE_ACCESS_TOKEN"
+    );
+  } else if (effective === "cloudflare") {
+    bearer = trimEnv(
+      "CLAWQL_CLOUDFLARE_API_TOKEN",
+      "CLOUDFLARE_API_TOKEN",
+      "CLAWQL_BEARER_TOKEN",
+      "GOOGLE_ACCESS_TOKEN"
+    );
+  } else {
+    bearer = trimEnv(
+      "CLAWQL_BEARER_TOKEN",
+      "GOOGLE_ACCESS_TOKEN",
+      "CLAWQL_CLOUDFLARE_API_TOKEN",
+      "CLOUDFLARE_API_TOKEN"
+    );
+  }
+
+  if (bearer) {
+    out.Authorization = `Bearer ${bearer}`;
+  }
+  return out;
+}

--- a/src/graphql-schema-builder.ts
+++ b/src/graphql-schema-builder.ts
@@ -4,11 +4,12 @@
  * Builds a live GraphQL schema from OpenAPI 3 via **@omnigraph/openapi**
  * (the same stack as [GraphQL Mesh OpenAPI](https://the-guild.dev/graphql/mesh/docs/handlers/openapi)).
  * Resolvers proxy to the upstream REST API with headers from
- * CLAWQL_HTTP_HEADERS, CLAWQL_BEARER_TOKEN, and/or GOOGLE_ACCESS_TOKEN.
+ * CLAWQL_HTTP_HEADERS and bearer selection (see auth-headers.ts).
  */
 
 import loadGraphQLSchemaFromOpenAPI from "@omnigraph/openapi";
 import type { GraphQLSchema } from "graphql";
+import { mergedAuthHeaders } from "./auth-headers.js";
 import { getPackageRoot } from "./package-root.js";
 
 interface SchemaResult {
@@ -16,29 +17,11 @@ interface SchemaResult {
   contextValue: Record<string, unknown>;
 }
 
-function mergeAuthHeaders(): Record<string, string> {
-  const out: Record<string, string> = {};
-  const raw = process.env.CLAWQL_HTTP_HEADERS;
-  if (raw) {
-    try {
-      Object.assign(out, JSON.parse(raw) as Record<string, string>);
-    } catch {
-      console.error("[graphql-schema] Invalid CLAWQL_HTTP_HEADERS (expected JSON object)");
-    }
-  }
-  const bearer =
-    process.env.CLAWQL_BEARER_TOKEN || process.env.GOOGLE_ACCESS_TOKEN;
-  if (bearer && !out.Authorization && !out.authorization) {
-    out.Authorization = `Bearer ${bearer}`;
-  }
-  return out;
-}
-
 export async function buildGraphQLSchema(
   openapi: object,
   baseUrl: string
 ): Promise<SchemaResult> {
-  const headers = mergeAuthHeaders();
+  const headers = mergedAuthHeaders();
 
   // `source` may be a file path, URL, or an in-memory OpenAPI object (Mesh dereferences it).
   const schema = await loadGraphQLSchemaFromOpenAPI("ClawQL", {

--- a/src/provider-registry.ts
+++ b/src/provider-registry.ts
@@ -130,13 +130,11 @@ async function resolveGoogleTop50Items(): Promise<ProviderGroupItem[]> {
 
 async function resolveDefaultMultiProviderItems(): Promise<ProviderGroupItem[]> {
   const root = getPackageRoot();
-  const google = await resolveGoogleTop50Items();
   const cloudflare = BUNDLED_PROVIDERS.cloudflare;
-  const jira = BUNDLED_PROVIDERS.jira;
+  const github = BUNDLED_PROVIDERS.github;
   return [
-    ...google,
+    { abs: resolvePath(root, github.bundledSpecPath), label: github.id },
     { abs: resolvePath(root, cloudflare.bundledSpecPath), label: cloudflare.id },
-    { abs: resolvePath(root, jira.bundledSpecPath), label: jira.id },
   ];
 }
 
@@ -166,6 +164,7 @@ async function resolveAllBundledProvidersItems(): Promise<ProviderGroupItem[]> {
 export const BUNDLED_PROVIDER_GROUPS: Record<string, BundledProviderGroup> = {
   atlassian: { providers: ["jira", "bitbucket"] },
   "google-top50": { resolve: resolveGoogleTop50Items },
+  /** Same as no spec env: GitHub + Cloudflare (see `resolveDefaultMultiProviderItems`). */
   "default-multi-provider": { resolve: resolveDefaultMultiProviderItems },
   /** Google top50 + every other bundled vendor (Jira, Bitbucket, Cloudflare, GitHub, Slack, Sentry, n8n). */
   "all-providers": { resolve: resolveAllBundledProvidersItems },

--- a/src/rest-operation.test.ts
+++ b/src/rest-operation.test.ts
@@ -34,6 +34,12 @@ afterEach(() => {
   delete process.env.CLAWQL_HTTP_HEADERS;
   delete process.env.CLAWQL_BEARER_TOKEN;
   delete process.env.GOOGLE_ACCESS_TOKEN;
+  delete process.env.CLAWQL_GITHUB_TOKEN;
+  delete process.env.GITHUB_TOKEN;
+  delete process.env.GH_TOKEN;
+  delete process.env.CLAWQL_CLOUDFLARE_API_TOKEN;
+  delete process.env.CLOUDFLARE_API_TOKEN;
+  delete process.env.CLAWQL_PROVIDER;
 });
 
 describe("rest-operation helpers", () => {
@@ -56,6 +62,31 @@ describe("rest-operation helpers", () => {
     process.env.CLAWQL_BEARER_TOKEN = "abc";
     expect(mergedAuthHeaders()).toEqual({
       Authorization: "Token xyz",
+    });
+  });
+
+  it("uses CLAWQL_GITHUB_TOKEN for specLabel github over CLAWQL_BEARER_TOKEN", () => {
+    process.env.CLAWQL_BEARER_TOKEN = "generic";
+    process.env.CLAWQL_GITHUB_TOKEN = "gh_tok";
+    expect(mergedAuthHeaders("github")).toEqual({
+      Authorization: "Bearer gh_tok",
+    });
+  });
+
+  it("uses CLOUDFLARE_API_TOKEN for specLabel cloudflare over CLAWQL_BEARER_TOKEN", () => {
+    process.env.CLAWQL_BEARER_TOKEN = "generic";
+    process.env.CLOUDFLARE_API_TOKEN = "cf_tok";
+    expect(mergedAuthHeaders("cloudflare")).toEqual({
+      Authorization: "Bearer cf_tok",
+    });
+  });
+
+  it("uses CLAWQL_PROVIDER when specLabel is unset (single-vendor)", () => {
+    process.env.CLAWQL_PROVIDER = "github";
+    process.env.CLAWQL_GITHUB_TOKEN = "gh_only";
+    delete process.env.CLAWQL_BEARER_TOKEN;
+    expect(mergedAuthHeaders()).toEqual({
+      Authorization: "Bearer gh_only",
     });
   });
 });

--- a/src/rest-operation.ts
+++ b/src/rest-operation.ts
@@ -5,26 +5,11 @@
 
 import fetch from "node-fetch";
 import type { RequestInit as FetchRequestInit } from "node-fetch";
+import { mergedAuthHeaders } from "./auth-headers.js";
 import { resolveApiBaseUrl, type OpenAPIDoc } from "./spec-loader.js";
 import type { Operation } from "./spec-loader.js";
 
-export function mergedAuthHeaders(): Record<string, string> {
-  const out: Record<string, string> = {};
-  const raw = process.env.CLAWQL_HTTP_HEADERS;
-  if (raw) {
-    try {
-      Object.assign(out, JSON.parse(raw) as Record<string, string>);
-    } catch {
-      // ignore
-    }
-  }
-  const bearer =
-    process.env.CLAWQL_BEARER_TOKEN || process.env.GOOGLE_ACCESS_TOKEN;
-  if (bearer && !out.Authorization && !out.authorization) {
-    out.Authorization = `Bearer ${bearer}`;
-  }
-  return out;
-}
+export { mergedAuthHeaders };
 
 /** Build JSON body: drop path/query args so `owner`/`repo` are not sent in PATCH/POST bodies. */
 export function buildRestRequestBodyFromArgs(
@@ -93,7 +78,7 @@ export async function executeRestOperation(
   const method = op.method.toUpperCase();
   const headers: Record<string, string> = {
     Accept: "application/json",
-    ...mergedAuthHeaders(),
+    ...mergedAuthHeaders(op.specLabel),
   };
   const init: FetchRequestInit = { method, headers };
   if (method !== "GET" && method !== "HEAD" && op.requestBody) {

--- a/src/sandbox-bridge-client.test.ts
+++ b/src/sandbox-bridge-client.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { callSandboxBridge, handleClawqlCodeToolInput } from "./sandbox-bridge-client.js";
+
+describe("sandbox-bridge-client", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    saved.CLAWQL_SANDBOX_BRIDGE_URL = process.env.CLAWQL_SANDBOX_BRIDGE_URL;
+    saved.CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN = process.env.CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN;
+    delete process.env.CLAWQL_SANDBOX_BRIDGE_URL;
+    delete process.env.CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const key of Object.keys(saved)) {
+      const v = saved[key as keyof typeof saved];
+      if (v === undefined) delete process.env[key];
+      else process.env[key] = v;
+    }
+  });
+
+  it("callSandboxBridge errors when bridge URL missing", async () => {
+    const r = await callSandboxBridge({ code: "x", language: "python" });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/CLAWQL_SANDBOX_BRIDGE_URL/);
+  });
+
+  it("callSandboxBridge errors when token missing", async () => {
+    process.env.CLAWQL_SANDBOX_BRIDGE_URL = "https://bridge.example.test";
+    const r = await callSandboxBridge({ code: "x", language: "python" });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN/);
+  });
+
+  it("callSandboxBridge posts JSON and maps response", async () => {
+    process.env.CLAWQL_SANDBOX_BRIDGE_URL = "https://bridge.example.test";
+    process.env.CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN = "secret";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          stdout: "ok\n",
+          stderr: "",
+          exitCode: 0,
+          success: true,
+          sandboxId: "session-default",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const r = await callSandboxBridge({ code: "print(1)", language: "python" });
+    expect(r.success).toBe(true);
+    expect(r.stdout).toBe("ok\n");
+    expect(r.exitCode).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toContain("/exec");
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer secret");
+    const body = JSON.parse(init.body as string) as { code: string; language: string };
+    expect(body.code).toBe("print(1)");
+    expect(body.language).toBe("python");
+  });
+
+  it("handleClawqlCodeToolInput returns JSON text", async () => {
+    process.env.CLAWQL_SANDBOX_BRIDGE_URL = "https://bridge.example.test";
+    process.env.CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN = "secret";
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ stdout: "", stderr: "", exitCode: 0, success: true }), {
+        status: 200,
+      })
+    );
+    const out = await handleClawqlCodeToolInput({ code: "1", language: "javascript" });
+    const parsed = JSON.parse(out.content[0].text) as { success: boolean };
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/src/sandbox-bridge-client.ts
+++ b/src/sandbox-bridge-client.ts
@@ -1,0 +1,144 @@
+/**
+ * Calls a Cloudflare Worker that runs @cloudflare/sandbox (SDK is Workers-only).
+ * Deploy: cloudflare/sandbox-bridge/
+ */
+
+export type SandboxLanguage = "python" | "javascript" | "shell";
+export type SandboxPersistenceMode = "ephemeral" | "session" | "persistent";
+
+export type SandboxCodeToolInput = {
+  code: string;
+  language: SandboxLanguage;
+  sessionId?: string;
+  persistenceMode?: SandboxPersistenceMode;
+  timeoutMs?: number;
+};
+
+export type SandboxBridgeResponse = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  success: boolean;
+  sandboxId?: string;
+  error?: string;
+};
+
+function defaultPersistence(): SandboxPersistenceMode {
+  const v = process.env.CLAWQL_SANDBOX_PERSISTENCE_MODE?.trim().toLowerCase();
+  if (v === "ephemeral" || v === "session" || v === "persistent") return v;
+  return "session";
+}
+
+function parseTimeoutMs(requested?: number): number {
+  const maxRaw = Number.parseInt(process.env.CLAWQL_SANDBOX_TIMEOUT_MS_MAX ?? "300000", 10);
+  const max = Number.isFinite(maxRaw) && maxRaw >= 1000 ? maxRaw : 300000;
+  const defRaw = Number.parseInt(process.env.CLAWQL_SANDBOX_TIMEOUT_MS ?? "120000", 10);
+  const def = Number.isFinite(defRaw) && defRaw >= 1000 ? defRaw : 120000;
+  const t = requested ?? def;
+  return Math.min(Math.max(t, 1000), max);
+}
+
+export async function callSandboxBridge(
+  input: SandboxCodeToolInput
+): Promise<SandboxBridgeResponse> {
+  const base = process.env.CLAWQL_SANDBOX_BRIDGE_URL?.trim();
+  const token = process.env.CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN?.trim();
+  if (!base) {
+    return {
+      stdout: "",
+      stderr: "",
+      exitCode: -1,
+      success: false,
+      error:
+        "CLAWQL_SANDBOX_BRIDGE_URL is not set. Deploy the Worker in cloudflare/sandbox-bridge/ and set this to its origin (e.g. https://clawql-sandbox.your-subdomain.workers.dev).",
+    };
+  }
+  if (!token) {
+    return {
+      stdout: "",
+      stderr: "",
+      exitCode: -1,
+      success: false,
+      error:
+        "CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN is not set. Use the same value as the Worker BRIDGE_SECRET (wrangler secret put BRIDGE_SECRET).",
+    };
+  }
+  const url = new URL("exec", base.endsWith("/") ? base : `${base}/`);
+  const persistenceMode = input.persistenceMode ?? defaultPersistence();
+  const acct = process.env.CLAWQL_CLOUDFLARE_ACCOUNT_ID?.trim();
+  const timeoutMs = parseTimeoutMs(input.timeoutMs);
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    };
+    if (acct) headers["CF-Account-ID"] = acct;
+
+    const res = await fetch(url.toString(), {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        code: input.code,
+        language: input.language,
+        sessionId: input.sessionId,
+        persistenceMode,
+      }),
+      signal: controller.signal,
+    });
+    const text = await res.text();
+    let data: Record<string, unknown>;
+    try {
+      data = JSON.parse(text) as Record<string, unknown>;
+    } catch {
+      return {
+        stdout: "",
+        stderr: text.slice(0, 4000),
+        exitCode: -1,
+        success: false,
+        error: `Bridge returned non-JSON (HTTP ${res.status})`,
+      };
+    }
+    if (!res.ok) {
+      return {
+        stdout: "",
+        stderr: typeof data.stderr === "string" ? data.stderr : "",
+        exitCode: -1,
+        success: false,
+        error:
+          typeof data.error === "string"
+            ? data.error
+            : `HTTP ${res.status}`,
+      };
+    }
+    return {
+      stdout: String(data.stdout ?? ""),
+      stderr: String(data.stderr ?? ""),
+      exitCode: Number(data.exitCode ?? -1),
+      success: Boolean(data.success),
+      sandboxId: typeof data.sandboxId === "string" ? data.sandboxId : undefined,
+    };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const aborted = e instanceof Error && e.name === "AbortError";
+    return {
+      stdout: "",
+      stderr: "",
+      exitCode: -1,
+      success: false,
+      error: aborted ? `Timed out after ${timeoutMs}ms` : msg,
+    };
+  } finally {
+    clearTimeout(id);
+  }
+}
+
+export async function handleClawqlCodeToolInput(
+  params: SandboxCodeToolInput
+): Promise<{ content: { type: "text"; text: string }[] }> {
+  const result = await callSandboxBridge(params);
+  return {
+    content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+  };
+}

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -79,6 +79,8 @@ describe("server (stdio)", () => {
         const names = new Set(tools.map((t) => t.name));
         expect(names.has("search")).toBe(true);
         expect(names.has("execute")).toBe(true);
+        expect(names.has("code")).toBe(true);
+        expect(names.has("sandbox_exec")).toBe(true);
       } finally {
         await client.close();
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@
  *
  * Entry point. Boots the MCP server over stdio (Claude Desktop, Cursor, etc.).
  *
- *   Agent → MCP (this file) → search / execute → graphql-client → graphql-proxy → REST API
+ *   Agent → MCP (this file) → search / execute / code → graphql-client → graphql-proxy → REST API
  *
  * Spec source: CLAWQL_SPEC_PATH, CLAWQL_SPEC_URL, CLAWQL_DISCOVERY_URL, or default
  * Cloud Run discovery. See README and .env.example.

--- a/src/spec-loader.ts
+++ b/src/spec-loader.ts
@@ -5,7 +5,7 @@
  * - Local file (JSON or YAML OpenAPI 3 / Swagger 2), or
  * - URL to fetch the same, or
  * - Google Discovery document URL, or
- * - Default: bundled multi-provider set (Google top50 + Cloudflare + Jira).
+ * - Default: bundled multi-provider set (GitHub + Cloudflare).
  * - Optional merged preset: CLAWQL_PROVIDER=all-providers (top50 + all other bundled vendors).
  *
  * Produces a flattened Operation list for search + OpenAPI 3 for GraphQL.
@@ -632,10 +632,10 @@ async function resolveMultiSpecItems(): Promise<
     const grouped = await resolveBundledProviderGroup("google-top50");
     if (grouped) return grouped;
   }
-  // No config: load a rich default set for first-run complex workflows.
+  // No config: load a lean default set for first-run GitHub + Cloudflare workflows.
   if (!filePath && !specUrl && !discoveryUrl && !providerRaw && !useGoogleTop50) {
     console.error(
-      "[spec-loader] No spec env/provider set — using default multi-provider bundle: google-top50 + cloudflare + jira"
+      "[spec-loader] No spec env/provider set — using default multi-provider bundle: github + cloudflare"
     );
     const defaultGroup = await resolveBundledProviderGroup("default-multi-provider");
     if (defaultGroup) return defaultGroup;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,7 +1,8 @@
 /**
  * tools.ts
  *
- * Two tools: search (spec discovery) and execute (GraphQL-backed REST call).
+ * Core tools: search (spec discovery) and execute (GraphQL-backed REST call).
+ * Optional: code / sandbox_exec — remote execution via cloudflare/sandbox-bridge Worker.
  * GraphQL field names are resolved via schema introspection — see resolveGraphQLField.
  */
 
@@ -26,6 +27,7 @@ import { loadSpec, resolveApiBaseUrl } from "./spec-loader.js";
 import { searchOperations, formatSearchResults } from "./spec-search.js";
 import { createGraphQLClient } from "./graphql-client.js";
 import { executeRestOperation } from "./rest-operation.js";
+import { handleClawqlCodeToolInput } from "./sandbox-bridge-client.js";
 import type { Operation } from "./spec-loader.js";
 import { INLINE_OPENAPI_REQUEST_BODY } from "./operation-types.js";
 
@@ -270,6 +272,38 @@ export function registerTools(server: McpServer) {
     },
     handleClawqlExecuteToolInput
   );
+
+  const sandboxCodeSchema = {
+    code: z
+      .string()
+      .describe("Source code to run in an isolated Cloudflare Sandbox (via deployed bridge Worker)."),
+    language: z
+      .enum(["python", "javascript", "shell"])
+      .describe(
+        "python (python3), javascript (Node .mjs), or shell (posix sh script body)."
+      ),
+    sessionId: z
+      .string()
+      .optional()
+      .describe(
+        "When persistenceMode is session or persistent, reuse the same id to keep a stable sandbox filesystem (e.g. persist files across calls)."
+      ),
+    persistenceMode: z
+      .enum(["ephemeral", "session", "persistent"])
+      .optional()
+      .describe(
+        "Overrides CLAWQL_SANDBOX_PERSISTENCE_MODE. ephemeral = new sandbox each call; session = per sessionId; persistent = one shared sandbox."
+      ),
+    timeoutMs: z
+      .number()
+      .int()
+      .min(1000)
+      .optional()
+      .describe("Optional wall-clock limit in ms (capped by CLAWQL_SANDBOX_TIMEOUT_MS_MAX)."),
+  };
+
+  server.tool("code", sandboxCodeSchema, handleClawqlCodeToolInput);
+  server.tool("sandbox_exec", sandboxCodeSchema, handleClawqlCodeToolInput);
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/website/src/app/benchmarks/page.mdx
+++ b/website/src/app/benchmarks/page.mdx
@@ -11,7 +11,7 @@ The ClawQL README highlights **planning-context** comparisons: the byte size of 
 ## What the highlights measure
 
 - **All-providers complex release-stack** — broad scenario across Google top50 plus Bitbucket, Cloudflare, GitHub, Jira, n8n, Sentry, Slack. Artifacts: [`docs/workflow-complex-release-stack-latest.json`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/workflow-complex-release-stack-latest.json), stats under [`docs/benchmarks/all-providers-complex-workflow/`](https://github.com/danielsmithdevelopment/ClawQL/tree/main/docs/benchmarks/all-providers-complex-workflow).
-- **Default multi-provider** — Google + Cloudflare + Jira. Artifacts: [`docs/workflow-multi-provider-latest.json`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/workflow-multi-provider-latest.json), stats under [`docs/benchmarks/multi-provider-complex-workflow/`](https://github.com/danielsmithdevelopment/ClawQL/tree/main/docs/benchmarks/multi-provider-complex-workflow).
+- **Default multi-provider** — GitHub + Cloudflare (historical runs may label older Google + Cloudflare + Jira bundles). Artifacts: [`docs/workflow-multi-provider-latest.json`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/workflow-multi-provider-latest.json), stats under [`docs/benchmarks/multi-provider-complex-workflow/`](https://github.com/danielsmithdevelopment/ClawQL/tree/main/docs/benchmarks/multi-provider-complex-workflow).
 
 Token estimates in docs often use **~4 characters per token** as a heuristic.
 

--- a/website/src/app/bundled-specs/page.mdx
+++ b/website/src/app/bundled-specs/page.mdx
@@ -13,7 +13,7 @@ The npm package ships **`providers/`**—optional on-disk API descriptions so co
 | `CLAWQL_PROVIDER` | Notes |
 | --- | --- |
 | `google-top50` | Merged ~50 curated Google Discovery services |
-| `default-multi-provider` | Same as **no spec env**: top50 + Cloudflare + Jira |
+| `default-multi-provider` | Same as **no spec env**: GitHub + Cloudflare |
 | `all-providers` | Top50 **plus** every other bundled vendor (GitHub, Slack, Sentry, n8n, …) |
 | `atlassian` | Jira + Bitbucket merged |
 | `google` | Single Discovery example (GKE); use top50 for multi-service |

--- a/website/src/app/page.mdx
+++ b/website/src/app/page.mdx
@@ -30,7 +30,7 @@ export const sections = [
 
 ## Getting started {{ anchor: false }}
 
-Install **`clawql-mcp`**, start **`clawql-graphql`** in one terminal and **`clawql-mcp`** in another, then point your MCP client (e.g. Cursor or Claude Desktop) at the stdio server. Optionally set **`CLAWQL_SPEC_PATH`**, **`CLAWQL_SPEC_URL`**, or **`CLAWQL_DISCOVERY_URL`**; if you set nothing, ClawQL loads a bundled **multi-provider** merge (**Google top 50 + Cloudflare + Jira**). {{ className: 'lead' }}
+Install **`clawql-mcp`**, start **`clawql-graphql`** in one terminal and **`clawql-mcp`** in another, then point your MCP client (e.g. Cursor or Claude Desktop) at the stdio server. Optionally set **`CLAWQL_SPEC_PATH`**, **`CLAWQL_SPEC_URL`**, or **`CLAWQL_DISCOVERY_URL`**; if you set nothing, ClawQL loads a bundled **multi-provider** merge (**GitHub + Cloudflare**). {{ className: 'lead' }}
 
 <div className="not-prose">
   <Button href="/mcp-clients" variant="text" arrow="right">

--- a/website/src/app/spec-configuration/page.mdx
+++ b/website/src/app/spec-configuration/page.mdx
@@ -20,7 +20,7 @@ Used when any of these applies (order matters):
 1. **`CLAWQL_SPEC_PATHS`** — merge local files (comma, semicolon, or newline separated).
 2. **`CLAWQL_PROVIDER`** — merged preset (`google-top50`, `default-multi-provider`, `all-providers`, `atlassian`, …).
 3. **`CLAWQL_GOOGLE_TOP50_SPECS`** (`1` / `true` / `yes`) — curated Google top 50 if not already merged above.
-4. **Built-in default** — only when no spec-related env vars are set: **Google top 50 + Cloudflare + Jira** (`default-multi-provider`).
+4. **Built-in default** — only when no spec-related env vars are set: **GitHub + Cloudflare** (`default-multi-provider`).
 
 ## Stage 2 — Single spec
 


### PR DESCRIPTION
## Summary
Implements **[#4](https://github.com/danielsmithdevelopment/ClawQL/issues/4)** (**`code` / `sandbox_exec`**) via a Cloudflare Worker bridge, and lands related **default-provider + auth** improvements.

### Cloudflare Sandbox (`code` / `sandbox_exec`)
- **Node MCP** (`src/sandbox-bridge-client.ts`): `POST` to bridge `/exec` with `CLAWQL_SANDBOX_BRIDGE_URL`, `CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN`, optional `CLAWQL_CLOUDFLARE_ACCOUNT_ID`, timeouts.
- **Worker** (`cloudflare/sandbox-bridge/`): Sandbox SDK, `POST /exec`, Bearer `BRIDGE_SECRET` (same value as MCP token).
- **Tools** (`src/tools.ts`): register `code` and `sandbox_exec` (same handler).

### Default bundle + auth (follow-up commit)
- **Empty env** default merge is now **GitHub + Cloudflare** (leaner than google-top50 + cloudflare + jira).
- **`src/auth-headers.ts`**: `mergedAuthHeaders()` for provider-aware bearer tokens + `CLAWQL_HTTP_HEADERS`; used by REST and GraphQL schema builder.
- Docs, `.env.example`, k8s script, website pages, tests.

### Testing
`npm test` — 75 tests.

Fixes #4