### PR TITLE
deploy: vault mount in K8s starter + optional Cloud Run env for sandbox/memory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ local-k8s-up:
 local-docker-up:
 	@docker compose -f docker/docker-compose.yml up -d --build
 
+# Optional exports for MCP-only features (memory / sandbox): CLAWQL_OBSIDIAN_VAULT_PATH,
+# CLAWQL_SANDBOX_BRIDGE_URL, CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN — see docs/deploy-cloud-run.md
 deploy-cloud-run:
 	@if [ -z "$$PROJECT_ID" ]; then echo "PROJECT_ID is required"; echo "Example: PROJECT_ID=my-proj REGION=us-central1 make deploy-cloud-run"; exit 1; fi
 	@REGION="$${REGION:-us-central1}" bash scripts/deploy-cloud-run.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,9 @@ WORKDIR /app
 ENV NODE_ENV=production
 # Prefer bundled files on disk; avoids surprise network fetches when a spec is missing.
 ENV CLAWQL_BUNDLED_OFFLINE=1
+# Writable mount for memory_* tools; override at runtime if your orchestrator mounts elsewhere.
 ENV CLAWQL_OBSIDIAN_VAULT_PATH=/vault
+# Optional at runtime (not baked in): CLAWQL_SANDBOX_BRIDGE_URL, CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN for sandbox_exec.
 
 COPY --from=builder --chown=nonroot:nonroot /app/node_modules ./node_modules
 COPY --from=builder --chown=nonroot:nonroot /app/dist ./dist

--- a/docker/README.md
+++ b/docker/README.md
@@ -143,6 +143,7 @@ Included resources:
 - Namespace: `clawql`
 - Deployments: `clawql-mcp-http`, `clawql-graphql`
 - Services: internal `clawql-graphql` + external `clawql-mcp-http` (`LoadBalancer`)
+- MCP pod: **`CLAWQL_OBSIDIAN_VAULT_PATH=/vault`** with an **`emptyDir`** volume at `/vault` (aligned with `docker/kustomize/base/deployment-mcp-http.yaml`) so **`memory_ingest`** / **`memory_recall`** can run. Replace `emptyDir` with a PVC or hostPath when you need a persistent Obsidian folder. **`sandbox_exec`** still requires **`CLAWQL_SANDBOX_BRIDGE_URL`** + token env (see [`.env.example`](../.env.example) and [`docs/mcp-tools.md`](../docs/mcp-tools.md)).
 
 After the external IP is ready, use:
 - `http://<external-ip>/mcp`

--- a/docker/kubernetes-starter.yaml
+++ b/docker/kubernetes-starter.yaml
@@ -94,6 +94,8 @@ spec:
               value: /mcp
             - name: CLAWQL_BUNDLED_OFFLINE
               value: "1"
+            - name: CLAWQL_OBSIDIAN_VAULT_PATH
+              value: /vault
             - name: NODE_OPTIONS
               value: "--max-old-space-size=1536"
           startupProbe:
@@ -124,6 +126,12 @@ spec:
             limits:
               cpu: "2"
               memory: "2Gi"
+          volumeMounts:
+            - name: obsidian-vault
+              mountPath: /vault
+      volumes:
+        - name: obsidian-vault
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/docs/deploy-cloud-run.md
+++ b/docs/deploy-cloud-run.md
@@ -39,6 +39,22 @@ Optional inputs:
 - `GRAPHQL_SERVICE` (default: `clawql-graphql`)
 - `ALLOW_UNAUTH` (`true` or `false`, default: `true`)
 
