### PR TITLE
chore(memory): align vault defaults to Memory and memory.db

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,7 +69,7 @@
 # CLAWQL_OBSIDIAN_VAULT_PATH=/vault
 
 # memory_recall (keyword + wikilink graph; optional overrides)
-# CLAWQL_MEMORY_RECALL_SCAN_ROOT=ClawQL/Memory
+# CLAWQL_MEMORY_RECALL_SCAN_ROOT=Memory
 # CLAWQL_MEMORY_RECALL_LIMIT=10
 # CLAWQL_MEMORY_RECALL_MAX_DEPTH=2
 # CLAWQL_MEMORY_RECALL_MIN_SCORE=1
@@ -78,7 +78,7 @@
 
 # Hybrid memory index (issue #27): SQLite under the vault unless CLAWQL_MEMORY_DB_PATH is absolute.
 # CLAWQL_MEMORY_DB=0                    # disable DB sync + recall graph merge
-# CLAWQL_MEMORY_DB_PATH=.clawql/memory.db
+# CLAWQL_MEMORY_DB_PATH=memory.db
 # CLAWQL_MEMORY_DB_SYNC_ON_RECALL=1     # optional: rewrite DB from every recall scan (heavier)
 # CLAWQL_MEMORY_CHUNK_MAX_CHARS=2000    # paragraph_v1 hard-split threshold
 

--- a/README.md
+++ b/README.md
@@ -356,14 +356,14 @@ If Stage 1 does **not** apply, one document is loaded in this order:
 | `CLAWQL_CLOUDFLARE_ACCOUNT_ID` | Optional; sent as `CF-Account-ID` on bridge requests. |
 | `CLAWQL_SANDBOX_PERSISTENCE_MODE` | Default `session` / `ephemeral` / `persistent` for sandbox tool calls (overridable per call). |
 | `CLAWQL_SANDBOX_TIMEOUT_MS` | Max wait for each bridge request (default `120000`). |
-| `CLAWQL_MEMORY_RECALL_SCAN_ROOT` | Subfolder under the vault to scan (default `ClawQL/Memory`). Set to empty to scan the whole vault. |
+| `CLAWQL_MEMORY_RECALL_SCAN_ROOT` | Subfolder under the vault to scan (default `Memory`). Set to empty to scan the whole vault. |
 | `CLAWQL_MEMORY_RECALL_LIMIT` | Default max notes returned by **`memory_recall`** (`10`). |
 | `CLAWQL_MEMORY_RECALL_MAX_DEPTH` | Default wikilink hops from a keyword hit (`2`). |
 | `CLAWQL_MEMORY_RECALL_MIN_SCORE` | Minimum keyword score to seed a note (`1`). |
 | `CLAWQL_MEMORY_RECALL_MAX_FILES` | Safety cap on Markdown files scanned (`2000`). |
 | `CLAWQL_MEMORY_RECALL_SNIPPET_CHARS` | Snippet length in characters (`520`). |
 | `CLAWQL_MEMORY_DB` | Set to **`0`** to disable the **`memory.db`** sidecar (no sync after ingest, no wikilink merge in recall). |
-| `CLAWQL_MEMORY_DB_PATH` | SQLite file path: default **`.clawql/memory.db`** under the vault; may be an **absolute** path. See [`docs/memory-db-schema.md`](docs/memory-db-schema.md). |
+| `CLAWQL_MEMORY_DB_PATH` | SQLite file path: default **`memory.db`** under the vault; may be an **absolute** path. See [`docs/memory-db-schema.md`](docs/memory-db-schema.md). |
 | `CLAWQL_MEMORY_DB_SYNC_ON_RECALL` | Set to **`1`** to rewrite **`memory.db`** from every **`memory_recall`** scan (optional; heavier than ingest-only sync). |
 | `CLAWQL_MEMORY_CHUNK_MAX_CHARS` | `paragraph_v1` chunker max window size before hard-split (`2000`). |
 | `CLAWQL_GITHUB_TOKEN` | GitHub PAT / fine-grained token for **`execute`** when the operation is from the **github** spec (or `CLAWQL_PROVIDER=github`). Also accepts **`GITHUB_TOKEN`** / **`GH_TOKEN`**. |
