### PR TITLE
feat: default bundle Google top50 + Cloudflare + GitHub; per-provider auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@
 #   2) CLAWQL_PROVIDER = merged preset (google-top50, default-multi-provider, all-providers, atlassian, …)
 #   3) CLAWQL_GOOGLE_TOP50_SPECS=1  (if #2 did not already pick multi-spec)
 #   4) Else if SPEC_PATHS / PATH / URL / DISCOVERY / CLAWQL_PROVIDER / GOOGLE_TOP50 are all unset →
-#      built-in default merge (github + cloudflare)
+#      built-in default merge (google-top50 + cloudflare + github)
 #
 # Stage 2 — Single spec (if Stage 1 does not apply), first match wins:
 #   CLAWQL_SPEC_PATH > CLAWQL_SPEC_URL > CLAWQL_DISCOVERY_URL > CLAWQL_PROVIDER (single vendor)
@@ -36,10 +36,11 @@
 # CLAWQL_API_BASE_URL=https://api.example.com
 
 # ─── Upstream API auth (execute / GraphQL proxy) ─────────────────────
-# Multi-spec default (github + cloudflare): set both so each vendor gets the right Bearer token.
-# CLAWQL_GITHUB_TOKEN=ghp_…
+# Multi-spec default (google-top50 + cloudflare + github): set all three for live calls.
+# CLAWQL_GOOGLE_ACCESS_TOKEN=…   # or GOOGLE_ACCESS_TOKEN (e.g. gcloud auth print-access-token)
 # CLAWQL_CLOUDFLARE_API_TOKEN=…
-# Optional fallback for other merged APIs or single-vendor mode:
+# CLAWQL_GITHUB_TOKEN=ghp_…
+# Optional fallback for other merged vendors or single-vendor mode:
 # CLAWQL_BEARER_TOKEN=…
 # Override headers entirely (JSON object; wins over bearer selection):
 # CLAWQL_HTTP_HEADERS={"Authorization":"Bearer …"}

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ manager). Deployments (Docker/K8s/Cloud Run) wire both for you.
 
 **Bring your own OpenAPI 3** (JSON/YAML file or URL), or use **Swagger 2**
 (converted automatically), or a **Google Discovery** document URL. If no spec
-env is set, ClawQL defaults to a bundled **multi-provider** merge (**GitHub +
-Cloudflare**). Single-provider **`cloudflare`** and other presets are
+env is set, ClawQL defaults to a bundled **multi-provider** merge (**Google top 50 +
+Cloudflare + GitHub**). Single-provider **`cloudflare`** and other presets are
 available via **`CLAWQL_PROVIDER`** (see [`providers/README.md`](providers/README.md)).
 
 **Repo vs npm:** GitHub **`ClawQL`** — published package **`clawql-mcp`**.
@@ -324,7 +324,7 @@ Used when any of the following applies (checked in this order):
 1. **`CLAWQL_SPEC_PATHS`** — merge these local files (comma, semicolon, or newline separated).
 2. **`CLAWQL_PROVIDER`** — if it names a **merged preset** (`google-top50`, `default-multi-provider`, `all-providers`, `atlassian`, …), load that bundle.
 3. **`CLAWQL_GOOGLE_TOP50_SPECS`** (`1` / `true` / `yes`) — merge curated **google-top50** if #1–2 did not already select multi-spec.
-4. **Built-in default merge** — only if **`CLAWQL_SPEC_PATHS`**, **`CLAWQL_SPEC_PATH`**, **`CLAWQL_SPEC_URL`**, **`CLAWQL_DISCOVERY_URL`**, **`CLAWQL_PROVIDER`**, and **`CLAWQL_GOOGLE_TOP50_SPECS`** are all unset: **GitHub + Cloudflare** (`default-multi-provider`).
+4. **Built-in default merge** — only if **`CLAWQL_SPEC_PATHS`**, **`CLAWQL_SPEC_PATH`**, **`CLAWQL_SPEC_URL`**, **`CLAWQL_DISCOVERY_URL`**, **`CLAWQL_PROVIDER`**, and **`CLAWQL_GOOGLE_TOP50_SPECS`** are all unset: **Google top50 + Cloudflare + GitHub** (`default-multi-provider`).
 
 If Stage 1 runs, you get one merged **search** index; **`execute`** uses **REST** per spec (see server logs: GraphQL is not used for multi-spec execute).
 
@@ -364,12 +364,13 @@ If Stage 1 does **not** apply, one document is loaded in this order:
 | `CLAWQL_MEMORY_RECALL_SNIPPET_CHARS` | Snippet length in characters (`520`). |
 | `CLAWQL_GITHUB_TOKEN` | GitHub PAT / fine-grained token for **`execute`** when the operation is from the **github** spec (or `CLAWQL_PROVIDER=github`). Also accepts **`GITHUB_TOKEN`** / **`GH_TOKEN`**. |
 | `CLAWQL_CLOUDFLARE_API_TOKEN` | Cloudflare API token for **`execute`** when the operation is from the **cloudflare** spec (or `CLAWQL_PROVIDER=cloudflare`). Also accepts **`CLOUDFLARE_API_TOKEN`**. |
