### PR TITLE
feat: memory_ingest MCP tool + Obsidian memory docs (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ available via **`CLAWQL_PROVIDER`** (see [`providers/README.md`](providers/READM
 
 **Repo vs npm:** GitHub **`ClawQL`** — published package **`clawql-mcp`**.
 
-**Enterprise agent stack:** **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** is the local-first Docker platform (LangGraph, Obsidian knowledge graph, optional Cloudflare Sandboxes, Langfuse) that uses **this repo** as the MCP **API engine** — token-efficient **`search` / `execute`** over OpenAPI/Discovery. The agent README’s unified tool story (`code()` / `sandbox_exec()`, `memory_ingest()`, `memory_recall()`) is the **parity target** for ClawQL; shipped tools and env wiring are tracked in-repo (see **[#11 — Parity milestone](https://github.com/danielsmithdevelopment/ClawQL/issues/11)**). Optional **`CLAWQL_OBSIDIAN_VAULT_PATH`** configures a shared Obsidian vault path for that roadmap (validated at startup when set; Docker/K8s default **`/vault`** — see [Obsidian vault](#obsidian-vault-optional)).
+**Enterprise agent stack:** **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** is the local-first Docker platform (LangGraph, Obsidian knowledge graph, optional Cloudflare Sandboxes, Langfuse) that uses **this repo** as the MCP **API engine** — token-efficient **`search` / `execute`** over OpenAPI/Discovery. The agent README’s unified tool story (`code()` / `sandbox_exec()`, `memory_ingest()`, `memory_recall()`) is the **parity target** for ClawQL; **`memory_ingest`** is implemented when a vault path is set (see [Obsidian vault](#obsidian-vault-optional) and [`docs/memory-obsidian.md`](docs/memory-obsidian.md)). Remaining parity items are tracked in **[#11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)**. Optional **`CLAWQL_OBSIDIAN_VAULT_PATH`** configures a shared Obsidian vault path for that roadmap (validated at startup when set; Docker/K8s default **`/vault`** — see [Obsidian vault](#obsidian-vault-optional)).
 
 ## First 5 minutes
 
@@ -386,7 +386,9 @@ See `.env.example` for a full list.
 
 ### Obsidian vault (optional)
 
-Set **`CLAWQL_OBSIDIAN_VAULT_PATH`** when you mount a directory for **Obsidian**-compatible Markdown (e.g. alongside **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** or a future **`memory_ingest` / `memory_recall`** MCP surface). If unset or empty, no vault check runs. If set, startup fails fast when the path is missing, not a directory, or not readable/writable. Implementation helpers live in **`src/vault-config.ts`** and **`src/vault-utils.ts`** (safe paths + cooperative write lock under the vault root).
+Set **`CLAWQL_OBSIDIAN_VAULT_PATH`** when you mount a directory for **Obsidian**-compatible Markdown (e.g. alongside **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** or **`memory_ingest` / `memory_recall`**). If unset or empty, no vault check runs. If set, startup fails fast when the path is missing, not a directory, or not readable/writable. Implementation helpers live in **`src/vault-config.ts`** and **`src/vault-utils.ts`** (safe paths + cooperative write lock under the vault root).
+
+**Concepts (why a vault):** Long-running agents often avoid *only* stuffing context with retrieved chunks. A complementary pattern—sometimes called **Karpathy-style** or an **“LLM wiki”**—is to **compile** durable notes as Markdown on disk and **link** them with **`[[wikilinks]]`**, so memory **compounds** across sessions. **Obsidian** is a common viewer (plain files, graph + backlinks); the agent writes; humans browse and edit. That pattern is sketched in [Karpathy’s `llm-wiki` gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f). ClawQL’s **`memory_ingest`** writes under **`ClawQL/Memory/`** when the vault path is set. See **[`docs/memory-obsidian.md`](docs/memory-obsidian.md)** for a fuller background.
 
 **Large / vendor OpenAPI docs:** The design goal is **the full spec** — token
 efficiency comes from **search + selective `execute`**, not from trimming the
@@ -460,7 +462,7 @@ In multi-spec mode, ClawQL keeps one merged operation index for discovery and ex
 
 ## Tools
 
-**Core tools:** **`search`** and **`execute`** (see [Architecture](#architecture)). **`code`** and **`sandbox_exec`** are the same tool under two names; they run snippets in **Cloudflare Sandboxes** through the HTTP bridge in [`cloudflare/sandbox-bridge/`](cloudflare/sandbox-bridge/README.md) (set **`CLAWQL_SANDBOX_BRIDGE_URL`** and **`CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN`** — see `.env.example`). **`memory_ingest` / `memory_recall`** remain on **[parity milestone #11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)**.
+**Core tools:** **`search`** and **`execute`** (see [Architecture](#architecture)). **`code`** and **`sandbox_exec`** are the same tool under two names; they run snippets in **Cloudflare Sandboxes** through the HTTP bridge in [`cloudflare/sandbox-bridge/`](cloudflare/sandbox-bridge/README.md) (set **`CLAWQL_SANDBOX_BRIDGE_URL`** and **`CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN`** — see `.env.example`). **`memory_ingest`** writes Markdown under **`CLAWQL_OBSIDIAN_VAULT_PATH`** (see [Obsidian vault](#obsidian-vault-optional)). **`memory_recall`** is tracked on **[parity milestone #11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)**.
 
 | Tool | Description |
 |---|---|
@@ -468,6 +470,7 @@ In multi-spec mode, ClawQL keeps one merged operation index for discovery and ex
 | `execute` | Run a discovered operation by `operationId`, with optional GraphQL field selection |
 | `code` | Run `code` + `language` in an isolated sandbox (alias: `sandbox_exec`) |
 | `sandbox_exec` | Same as `code` — use one name consistently in agent prompts |
+| `memory_ingest` | Compile insights / tool output / conversation into Obsidian notes (`ClawQL/Memory/…`) when the vault path is set — see [`docs/memory-obsidian.md`](docs/memory-obsidian.md) |
 
 ### Agent workflow example
 
@@ -611,8 +614,8 @@ See [`docs/deploy-k8s.md`](docs/deploy-k8s.md).
 
 ## Extending the server
 
-The default API surface is **`search`** and **`execute`**; **`code`** / **`sandbox_exec`** are registered in the same module and call **`src/sandbox-bridge-client.ts`**. To add more tools
-(e.g. `memory_*` — see **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** / [#11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)), register them in `src/tools.ts` the same way (`server.tool(...)`). Vault path configuration and filesystem helpers for Obsidian-backed tools are in **`src/vault-config.ts`** and **`src/vault-utils.ts`**.
+The default API surface is **`search`** and **`execute`**; **`code`** / **`sandbox_exec`** call **`src/sandbox-bridge-client.ts`**; **`memory_ingest`** uses **`src/memory-ingest.ts`** plus **`src/vault-config.ts`** / **`src/vault-utils.ts`**. To add more tools
+(e.g. `memory_recall` — see **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** / [#11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)), register them in `src/tools.ts` the same way (`server.tool(...)`).
 
 GraphQL field names are **auto-resolved** in `execute` via schema introspection
 (candidates include run-style names, legacy path-derived names, and response-type

--- a/docs/memory-obsidian.md
+++ b/docs/memory-obsidian.md
@@ -1,0 +1,35 @@
+# Memory, Obsidian, and the “LLM wiki” pattern
+
+This note explains **why** ClawQL supports an Obsidian vault path and a **`memory_ingest`** tool, in terms readers may have seen described as **Karpathy-style** or **incremental wiki** memory.
+
+## Beyond one-shot RAG
+
+A common pattern in long-running agent setups is **not** to rely only on retrieving chunks into the prompt for every answer. Instead, the system **persists distilled knowledge as Markdown on disk** and updates it over time: summaries, entities, session takeaways, and links between notes. The model acts partly as an **editor of a small wiki**, not only as a stateless answerer.
+
+That idea has been discussed publicly in connection with [Andrej Karpathy’s `llm-wiki` write-up](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) (gist sketch of an LLM-maintained markdown wiki). Independent summaries and commentary also describe a **two-layer** habit: raw or clipped material in an inbox, then a **compiled** layer the agent curates into stable pages.
+
+## Why Obsidian
+
+**Obsidian** is a practical front-end for that compiled layer because:
+
+- Notes are **plain Markdown files** in a folder (easy to back up, diff, and audit).
+- **`[[wikilinks]]`** create a **graph**: forward links and **backlinks** without a custom database.
+- You can open the same vault from the desktop app while agents write into it from automation.
+
+ClawQL does not require Obsidian; any editor works. Obsidian is the usual reference because it matches how people **inspect** what agents stored.
+
+## How ClawQL fits in
+
+- **`CLAWQL_OBSIDIAN_VAULT_PATH`** points the MCP server at a vault directory (validated at startup when set).
+- **`memory_ingest`** writes structured notes under **`ClawQL/Memory/`** (see implementation in `src/memory-ingest.ts`), with YAML frontmatter and optional **`[[wikilinks]]`** to other pages.
+
+This is intentionally **lightweight**: no embedding database inside ClawQL for ingest; the vault remains the source of truth. **`memory_recall`** (planned) can add retrieval over these files in a later iteration.
+
+## Wikilinks and semantics
+
+`[[Page Name]]` links are **untyped**: they mean “related page,” not “contradicts” vs “supports.” For richer semantics, teams combine tags, folders, or prose in the note body—same as in human-maintained wikis.
+
+## See also
+
+- **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** — full stack that combines ClawQL MCP with orchestration and vault-backed memory.
+- **[Parity milestone #11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)** — tracking **`memory_recall`** and related parity items.

--- a/src/memory-ingest.test.ts
+++ b/src/memory-ingest.test.ts
@@ -1,0 +1,74 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  extractIngestHashes,
+  hashIngestSection,
+  runMemoryIngest,
+  slugifyTitle,
+} from "./memory-ingest.js";
+
+describe("memory-ingest", () => {
+  const saved = process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "clawql-vault-"));
+    process.env.CLAWQL_OBSIDIAN_VAULT_PATH = dir;
+  });
+
+  afterEach(async () => {
+    if (saved === undefined) delete process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+    else process.env.CLAWQL_OBSIDIAN_VAULT_PATH = saved;
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("slugifyTitle produces stable slugs", () => {
+    expect(slugifyTitle("Hello World!")).toBe("hello-world");
+    expect(slugifyTitle("!!!")).toBe("note");
+  });
+
+  it("runMemoryIngest writes Obsidian markdown under ClawQL/Memory", async () => {
+    const r = await runMemoryIngest({
+      title: "Test Note",
+      insights: "Learned something.",
+      wikilinks: ["Other"],
+    });
+    expect(r.ok).toBe(true);
+    expect(r.path).toBe("ClawQL/Memory/test-note.md");
+    const text = await readFile(join(dir, "ClawQL", "Memory", "test-note.md"), "utf8");
+    expect(text).toContain("clawql_ingest: true");
+    expect(text).toContain("# Test Note");
+    expect(text).toContain("[[Other]]");
+    expect(text).toContain("Learned something.");
+  });
+
+  it("skips duplicate payload (same hash)", async () => {
+    const input = { title: "Dup", insights: "same" };
+    const h = hashIngestSection(input);
+    expect(h.length).toBe(64);
+    const a = await runMemoryIngest(input);
+    expect(a.skipped).toBeUndefined();
+    const b = await runMemoryIngest(input);
+    expect(b.skipped).toBe(true);
+  });
+
+  it("append adds a second section", async () => {
+    await runMemoryIngest({ title: "Multi", insights: "one" });
+    const r = await runMemoryIngest({ title: "Multi", insights: "two" });
+    expect(r.skipped).toBeUndefined();
+    const text = await readFile(join(dir, "ClawQL", "Memory", "multi.md"), "utf8");
+    expect(text).toContain("one");
+    expect(text).toContain("two");
+    const hashes = extractIngestHashes(text);
+    expect(hashes.size).toBe(2);
+  });
+
+  it("errors when vault not configured", async () => {
+    delete process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+    const r = await runMemoryIngest({ title: "X" });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/CLAWQL_OBSIDIAN_VAULT_PATH/);
+  });
+});

--- a/src/memory-ingest.ts
+++ b/src/memory-ingest.ts
@@ -1,0 +1,216 @@
+/**
+ * memory_ingest MCP tool — writes Obsidian-compatible Markdown under the vault.
+ */
+
+import { createHash } from "node:crypto";
+import { getObsidianVaultPath } from "./vault-config.js";
+import {
+  readVaultTextFile,
+  withVaultWriteLock,
+  writeVaultTextFileAtomic,
+} from "./vault-utils.js";
+
+const MEMORY_DIR = "ClawQL/Memory";
+
+export type MemoryIngestInput = {
+  title: string;
+  insights?: string;
+  conversation?: string;
+  toolOutputs?: string | string[];
+  wikilinks?: string[];
+  sessionId?: string;
+  /** When true (default), append a new section to an existing page; duplicate payloads are skipped. */
+  append?: boolean;
+};
+
+export type MemoryIngestResult = {
+  ok: boolean;
+  path?: string;
+  skipped?: boolean;
+  reason?: string;
+  error?: string;
+};
+
+export function slugifyTitle(title: string): string {
+  const s = title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 96);
+  return s || "note";
+}
+
+function normalizeWikilink(name: string): string {
+  const t = name.trim();
+  const m = t.match(/^\[\[(.+)\]\]$/);
+  return (m ? m[1] : t).trim();
+}
+
+function formatToolOutputs(toolOutputs: string | string[] | undefined): string {
+  if (toolOutputs === undefined) return "";
+  if (Array.isArray(toolOutputs)) {
+    return toolOutputs.map((s) => s.trim()).filter(Boolean).join("\n\n---\n\n");
+  }
+  return toolOutputs.trim();
+}
+
+function sectionPayload(input: MemoryIngestInput): string {
+  const toolText = formatToolOutputs(input.toolOutputs);
+  return [input.insights?.trim() ?? "", toolText, input.conversation?.trim() ?? ""].join(
+    "\n\u0000\n"
+  );
+}
+
+export function hashIngestSection(input: MemoryIngestInput): string {
+  const h = createHash("sha256");
+  h.update(sectionPayload(input), "utf8");
+  return h.digest("hex");
+}
+
+export function extractIngestHashes(markdown: string): Set<string> {
+  const set = new Set<string>();
+  const re = /<!--\s*clawql-hash:([a-f0-9]{64})\s*-->/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(markdown)) !== null) {
+    set.add(m[1]);
+  }
+  return set;
+}
+
+function buildSectionBody(input: MemoryIngestInput, when: string): string {
+  const lines: string[] = [];
+  lines.push(`### Ingestion (${when})`);
+  if (input.sessionId?.trim()) {
+    lines.push(`_Session:_ \`${input.sessionId.trim().replace(/`/g, "'")}\``);
+    lines.push("");
+  }
+  if (input.insights?.trim()) {
+    lines.push("#### Insights");
+    lines.push(input.insights.trim());
+    lines.push("");
+  }
+  const toolText = formatToolOutputs(input.toolOutputs);
+  if (toolText) {
+    lines.push("#### Tool outputs");
+    lines.push("```text");
+    lines.push(toolText);
+    lines.push("```");
+    lines.push("");
+  }
+  if (input.conversation?.trim()) {
+    lines.push("#### Conversation");
+    lines.push("```text");
+    lines.push(input.conversation.trim());
+    lines.push("```");
+    lines.push("");
+  }
+  const hash = hashIngestSection(input);
+  lines.push(`<!-- clawql-hash:${hash} -->`);
+  return lines.join("\n");
+}
+
+function buildRelatedLinks(wikilinks: string[] | undefined): string {
+  if (!wikilinks?.length) return "";
+  const items = wikilinks.map((w) => `- [[${normalizeWikilink(w)}]]`).join("\n");
+  return `## Related\n\n${items}\n\n`;
+}
+
+function buildFrontmatter(title: string): string {
+  const iso = new Date().toISOString();
+  return [
+    "---",
+    `title: ${JSON.stringify(title)}`,
+    `date: ${iso}`,
+    "tags: [clawql-ingest]",
+    "clawql_ingest: true",
+    "---",
+    "",
+  ].join("\n");
+}
+
+export async function runMemoryIngest(input: MemoryIngestInput): Promise<MemoryIngestResult> {
+  const vault = getObsidianVaultPath();
+  if (!vault) {
+    return {
+      ok: false,
+      error:
+        "Obsidian vault is not configured. Set CLAWQL_OBSIDIAN_VAULT_PATH to a writable directory.",
+    };
+  }
+
+  const title = input.title?.trim();
+  if (!title) {
+    return { ok: false, error: "title is required" };
+  }
+
+  const slug = slugifyTitle(title);
+  const rel = `${MEMORY_DIR}/${slug}.md`;
+  const append = input.append !== false;
+  const hash = hashIngestSection(input);
+  const when = new Date().toISOString();
+
+  return withVaultWriteLock(vault, async () => {
+    let existing = "";
+    try {
+      existing = await readVaultTextFile(vault, rel);
+    } catch {
+      existing = "";
+    }
+
+    if (existing && extractIngestHashes(existing).has(hash)) {
+      return {
+        ok: true,
+        path: rel,
+        skipped: true,
+        reason: "Identical ingest payload was already stored (content hash match).",
+      };
+    }
+
+    const section = buildSectionBody(input, when);
+    const related = buildRelatedLinks(input.wikilinks);
+
+    if (!existing) {
+      const body = [
+        buildFrontmatter(title),
+        `# ${title}`,
+        "",
+        related,
+        "---",
+        "",
+        section,
+        "",
+      ].join("\n");
+      await writeVaultTextFileAtomic(vault, rel, body);
+      return { ok: true, path: rel };
+    }
+
+    if (!append) {
+      const body = [
+        buildFrontmatter(title),
+        `# ${title}`,
+        "",
+        related,
+        "---",
+        "",
+        section,
+        "",
+      ].join("\n");
+      await writeVaultTextFileAtomic(vault, rel, body);
+      return { ok: true, path: rel };
+    }
+
+    const next = `${existing.trimEnd()}\n\n---\n\n${section}\n`;
+    await writeVaultTextFileAtomic(vault, rel, next);
+    return { ok: true, path: rel };
+  });
+}
+
+export async function handleMemoryIngestToolInput(
+  params: MemoryIngestInput
+): Promise<{ content: { type: "text"; text: string }[] }> {
+  const result = await runMemoryIngest(params);
+  return {
+    content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+  };
+}

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -81,6 +81,7 @@ describe("server (stdio)", () => {
         expect(names.has("execute")).toBe(true);
         expect(names.has("code")).toBe(true);
         expect(names.has("sandbox_exec")).toBe(true);
+        expect(names.has("memory_ingest")).toBe(true);
       } finally {
         await client.close();
       }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3,6 +3,7 @@
  *
  * Core tools: search (spec discovery) and execute (GraphQL-backed REST call).
  * Optional: code / sandbox_exec — remote execution via cloudflare/sandbox-bridge Worker.
+ * Optional: memory_ingest — Obsidian Markdown pages under CLAWQL_OBSIDIAN_VAULT_PATH.
  * GraphQL field names are resolved via schema introspection — see resolveGraphQLField.
  */
 
@@ -28,6 +29,7 @@ import { searchOperations, formatSearchResults } from "./spec-search.js";
 import { createGraphQLClient } from "./graphql-client.js";
 import { executeRestOperation } from "./rest-operation.js";
 import { handleClawqlCodeToolInput } from "./sandbox-bridge-client.js";
+import { handleMemoryIngestToolInput } from "./memory-ingest.js";
 import type { Operation } from "./spec-loader.js";
 import { INLINE_OPENAPI_REQUEST_BODY } from "./operation-types.js";
 
@@ -304,6 +306,39 @@ export function registerTools(server: McpServer) {
 
   server.tool("code", sandboxCodeSchema, handleClawqlCodeToolInput);
   server.tool("sandbox_exec", sandboxCodeSchema, handleClawqlCodeToolInput);
+
+  server.tool(
+    "memory_ingest",
+    {
+      title: z
+        .string()
+        .min(1)
+        .describe("Suggested Obsidian page title (used for the file name and heading)."),
+      insights: z.string().optional().describe("Key insights to persist."),
+      conversation: z
+        .string()
+        .optional()
+        .describe("Conversation transcript or summary text."),
+      toolOutputs: z
+        .union([z.string(), z.array(z.string())])
+        .optional()
+        .describe("Tool result body, or a list of results to record."),
+      wikilinks: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Other vault page names to link with Obsidian [[wikilinks]] (plain names; brackets optional)."
+        ),
+      sessionId: z.string().optional().describe("Optional session label (shown in the note)."),
+      append: z
+        .boolean()
+        .optional()
+        .describe(
+          "When the page already exists, append a new section (default true). Set false to replace the file."
+        ),
+    },
+    handleMemoryIngestToolInput
+  );
 }
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Implements **[#6](https://github.com/danielsmithdevelopment/ClawQL/issues/6)**: MCP tool **** that writes Obsidian-compatible Markdown under `CLAWQL_OBSIDIAN_VAULT_PATH` when set.

## Behavior
- Notes under `ClawQL/Memory/<slug>.md` with YAML frontmatter, optional `[[wikilinks]]`, sections for insights / tool output / conversation.
- **Append** mode (default): new ingestions append; **SHA-256** content hash in HTML comments skips duplicate payloads.
- Uses `withVaultWriteLock` + `writeVaultTextFileAtomic` from `vault-utils.ts`.

## Docs
- New **[docs/memory-obsidian.md](docs/memory-obsidian.md)** — Karpathy-style / LLM wiki + Obsidian context, link to [llm-wiki gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).
- README: Obsidian section + tools table + enterprise blurb updated.

## Testing
`npm test` — **80** tests.

Fixes #6