@@ -401,7 +401,7 @@ See `.env.example` for a full list.
 
 Set **`CLAWQL_OBSIDIAN_VAULT_PATH`** when you mount a directory for **Obsidian**-compatible Markdown (e.g. alongside **[ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)** or **`memory_ingest` / `memory_recall`**). If unset or empty, no vault check runs. If set, startup fails fast when the path is missing, not a directory, or not readable/writable. Implementation helpers live in **`src/vault-config.ts`** and **`src/vault-utils.ts`** (safe paths + cooperative write lock under the vault root).
 
-**Concepts (why a vault):** Long-running agents often avoid *only* stuffing context with retrieved chunks. A complementary pattern—sometimes called **Karpathy-style** or an **“LLM wiki”**—is to **compile** durable notes as Markdown on disk and **link** them with **`[[wikilinks]]`**, so memory **compounds** across sessions. **Obsidian** is a common viewer (plain files, graph + backlinks); the agent writes; humans browse and edit. That pattern is sketched in [Karpathy’s `llm-wiki` gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f). ClawQL’s **`memory_ingest`** writes under **`ClawQL/Memory/`** when the vault path is set. See **[`docs/memory-obsidian.md`](docs/memory-obsidian.md)** for a fuller background.
+**Concepts (why a vault):** Long-running agents often avoid *only* stuffing context with retrieved chunks. A complementary pattern—sometimes called **Karpathy-style** or an **“LLM wiki”**—is to **compile** durable notes as Markdown on disk and **link** them with **`[[wikilinks]]`**, so memory **compounds** across sessions. **Obsidian** is a common viewer (plain files, graph + backlinks); the agent writes; humans browse and edit. That pattern is sketched in [Karpathy’s `llm-wiki` gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f). ClawQL’s **`memory_ingest`** writes under **`Memory/`** when the vault path is set. See **[`docs/memory-obsidian.md`](docs/memory-obsidian.md)** for a fuller background.
 
 **Large / vendor OpenAPI docs:** The design goal is **the full spec** — token
 efficiency comes from **search + selective `execute`**, not from trimming the
@@ -484,7 +484,7 @@ In multi-spec mode, ClawQL keeps one merged operation index for discovery and ex
 | `search` | Search the active OpenAPI/Discovery spec by natural language intent |
 | `execute` | Run a discovered operation by `operationId`, with optional GraphQL field selection |
 | `sandbox_exec` | Remote sandbox: pass **`code`** (source) + **`language`**; not your local shell |
-| `memory_ingest` | Compile insights / tool output / conversation into Obsidian notes (`ClawQL/Memory/…`) when the vault path is set — see [`docs/memory-obsidian.md`](docs/memory-obsidian.md) |
+| `memory_ingest` | Compile insights / tool output / conversation into Obsidian notes (`Memory/…`) when the vault path is set — see [`docs/memory-obsidian.md`](docs/memory-obsidian.md) |
 | `memory_recall` | Keyword search over vault Markdown plus `[[wikilinks]]` hops (no embeddings; tunable via `CLAWQL_MEMORY_RECALL_*`) |
 
 ### Agent workflow example

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -7,7 +7,7 @@ ClawQL exposes **five** tools over MCP (stdio or Streamable HTTP). The **core** 
 | `search` | Loaded spec | Rank operations by natural-language intent |
 | `execute` | GraphQL proxy (`GRAPHQL_URL`) for single-spec; REST in multi-spec | Run one operation with lean responses |
 | `sandbox_exec` | `CLAWQL_SANDBOX_BRIDGE_URL` + token | Run a snippet in a remote Cloudflare Sandbox via Worker bridge (not local execution) |