-| `CLAWQL_BEARER_TOKEN` | Fallback bearer when a provider-specific token is not set; also used for Google and other merged labels. |
+| `CLAWQL_GOOGLE_ACCESS_TOKEN` | OAuth access token for **Google Cloud** APIs (`compute-v1`, … top50 slugs, or `CLAWQL_PROVIDER=google` / `google-top50`). Also accepts **`GOOGLE_ACCESS_TOKEN`**. |
+| `CLAWQL_BEARER_TOKEN` | Fallback bearer when a provider-specific token is not set; also used for non-Google merged vendors (e.g. Jira in **`all-providers`**). |
 
 **GCP multi-service:** use **`CLAWQL_GOOGLE_TOP50_SPECS=1`**, **`CLAWQL_PROVIDER=google-top50`**, or **`CLAWQL_SPEC_PATHS`** so `search` / `execute` see every merged API in one server; `execute` uses REST in that mode. For **every bundled vendor** (Google top50 + Jira, Bitbucket, Cloudflare, GitHub, Slack, Sentry, n8n), use **`CLAWQL_PROVIDER=all-providers`**. See [`docs/workflow-gcp-multi-service.md`](docs/workflow-gcp-multi-service.md).  
 **Integration check:** `npm run workflow:gcp-multi` runs **`tools/call` → `search`** over real MCP stdio and writes `docs/workflow-gcp-multi-latest.json` (full `CallToolResult` + parsed body). `npm run workflow:gcp-multi:direct` is a faster in-process-only variant for debugging rankers. One-page results summary: [`docs/gcp-multi-mcp-test-summary.md`](docs/gcp-multi-mcp-test-summary.md). Detailed experiment write-up (queries, APIs, token heuristic, MCP samples): [`docs/experiment-gcp-multi-mcp-workflow.md`](docs/experiment-gcp-multi-mcp-workflow.md); `npm run report:gcp-multi-experiment` refreshes [`docs/experiment-gcp-multi-mcp-stats.json`](docs/experiment-gcp-multi-mcp-stats.json).
 
-The default **first-run** bundle is **Stage 1 #4** above (**GitHub + Cloudflare**). Set **`CLAWQL_GITHUB_TOKEN`** and **`CLAWQL_CLOUDFLARE_API_TOKEN`** together so **`execute`** can call both APIs. To use another bundled spec or merged preset, set **`CLAWQL_PROVIDER`** — e.g. **`google`**,
+The default **first-run** bundle is **Stage 1 #4** above (**Google top50 + Cloudflare + GitHub**). Set **`CLAWQL_GOOGLE_ACCESS_TOKEN`** (or **`GOOGLE_ACCESS_TOKEN`**), **`CLAWQL_CLOUDFLARE_API_TOKEN`**, and **`CLAWQL_GITHUB_TOKEN`** so **`execute`** can call all three. To use another bundled spec or merged preset, set **`CLAWQL_PROVIDER`** — e.g. **`google`**,
 **`atlassian`**, **`cloudflare`**, **`github`**, **`slack`**, **`sentry`**, or **`n8n`**
 (see `providers/README.md`; **`all-providers`** = top50 + all other bundled vendors).  
 Compatibility aliases currently also exist for **`jira`** and **`bitbucket`**.  
@@ -626,7 +627,7 @@ Run **MCP Streamable HTTP** and **clawql-graphql** in a local cluster so clients
    This builds **`clawql-mcp:latest`**, applies **`docker/kustomize/overlays/local`**, and waits for rollouts. The script uses the **`docker-desktop`** kubectl context when present.
 
 3. **Health:** `curl -s http://localhost:8080/healthz` should return `{"status":"ok",...}` before connecting the client.
-4. **GitHub + Cloudflare auth:** `bash scripts/k8s-docker-desktop-set-github-token.sh` (optional `CLAWQL_CLOUDFLARE_API_TOKEN` in the environment for the same run). See [`docker/README.md`](docker/README.md).
+4. **GitHub + Cloudflare + Google auth:** `bash scripts/k8s-docker-desktop-set-github-token.sh` (optional `CLAWQL_CLOUDFLARE_API_TOKEN` and `GOOGLE_ACCESS_TOKEN` / `CLAWQL_GOOGLE_ACCESS_TOKEN` in the environment). See [`docker/README.md`](docker/README.md).
 
 **Teardown:** `kubectl --context docker-desktop delete namespace clawql`
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -90,16 +90,16 @@ make local-k8s-up
 
 This tags **`clawql-mcp:latest`** (same daemon as Docker Desktop; no registry push). The overlay lives at `docker/kustomize/overlays/local`.
 
