### PR TITLE
feat: memory_recall MCP tool — keyword search + wikilink graph (#7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,14 @@
 # Docker images default to /vault (see docker/Dockerfile). Omit locally to skip the check.
 # CLAWQL_OBSIDIAN_VAULT_PATH=/vault
 
+# memory_recall (keyword + wikilink graph; optional overrides)
+# CLAWQL_MEMORY_RECALL_SCAN_ROOT=ClawQL/Memory
+# CLAWQL_MEMORY_RECALL_LIMIT=10
+# CLAWQL_MEMORY_RECALL_MAX_DEPTH=2
+# CLAWQL_MEMORY_RECALL_MIN_SCORE=1
+# CLAWQL_MEMORY_RECALL_MAX_FILES=2000
+# CLAWQL_MEMORY_RECALL_SNIPPET_CHARS=520
+
 # ─── Cloudflare Sandbox (code / sandbox_exec MCP tools) ───────────────
 # The Sandbox SDK runs in a Worker; MCP calls this bridge over HTTPS.
 # Deploy: cloudflare/sandbox-bridge/ — set BRIDGE_SECRET to match the token below.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ available via **`CLAWQL_PROVIDER`** (see [`providers/README.md`](providers/READM
 
 **Repo vs npm:** GitHub **`ClawQL`** — published package **`clawql-mcp`**.
 
-**Enterprise agent stack:** **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** is the local-first Docker platform (LangGraph, Obsidian knowledge graph, optional Cloudflare Sandboxes, Langfuse) that uses **this repo** as the MCP **API engine** — token-efficient **`search` / `execute`** over OpenAPI/Discovery. The agent README’s unified tool story (`code()` / `sandbox_exec()`, `memory_ingest()`, `memory_recall()`) is the **parity target** for ClawQL; **`memory_ingest`** is implemented when a vault path is set (see [Obsidian vault](#obsidian-vault-optional) and [`docs/memory-obsidian.md`](docs/memory-obsidian.md)). Remaining parity items are tracked in **[#11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)**. Optional **`CLAWQL_OBSIDIAN_VAULT_PATH`** configures a shared Obsidian vault path for that roadmap (validated at startup when set; Docker/K8s default **`/vault`** — see [Obsidian vault](#obsidian-vault-optional)).
+**Enterprise agent stack:** **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** is the local-first Docker platform (LangGraph, Obsidian knowledge graph, optional Cloudflare Sandboxes, Langfuse) that uses **this repo** as the MCP **API engine** — token-efficient **`search` / `execute`** over OpenAPI/Discovery. The agent README’s unified tool story (`code()` / `sandbox_exec()`, `memory_ingest()`, `memory_recall()`) is the **parity target** for ClawQL; **`memory_ingest`** and **`memory_recall`** run when **`CLAWQL_OBSIDIAN_VAULT_PATH`** is set (see [Obsidian vault](#obsidian-vault-optional) and [`docs/memory-obsidian.md`](docs/memory-obsidian.md)). Further parity items are tracked in **[#11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)**. Optional **`CLAWQL_OBSIDIAN_VAULT_PATH`** configures a shared Obsidian vault path for that roadmap (validated at startup when set; Docker/K8s default **`/vault`** — see [Obsidian vault](#obsidian-vault-optional)).
 
 ## First 5 minutes
 
@@ -354,6 +354,12 @@ If Stage 1 does **not** apply, one document is loaded in this order:
 | `CLAWQL_CLOUDFLARE_ACCOUNT_ID` | Optional; sent as `CF-Account-ID` on bridge requests. |
 | `CLAWQL_SANDBOX_PERSISTENCE_MODE` | Default `session` / `ephemeral` / `persistent` for sandbox tool calls (overridable per call). |
 | `CLAWQL_SANDBOX_TIMEOUT_MS` | Max wait for each bridge request (default `120000`). |
+| `CLAWQL_MEMORY_RECALL_SCAN_ROOT` | Subfolder under the vault to scan (default `ClawQL/Memory`). Set to empty to scan the whole vault. |
+| `CLAWQL_MEMORY_RECALL_LIMIT` | Default max notes returned by **`memory_recall`** (`10`). |
+| `CLAWQL_MEMORY_RECALL_MAX_DEPTH` | Default wikilink hops from a keyword hit (`2`). |
+| `CLAWQL_MEMORY_RECALL_MIN_SCORE` | Minimum keyword score to seed a note (`1`). |
+| `CLAWQL_MEMORY_RECALL_MAX_FILES` | Safety cap on Markdown files scanned (`2000`). |
+| `CLAWQL_MEMORY_RECALL_SNIPPET_CHARS` | Snippet length in characters (`520`). |
 | `CLAWQL_GITHUB_TOKEN` | GitHub PAT / fine-grained token for **`execute`** when the operation is from the **github** spec (or `CLAWQL_PROVIDER=github`). Also accepts **`GITHUB_TOKEN`** / **`GH_TOKEN`**. |
 | `CLAWQL_CLOUDFLARE_API_TOKEN` | Cloudflare API token for **`execute`** when the operation is from the **cloudflare** spec (or `CLAWQL_PROVIDER=cloudflare`). Also accepts **`CLOUDFLARE_API_TOKEN`**. |
 | `CLAWQL_BEARER_TOKEN` | Fallback bearer when a provider-specific token is not set; also used for Google and other merged labels. |
@@ -462,7 +468,7 @@ In multi-spec mode, ClawQL keeps one merged operation index for discovery and ex
 
 ## Tools
 
-**Core tools:** **`search`** and **`execute`** (see [Architecture](#architecture)). **`code`** and **`sandbox_exec`** are the same tool under two names; they run snippets in **Cloudflare Sandboxes** through the HTTP bridge in [`cloudflare/sandbox-bridge/`](cloudflare/sandbox-bridge/README.md) (set **`CLAWQL_SANDBOX_BRIDGE_URL`** and **`CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN`** — see `.env.example`). **`memory_ingest`** writes Markdown under **`CLAWQL_OBSIDIAN_VAULT_PATH`** (see [Obsidian vault](#obsidian-vault-optional)). **`memory_recall`** is tracked on **[parity milestone #11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)**.
+**Core tools:** **`search`** and **`execute`** (see [Architecture](#architecture)). **`code`** and **`sandbox_exec`** are the same tool under two names; they run snippets in **Cloudflare Sandboxes** through the HTTP bridge in [`cloudflare/sandbox-bridge/`](cloudflare/sandbox-bridge/README.md) (set **`CLAWQL_SANDBOX_BRIDGE_URL`** and **`CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN`** — see `.env.example`). **`memory_ingest`** / **`memory_recall`** need a configured vault (see [Obsidian vault](#obsidian-vault-optional)). Remaining parity work is tracked on **[#11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)**.
 
 | Tool | Description |
 |---|---|
@@ -471,6 +477,7 @@ In multi-spec mode, ClawQL keeps one merged operation index for discovery and ex
 | `code` | Run `code` + `language` in an isolated sandbox (alias: `sandbox_exec`) |
 | `sandbox_exec` | Same as `code` — use one name consistently in agent prompts |
 | `memory_ingest` | Compile insights / tool output / conversation into Obsidian notes (`ClawQL/Memory/…`) when the vault path is set — see [`docs/memory-obsidian.md`](docs/memory-obsidian.md) |
+| `memory_recall` | Keyword search over vault Markdown plus `[[wikilinks]]` hops (no embeddings; tunable via `CLAWQL_MEMORY_RECALL_*`) |
 
 ### Agent workflow example
 
@@ -614,8 +621,8 @@ See [`docs/deploy-k8s.md`](docs/deploy-k8s.md).
 
 ## Extending the server
 
-The default API surface is **`search`** and **`execute`**; **`code`** / **`sandbox_exec`** call **`src/sandbox-bridge-client.ts`**; **`memory_ingest`** uses **`src/memory-ingest.ts`** plus **`src/vault-config.ts`** / **`src/vault-utils.ts`**. To add more tools
-(e.g. `memory_recall` — see **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** / [#11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)), register them in `src/tools.ts` the same way (`server.tool(...)`).
+The default API surface is **`search`** and **`execute`**; **`code`** / **`sandbox_exec`** call **`src/sandbox-bridge-client.ts`**; **`memory_ingest`** / **`memory_recall`** use **`src/memory-ingest.ts`**, **`src/memory-recall.ts`**, and **`src/vault-config.ts`** / **`src/vault-utils.ts`**. To add more tools
+(see **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** / [#11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)), register them in `src/tools.ts` the same way (`server.tool(...)`).
 
 GraphQL field names are **auto-resolved** in `execute` via schema introspection
 (candidates include run-style names, legacy path-derived names, and response-type

--- a/docs/memory-obsidian.md
+++ b/docs/memory-obsidian.md
@@ -21,9 +21,10 @@ ClawQL does not require Obsidian; any editor works. Obsidian is the usual refere
 ## How ClawQL fits in
 
 - **`CLAWQL_OBSIDIAN_VAULT_PATH`** points the MCP server at a vault directory (validated at startup when set).
-- **`memory_ingest`** writes structured notes under **`ClawQL/Memory/`** (see implementation in `src/memory-ingest.ts`), with YAML frontmatter and optional **`[[wikilinks]]`** to other pages.
+- **`memory_ingest`** writes structured notes under **`ClawQL/Memory/`** (see `src/memory-ingest.ts`), with YAML frontmatter and optional **`[[wikilinks]]`** to other pages.
+- **`memory_recall`** (`src/memory-recall.ts`) does **keyword scoring** over Markdown (plus headings / filenames) and **walks the wikilink graph** (forward + backward) up to a configurable depth. It does **not** load embedding models—tuned for low latency in agent loops. Tune defaults with **`CLAWQL_MEMORY_RECALL_*`** env vars (see README).
 
-This is intentionally **lightweight**: no embedding database inside ClawQL for ingest; the vault remains the source of truth. **`memory_recall`** (planned) can add retrieval over these files in a later iteration.
+The design stays **lightweight**: the vault remains the source of truth; retrieval is “good enough” lexical + graph context rather than semantic vectors in-process.
 
 ## Wikilinks and semantics
 
@@ -32,4 +33,4 @@ This is intentionally **lightweight**: no embedding database inside ClawQL for i
 ## See also
 
 - **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** — full stack that combines ClawQL MCP with orchestration and vault-backed memory.
-- **[Parity milestone #11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)** — tracking **`memory_recall`** and related parity items.
+- **[Parity milestone #11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)** — remaining stack parity (beyond ingest/recall).

--- a/src/memory-recall.test.ts
+++ b/src/memory-recall.test.ts
@@ -1,0 +1,86 @@
+import { mkdir, mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  extractWikilinkTargets,
+  keywordScore,
+  runMemoryRecall,
+} from "./memory-recall.js";
+
+describe("memory-recall helpers", () => {
+  it("keywordScore sums token matches", () => {
+    expect(keywordScore("hello world", "Hello hello WORLD")).toBeGreaterThan(0);
+  });
+
+  it("extractWikilinkTargets parses Obsidian links", () => {
+    expect(extractWikilinkTargets("See [[Foo Bar]] and [[x|alias]]")).toEqual([
+      "Foo Bar",
+      "x",
+    ]);
+  });
+});
+
+describe("memory-recall vault", () => {
+  const saved = process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "clawql-vault-"));
+    process.env.CLAWQL_OBSIDIAN_VAULT_PATH = dir;
+    await mkdir(join(dir, "ClawQL", "Memory"), { recursive: true });
+    await writeFile(
+      join(dir, "ClawQL/Memory/alpha.md"),
+      [
+        "---",
+        'title: "Alpha"',
+        "---",
+        "",
+        "# Alpha",
+        "",
+        "Discuss [[Beta Page]] here.",
+        "",
+        "GitHub API patterns for PAT rotation.",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+    await writeFile(
+      join(dir, "ClawQL/Memory/beta-page.md"),
+      ["---", 'title: "Beta"', "---", "", "# Beta Page", "", "Secondary note body.", ""].join(
+        "\n"
+      ),
+      "utf8"
+    );
+  });
+
+  afterEach(async () => {
+    if (saved === undefined) delete process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+    else process.env.CLAWQL_OBSIDIAN_VAULT_PATH = saved;
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("finds keyword hits and follows wikilinks", async () => {
+    const r = await runMemoryRecall({
+      query: "github pat",
+      limit: 10,
+      maxDepth: 2,
+      minScore: 1,
+    });
+    expect(r.ok).toBe(true);
+    expect(r.results?.length).toBeGreaterThanOrEqual(2);
+    const paths = r.results!.map((x) => x.path);
+    expect(paths.some((p) => p.includes("alpha.md"))).toBe(true);
+    expect(paths.some((p) => p.includes("beta-page.md"))).toBe(true);
+    const beta = r.results!.find((x) => x.path.endsWith("beta-page.md"));
+    expect(beta?.reason).toBe("link");
+    expect(beta?.linkFrom).toMatch(/alpha\.md$/);
+  });
+
+  it("errors when vault unset", async () => {
+    delete process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+    const r = await runMemoryRecall({ query: "x" });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/CLAWQL_OBSIDIAN_VAULT_PATH/);
+  });
+});

--- a/src/memory-recall.ts
+++ b/src/memory-recall.ts
@@ -1,0 +1,297 @@
+/**
+ * memory_recall MCP tool — keyword search + wikilink graph traversal in the vault.
+ * Lightweight (no embeddings); suitable for agent loops.
+ */
+
+import { readdir } from "node:fs/promises";
+import { basename, extname, join } from "node:path";
+import { getObsidianVaultPath } from "./vault-config.js";
+import { readVaultTextFile } from "./vault-utils.js";
+import { slugifyTitle } from "./memory-ingest.js";
+
+export type MemoryRecallInput = {
+  query: string;
+  /** Max notes to return (default from CLAWQL_MEMORY_RECALL_LIMIT). */
+  limit?: number;
+  /** Wikilink hops from keyword hits (default from CLAWQL_MEMORY_RECALL_MAX_DEPTH). */
+  maxDepth?: number;
+  /** Minimum keyword score to seed recall (default from CLAWQL_MEMORY_RECALL_MIN_SCORE). */
+  minScore?: number;
+};
+
+export type RecallHit = {
+  path: string;
+  score: number;
+  depth: number;
+  reason: "keyword" | "link";
+  linkFrom?: string;
+  snippet: string;
+};
+
+export type MemoryRecallResult = {
+  ok: boolean;
+  query?: string;
+  results?: RecallHit[];
+  truncated?: boolean;
+  scannedFiles?: number;
+  error?: string;
+};
+
+function envInt(key: string, def: number): number {
+  const v = process.env[key]?.trim();
+  if (!v) return def;
+  const n = Number.parseInt(v, 10);
+  return Number.isFinite(n) ? n : def;
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length > 1);
+}
+
+function countOccurrences(hay: string, needle: string): number {
+  if (needle.length < 2) return 0;
+  let c = 0;
+  let i = 0;
+  while ((i = hay.indexOf(needle, i)) !== -1) {
+    c++;
+    i += needle.length;
+  }
+  return c;
+}
+
+/** Exported for tests. */
+export function keywordScore(query: string, text: string): number {
+  const terms = tokenize(query);
+  if (terms.length === 0) return 0;
+  const lower = text.toLowerCase();
+  let s = 0;
+  for (const t of terms) {
+    s += Math.min(countOccurrences(lower, t), 25);
+  }
+  return s;
+}
+
+function stripFrontmatter(s: string): string {
+  if (s.startsWith("---\n")) {
+    const end = s.indexOf("\n---\n", 4);
+    if (end !== -1) return s.slice(end + 5).trim();
+  }
+  return s;
+}
+
+/** Exported for tests. Obsidian `[[note|alias]]` uses the left side as target. */
+export function extractWikilinkTargets(markdown: string): string[] {
+  const out: string[] = [];
+  const re = /\[\[([^\]]+)\]\]/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(markdown)) !== null) {
+    const raw = m[1].split("|")[0]?.trim();
+    if (raw) out.push(raw);
+  }
+  return out;
+}
+
+function buildSnippet(text: string, query: string, maxLen: number): string {
+  const body = stripFrontmatter(text);
+  const terms = tokenize(query);
+  const lower = body.toLowerCase();
+  let pos = 0;
+  for (const t of terms) {
+    const i = lower.indexOf(t);
+    if (i !== -1) {
+      pos = Math.max(0, i - Math.floor(maxLen / 4));
+      break;
+    }
+  }
+  const slice = body.slice(pos, pos + maxLen).trim();
+  return slice.length < body.length ? `${slice}…` : slice;
+}
+
+async function listMarkdownFiles(
+  vaultAbs: string,
+  subRel: string,
+  maxFiles: number
+): Promise<string[]> {
+  const out: string[] = [];
+  async function walk(rel: string): Promise<void> {
+    if (out.length >= maxFiles) return;
+    const abs = join(vaultAbs, rel);
+    const entries = await readdir(abs, { withFileTypes: true });
+    for (const e of entries) {
+      if (out.length >= maxFiles) return;
+      if (e.name.startsWith(".")) continue;
+      const nextRel = rel ? `${rel}/${e.name}` : e.name;
+      if (e.isDirectory()) {
+        await walk(nextRel);
+      } else if (e.isFile() && extname(e.name).toLowerCase() === ".md") {
+        out.push(nextRel.replace(/\\/g, "/"));
+      }
+    }
+  }
+  await walk(subRel.replace(/\\/g, "/").replace(/^\/+/, ""));
+  return out;
+}
+
+function defaultScanRoot(): string {
+  const v = process.env.CLAWQL_MEMORY_RECALL_SCAN_ROOT;
+  if (v === undefined) return "ClawQL/Memory";
+  const t = v.trim();
+  return t === "" ? "" : t;
+}
+
+export async function runMemoryRecall(input: MemoryRecallInput): Promise<MemoryRecallResult> {
+  const vault = getObsidianVaultPath();
+  if (!vault) {
+    return {
+      ok: false,
+      error:
+        "Obsidian vault is not configured. Set CLAWQL_OBSIDIAN_VAULT_PATH to a writable directory.",
+    };
+  }
+
+  const query = input.query?.trim();
+  if (!query) {
+    return { ok: false, error: "query is required" };
+  }
+
+  const limit = input.limit !== undefined ? input.limit : envInt("CLAWQL_MEMORY_RECALL_LIMIT", 10);
+  const maxDepth =
+    input.maxDepth !== undefined ? input.maxDepth : envInt("CLAWQL_MEMORY_RECALL_MAX_DEPTH", 2);
+  const minScore =
+    input.minScore !== undefined ? input.minScore : envInt("CLAWQL_MEMORY_RECALL_MIN_SCORE", 1);
+  const maxFiles = envInt("CLAWQL_MEMORY_RECALL_MAX_FILES", 2000);
+  const snippetChars = envInt("CLAWQL_MEMORY_RECALL_SNIPPET_CHARS", 520);
+  const scanRoot = defaultScanRoot();
+
+  let mdFiles: string[];
+  try {
+    mdFiles = await listMarkdownFiles(vault, scanRoot, maxFiles);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: `Cannot scan vault: ${msg}` };
+  }
+
+  const truncated = mdFiles.length >= maxFiles;
+
+  type FileInfo = { rel: string; text: string; score: number };
+  const files: FileInfo[] = [];
+  for (const rel of mdFiles) {
+    try {
+      const text = await readVaultTextFile(vault, rel);
+      const score = keywordScore(query, text);
+      files.push({ rel, text, score });
+    } catch {
+      /* skip unreadable */
+    }
+  }
+
+  const slugToPath = new Map<string, string>();
+  for (const f of files) {
+    const s = slugifyTitle(basename(f.rel, ".md"));
+    if (!slugToPath.has(s)) slugToPath.set(s, f.rel);
+    const h = stripFrontmatter(f.text);
+    const hm = h.match(/^#\s+(.+)$/m);
+    if (hm) {
+      const hs = slugifyTitle(hm[1].trim());
+      if (!slugToPath.has(hs)) slugToPath.set(hs, f.rel);
+    }
+  }
+
+  const forward = new Map<string, Set<string>>();
+  const back = new Map<string, Set<string>>();
+  function addEdge(a: string, b: string): void {
+    if (a === b) return;
+    if (!forward.has(a)) forward.set(a, new Set());
+    forward.get(a)!.add(b);
+    if (!back.has(b)) back.set(b, new Set());
+    back.get(b)!.add(a);
+  }
+
+  for (const { rel, text } of files) {
+    for (const target of extractWikilinkTargets(text)) {
+      const slug = slugifyTitle(target);
+      const dest = slugToPath.get(slug);
+      if (dest) addEdge(rel, dest);
+    }
+  }
+
+  function neighbors(p: string): string[] {
+    const a = [...(forward.get(p) ?? [])];
+    const b = [...(back.get(p) ?? [])];
+    return [...new Set([...a, ...b])];
+  }
+
+  const seeds = files
+    .filter((f) => f.score >= minScore)
+    .sort((a, b) => b.score - a.score)
+    .map((f) => f.rel);
+
+  const textByRel = new Map(files.map((f) => [f.rel, f.text]));
+  const scoreByRel = new Map(files.map((f) => [f.rel, f.score]));
+
+  type Q = { rel: string; depth: number; reason: "keyword" | "link"; from?: string };
+  const queue: Q[] = [];
+  const seen = new Set<string>();
+
+  for (const s of seeds) {
+    if (!seen.has(s)) {
+      queue.push({ rel: s, depth: 0, reason: "keyword" });
+      seen.add(s);
+    }
+  }
+
+  const hits: RecallHit[] = [];
+  while (queue.length > 0 && hits.length < limit) {
+    const cur = queue.shift()!;
+    const t = textByRel.get(cur.rel);
+    if (!t) continue;
+
+    hits.push({
+      path: cur.rel,
+      score: scoreByRel.get(cur.rel) ?? 0,
+      depth: cur.depth,
+      reason: cur.reason,
+      linkFrom: cur.from,
+      snippet: buildSnippet(t, query, snippetChars),
+    });
+
+    if (cur.depth >= maxDepth) continue;
+
+    for (const n of neighbors(cur.rel)) {
+      if (seen.has(n)) continue;
+      seen.add(n);
+      queue.push({
+        rel: n,
+        depth: cur.depth + 1,
+        reason: "link",
+        from: cur.rel,
+      });
+    }
+  }
+
+  hits.sort((a, b) => {
+    if (a.depth !== b.depth) return a.depth - b.depth;
+    return b.score - a.score;
+  });
+
+  return {
+    ok: true,
+    query,
+    results: hits.slice(0, limit),
+    truncated,
+    scannedFiles: files.length,
+  };
+}
+
+export async function handleMemoryRecallToolInput(
+  params: MemoryRecallInput
+): Promise<{ content: { type: "text"; text: string }[] }> {
+  const result = await runMemoryRecall(params);
+  return {
+    content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+  };
+}

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -82,6 +82,7 @@ describe("server (stdio)", () => {
         expect(names.has("code")).toBe(true);
         expect(names.has("sandbox_exec")).toBe(true);
         expect(names.has("memory_ingest")).toBe(true);
+        expect(names.has("memory_recall")).toBe(true);
       } finally {
         await client.close();
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@
  *
  * Entry point. Boots the MCP server over stdio (Claude Desktop, Cursor, etc.).
  *
- *   Agent → MCP (this file) → search / execute / code → graphql-client → graphql-proxy → REST API
+ *   Agent → MCP (this file) → search / execute / code / memory_* → graphql-client → graphql-proxy → REST API
  *
  * Spec source: CLAWQL_SPEC_PATH, CLAWQL_SPEC_URL, CLAWQL_DISCOVERY_URL, or default
  * Cloud Run discovery. See README and .env.example.

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3,7 +3,7 @@
  *
  * Core tools: search (spec discovery) and execute (GraphQL-backed REST call).
  * Optional: code / sandbox_exec — remote execution via cloudflare/sandbox-bridge Worker.
- * Optional: memory_ingest — Obsidian Markdown pages under CLAWQL_OBSIDIAN_VAULT_PATH.
+ * Optional: memory_ingest / memory_recall — Obsidian vault notes (ingest + recall).
  * GraphQL field names are resolved via schema introspection — see resolveGraphQLField.
  */
 
@@ -30,6 +30,7 @@ import { createGraphQLClient } from "./graphql-client.js";
 import { executeRestOperation } from "./rest-operation.js";
 import { handleClawqlCodeToolInput } from "./sandbox-bridge-client.js";
 import { handleMemoryIngestToolInput } from "./memory-ingest.js";
+import { handleMemoryRecallToolInput } from "./memory-recall.js";
 import type { Operation } from "./spec-loader.js";
 import { INLINE_OPENAPI_REQUEST_BODY } from "./operation-types.js";
 
@@ -338,6 +339,42 @@ export function registerTools(server: McpServer) {
         ),
     },
     handleMemoryIngestToolInput
+  );
+
+  server.tool(
+    "memory_recall",
+    {
+      query: z
+        .string()
+        .min(1)
+        .describe(
+          "Natural language or keywords to find in vault Markdown (filename + body + headings)."
+        ),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(50)
+        .optional()
+        .describe("Max notes to return (default: CLAWQL_MEMORY_RECALL_LIMIT or 10)."),
+      maxDepth: z
+        .number()
+        .int()
+        .min(0)
+        .max(10)
+        .optional()
+        .describe(
+          "How many wikilink hops to follow from keyword hits (default: CLAWQL_MEMORY_RECALL_MAX_DEPTH or 2)."
+        ),
+      minScore: z
+        .number()
+        .min(0)
+        .optional()
+        .describe(
+          "Minimum keyword match score to seed a note (default: CLAWQL_MEMORY_RECALL_MIN_SCORE or 1)."
+        ),
+    },
+    handleMemoryRecallToolInput
   );
 }
 


### PR DESCRIPTION
## Summary
Closes **[#7](https://github.com/danielsmithdevelopment/ClawQL/issues/7)**.

## Behavior
- **Keyword scoring** over Markdown (full text + headings); token overlap, no embeddings.
- **Wikilink graph**: resolve `[[links]]` to notes by slug (filename + first `#` heading); **BFS** from keyword hits with forward + **backlink** edges.
- **Snippets** around first query-token hit (length via `CLAWQL_MEMORY_RECALL_SNIPPET_CHARS`).
- Default scan root `ClawQL/Memory`; optional `CLAWQL_MEMORY_RECALL_SCAN_ROOT=` (empty = whole vault).

## Files
- `src/memory-recall.ts`, `src/memory-recall.test.ts`
- `src/tools.ts` — register `memory_recall`
- README env table, `.env.example`, `docs/memory-obsidian.md`, `server.test.ts`, `server.ts` comment

## Tests
`npm test` — 84 tests.

Fixes #7