-| `memory_ingest` | `CLAWQL_OBSIDIAN_VAULT_PATH` | Write Obsidian Markdown under `ClawQL/Memory/`; refreshes **`memory.db`** (see **[memory-db-schema.md](memory-db-schema.md)**) when enabled |
+| `memory_ingest` | `CLAWQL_OBSIDIAN_VAULT_PATH` | Write Obsidian Markdown under `Memory/`; refreshes **`memory.db`** (see **[memory-db-schema.md](memory-db-schema.md)**) when enabled |
 | `memory_recall` | `CLAWQL_OBSIDIAN_VAULT_PATH` | Keyword search + `[[wikilink]]` hops; optionally merges edges from **`memory.db`** and can resync the DB when **`CLAWQL_MEMORY_DB_SYNC_ON_RECALL=1`** |
 
 See also: **[memory-obsidian.md](memory-obsidian.md)** (vault concepts), **[memory-db-schema.md](memory-db-schema.md)** (SQLite sidecar), **[README](../README.md)** (install, env tables), **[cloudflare/sandbox-bridge/README.md](../cloudflare/sandbox-bridge/README.md)** (Worker deploy).
@@ -88,7 +88,7 @@ Runs a snippet in an isolated **Cloudflare Sandbox** through a **Worker** you de
 }
 ```
 
-Writes **`ClawQL/Memory/<slug>.md`** with YAML frontmatter and optional `[[wikilinks]]`. Duplicate payloads (same content hash) are skipped when appending.
+Writes **`Memory/<slug>.md`** with YAML frontmatter and optional `[[wikilinks]]`. Duplicate payloads (same content hash) are skipped when appending.
 
 ---
 

--- a/docs/memory-db-hybrid-implementation.md
+++ b/docs/memory-db-hybrid-implementation.md
@@ -44,7 +44,7 @@ flowchart LR
   MR --> MD
 ```
 
-- **`memory_ingest`** writes or appends Markdown under `ClawQL/Memory/` (unchanged contract). After a **successful, non-skipped** write, it triggers a **full rescan** of the same subtree `memory_recall` uses and **rebuilds** rows in `memory.db` for every Markdown file in that scan.
+- **`memory_ingest`** writes or appends Markdown under `Memory/` (unchanged contract). After a **successful, non-skipped** write, it triggers a **full rescan** of the same subtree `memory_recall` uses and **rebuilds** rows in `memory.db` for every Markdown file in that scan.
 - **`memory_recall`** still scores keywords and walks wikilinks **from parsed file contents**. Additionally, when the DB feature is enabled, it **merges** edges read from **`wikilink_edge`** into the adjacency structure so recall can benefit from **persisted** link rows (e.g. after ingest) even before vectors exist.
 
 ---
@@ -105,7 +105,7 @@ Implemented as **`vaultChunkId()`** so re-ingest replaces the same logical chunk
 | **`src/memory-recall.ts`** | Uses slug index + vault markdown helpers; optional **`syncMemoryDbFromDocuments`** when **`CLAWQL_MEMORY_DB_SYNC_ON_RECALL=1`**; merges DB edges when DB enabled. Re-exports **`extractWikilinkTargets`** for compatibility. |
 | **`src/memory-ingest.ts`** | After vault lock completes successfully, **`await import("./memory-db.js")`** then **`syncMemoryDbForVaultScanRoot`** — **dynamic import** avoids a static circular dependency (`memory-db` imports `slugifyTitle` from `memory-ingest`). |
 | **`src/memory-db.test.ts`**, **`src/memory-chunk.test.ts`** | Contract + persistence tests. |
-| **`src/memory-ingest.test.ts`** | Asserts **`.clawql/memory.db`** exists after ingest. |
+| **`src/memory-ingest.test.ts`** | Asserts **`memory.db`** exists after ingest. |
 
 ---
 
@@ -115,7 +115,7 @@ Implemented as **`vaultChunkId()`** so re-ingest replaces the same logical chunk
 |----------|---------------------|
 | **`CLAWQL_OBSIDIAN_VAULT_PATH`** | Required for any vault or DB behavior (unchanged). |
 | **`CLAWQL_MEMORY_DB`** | Set **`0`** to disable DB sync on ingest, DB merge on recall, and DB refresh on recall. |