-- **`CLAWQL_PROVIDER`:** The **local** overlay sets **`default-multi-provider`** (GitHub + Cloudflare, same as bare `npx clawql-mcp`). Edit `docker/kustomize/overlays/local/patch-local-provider-env.yaml` to **`all-providers`** when you need the full merge for multi-vendor MCP or **`workflow:complex-release-stack:mcp`** over HTTP. The **base** manifest defaults to **`google-top50`** when no overlay patch applies.
+- **`CLAWQL_PROVIDER`:** The **local** overlay sets **`default-multi-provider`** (Google top50 + Cloudflare + GitHub, same as bare `npx clawql-mcp`). Edit `docker/kustomize/overlays/local/patch-local-provider-env.yaml` to **`all-providers`** when you need the full merge for multi-vendor MCP or **`workflow:complex-release-stack:mcp`** over HTTP. The **base** manifest defaults to **`google-top50`** when no overlay patch applies.
 - **`kubectl` context:** The script targets **`docker-desktop`** when that context exists (so your default context can stay on EKS or another cluster).
 - **Restart behavior:** Deployments keep **`replicas: 1`** and Kubernetes **restarts failed containers** automatically (Pod `restartPolicy` is `Always`).
 - **MCP URL:** `http://localhost:8080/mcp` once `kubectl -n clawql get svc clawql-mcp-http` shows an external address (often `localhost` on Docker Desktop).
 - **Cold start:** The MCP container loads every bundled spec before `listen()`; hitting `:8080` too early can produce `fetch failed` / “other side closed” in Node. Wait until `curl http://localhost:8080/healthz` returns `{"status":"ok"…}` or the pod is **Ready** (the MCP Deployment includes `/healthz` startup/readiness probes). The `workflow:complex-release-stack:mcp` script polls `/healthz` when `CLAWQL_MCP_URL` is set.
 - **Teardown:** `kubectl delete namespace clawql` (or `kubectl --context docker-desktop delete namespace clawql`)
 
-### GitHub + Cloudflare API auth on Docker Desktop K8s
+### GitHub + Cloudflare + Google API auth on Docker Desktop K8s
 
-Merged **`execute`** calls pick the bearer per vendor (`specLabel`): **`CLAWQL_GITHUB_TOKEN`** / **`GITHUB_TOKEN`** for GitHub operations and **`CLAWQL_CLOUDFLARE_API_TOKEN`** / **`CLOUDFLARE_API_TOKEN`** for Cloudflare (see `src/auth-headers.ts`). **`CLAWQL_BEARER_TOKEN`** remains a fallback. For the default **GitHub + Cloudflare** bundle, set both tokens in the cluster.
+Merged **`execute`** calls pick the bearer per **`specLabel`**: GitHub, Cloudflare, and Google top50 API slugs (e.g. `compute-v1`) each use their own env vars (see `src/auth-headers.ts`). **`CLAWQL_BEARER_TOKEN`** remains a fallback for other vendors. For the default **Google top50 + Cloudflare + GitHub** bundle, set all three token types in the cluster when you need live calls to every provider.
 
 1. **One-shot (recommended):** from the ClawQL repo root, with `gh` logged in:
 
@@ -107,7 +107,7 @@ Merged **`execute`** calls pick the bearer per vendor (`specLabel`): **`CLAWQL_G
    bash scripts/k8s-docker-desktop-set-github-token.sh
    ```
 
-   Optional: `export CLAWQL_CLOUDFLARE_API_TOKEN=…` in the same shell so the script stores **both** keys in Secret **`clawql-github-auth`** and attaches **`CLAWQL_GITHUB_TOKEN`** (and **`CLAWQL_CLOUDFLARE_API_TOKEN`** when set) to **`deployment/clawql-mcp-http`**, then **`rollout restart`**s it.
+   Optional: `export CLAWQL_CLOUDFLARE_API_TOKEN=…` and/or **`GOOGLE_ACCESS_TOKEN`** / **`CLAWQL_GOOGLE_ACCESS_TOKEN`** in the same shell so the script stores those keys in Secret **`clawql-github-auth`** and attaches them to **`deployment/clawql-mcp-http`**, then **`rollout restart`**s it.
 
    You can also pipe a PAT: `gh auth token | bash scripts/k8s-docker-desktop-set-github-token.sh`, or `export CLAWQL_GITHUB_TOKEN=…` / `CLAWQL_BEARER_TOKEN=…` before the script.
 
