### PR TITLE
test: handler coverage for sandbox_exec and memory tools

### DIFF
--- a/src/tools-handlers.test.ts
+++ b/src/tools-handlers.test.ts
@@ -1,7 +1,13 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as specLoader from "./spec-loader.js";
 import type { OpenAPIDoc } from "./spec-loader.js";
 import type { Operation } from "./spec-loader.js";
+import { handleMemoryIngestToolInput } from "./memory-ingest.js";
+import { handleMemoryRecallToolInput } from "./memory-recall.js";
+import { handleClawqlCodeToolInput } from "./sandbox-bridge-client.js";
 import {
   handleClawqlExecuteToolInput,
   handleClawqlSearchToolInput,
@@ -117,5 +123,142 @@ describe("MCP tool handlers", () => {
         expect(data.ok).toBe(true);
       }
     );
+  });
+});
+
+describe("optional tool handlers (MCP content shape)", () => {
+  describe("handleClawqlCodeToolInput (MCP sandbox_exec)", () => {
+    const saved: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+      saved.CLAWQL_SANDBOX_BRIDGE_URL = process.env.CLAWQL_SANDBOX_BRIDGE_URL;
+      saved.CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN = process.env.CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN;
+      delete process.env.CLAWQL_SANDBOX_BRIDGE_URL;
+      delete process.env.CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN;
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      for (const key of Object.keys(saved)) {
+        const v = saved[key as keyof typeof saved];
+        if (v === undefined) delete process.env[key];
+        else process.env[key] = v;
+      }
+    });
+
+    it("returns text content with JSON from mocked bridge (no network)", async () => {
+      process.env.CLAWQL_SANDBOX_BRIDGE_URL = "https://bridge.example.test";
+      process.env.CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN = "secret";
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            stdout: "hi\n",
+            stderr: "",
+            exitCode: 0,
+            success: true,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      );
+
+      const out = await handleClawqlCodeToolInput({
+        code: "print(1)",
+        language: "python",
+      });
+      expect(out.content).toHaveLength(1);
+      expect(out.content[0].type).toBe("text");
+      const parsed = JSON.parse(out.content[0].text) as { success: boolean; stdout: string };
+      expect(parsed.success).toBe(true);
+      expect(parsed.stdout).toBe("hi\n");
+    });
+
+    it("returns JSON error when bridge URL is not configured", async () => {
+      const out = await handleClawqlCodeToolInput({ code: "x", language: "shell" });
+      const parsed = JSON.parse(out.content[0].text) as { success: boolean; error?: string };
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toMatch(/CLAWQL_SANDBOX_BRIDGE_URL/);
+    });
+  });
+
+  describe("handleMemoryIngestToolInput", () => {
+    const savedVault = process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+    let dir: string;
+
+    beforeEach(async () => {
+      dir = await mkdtemp(join(tmpdir(), "clawql-vault-"));
+      process.env.CLAWQL_OBSIDIAN_VAULT_PATH = dir;
+    });
+
+    afterEach(async () => {
+      if (savedVault === undefined) delete process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+      else process.env.CLAWQL_OBSIDIAN_VAULT_PATH = savedVault;
+      await rm(dir, { recursive: true, force: true });
+    });
+
+    it("returns MCP text with ingest result JSON", async () => {
+      const out = await handleMemoryIngestToolInput({
+        title: "Handler Note",
+        insights: "from tools-handlers test",
+      });
+      expect(out.content[0].type).toBe("text");
+      const parsed = JSON.parse(out.content[0].text) as { ok: boolean; path?: string };
+      expect(parsed.ok).toBe(true);
+      expect(parsed.path).toBe("ClawQL/Memory/handler-note.md");
+    });
+
+    it("returns ok false when vault is not configured", async () => {
+      delete process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+      const out = await handleMemoryIngestToolInput({ title: "X" });
+      const parsed = JSON.parse(out.content[0].text) as { ok: boolean; error?: string };
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toMatch(/CLAWQL_OBSIDIAN_VAULT_PATH/);
+    });
+  });
+
+  describe("handleMemoryRecallToolInput", () => {
+    const savedVault = process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+    let dir: string;
+
+    beforeEach(async () => {
+      dir = await mkdtemp(join(tmpdir(), "clawql-vault-"));
+      process.env.CLAWQL_OBSIDIAN_VAULT_PATH = dir;
+      await mkdir(join(dir, "ClawQL", "Memory"), { recursive: true });
+      await writeFile(
+        join(dir, "ClawQL/Memory/note-a.md"),
+        ["# A", "", "keyword match pat rotation [[Note B]]", ""].join("\n"),
+        "utf8"
+      );
+      await writeFile(join(dir, "ClawQL/Memory/note-b.md"), ["# B", "", "body b", ""].join("\n"), "utf8");
+    });
+
+    afterEach(async () => {
+      if (savedVault === undefined) delete process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+      else process.env.CLAWQL_OBSIDIAN_VAULT_PATH = savedVault;
+      await rm(dir, { recursive: true, force: true });
+    });
+
+    it("returns MCP text with recall result JSON", async () => {
+      const out = await handleMemoryRecallToolInput({
+        query: "pat rotation",
+        limit: 5,
+        maxDepth: 2,
+        minScore: 1,
+      });
+      expect(out.content[0].type).toBe("text");
+      const parsed = JSON.parse(out.content[0].text) as {
+        ok: boolean;
+        results?: { path: string }[];
+      };
+      expect(parsed.ok).toBe(true);
+      expect(parsed.results?.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("returns ok false when vault is not configured", async () => {
+      delete process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+      const out = await handleMemoryRecallToolInput({ query: "x" });
+      const parsed = JSON.parse(out.content[0].text) as { ok: boolean; error?: string };
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toMatch(/CLAWQL_OBSIDIAN_VAULT_PATH/);
+    });
   });
 });


### PR DESCRIPTION
Closes #9.

## What
- Extends `src/tools-handlers.test.ts` with MCP-shaped tests for:
  - **`handleClawqlCodeToolInput`** (registered as `sandbox_exec`): mocked `fetch`, no network; plus error path when bridge URL unset.
  - **`handleMemoryIngestToolInput`**: temp vault via `CLAWQL_OBSIDIAN_VAULT_PATH`, success + vault-unset error.
  - **`handleMemoryRecallToolInput`**: minimal vault fixture, success + vault-unset error.

## Notes
- Issue #3 was closed separately as a test ticket.
- `npm test`: 90 tests passing.