-| **`CLAWQL_MEMORY_DB_PATH`** | Relative path is resolved **under the vault** via `resolveVaultPath` (no `..`). Default **`.clawql/memory.db`**. Absolute paths allowed for custom mount layouts. |
+| **`CLAWQL_MEMORY_DB_PATH`** | Relative path is resolved **under the vault** via `resolveVaultPath` (no `..`). Default **`memory.db`**. Absolute paths allowed for custom mount layouts. |
 | **`CLAWQL_MEMORY_DB_SYNC_ON_RECALL`** | Set **`1`** to run **`syncMemoryDbFromDocuments`** with the same file set recall just read (full sql.js **export** each time — heavier). Default **unset / off**. |
 | **`CLAWQL_MEMORY_CHUNK_MAX_CHARS`** | Paragraph window size before hard-split (`2000`). |
 | **`CLAWQL_MEMORY_RECALL_SCAN_ROOT`**, **`CLAWQL_MEMORY_RECALL_MAX_FILES`** | Define which files participate in both recall and **ingest-triggered full rescan**. |

--- a/docs/memory-db-schema.md
+++ b/docs/memory-db-schema.md
@@ -1,6 +1,6 @@
 # `memory.db` schema (hybrid memory, issue #27)
 
-ClawQL stores a **file-backed SQLite** database beside the Obsidian vault (default **`.clawql/memory.db`**) to back the hybrid memory track: **structured rows** today (documents, paragraph chunks, wikilink edges), and **vector columns** reserved for sqlite-vec / embeddings in later issues.
+ClawQL stores a **file-backed SQLite** database beside the Obsidian vault (default **`memory.db`**) to back the hybrid memory track: **structured rows** today (documents, paragraph chunks, wikilink edges), and **vector columns** reserved for sqlite-vec / embeddings in later issues.
 
 **Implementation narrative (modules, flows, migrations, tests):** **[memory-db-hybrid-implementation.md](memory-db-hybrid-implementation.md)**.
 
@@ -11,7 +11,7 @@ The vault Markdown files remain the **source of truth**; the DB is a **derived i
 | Env | Meaning |
 |-----|---------|
 | `CLAWQL_OBSIDIAN_VAULT_PATH` | Required for any memory DB work (same as `memory_*` tools). |
-| `CLAWQL_MEMORY_DB_PATH` | Optional. **Unset:** `.clawql/memory.db` under the vault. **Absolute path:** use that file instead. |
+| `CLAWQL_MEMORY_DB_PATH` | Optional. **Unset:** `memory.db` under the vault. **Absolute path:** use that file instead. |
 | `CLAWQL_MEMORY_DB=0` | Disable all DB open / sync / merge (lexical recall only). |
 
 ## Migrations
@@ -26,7 +26,7 @@ One row per indexed Markdown path (vault-relative, `/` separators).
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `path` | TEXT PK | Vault-relative path, e.g. `ClawQL/Memory/foo.md`. |
+| `path` | TEXT PK | Vault-relative path, e.g. `Memory/foo.md`. |
 | `title` | TEXT | Display title from frontmatter / first `#` heading / filename slug. |
 | `body_sha256` | TEXT | SHA-256 of the **full file** UTF-8 bytes. |
 | `byte_length` | INTEGER | `Buffer.byteLength` of the file. |

--- a/docs/memory-obsidian.md
+++ b/docs/memory-obsidian.md
@@ -21,7 +21,7 @@ ClawQL does not require Obsidian; any editor works. Obsidian is the usual refere
 ## How ClawQL fits in
 
 - **`CLAWQL_OBSIDIAN_VAULT_PATH`** points the MCP server at a vault directory (validated at startup when set).
-- **`memory_ingest`** writes structured notes under **`ClawQL/Memory/`** (see `src/memory-ingest.ts`), with YAML frontmatter and optional **`[[wikilinks]]`** to other pages.
+- **`memory_ingest`** writes structured notes under **`Memory/`** (see `src/memory-ingest.ts`), with YAML frontmatter and optional **`[[wikilinks]]`** to other pages.
 - **`memory_recall`** (`src/memory-recall.ts`) does **keyword scoring** over Markdown (plus headings / filenames) and **walks the wikilink graph** (forward + backward) up to a configurable depth. It does **not** load embedding models—tuned for low latency in agent loops. Tune defaults with **`CLAWQL_MEMORY_RECALL_*`** env vars (see README).
 
 The design stays **lightweight**: the vault remains the source of truth; retrieval is “good enough” lexical + graph context rather than semantic vectors in-process.