@@ -117,9 +117,10 @@ Merged **`execute`** calls pick the bearer per vendor (`specLabel`): **`CLAWQL_G
    kubectl create secret generic clawql-github-auth -n clawql \
      --from-literal=CLAWQL_GITHUB_TOKEN="$(gh auth token)" \
      --from-literal=CLAWQL_CLOUDFLARE_API_TOKEN="YOUR_CF_TOKEN" \
+     --from-literal=GOOGLE_ACCESS_TOKEN="$(gcloud auth print-access-token)" \
      --dry-run=client -o yaml | kubectl apply -f -
    kubectl -n clawql set env deployment/clawql-mcp-http \
-     --from=secret/clawql-github-auth --keys=CLAWQL_GITHUB_TOKEN,CLAWQL_CLOUDFLARE_API_TOKEN --overwrite
+     --from=secret/clawql-github-auth --keys=CLAWQL_GITHUB_TOKEN,CLAWQL_CLOUDFLARE_API_TOKEN,GOOGLE_ACCESS_TOKEN --overwrite
    kubectl -n clawql rollout restart deployment/clawql-mcp-http
    ```
 

--- a/docker/kustomize/overlays/local/patch-local-provider-env.yaml
+++ b/docker/kustomize/overlays/local/patch-local-provider-env.yaml
@@ -1,4 +1,4 @@
-# Local Docker Desktop: same default merge as bare npm (GitHub + Cloudflare).
+# Local Docker Desktop: same default merge as bare npm (Google top50 + Cloudflare + GitHub).
 # Pin github, cloudflare, google-top50, or all-providers if you prefer.
 apiVersion: apps/v1
 kind: Deployment

--- a/providers/README.md
+++ b/providers/README.md
@@ -15,7 +15,7 @@ start avoids downloading multi‑MB specs.
 | `jira` | `atlassian/jira/openapi.yaml` | Jira Cloud REST (alias of single-spec mode; also part of `atlassian` / `all-providers`). |
 | `bitbucket` | `atlassian/bitbucket/openapi.yaml` | Bitbucket Cloud REST (alias; also part of `atlassian` / `all-providers`). |
 | `google-top50` | *(merged preset)* | Curated [`google-top50-apis.json`](google/google-top50-apis.json) only (~50 Discovery specs). |
-| `default-multi-provider` | *(merged preset)* | Same as **no spec env**: GitHub + Cloudflare. |
+| `default-multi-provider` | *(merged preset)* | Same as **no spec env**: Google top50 + Cloudflare + GitHub. |
 | `all-providers` | *(merged preset)* | Top50 + **every** other `BUNDLED_PROVIDERS` vendor (adds Bitbucket, GitHub, Slack, Sentry, n8n, …). |
 
 Compatibility aliases for merged groups: `atlassian` = Jira + Bitbucket together.
@@ -24,7 +24,7 @@ Compatibility aliases for merged groups: `atlassian` = Jira + Bitbucket together
 
 **Google “top 50” offline bundle:** Pinned Discovery JSON (and optional `introspection.json` / `schema.graphql`) for common GCP services — under [`google/apis/`](google/apis/README.md). Manifest: `google/google-top50-apis.json`. Refresh: `npm run fetch-google-top50` then `npm run build && npm run pregenerate-google-top50-graphql`, or `npm run refresh-google-top50`.
 
-**Default no-config mode:** when no spec env vars are set, ClawQL loads a bundled multi-provider set (**GitHub + Cloudflare**) so agents can **`search`** / **`execute`** both APIs in one process. Set **`CLAWQL_GITHUB_TOKEN`** and **`CLAWQL_CLOUDFLARE_API_TOKEN`** (or **`GITHUB_TOKEN`** / **`CLOUDFLARE_API_TOKEN`**) together for live calls — see `src/auth-headers.ts`.
+**Default no-config mode:** when no spec env vars are set, ClawQL loads a bundled multi-provider set (**Google top50 + Cloudflare + GitHub**). Set **`CLAWQL_GOOGLE_ACCESS_TOKEN`** / **`GOOGLE_ACCESS_TOKEN`**, **`CLAWQL_CLOUDFLARE_API_TOKEN`**, and **`CLAWQL_GITHUB_TOKEN`** for live **`execute`** calls — see `src/auth-headers.ts`.
 
 **All-providers merged preset:** set **`CLAWQL_PROVIDER=all-providers`** to load **Google top50 + every other bundled vendor** (Jira, Bitbucket, Cloudflare, GitHub, Slack, Sentry, n8n) in one merged operation index. This wins over **`CLAWQL_GOOGLE_TOP50_SPECS`** when both are set. Adding a new entry under `BUNDLED_PROVIDERS` automatically includes it here.
 

--- a/scripts/k8s-docker-desktop-set-github-token.sh
+++ b/scripts/k8s-docker-desktop-set-github-token.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Create/update a Kubernetes Secret with GitHub + optional Cloudflare API tokens,
+# Create/update a Kubernetes Secret with GitHub + optional Cloudflare + optional Google tokens,
 # wire them into clawql-mcp-http, set CORS for browser/Gallery clients, and restart.
 #
