### PR TITLE
Docs: MCP tools reference + sandbox_exec naming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,7 +75,7 @@
 # CLAWQL_MEMORY_RECALL_MAX_FILES=2000
 # CLAWQL_MEMORY_RECALL_SNIPPET_CHARS=520
 
-# ─── Cloudflare Sandbox (code / sandbox_exec MCP tools) ───────────────
+# ─── Cloudflare Sandbox (`sandbox_exec` MCP tool) ─────────────────────
 # The Sandbox SDK runs in a Worker; MCP calls this bridge over HTTPS.
 # Deploy: cloudflare/sandbox-bridge/ — set BRIDGE_SECRET to match the token below.
 # CLAWQL_SANDBOX_BRIDGE_URL=https://clawql-sandbox-bridge.your-subdomain.workers.dev

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ClawQL
 
-MCP server with **`search`** and **`execute`** (OpenAPI/Discovery), plus optional **`code`** / **`sandbox_exec`** (isolated execution via a [Cloudflare Sandbox](https://developers.cloudflare.com/sandbox/) **bridge Worker**). An internal **GraphQL** layer keeps **`execute`** responses lean; **spec-driven discovery** means agents don’t load full OpenAPI definitions into context.
+MCP server: **core** tools **`search`** and **`execute`** (OpenAPI/Discovery), plus optional **`sandbox_exec`** ([Cloudflare Sandbox](https://developers.cloudflare.com/sandbox/) **bridge Worker**), **`memory_ingest`**, and **`memory_recall`** (Obsidian vault). An internal **GraphQL** layer keeps **`execute`** responses lean; **spec-driven discovery** means agents don’t load full OpenAPI definitions into context. Full tool reference: **[`docs/mcp-tools.md`](docs/mcp-tools.md)**.
 
 **What is MCP?** [Model Context Protocol](https://modelcontextprotocol.io) is how
 clients such as [Cursor](https://cursor.com/docs/context/mcp) or Claude Desktop
-run this server over **stdio** or **HTTP** and expose **`search`**, **`execute`**, and (when configured) **`code`** / **`sandbox_exec`** to the model.
+run this server over **stdio** or **HTTP** and expose **`search`**, **`execute`**, and (when configured) **`sandbox_exec`**, **`memory_ingest`**, **`memory_recall`** to the model.
 
 **Why two processes?** `search` runs inside the MCP process. The **`execute`**
 tool calls a **local GraphQL proxy** (`clawql-graphql`, default
@@ -20,7 +20,7 @@ available via **`CLAWQL_PROVIDER`** (see [`providers/README.md`](providers/READM
 
 **Repo vs npm:** GitHub **`ClawQL`** — published package **`clawql-mcp`**.
 
-**Enterprise agent stack:** **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** is the local-first Docker platform (LangGraph, Obsidian knowledge graph, optional Cloudflare Sandboxes, Langfuse) that uses **this repo** as the MCP **API engine** — token-efficient **`search` / `execute`** over OpenAPI/Discovery. The agent README’s unified tool story (`code()` / `sandbox_exec()`, `memory_ingest()`, `memory_recall()`) is the **parity target** for ClawQL; **`memory_ingest`** and **`memory_recall`** run when **`CLAWQL_OBSIDIAN_VAULT_PATH`** is set (see [Obsidian vault](#obsidian-vault-optional) and [`docs/memory-obsidian.md`](docs/memory-obsidian.md)). Further parity items are tracked in **[#11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)**. Optional **`CLAWQL_OBSIDIAN_VAULT_PATH`** configures a shared Obsidian vault path for that roadmap (validated at startup when set; Docker/K8s default **`/vault`** — see [Obsidian vault](#obsidian-vault-optional)).
+**Enterprise agent stack:** **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** is the local-first Docker platform (LangGraph, Obsidian knowledge graph, optional Cloudflare Sandboxes, Langfuse) that uses **this repo** as the MCP **API engine** — token-efficient **`search` / `execute`** over OpenAPI/Discovery. The agent README’s unified tool story (`sandbox_exec()`, `memory_ingest()`, `memory_recall()`) is the **parity target** for ClawQL; **`memory_ingest`** and **`memory_recall`** run when **`CLAWQL_OBSIDIAN_VAULT_PATH`** is set (see [Obsidian vault](#obsidian-vault-optional) and [`docs/memory-obsidian.md`](docs/memory-obsidian.md)). Further parity items are tracked in **[#11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)**. Optional **`CLAWQL_OBSIDIAN_VAULT_PATH`** configures a shared Obsidian vault path for that roadmap (validated at startup when set; Docker/K8s default **`/vault`** — see [Obsidian vault](#obsidian-vault-optional)).
 
 ## First 5 minutes
 
@@ -58,6 +58,8 @@ From there: custom spec via `CLAWQL_SPEC_PATH` / `CLAWQL_SPEC_URL`, or read [Con
      ```
 
   **Google Discovery** (GCP APIs, etc.): use **`CLAWQL_DISCOVERY_URL`** instead of `CLAWQL_SPEC_URL`. Merge many specs or other presets: [Configure the API spec](#configure-the-api-spec).
+
+- **All MCP tools (API + vault + sandbox):** see **[`docs/mcp-tools.md`](docs/mcp-tools.md)** — examples for `sandbox_exec`, `memory_ingest`, `memory_recall`, env vars.
 
 - **Benchmarks & raw artifacts:** [Benchmarks and results](#benchmarks-and-results) — quick links to [all-providers stats](docs/benchmarks/all-providers-complex-workflow/experiment-all-providers-complex-workflow-stats.json), [default multi-provider stats](docs/benchmarks/multi-provider-complex-workflow/experiment-multi-provider-complex-workflow-stats.json), and workflow JSON outputs.
 
@@ -104,7 +106,7 @@ Same **two-terminal** pattern with a **local file** (`CLAWQL_SPEC_PATH=…`) or 
 
 ### Docker
 
-A multi-stage [Distroless](https://github.com/GoogleContainerTools/distroless) image bundles `dist/`, `bin/`, and `providers/` for local spec lookup. Build and run (stdio) are documented in [`docker/README.md`](docker/README.md).
+A multi-stage [Distroless](https://github.com/GoogleContainerTools/distroless) image bundles `dist/`, `bin/`, and `providers/` for local spec lookup. Build and run (stdio) are documented in [`docker/README.md`](docker/README.md). The image sets **`CLAWQL_OBSIDIAN_VAULT_PATH=/vault`** so **`memory_ingest`** / **`memory_recall`** can run when `/vault` is mounted; **`sandbox_exec`** still needs **`CLAWQL_SANDBOX_BRIDGE_URL`** and a deployed [sandbox bridge](cloudflare/sandbox-bridge/README.md) (not bundled in the image).
 
 ### Remote MCP (HTTP)
 
@@ -349,7 +351,7 @@ If Stage 1 does **not** apply, one document is loaded in this order:
 | `CLAWQL_INTROSPECTION_PATH` | Pregenerated GraphQL introspection JSON (optional; speeds MCP `execute` field matching) |
 | `CLAWQL_API_BASE_URL` | Override REST base URL (if spec has no `servers` or you need a different host) |
 | `CLAWQL_OBSIDIAN_VAULT_PATH` | Absolute path to an Obsidian Markdown vault (shared volume/NFS). When set, the server **checks** the path exists and is readable/writable at startup. Omit locally to skip the check; container images default to **`/vault`** (see [Docker](docker/README.md)). Used with **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** and future memory tools. |
-| `CLAWQL_SANDBOX_BRIDGE_URL` | Origin of the [sandbox bridge Worker](cloudflare/sandbox-bridge/README.md) (e.g. `https://….workers.dev`). Required for **`code`** / **`sandbox_exec`**. |
+| `CLAWQL_SANDBOX_BRIDGE_URL` | Origin of the [sandbox bridge Worker](cloudflare/sandbox-bridge/README.md) (e.g. `https://….workers.dev`). Required for **`sandbox_exec`**. |
 | `CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN` | Bearer token for **`POST /exec`**; must match the Worker `BRIDGE_SECRET`. |
 | `CLAWQL_CLOUDFLARE_ACCOUNT_ID` | Optional; sent as `CF-Account-ID` on bridge requests. |
 | `CLAWQL_SANDBOX_PERSISTENCE_MODE` | Default `session` / `ephemeral` / `persistent` for sandbox tool calls (overridable per call). |
@@ -419,18 +421,20 @@ Very large specs may need a different retrieval strategy later.
 
 ```
 Agent
-  └─▶ MCP Server  (stdio)
+  └─▶ MCP Server  (stdio / HTTP)
         ├─▶ search tool  ──▶ In-memory spec search  (zero latency, zero tokens)
-        └─▶ execute tool  ──▶ GraphQL Client
-                                    └─▶ GraphQL Proxy  (localhost:4000)
-                                          │  [@omnigraph/openapi / Mesh, auto-generated]
-                                          │  [selects ONLY requested fields]
-                                          └─▶ Your REST API  (from OpenAPI servers / CLAWQL_API_BASE_URL)
+        ├─▶ execute tool  ──▶ GraphQL Client ──▶ GraphQL Proxy (localhost:4000) ──▶ REST API
+        ├─▶ sandbox_exec  ──▶ HTTPS ──▶ Cloudflare Sandbox bridge Worker (optional)
+        └─▶ memory_ingest / memory_recall  ──▶ Obsidian vault on disk (optional)
 ```
-An agent connects to ClawQL over MCP stdio and uses two tools:
+An agent connects to ClawQL over MCP and registers **up to five tools** (see [`docs/mcp-tools.md`](docs/mcp-tools.md)):
 
-- `search` runs against an in-memory operation index built from the loaded spec(s), so discovery is fast and does not require sending full OpenAPI documents into prompt context.
-- `execute` resolves the selected operation and calls the local GraphQL proxy, which projects only requested fields before invoking the upstream REST API (using spec `servers` or `CLAWQL_API_BASE_URL`).
+- **`search`** — in-memory operation index from the loaded spec(s); no upstream HTTP.
+- **`execute`** — GraphQL proxy (single-spec) or REST (multi-spec) for lean responses.
+- **`sandbox_exec`** — run snippet in remote Cloudflare Sandbox via **`CLAWQL_SANDBOX_BRIDGE_URL`** (not local execution).
+- **`memory_ingest`** / **`memory_recall`** — require **`CLAWQL_OBSIDIAN_VAULT_PATH`**.
+
+Core API workflow remains **`search` → `execute`**. Optional tools do not replace the GraphQL proxy for REST APIs.
 
 In multi-spec mode, ClawQL keeps one merged operation index for discovery and executes each operation against its owning spec.
 
@@ -468,14 +472,13 @@ In multi-spec mode, ClawQL keeps one merged operation index for discovery and ex
 
 ## Tools
 
-**Core tools:** **`search`** and **`execute`** (see [Architecture](#architecture)). **`code`** and **`sandbox_exec`** are the same tool under two names; they run snippets in **Cloudflare Sandboxes** through the HTTP bridge in [`cloudflare/sandbox-bridge/`](cloudflare/sandbox-bridge/README.md) (set **`CLAWQL_SANDBOX_BRIDGE_URL`** and **`CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN`** — see `.env.example`). **`memory_ingest`** / **`memory_recall`** need a configured vault (see [Obsidian vault](#obsidian-vault-optional)). Remaining parity work is tracked on **[#11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)**.
+**Core tools:** **`search`** and **`execute`** (see [Architecture](#architecture)). **`sandbox_exec`** runs snippets in **Cloudflare Sandboxes** through the HTTP bridge in [`cloudflare/sandbox-bridge/`](cloudflare/sandbox-bridge/README.md) (set **`CLAWQL_SANDBOX_BRIDGE_URL`** and **`CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN`** — see `.env.example`). The tool name avoids confusion with “coding locally”; arguments still use a **`code`** field for the source string. **`memory_ingest`** / **`memory_recall`** need a configured vault (see [Obsidian vault](#obsidian-vault-optional)). Remaining parity work is tracked on **[#11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)**.
 
 | Tool | Description |
 |---|---|
 | `search` | Search the active OpenAPI/Discovery spec by natural language intent |
 | `execute` | Run a discovered operation by `operationId`, with optional GraphQL field selection |
-| `code` | Run `code` + `language` in an isolated sandbox (alias: `sandbox_exec`) |
-| `sandbox_exec` | Same as `code` — use one name consistently in agent prompts |
+| `sandbox_exec` | Remote sandbox: pass **`code`** (source) + **`language`**; not your local shell |
 | `memory_ingest` | Compile insights / tool output / conversation into Obsidian notes (`ClawQL/Memory/…`) when the vault path is set — see [`docs/memory-obsidian.md`](docs/memory-obsidian.md) |
 | `memory_recall` | Keyword search over vault Markdown plus `[[wikilinks]]` hops (no embeddings; tunable via `CLAWQL_MEMORY_RECALL_*`) |
 
@@ -496,6 +499,26 @@ In multi-spec mode, ClawQL keeps one merged operation index for discovery and ex
      })
    → GraphQL internally maps args + resolves the real field name; returns lean JSON
 ```
+
+### Optional tools (quick examples)
+
+**`sandbox_exec`** (**deploy [cloudflare/sandbox-bridge](cloudflare/sandbox-bridge/README.md) first**). The **`code`** key is the snippet body sent to the remote sandbox:
+
+```json
+{ "code": "print('ok')", "language": "python", "sessionId": "s1" }
+```
+
+Vault (**set `CLAWQL_OBSIDIAN_VAULT_PATH`**):
+
+```json
+{ "title": "Runbook", "insights": "Remember to rotate tokens.", "wikilinks": ["Security"] }
+```
+
+```json
+{ "query": "rotate token kubernetes", "limit": 5, "maxDepth": 2 }
+```
+
+More parameters and env defaults: **[`docs/mcp-tools.md`](docs/mcp-tools.md)**.
 
 ---
 
@@ -621,7 +644,7 @@ See [`docs/deploy-k8s.md`](docs/deploy-k8s.md).
 
 ## Extending the server
 
-The default API surface is **`search`** and **`execute`**; **`code`** / **`sandbox_exec`** call **`src/sandbox-bridge-client.ts`**; **`memory_ingest`** / **`memory_recall`** use **`src/memory-ingest.ts`**, **`src/memory-recall.ts`**, and **`src/vault-config.ts`** / **`src/vault-utils.ts`**. To add more tools
+The default API surface is **`search`** and **`execute`**; **`sandbox_exec`** calls **`src/sandbox-bridge-client.ts`**; **`memory_ingest`** / **`memory_recall`** use **`src/memory-ingest.ts`**, **`src/memory-recall.ts`**, and **`src/vault-config.ts`** / **`src/vault-utils.ts`**. To add more tools
 (see **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** / [#11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)), register them in `src/tools.ts` the same way (`server.tool(...)`).
 
 GraphQL field names are **auto-resolved** in `execute` via schema introspection

--- a/cloudflare/sandbox-bridge/README.md
+++ b/cloudflare/sandbox-bridge/README.md
@@ -1,6 +1,6 @@
 # ClawQL sandbox bridge (Cloudflare Worker)
 
-The [Sandbox SDK](https://developers.cloudflare.com/sandbox/) runs **inside Workers** with a container binding. The Node-based `clawql-mcp` server cannot load `@cloudflare/sandbox` directly, so this Worker exposes a small **POST `/exec`** API that the MCP tools **`code`** and **`sandbox_exec`** call using HTTP.
+The [Sandbox SDK](https://developers.cloudflare.com/sandbox/) runs **inside Workers** with a container binding. The Node-based `clawql-mcp` server cannot load `@cloudflare/sandbox` directly, so this Worker exposes a small **POST `/exec`** API that the MCP **`sandbox_exec`** tool calls using HTTP.
 
 ## Deploy
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -32,7 +32,11 @@ docker run --rm -p 8080:8080 -e CLAWQL_PROVIDER=github clawql-mcp
 
 Single-spec `execute` uses a GraphQL proxy at `GRAPHQL_URL` (default `http://localhost:4000/graphql`). Point it at a reachable proxy or use multi-spec presets (REST execution) when you do not run the proxy beside the container.
 
-**Obsidian vault:** The image sets **`CLAWQL_OBSIDIAN_VAULT_PATH=/vault`** and includes a writable **`/vault`** directory for **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** / future memory tooling. Compose mounts a named volume at `/vault`; override the path or mount your host Obsidian folder as needed. See the main [README](../README.md#obsidian-vault-optional).
+**Obsidian vault:** The image sets **`CLAWQL_OBSIDIAN_VAULT_PATH=/vault`** and includes a writable **`/vault`** directory for **`memory_ingest`** / **`memory_recall`** and **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)**. Compose mounts a named volume at `/vault`; override the path or mount your host Obsidian folder as needed. See the main [README](../README.md#obsidian-vault-optional).
+
+**Sandbox (`sandbox_exec`):** Not bundled. Set **`CLAWQL_SANDBOX_BRIDGE_URL`** and **`CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN`** to a deployed [sandbox bridge](../cloudflare/sandbox-bridge/README.md) Worker; the container only calls it over HTTPS.
+
+Full MCP tool list and JSON examples: **[`docs/mcp-tools.md`](../docs/mcp-tools.md)**.
 
 ## Run (stdio, optional)
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,0 +1,110 @@
+# MCP tools reference
+
+ClawQL exposes **five** tools over MCP (stdio or Streamable HTTP). The **core** pair is **`search`** + **`execute`** for OpenAPI/Discovery APIs. The other three are **optional** and depend on configuration (vault path, Cloudflare Sandbox bridge).
+
+| Tool | Requires | Purpose |
+|------|----------|---------|
+| `search` | Loaded spec | Rank operations by natural-language intent |
+| `execute` | GraphQL proxy (`GRAPHQL_URL`) for single-spec; REST in multi-spec | Run one operation with lean responses |
+| `sandbox_exec` | `CLAWQL_SANDBOX_BRIDGE_URL` + token | Run a snippet in a remote Cloudflare Sandbox via Worker bridge (not local execution) |
+| `memory_ingest` | `CLAWQL_OBSIDIAN_VAULT_PATH` | Write Obsidian Markdown under `ClawQL/Memory/` |
+| `memory_recall` | `CLAWQL_OBSIDIAN_VAULT_PATH` | Keyword search + `[[wikilink]]` hops in the vault |
+
+See also: **[memory-obsidian.md](memory-obsidian.md)** (vault concepts), **[README](../README.md)** (install, env tables), **[cloudflare/sandbox-bridge/README.md](../cloudflare/sandbox-bridge/README.md)** (Worker deploy).
+
+---
+
+## `search`
+
+**Input (conceptual):**
+
+```json
+{
+  "query": "list kubernetes clusters in a project",
+  "limit": 5
+}
+```
+
+Returns ranked **`operationId`** candidates and metadata — no upstream HTTP.
+
+---
+
+## `execute`
+
+**Input:**
+
+```json
+{
+  "operationId": "run.projects.locations.services.list",
+  "args": {
+    "parent": "projects/my-proj/locations/us-central1",
+    "pageSize": 10
+  },
+  "fields": ["name", "uri"]
+}
+```
+
+`fields` is optional; omit for defaults. Requires **`clawql-graphql`** when not in multi-spec REST mode.
+
+---
+
+## `sandbox_exec`
+
+Runs a snippet in an isolated **Cloudflare Sandbox** through a **Worker** you deploy (`cloudflare/sandbox-bridge`). The Node MCP process does not load the Sandbox SDK directly. The MCP tool is named **`sandbox_exec`** so it is not confused with editing or running code on the host machine; the JSON argument for the source text is still **`code`**.
+
+**Env:** `CLAWQL_SANDBOX_BRIDGE_URL`, `CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN` (same value as Worker `BRIDGE_SECRET`), optional `CLAWQL_CLOUDFLARE_ACCOUNT_ID`, `CLAWQL_SANDBOX_*`.
+
+**Input:**
+
+```json
+{
+  "code": "print(2 + 2)",
+  "language": "python",
+  "sessionId": "thread-1",
+  "persistenceMode": "session",
+  "timeoutMs": 120000
+}
+```
+
+`language`: `python` | `javascript` | `shell`.
+
+---
+
+## `memory_ingest`
+
+**Env:** `CLAWQL_OBSIDIAN_VAULT_PATH` (directory must exist and be writable at startup).
+
+**Input:**
+
+```json
+{
+  "title": "Session 2026-04-15 API notes",
+  "insights": "Use ETag when polling GitHub APIs.",
+  "conversation": "User: …\nAssistant: …",
+  "toolOutputs": "{ \"status\": 200 }",
+  "wikilinks": ["GitHub API", "Rate limits"],
+  "sessionId": "abc-123",
+  "append": true
+}
+```
+
+Writes **`ClawQL/Memory/<slug>.md`** with YAML frontmatter and optional `[[wikilinks]]`. Duplicate payloads (same content hash) are skipped when appending.
+
+---
+
+## `memory_recall`
+
+**Env:** `CLAWQL_OBSIDIAN_VAULT_PATH`, optional `CLAWQL_MEMORY_RECALL_*` (scan root, limits, depth, snippet size).
+
+**Input:**
+
+```json
+{
+  "query": "github rate limit pat",
+  "limit": 10,
+  "maxDepth": 2,
+  "minScore": 1
+}
+```
+
+Returns JSON with **`results[]`**: `path`, `score`, `depth`, `reason` (`keyword` | `link`), `snippet`, optional `linkFrom`. **No vector embeddings** — lexical match + graph expansion via wikilinks. See [issue #16](https://github.com/danielsmithdevelopment/ClawQL/issues/16) for future semantic search.

--- a/docs/memory-obsidian.md
+++ b/docs/memory-obsidian.md
@@ -1,6 +1,6 @@
 # Memory, Obsidian, and the “LLM wiki” pattern
 
-This note explains **why** ClawQL supports an Obsidian vault path and a **`memory_ingest`** tool, in terms readers may have seen described as **Karpathy-style** or **incremental wiki** memory.
+This note explains **why** ClawQL supports an Obsidian vault path and a **`memory_ingest`** tool, in terms readers may have seen described as **Karpathy-style** or **incremental wiki** memory. For all MCP tools (including **`memory_recall`**), see **[mcp-tools.md](mcp-tools.md)**.
 
 ## Beyond one-shot RAG
 

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -79,7 +79,6 @@ describe("server (stdio)", () => {
         const names = new Set(tools.map((t) => t.name));
         expect(names.has("search")).toBe(true);
         expect(names.has("execute")).toBe(true);
-        expect(names.has("code")).toBe(true);
         expect(names.has("sandbox_exec")).toBe(true);
         expect(names.has("memory_ingest")).toBe(true);
         expect(names.has("memory_recall")).toBe(true);

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@
  *
  * Entry point. Boots the MCP server over stdio (Claude Desktop, Cursor, etc.).
  *
- *   Agent → MCP (this file) → search / execute / code / memory_* → graphql-client → graphql-proxy → REST API
+ *   Agent → MCP (this file) → search / execute / sandbox_exec / memory_* → graphql-client → graphql-proxy → REST API
  *
  * Spec source: CLAWQL_SPEC_PATH, CLAWQL_SPEC_URL, CLAWQL_DISCOVERY_URL, or default
  * Cloud Run discovery. See README and .env.example.

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -2,7 +2,7 @@
  * tools.ts
  *
  * Core tools: search (spec discovery) and execute (GraphQL-backed REST call).
- * Optional: code / sandbox_exec — remote execution via cloudflare/sandbox-bridge Worker.
+ * Optional: sandbox_exec — remote execution via cloudflare/sandbox-bridge Worker.
  * Optional: memory_ingest / memory_recall — Obsidian vault notes (ingest + recall).
  * GraphQL field names are resolved via schema introspection — see resolveGraphQLField.
  */
@@ -305,7 +305,6 @@ export function registerTools(server: McpServer) {
       .describe("Optional wall-clock limit in ms (capped by CLAWQL_SANDBOX_TIMEOUT_MS_MAX)."),
   };
 
-  server.tool("code", sandboxCodeSchema, handleClawqlCodeToolInput);
   server.tool("sandbox_exec", sandboxCodeSchema, handleClawqlCodeToolInput);
 
   server.tool(

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
     default: 'ClawQL',
   },
   description:
-    'MCP server with search and execute tools, internal GraphQL projection, and OpenAPI-driven discovery.',
+    'MCP server: search and execute for APIs; optional sandbox_exec and memory tools; internal GraphQL projection and OpenAPI-driven discovery.',
   icons: {
     icon: [{ url: '/ClawQL-logo.jpeg', type: 'image/jpeg' }],
     apple: [{ url: '/ClawQL-logo.jpeg', type: 'image/jpeg' }],

--- a/website/src/app/mcp-clients/page.mdx
+++ b/website/src/app/mcp-clients/page.mdx
@@ -1,12 +1,12 @@
 export const metadata = {
   title: 'MCP clients',
   description:
-    'Configure Cursor, Claude Desktop, or other MCP hosts for ClawQL over stdio or HTTP, including GRAPHQL_URL.',
+    'Configure Cursor, Claude Desktop, or other MCP hosts for ClawQL over stdio or HTTP: GRAPHQL_URL, vault, sandbox bridge.',
 }
 
 # MCP clients
 
-[Model Context Protocol](https://modelcontextprotocol.io) is how editors and assistants connect to ClawQL and expose the **`search`** and **`execute`** tools. [Cursor](https://cursor.com/docs/context/mcp) and Claude Desktop are common hosts. {{ className: 'lead' }}
+[Model Context Protocol](https://modelcontextprotocol.io) is how editors and assistants connect to ClawQL. Hosts register **`search`** and **`execute`** for API work, and (when env is set) optional **`sandbox_exec`**, **`memory_ingest`**, **`memory_recall`**. [Cursor](https://cursor.com/docs/context/mcp) and Claude Desktop are common hosts. {{ className: 'lead' }}
 
 ## What is MCP?
 

--- a/website/src/app/page.mdx
+++ b/website/src/app/page.mdx
@@ -5,7 +5,7 @@ import { HeroPattern } from '@/components/HeroPattern'
 export const metadata = {
   title: 'ClawQL documentation',
   description:
-    'ClawQL is an MCP server with search and execute tools, an internal GraphQL layer, and spec-driven discovery for OpenAPI and Google APIs.',
+    'ClawQL is an MCP server: core search and execute tools, optional sandbox_exec and Obsidian memory tools, internal GraphQL layer, and spec-driven discovery for OpenAPI and Google APIs.',
 }
 
 export const sections = [
@@ -17,7 +17,7 @@ export const sections = [
 
 # ClawQL documentation
 
-**ClawQL** is an MCP server with two tools—**`search`** and **`execute`**—plus an internal **GraphQL** projection layer so agents can work with **OpenAPI 3**, **Swagger 2**, or **Google Discovery** APIs without loading full specifications into context. {{ className: 'lead' }}
+**ClawQL** registers **core** tools **`search`** and **`execute`**, plus optional **`sandbox_exec`** (remote code in a Cloudflare Sandbox via bridge), **`memory_ingest`**, and **`memory_recall`** (Obsidian vault). An internal **GraphQL** projection layer keeps API responses lean for **OpenAPI 3**, **Swagger 2**, and **Google Discovery**. [Full tool reference (repo)](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/mcp-tools.md). {{ className: 'lead' }}
 
 <div className="not-prose mt-6 mb-16 flex gap-3">
   <Button href="/quickstart" arrow="right">

--- a/website/src/app/tools/page.mdx
+++ b/website/src/app/tools/page.mdx
@@ -1,12 +1,12 @@
 export const metadata = {
   title: 'Tools',
   description:
-    'ClawQL MCP tools: search for operations by intent, execute with lean field-selected responses.',
+    'ClawQL MCP tools: search and execute for APIs; optional sandbox_exec and Obsidian memory tools.',
 }
 
 # Tools
 
-ClawQL exposes exactly **two** MCP tools. Agents call **`search`** to discover operations and parameters, then **`execute`** to run a chosen **`operationId`** with optional field selection. {{ className: 'lead' }}
+ClawQL exposes **five** tools when optional features are configured; the **data plane** for REST/Discovery APIs is **`search`** then **`execute`**. Agents call **`search`** to discover operations and parameters, then **`execute`** to run a chosen **`operationId`** with optional field selection. [Canonical reference with examples](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/mcp-tools.md). {{ className: 'lead' }}
 
 ## `search`
 
@@ -29,3 +29,12 @@ Runs a discovered operation by **`operationId`** with arguments shaped from the 
 ```
 
 See [GraphQL proxy](/graphql-proxy) for when the proxy participates and how **`GRAPHQL_URL`** is wired.
+
+## Optional tools
+
+| Tool | Needs |
+|------|--------|
+| `sandbox_exec` | Deployed [sandbox bridge](https://github.com/danielsmithdevelopment/ClawQL/tree/main/cloudflare/sandbox-bridge) Worker + `CLAWQL_SANDBOX_BRIDGE_URL` (remote sandbox; args include **`code`**) |
+| `memory_ingest`, `memory_recall` | `CLAWQL_OBSIDIAN_VAULT_PATH` (writable vault directory) |
+
+They do not replace **`execute`** for calling upstream APIs.

--- a/website/src/components/Resources.tsx
+++ b/website/src/components/Resources.tsx
@@ -32,7 +32,7 @@ const resources: Array<Resource> = [
     href: '/tools',
     name: 'Tools',
     description:
-      'The search and execute MCP tools: discover operations, then run them with lean responses.',
+      'Core search and execute; optional sandbox_exec and Obsidian memory tools — discover, run APIs, and more.',
     icon: BoltIcon,
     pattern: {
       y: 16,


### PR DESCRIPTION
Closes #8.

## Summary
- Adds `docs/mcp-tools.md` as the canonical reference for all five MCP tools (`search`, `execute`, `sandbox_exec`, `memory_ingest`, `memory_recall`) with env requirements and JSON examples.
- Updates README, Docker README, `memory-obsidian.md`, and website (home, tools, MCP clients, layout, resources) so the product is not described as search + execute only.
- Registers the remote sandbox tool as **`sandbox_exec`** (replacing the ambiguous `code` tool name); the request body still uses a `code` field for the snippet sent to the bridge Worker.

## Testing
- `npm test` (all passing locally).