--- a/src/memory-db.test.ts
+++ b/src/memory-db.test.ts
@@ -31,7 +31,7 @@ describe("memory-db", () => {
 
   it("resolveMemoryDatabasePath defaults under the vault", () => {
     expect(resolveMemoryDatabasePath(dir).startsWith(dir)).toBe(true);
-    expect(resolveMemoryDatabasePath(dir)).toMatch(/\.clawql[/\\]memory\.db$/);
+    expect(resolveMemoryDatabasePath(dir)).toMatch(/memory\.db$/);
   });
 
   it("syncMemoryDbFromDocuments writes chunks and wikilink edges", async () => {

--- a/src/memory-db.ts
+++ b/src/memory-db.ts
@@ -34,13 +34,13 @@ async function loadSqlJs(): Promise<ReturnType<typeof initSqlJs>> {
   return sqlJsPromise;
 }
 
-/** When unset or relative, DB lives under the vault (default `.clawql/memory.db`). */
+/** When unset or relative, DB lives under the vault (default `memory.db`). */
 export function resolveMemoryDatabasePath(vaultRoot: string): string {
   const raw = process.env.CLAWQL_MEMORY_DB_PATH?.trim();
   if (raw && isAbsolute(raw)) {
     return raw;
   }
-  const rel = (raw || ".clawql/memory.db").replace(/\\/g, "/").replace(/^\/+/, "");
+  const rel = (raw || "memory.db").replace(/\\/g, "/").replace(/^\/+/, "");
   return resolveVaultPath(vaultRoot, rel);
 }
 
@@ -167,7 +167,7 @@ async function persistDb(db: Database, absDbPath: string): Promise<void> {
 
 function defaultScanRoot(): string {
   const v = process.env.CLAWQL_MEMORY_RECALL_SCAN_ROOT;
-  if (v === undefined) return "ClawQL/Memory";
+  if (v === undefined) return "Memory";
   const t = v.trim();
   return t === "" ? "" : t;
 }

--- a/src/memory-ingest.test.ts
+++ b/src/memory-ingest.test.ts
@@ -30,15 +30,15 @@ describe("memory-ingest", () => {
     expect(slugifyTitle("!!!")).toBe("note");
   });
 
-  it("runMemoryIngest writes Obsidian markdown under ClawQL/Memory", async () => {
+  it("runMemoryIngest writes Obsidian markdown under Memory", async () => {
     const r = await runMemoryIngest({
       title: "Test Note",
       insights: "Learned something.",
       wikilinks: ["Other"],
     });
     expect(r.ok).toBe(true);
-    expect(r.path).toBe("ClawQL/Memory/test-note.md");
-    const text = await readFile(join(dir, "ClawQL", "Memory", "test-note.md"), "utf8");
+    expect(r.path).toBe("Memory/test-note.md");
+    const text = await readFile(join(dir, "Memory", "test-note.md"), "utf8");
     expect(text).toContain("clawql_ingest: true");
     expect(text).toContain("# Test Note");
     expect(text).toContain("[[Other]]");
@@ -59,7 +59,7 @@ describe("memory-ingest", () => {
     await runMemoryIngest({ title: "Multi", insights: "one" });
     const r = await runMemoryIngest({ title: "Multi", insights: "two" });
     expect(r.skipped).toBeUndefined();
-    const text = await readFile(join(dir, "ClawQL", "Memory", "multi.md"), "utf8");
+    const text = await readFile(join(dir, "Memory", "multi.md"), "utf8");
     expect(text).toContain("one");
     expect(text).toContain("two");
     const hashes = extractIngestHashes(text);
@@ -76,6 +76,6 @@ describe("memory-ingest", () => {
   it("writes memory.db under the vault after successful ingest", async () => {
     const r = await runMemoryIngest({ title: "Indexed", insights: "hello" });
     expect(r.ok).toBe(true);
-    await access(join(dir, ".clawql", "memory.db"), constants.R_OK);
+    await access(join(dir, "memory.db"), constants.R_OK);
   });
 });

--- a/src/memory-ingest.ts
+++ b/src/memory-ingest.ts
@@ -10,7 +10,7 @@ import {
   writeVaultTextFileAtomic,
 } from "./vault-utils.js";
 
-const MEMORY_DIR = "ClawQL/Memory";
+const MEMORY_DIR = "Memory";
 
 export type MemoryIngestInput = {
   title: string;

--- a/src/memory-recall.test.ts
+++ b/src/memory-recall.test.ts
@@ -28,9 +28,9 @@ describe("memory-recall vault", () => {
   beforeEach(async () => {
     dir = await mkdtemp(join(tmpdir(), "clawql-vault-"));
     process.env.CLAWQL_OBSIDIAN_VAULT_PATH = dir;
-    await mkdir(join(dir, "ClawQL", "Memory"), { recursive: true });
+    await mkdir(join(dir, "Memory"), { recursive: true });
     await writeFile(
-      join(dir, "ClawQL/Memory/alpha.md"),
+      join(dir, "Memory/alpha.md"),
       [
         "---",
         'title: "Alpha"',
@@ -46,7 +46,7 @@ describe("memory-recall vault", () => {
       "utf8"
     );
     await writeFile(
-      join(dir, "ClawQL/Memory/beta-page.md"),
+      join(dir, "Memory/beta-page.md"),
       ["---", 'title: "Beta"', "---", "", "# Beta Page", "", "Secondary note body.", ""].join(
         "\n"
       ),

--- a/src/memory-recall.ts
+++ b/src/memory-recall.ts
@@ -102,7 +102,7 @@ function buildSnippet(text: string, query: string, maxLen: number): string {
 
 function defaultScanRoot(): string {
   const v = process.env.CLAWQL_MEMORY_RECALL_SCAN_ROOT;
-  if (v === undefined) return "ClawQL/Memory";
+  if (v === undefined) return "Memory";
   const t = v.trim();
   return t === "" ? "" : t;
 }

--- a/src/tools-handlers.test.ts
+++ b/src/tools-handlers.test.ts
@@ -203,7 +203,7 @@ describe("optional tool handlers (MCP content shape)", () => {
       expect(out.content[0].type).toBe("text");
       const parsed = JSON.parse(out.content[0].text) as { ok: boolean; path?: string };
       expect(parsed.ok).toBe(true);
-      expect(parsed.path).toBe("ClawQL/Memory/handler-note.md");
+      expect(parsed.path).toBe("Memory/handler-note.md");
     });
 
     it("returns ok false when vault is not configured", async () => {
@@ -222,13 +222,13 @@ describe("optional tool handlers (MCP content shape)", () => {
     beforeEach(async () => {
       dir = await mkdtemp(join(tmpdir(), "clawql-vault-"));
       process.env.CLAWQL_OBSIDIAN_VAULT_PATH = dir;
-      await mkdir(join(dir, "ClawQL", "Memory"), { recursive: true });
+      await mkdir(join(dir, "Memory"), { recursive: true });
       await writeFile(
-        join(dir, "ClawQL/Memory/note-a.md"),
+        join(dir, "Memory/note-a.md"),
         ["# A", "", "keyword match pat rotation [[Note B]]", ""].join("\n"),
         "utf8"
       );
-      await writeFile(join(dir, "ClawQL/Memory/note-b.md"), ["# B", "", "body b", ""].join("\n"), "utf8");
+      await writeFile(join(dir, "Memory/note-b.md"), ["# B", "", "body b", ""].join("\n"), "utf8");
     });
 
     afterEach(async () => {


### PR DESCRIPTION
## Summary
- Default `memory_ingest` output directory to `Memory/` (was `ClawQL/Memory/`).
- Default `memory.db` location to `memory.db` at the vault root (was `.clawql/memory.db`).
- Update docs + tests to match.

## Test plan
- `npm test`