-# For the default merged bundle (GitHub + Cloudflare), set both:
-#   CLAWQL_GITHUB_TOKEN / CLAWQL_CLOUDFLARE_API_TOKEN
-# (see src/auth-headers.ts). CLAWQL_BEARER_TOKEN still works for single-vendor or as a fallback.
+# For the default merged bundle (Google top50 + Cloudflare + GitHub), set:
+#   CLAWQL_GITHUB_TOKEN, CLAWQL_CLOUDFLARE_API_TOKEN, CLAWQL_GOOGLE_ACCESS_TOKEN or GOOGLE_ACCESS_TOKEN
+# (see src/auth-headers.ts). CLAWQL_BEARER_TOKEN still works as a fallback.
 #
 # Prerequisites:
 #   - Docker Desktop Kubernetes running; context docker-desktop (or docker-for-desktop)
@@ -15,7 +15,7 @@
 #   bash scripts/k8s-docker-desktop-set-github-token.sh
 #   gh auth token | bash scripts/k8s-docker-desktop-set-github-token.sh
 #   CLAWQL_GITHUB_TOKEN=ghp_xxx bash scripts/k8s-docker-desktop-set-github-token.sh
-#   CLAWQL_CLOUDFLARE_API_TOKEN=… CLAWQL_GITHUB_TOKEN=… bash scripts/k8s-docker-desktop-set-github-token.sh
+#   CLAWQL_CLOUDFLARE_API_TOKEN=… CLAWQL_GOOGLE_ACCESS_TOKEN="$(gcloud auth print-access-token)" bash scripts/k8s-docker-desktop-set-github-token.sh
 #
 # CORS (CLAWQL_CORS_ALLOW_ORIGIN on clawql-mcp-http — see server-http.ts):
 #   Default: *  (Gallery / iPhone webview, Cloudflare Tunnel, etc.)
@@ -66,22 +66,26 @@ if [[ -z "${TOKEN// }" ]]; then
 fi
 
 CF_TOKEN="${CLAWQL_CLOUDFLARE_API_TOKEN:-}"
+GOOGLE_TOKEN="${CLAWQL_GOOGLE_ACCESS_TOKEN:-${GOOGLE_ACCESS_TOKEN:-}}"
 
 echo "==> Creating/updating secret $SECRET_NAME in namespace $NAMESPACE"
+SECRET_ARGS=( -n "$NAMESPACE" create secret generic "$SECRET_NAME"
+  --from-literal=CLAWQL_GITHUB_TOKEN="$TOKEN" )
 if [[ -n "${CF_TOKEN// }" ]]; then
-  kc -n "$NAMESPACE" create secret generic "$SECRET_NAME" \
-    --from-literal=CLAWQL_GITHUB_TOKEN="$TOKEN" \
-    --from-literal=CLAWQL_CLOUDFLARE_API_TOKEN="$CF_TOKEN" \
-    --dry-run=client -o yaml | kc apply -f -
-else
-  kc -n "$NAMESPACE" create secret generic "$SECRET_NAME" \
-    --from-literal=CLAWQL_GITHUB_TOKEN="$TOKEN" \
-    --dry-run=client -o yaml | kc apply -f -
+  SECRET_ARGS+=( --from-literal=CLAWQL_CLOUDFLARE_API_TOKEN="$CF_TOKEN" )
 fi
+if [[ -n "${GOOGLE_TOKEN// }" ]]; then
+  SECRET_ARGS+=( --from-literal=GOOGLE_ACCESS_TOKEN="$GOOGLE_TOKEN" )
+fi
+SECRET_ARGS+=( --dry-run=client -o yaml )
+kc "${SECRET_ARGS[@]}" | kc apply -f -
 
 ENV_KEYS="CLAWQL_GITHUB_TOKEN"
 if [[ -n "${CF_TOKEN// }" ]]; then
-  ENV_KEYS="CLAWQL_GITHUB_TOKEN,CLAWQL_CLOUDFLARE_API_TOKEN"
+  ENV_KEYS="${ENV_KEYS},CLAWQL_CLOUDFLARE_API_TOKEN"
+fi
+if [[ -n "${GOOGLE_TOKEN// }" ]]; then
+  ENV_KEYS="${ENV_KEYS},GOOGLE_ACCESS_TOKEN"
 fi
 
 echo "==> Attaching secret env to deployment/$DEPLOY ($ENV_KEYS)"