+Optional **MCP-only** environment variables (exported before running the script; appended to the MCP Cloud Run service only):
+
+| Variable | Enables | Notes |
+|----------|---------|--------|
+| `CLAWQL_OBSIDIAN_VAULT_PATH` | `memory_ingest` / `memory_recall` | Default in the image is `/vault` (writable). On Cloud Run this is **ephemeral** unless you attach a [volume](https://cloud.google.com/run/docs/configuring/services/cloud-storage-volume-mounts) (GCS bucket, NFS, etc.). Omit or unset for search/execute-only. |
+| `CLAWQL_SANDBOX_BRIDGE_URL` | `sandbox_exec` | HTTPS origin of your [sandbox bridge Worker](../cloudflare/sandbox-bridge/README.md). |
+| `CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN` | `sandbox_exec` | Same value as the Worker `BRIDGE_SECRET`. **Do not commit**; for production prefer [Secret Manager](#secrets-for-sandbox-token) instead of plain `export`. |
+
+Example (local shell, not for CI logs):
+
+```bash
+export CLAWQL_SANDBOX_BRIDGE_URL="https://clawql-sandbox-bridge.example.workers.dev"
+export CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN="$(cat ~/.config/clawql/sandbox-token)"
+PROJECT_ID="your-project-id" REGION="us-central1" bash scripts/deploy-cloud-run.sh
+```
+
 ## What the script deploys
 
 1. Creates Artifact Registry repo (idempotent).
@@ -68,3 +84,21 @@ Optional inputs:
   - MCP: `2 vCPU`, `2Gi`, `min-instances=1`
   - GraphQL: `1 vCPU`, `1Gi`, `min-instances=0`
 - Tune provider scope (`PROVIDER`) for latency/cost.
+- **Optional tools** (`sandbox_exec`, `memory_*`) work the same as locally: configure env on the **MCP** service only. The GraphQL service does not need vault or sandbox variables.
+- With **no** optional env vars set, behavior matches a **search + execute** deployment (image defaults still set `CLAWQL_OBSIDIAN_VAULT_PATH=/vault` in the container; memory tools write under `/vault` on ephemeral instance storage unless you add a durable volume).
+
+### Secrets (sandbox token)
+
+Avoid passing `CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN` on the command line in CI. Create a secret and attach it to the MCP service:
+
+```bash
+# One-time: store the bridge shared secret
+echo -n 'your-bridge-secret' | gcloud secrets create clawql-sandbox-token \
+  --data-file=- --replication-policy=automatic
+
+gcloud run services update clawql-mcp-http \
+  --region "${REGION}" \
+  --set-secrets="CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN=clawql-sandbox-token:latest"
+```
+
+You still need `CLAWQL_SANDBOX_BRIDGE_URL` set (via `gcloud run services update --set-env-vars` or the deploy script with `export` for non-secret values).

--- a/scripts/deploy-cloud-run.sh
+++ b/scripts/deploy-cloud-run.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 # Deploy ClawQL as two Cloud Run services:
 # - MCP HTTP service
 # - GraphQL proxy service
+#
+# Optional MCP env (export before running; see docs/deploy-cloud-run.md):
+#   CLAWQL_OBSIDIAN_VAULT_PATH   — memory_ingest / memory_recall (default in image: /vault)
+#   CLAWQL_SANDBOX_BRIDGE_URL    — sandbox_exec (Cloudflare Worker origin)
+#   CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN — bridge shared secret (prefer Secret Manager in prod)
 
 PROJECT_ID="${PROJECT_ID:-}"
 REGION="${REGION:-us-central1}"
@@ -78,13 +83,26 @@ GRAPHQL_BASE_URL="$(gcloud run services describe "${GRAPHQL_SERVICE}" \
   --format='value(status.url)')"
 GRAPHQL_URL="${GRAPHQL_BASE_URL}/graphql"
 
+# MCP env: base + optional vault / Cloudflare Sandbox bridge (memory_ingest / memory_recall / sandbox_exec).
+# Prefer Secret Manager for CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN in production (see docs/deploy-cloud-run.md).
+MCP_ENV_VARS="CLAWQL_PROVIDER=${PROVIDER},GRAPHQL_URL=${GRAPHQL_URL},PORT=8080,MCP_PATH=/mcp,CLAWQL_BUNDLED_OFFLINE=1"
+if [[ -n "${CLAWQL_OBSIDIAN_VAULT_PATH:-}" ]]; then
+  MCP_ENV_VARS="${MCP_ENV_VARS},CLAWQL_OBSIDIAN_VAULT_PATH=${CLAWQL_OBSIDIAN_VAULT_PATH}"
+fi
+if [[ -n "${CLAWQL_SANDBOX_BRIDGE_URL:-}" ]]; then
+  MCP_ENV_VARS="${MCP_ENV_VARS},CLAWQL_SANDBOX_BRIDGE_URL=${CLAWQL_SANDBOX_BRIDGE_URL}"
+fi
+if [[ -n "${CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN:-}" ]]; then
+  MCP_ENV_VARS="${MCP_ENV_VARS},CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN=${CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN}"
+fi
+
 echo "==> Deploying MCP service: ${MCP_SERVICE}"
 gcloud run deploy "${MCP_SERVICE}" \
   --image "${IMAGE_URI}" \
   --region "${REGION}" \
   --platform managed \
   ${AUTH_FLAG} \
-  --set-env-vars "CLAWQL_PROVIDER=${PROVIDER},GRAPHQL_URL=${GRAPHQL_URL},PORT=8080,MCP_PATH=/mcp,CLAWQL_BUNDLED_OFFLINE=1" \
+  --set-env-vars "${MCP_ENV_VARS}" \
   --port 8080 \
   --cpu 2 \
   --memory 2Gi \


### PR DESCRIPTION
Closes #10.

## Summary
- **`docker/kubernetes-starter.yaml`**: Adds `CLAWQL_OBSIDIAN_VAULT_PATH=/vault`, `emptyDir` volume, and mount — matches `docker/kustomize/base/deployment-mcp-http.yaml` so starter K8s matches Compose/kustomize for memory tools.
- **`scripts/deploy-cloud-run.sh`**: Builds MCP `--set-env-vars` with optional `CLAWQL_OBSIDIAN_VAULT_PATH`, `CLAWQL_SANDBOX_BRIDGE_URL`, `CLAWQL_CLOUDFLARE_SANDBOX_API_TOKEN` when exported before deploy (default deploy unchanged if unset).
- **`docs/deploy-cloud-run.md`**: Table of optional vars, example exports, notes on ephemeral vault on Cloud Run, Secret Manager snippet for bridge token.
- **`docker/README.md`**, **`docker/Dockerfile`**, **`Makefile`**: Short comments linking optional runtime env.

## Validation
- `kubectl apply --dry-run=client -f docker/kubernetes-starter.yaml` OK.