### PR TITLE
docs: vector search design (SQLite + Postgres for #16)

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -107,4 +107,4 @@ Writes **`ClawQL/Memory/<slug>.md`** with YAML frontmatter and optional `[[wikil
 }
 ```
 
-Returns JSON with **`results[]`**: `path`, `score`, `depth`, `reason` (`keyword` | `link`), `snippet`, optional `linkFrom`. **No vector embeddings** — lexical match + graph expansion via wikilinks. See [issue #16](https://github.com/danielsmithdevelopment/ClawQL/issues/16) for future semantic search.
+Returns JSON with **`results[]`**: `path`, `score`, `depth`, `reason` (`keyword` | `link`), `snippet`, optional `linkFrom`. **No vector embeddings** — lexical match + graph expansion via wikilinks. See [issue #16](https://github.com/danielsmithdevelopment/ClawQL/issues/16) and [vector-search-design.md](vector-search-design.md) for planned semantic retrieval (SQLite + Postgres backends).

--- a/docs/memory-obsidian.md
+++ b/docs/memory-obsidian.md
@@ -33,4 +33,4 @@ The design stays **lightweight**: the vault remains the source of truth; retriev
 ## See also
 
 - **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** — full stack that combines ClawQL MCP with orchestration and vault-backed memory.
-- **[Parity v1 #11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)** — MCP surface aligned with the agent stack (complete); future retrieval work may follow **[#16](https://github.com/danielsmithdevelopment/ClawQL/issues/16)**.
+- **[Parity v1 #11](https://github.com/danielsmithdevelopment/ClawQL/issues/11)** — MCP surface aligned with the agent stack (complete); future retrieval work may follow **[#16](https://github.com/danielsmithdevelopment/ClawQL/issues/16)** ([design: vector backends](vector-search-design.md)).

--- a/docs/vector-search-design.md
+++ b/docs/vector-search-design.md
@@ -1,0 +1,88 @@
+# Vector search & embeddings — backend design (draft)
+
+This note captures a **direction** for **[#16](https://github.com/danielsmithdevelopment/ClawQL/issues/16)** (optional semantic retrieval for `memory_recall` and spec `search`). It is **not** a committed roadmap until implementation lands.
+
+## Goals
+
+- **Pluggable embeddings** — local small model and/or remote API; off by default so core installs stay lean.
+- **Two vector stores** — **SQLite** (file-backed, minimal ops) and **Postgres + pgvector** (shared DB, concurrent writers, backups).
+- **Shared indexing rules** — chunking, metadata, and reindex triggers live in one place; only the **storage backend** differs.
+- **Gradual rollout** — keep lexical + wikilink behavior; add vectors as an **optional** path when configured.
+
+## Non-goals (initially)
+
+- Replacing keyword search entirely.
+- Requiring GPU or a large model for default installs.
+
+## Architecture
+
+### 1. Embedding provider (orthogonal to DB)
+
+A small internal interface (names illustrative):
+
+- `embed(text: string): Promise<number[]>` (or batch variant).
+- Implementations: HTTP OpenAI-compatible, local `transformers`/ONNX, etc.
+- Selected via env (e.g. `CLAWQL_EMBEDDING_PROVIDER`, model IDs, API keys). **Unset ⇒ vector features off.**
+
+### 2. Canonical chunk record
+
+Something stable both backends must persist:
+
+| Field | Purpose |
+|-------|---------|
+| `id` | Stable UUID or hash-derived id |
+| `source_kind` | e.g. `vault`, `spec_operation` |
+| `source_id` | Vault-relative path, or `operationId` / composite key |
+| `text` | Chunk plain text used for embedding |
+| `embedding` | Float vector (fixed dimension per model) |
+| `metadata` | JSON: headings, mtime, provider label, etc. |
+
+### 3. Vector store interface (backend-agnostic)
+
+Operations the rest of ClawQL would call:
+
+- `upsert(chunks)` — insert or replace by `id` / dedupe key.
+- `deleteBySource(source_kind, source_id)` — reindex / vault file delete.
+- `query(vector, { limit, filter })` — kNN + optional metadata filters (path prefix, provider, etc.).
+
+Implementations:
+
+- **`VectorStoreSqlite`** — single SQLite file (path from env).
+- **`VectorStorePostgres`** — Postgres with **`pgvector`** (schema + migrations).
+
+Selection:
+
+- **`CLAWQL_VECTOR_BACKEND=off|sqlite|postgres`** (default `off`).
+- **SQLite:** e.g. `CLAWQL_VECTOR_SQLITE_PATH` (absolute path to a file; created as needed).
+- **Postgres:** e.g. `CLAWQL_VECTOR_DATABASE_URL` (connection string; app enables `pgvector` extension in migration or documents manual `CREATE EXTENSION`).
+
+### 4. SQLite vs Postgres — when to use which
+
+| Profile | Store | Typical use |
+|--------|--------|-------------|
+| **Lean / local** | SQLite | `npx`, laptop, single user; no extra container. |
+| **Compose / K8s / prod** | Postgres | Multiple replicas, HA, familiar ops, easier hybrid SQL later. |
+
+Same embedding provider and chunking code; only **connection + SQL** differ.
+
+### 5. Integration points (future)
+
+- **`memory_recall`:** hybrid lexical + vector + wikilink graph (weights TBD).
+- **`search`:** optional vector re-rank or parallel index over operation descriptions when an index exists; fallback to current keyword ranker in `spec-search`.
+
+## Phasing (suggested)
+
+1. **Interface + SQLite** — smallest dependency footprint for developers; prove end-to-end ingest + query.
+2. **Postgres + pgvector** — second implementation behind the same interface; Docker Compose service optional.
+3. **Hybrid & tuning** — FTS / keyword + vector, score fusion, reindex hooks.
+
+## Open decisions
+
+- Exact SQLite stack (**sqlite-vec**, **sqlite-vss**, or store vectors as BLOB + custom index) — pick at implementation time based on maintenance and Node bindings.
+- Whether to support **migrating** an index from SQLite → Postgres (export/re-embed vs copy vectors).
+- Dimension / model versioning when embeddings change (namespace tables or `embedding_model` column).
+
+## Related docs
+
+- [`memory-obsidian.md`](memory-obsidian.md) — vault semantics for ingest/recall today.
+- [`mcp-tools.md`](mcp-tools.md) — current MCP tools (no vector fields until shipped).


### PR DESCRIPTION
## Summary
Adds **[docs/vector-search-design.md](docs/vector-search-design.md)** — draft architecture for optional embeddings / vector retrieval: pluggable embedding provider, canonical chunk model, `VectorStore` interface with **SQLite** and **Postgres (pgvector)** implementations, proposed env vars, deployment profiles, and phasing.

Cross-links from `docs/memory-obsidian.md` and `docs/mcp-tools.md`.

Refs #16 (does not close — tracking issue).