--- a/src/auth-headers.test.ts
+++ b/src/auth-headers.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { isGoogleDiscoverySpecLabel, mergedAuthHeaders } from "./auth-headers.js";
+
+afterEach(() => {
+  delete process.env.CLAWQL_HTTP_HEADERS;
+  delete process.env.CLAWQL_BEARER_TOKEN;
+  delete process.env.GOOGLE_ACCESS_TOKEN;
+  delete process.env.CLAWQL_GOOGLE_ACCESS_TOKEN;
+  delete process.env.CLAWQL_GITHUB_TOKEN;
+  delete process.env.CLAWQL_CLOUDFLARE_API_TOKEN;
+  delete process.env.CLOUDFLARE_API_TOKEN;
+  delete process.env.CLAWQL_PROVIDER;
+});
+
+describe("isGoogleDiscoverySpecLabel", () => {
+  it("matches top50 slugs and single provider id", () => {
+    expect(isGoogleDiscoverySpecLabel("compute-v1")).toBe(true);
+    expect(isGoogleDiscoverySpecLabel("networksecurity-v1beta1")).toBe(true);
+    expect(isGoogleDiscoverySpecLabel("dataflow-v1b3")).toBe(true);
+    expect(isGoogleDiscoverySpecLabel("google")).toBe(true);
+  });
+
+  it("rejects other merged vendor labels", () => {
+    expect(isGoogleDiscoverySpecLabel("github")).toBe(false);
+    expect(isGoogleDiscoverySpecLabel("cloudflare")).toBe(false);
+    expect(isGoogleDiscoverySpecLabel("jira")).toBe(false);
+  });
+});
+
+describe("mergedAuthHeaders", () => {
+  it("uses Google access token for compute-v1 specLabel over generic bearer", () => {
+    process.env.CLAWQL_BEARER_TOKEN = "wrong";
+    process.env.CLAWQL_GOOGLE_ACCESS_TOKEN = "ya29.google";
+    expect(mergedAuthHeaders("compute-v1")).toEqual({
+      Authorization: "Bearer ya29.google",
+    });
+  });
+
+  it("uses CLAWQL_PROVIDER=google-top50 for GraphQL-style calls without specLabel", () => {
+    process.env.CLAWQL_PROVIDER = "google-top50";
+    process.env.GOOGLE_ACCESS_TOKEN = "ya29.x";
+    delete process.env.CLAWQL_BEARER_TOKEN;
+    expect(mergedAuthHeaders()).toEqual({
+      Authorization: "Bearer ya29.x",
+    });
+  });
+});

--- a/src/auth-headers.ts
+++ b/src/auth-headers.ts
@@ -12,10 +12,20 @@ function trimEnv(...keys: string[]): string | undefined {
 }
 
 /**
+ * True for bundled single provider `google`, or Google top50 manifest slugs
+ * (e.g. `compute-v1`, `networksecurity-v1beta1`, `dataflow-v1b3`).
+ */
+export function isGoogleDiscoverySpecLabel(label: string): boolean {
+  const s = label.trim().toLowerCase();
+  if (s === "google") return true;
+  return /^[a-z0-9][a-z0-9-]*-v[a-z0-9]+$/i.test(s);
+}
+
+/**
  * Resolve `Authorization: Bearer …` for an operation.
- * - When `specLabel` is set (multi-spec merge), it selects GitHub vs Cloudflare tokens.
- * - When unset, `CLAWQL_PROVIDER` selects the same for single-vendor mode.
- * - Falls back to `CLAWQL_BEARER_TOKEN` / `GOOGLE_ACCESS_TOKEN`.
+ * - `specLabel` `github` / `cloudflare` → provider-specific env vars.
+ * - Google top50 slugs (see `isGoogleDiscoverySpecLabel`) or `CLAWQL_PROVIDER=google` → GCP/OAuth access token env vars.
+ * - Other merged vendors (e.g. Jira in `all-providers`) → `CLAWQL_BEARER_TOKEN` / `GOOGLE_ACCESS_TOKEN`.
  */
 export function mergedAuthHeaders(specLabel?: string): Record<string, string> {
   const out: Record<string, string> = {};
@@ -53,13 +63,18 @@ export function mergedAuthHeaders(specLabel?: string): Record<string, string> {
       "CLAWQL_BEARER_TOKEN",
       "GOOGLE_ACCESS_TOKEN"
     );
-  } else {
+  } else if (
+    (label && isGoogleDiscoverySpecLabel(label)) ||
+    effective === "google" ||
+    effective === "google-top50"
+  ) {
     bearer = trimEnv(
-      "CLAWQL_BEARER_TOKEN",
+      "CLAWQL_GOOGLE_ACCESS_TOKEN",
       "GOOGLE_ACCESS_TOKEN",
-      "CLAWQL_CLOUDFLARE_API_TOKEN",
-      "CLOUDFLARE_API_TOKEN"
+      "CLAWQL_BEARER_TOKEN"
     );
+  } else {
+    bearer = trimEnv("CLAWQL_BEARER_TOKEN", "GOOGLE_ACCESS_TOKEN");
   }
 
   if (bearer) {

--- a/src/provider-registry.ts
+++ b/src/provider-registry.ts
@@ -130,11 +130,13 @@ async function resolveGoogleTop50Items(): Promise<ProviderGroupItem[]> {
 
 async function resolveDefaultMultiProviderItems(): Promise<ProviderGroupItem[]> {
   const root = getPackageRoot();
+  const google = await resolveGoogleTop50Items();
   const cloudflare = BUNDLED_PROVIDERS.cloudflare;
   const github = BUNDLED_PROVIDERS.github;
   return [
-    { abs: resolvePath(root, github.bundledSpecPath), label: github.id },
+    ...google,
     { abs: resolvePath(root, cloudflare.bundledSpecPath), label: cloudflare.id },
+    { abs: resolvePath(root, github.bundledSpecPath), label: github.id },
   ];
 }
 
@@ -164,7 +166,7 @@ async function resolveAllBundledProvidersItems(): Promise<ProviderGroupItem[]> {
 export const BUNDLED_PROVIDER_GROUPS: Record<string, BundledProviderGroup> = {
   atlassian: { providers: ["jira", "bitbucket"] },
   "google-top50": { resolve: resolveGoogleTop50Items },
-  /** Same as no spec env: GitHub + Cloudflare (see `resolveDefaultMultiProviderItems`). */
+  /** Same as no spec env: Google top50 + Cloudflare + GitHub (see `resolveDefaultMultiProviderItems`). */
   "default-multi-provider": { resolve: resolveDefaultMultiProviderItems },
   /** Google top50 + every other bundled vendor (Jira, Bitbucket, Cloudflare, GitHub, Slack, Sentry, n8n). */
   "all-providers": { resolve: resolveAllBundledProvidersItems },

--- a/src/rest-operation.test.ts
+++ b/src/rest-operation.test.ts
@@ -34,6 +34,7 @@ afterEach(() => {
   delete process.env.CLAWQL_HTTP_HEADERS;
   delete process.env.CLAWQL_BEARER_TOKEN;
   delete process.env.GOOGLE_ACCESS_TOKEN;
+  delete process.env.CLAWQL_GOOGLE_ACCESS_TOKEN;
   delete process.env.CLAWQL_GITHUB_TOKEN;
   delete process.env.GITHUB_TOKEN;
   delete process.env.GH_TOKEN;
@@ -87,6 +88,14 @@ describe("rest-operation helpers", () => {
     delete process.env.CLAWQL_BEARER_TOKEN;
     expect(mergedAuthHeaders()).toEqual({
       Authorization: "Bearer gh_only",
+    });
+  });
+
+  it("uses GOOGLE_ACCESS_TOKEN for Google top50 specLabel", () => {
+    process.env.CLAWQL_BEARER_TOKEN = "generic";
+    process.env.GOOGLE_ACCESS_TOKEN = "ya29.gcp";
+    expect(mergedAuthHeaders("container-v1")).toEqual({
+      Authorization: "Bearer ya29.gcp",
     });
   });
 });

--- a/src/spec-loader.ts
+++ b/src/spec-loader.ts
@@ -5,7 +5,7 @@
  * - Local file (JSON or YAML OpenAPI 3 / Swagger 2), or
  * - URL to fetch the same, or
  * - Google Discovery document URL, or
- * - Default: bundled multi-provider set (GitHub + Cloudflare).
+ * - Default: bundled multi-provider set (Google top50 + Cloudflare + GitHub).
  * - Optional merged preset: CLAWQL_PROVIDER=all-providers (top50 + all other bundled vendors).
  *
  * Produces a flattened Operation list for search + OpenAPI 3 for GraphQL.
@@ -632,10 +632,10 @@ async function resolveMultiSpecItems(): Promise<
     const grouped = await resolveBundledProviderGroup("google-top50");
     if (grouped) return grouped;
   }
-  // No config: load a lean default set for first-run GitHub + Cloudflare workflows.
+  // No config: default merge — Google top50 + Cloudflare + GitHub.
   if (!filePath && !specUrl && !discoveryUrl && !providerRaw && !useGoogleTop50) {
     console.error(
-      "[spec-loader] No spec env/provider set — using default multi-provider bundle: github + cloudflare"
+      "[spec-loader] No spec env/provider set — using default multi-provider bundle: google-top50 + cloudflare + github"
     );
     const defaultGroup = await resolveBundledProviderGroup("default-multi-provider");
     if (defaultGroup) return defaultGroup;

--- a/website/src/app/benchmarks/page.mdx
+++ b/website/src/app/benchmarks/page.mdx
@@ -11,7 +11,7 @@ The ClawQL README highlights **planning-context** comparisons: the byte size of 
 ## What the highlights measure
 
 - **All-providers complex release-stack** — broad scenario across Google top50 plus Bitbucket, Cloudflare, GitHub, Jira, n8n, Sentry, Slack. Artifacts: [`docs/workflow-complex-release-stack-latest.json`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/workflow-complex-release-stack-latest.json), stats under [`docs/benchmarks/all-providers-complex-workflow/`](https://github.com/danielsmithdevelopment/ClawQL/tree/main/docs/benchmarks/all-providers-complex-workflow).
-- **Default multi-provider** — GitHub + Cloudflare (historical runs may label older Google + Cloudflare + Jira bundles). Artifacts: [`docs/workflow-multi-provider-latest.json`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/workflow-multi-provider-latest.json), stats under [`docs/benchmarks/multi-provider-complex-workflow/`](https://github.com/danielsmithdevelopment/ClawQL/tree/main/docs/benchmarks/multi-provider-complex-workflow).
+- **Default multi-provider** — Google top50 + Cloudflare + GitHub (older artifacts may reflect prior defaults). Artifacts: [`docs/workflow-multi-provider-latest.json`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/workflow-multi-provider-latest.json), stats under [`docs/benchmarks/multi-provider-complex-workflow/`](https://github.com/danielsmithdevelopment/ClawQL/tree/main/docs/benchmarks/multi-provider-complex-workflow).
 
 Token estimates in docs often use **~4 characters per token** as a heuristic.
 

--- a/website/src/app/bundled-specs/page.mdx
+++ b/website/src/app/bundled-specs/page.mdx
@@ -13,7 +13,7 @@ The npm package ships **`providers/`**—optional on-disk API descriptions so co
 | `CLAWQL_PROVIDER` | Notes |
 | --- | --- |
 | `google-top50` | Merged ~50 curated Google Discovery services |
-| `default-multi-provider` | Same as **no spec env**: GitHub + Cloudflare |
+| `default-multi-provider` | Same as **no spec env**: Google top50 + Cloudflare + GitHub |
 | `all-providers` | Top50 **plus** every other bundled vendor (GitHub, Slack, Sentry, n8n, …) |
 | `atlassian` | Jira + Bitbucket merged |
 | `google` | Single Discovery example (GKE); use top50 for multi-service |

--- a/website/src/app/page.mdx
+++ b/website/src/app/page.mdx
@@ -30,7 +30,7 @@ export const sections = [
 
 ## Getting started {{ anchor: false }}
 
-Install **`clawql-mcp`**, start **`clawql-graphql`** in one terminal and **`clawql-mcp`** in another, then point your MCP client (e.g. Cursor or Claude Desktop) at the stdio server. Optionally set **`CLAWQL_SPEC_PATH`**, **`CLAWQL_SPEC_URL`**, or **`CLAWQL_DISCOVERY_URL`**; if you set nothing, ClawQL loads a bundled **multi-provider** merge (**GitHub + Cloudflare**). {{ className: 'lead' }}
+Install **`clawql-mcp`**, start **`clawql-graphql`** in one terminal and **`clawql-mcp`** in another, then point your MCP client (e.g. Cursor or Claude Desktop) at the stdio server. Optionally set **`CLAWQL_SPEC_PATH`**, **`CLAWQL_SPEC_URL`**, or **`CLAWQL_DISCOVERY_URL`**; if you set nothing, ClawQL loads a bundled **multi-provider** merge (**Google top 50 + Cloudflare + GitHub**). {{ className: 'lead' }}
 
 <div className="not-prose">
   <Button href="/mcp-clients" variant="text" arrow="right">

--- a/website/src/app/spec-configuration/page.mdx
+++ b/website/src/app/spec-configuration/page.mdx
@@ -20,7 +20,7 @@ Used when any of these applies (order matters):
 1. **`CLAWQL_SPEC_PATHS`** — merge local files (comma, semicolon, or newline separated).
 2. **`CLAWQL_PROVIDER`** — merged preset (`google-top50`, `default-multi-provider`, `all-providers`, `atlassian`, …).
 3. **`CLAWQL_GOOGLE_TOP50_SPECS`** (`1` / `true` / `yes`) — curated Google top 50 if not already merged above.
-4. **Built-in default** — only when no spec-related env vars are set: **GitHub + Cloudflare** (`default-multi-provider`).
+4. **Built-in default** — only when no spec-related env vars are set: **Google top50 + Cloudflare + GitHub** (`default-multi-provider`).
 
 ## Stage 2 — Single spec
 


### PR DESCRIPTION
## Summary

- **Default `default-multi-provider` bundle** (no spec env) is now **Google top50 + Cloudflare + GitHub**, in that merge order.
- **Per-provider `execute` auth** via `specLabel`: GitHub and Cloudflare env vars unchanged; **Google** APIs use `isGoogleDiscoverySpecLabel` (top50 slugs like `compute-v1`) plus `CLAWQL_PROVIDER` `google` / `google-top50` for `CLAWQL_GOOGLE_ACCESS_TOKEN` / `GOOGLE_ACCESS_TOKEN`.
- **K8s token script** optionally adds `GOOGLE_ACCESS_TOKEN` to the secret and deployment.
- **Docs** (README, providers, website, docker, `.env.example`) and **local kustomize** overlay comment aligned.

## Tests

`npm test` — 95 passed.