### PR TITLE
chore(deps): consolidate Dependabot upgrades (ESLint 10, TS 6, Zod 4, Express 5, Actions)

### DIFF
--- a/.github/workflows/audit-scheduled.yml
+++ b/.github/workflows/audit-scheduled.yml
@@ -14,9 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      # actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      # actions/setup-node@v6.3.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      # actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      # actions/setup-node@v6.3.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: "22"
           cache: npm
@@ -61,7 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      # actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install ShellCheck
         run: |
@@ -84,9 +87,11 @@ jobs:
       matrix:
         node-version: [20, 22, 24]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      # actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      # actions/setup-node@v6.3.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,14 +25,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      # v4.2.2
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      # actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      # v3 → commit ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a
-      - uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a
+      # github/codeql-action@v4.35.2
+      - uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
         with:
           languages: javascript-typescript
 
-      - uses: github/codeql-action/autobuild@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a
+      - uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
 
-      - uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a
+      - uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ From there: custom spec via `CLAWQL_SPEC_PATH` / `CLAWQL_SPEC_URL`, or read [Con
 
 - **Install:** `npm install clawql-mcp` — full [Install](#install-npm--yarn--bun) notes (binaries, `npx`, **~90 MB** on disk).
 - **Run** (no global install). **Pick one** spec source:
-
   1. **Bundled specs** — nothing to download; uses pre-shipped `providers/` in the package (**`CLAWQL_PROVIDER=all-providers`** = every bundled vendor):
 
      ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
             "version": "3.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@graphql-mesh/utils": "^0.104.29",
+                "@graphql-mesh/utils": "^0.104.35",
                 "@modelcontextprotocol/sdk": "^1.27.1",
                 "@omnigraph/openapi": "^0.109.41",
-                "express": "^4.18.2",
+                "express": "^5.2.1",
                 "graphql": "^16.8.1",
                 "graphql-http": "^1.22.0",
                 "node-fetch": "^3.3.2",
@@ -20,23 +20,23 @@
                 "sql.js": "^1.14.1",
                 "swagger2openapi": "^7.0.8",
                 "yaml": "^2.8.2",
-                "zod": "^3.22.4"
+                "zod": "^4.3.6"
             },
             "bin": {
                 "clawql-mcp": "bin/clawql-mcp.mjs",
                 "clawql-mcp-http": "bin/clawql-mcp-http.mjs"
             },
             "devDependencies": {
-                "@eslint/js": "^9.39.4",
-                "@types/express": "^4.17.21",
-                "@types/node": "^20.0.0",
+                "@eslint/js": "^10.0.1",
+                "@types/express": "^5.0.0",
+                "@types/node": "^22.0.0",
                 "@types/pg": "^8.20.0",
                 "@types/sql.js": "^1.4.11",
                 "@vitest/coverage-v8": "^4.1.1",
-                "eslint": "^9.39.4",
-                "prettier": "^3.4.2",
+                "eslint": "^10.2.0",
+                "prettier": "^3.8.3",
                 "tsx": "^4.7.0",
-                "typescript": "^5.3.0",
+                "typescript": "^6.0.2",
                 "typescript-eslint": "^8.58.2",
                 "vitest": "^4.1.1"
             },
@@ -662,241 +662,89 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.21.2",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-            "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+            "version": "0.23.5",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+            "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/object-schema": "^2.1.7",
+                "@eslint/object-schema": "^3.0.5",
                 "debug": "^4.3.1",
-                "minimatch": "^3.1.5"
+                "minimatch": "^10.2.4"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             }
-        },
-        "node_modules/@eslint/config-array/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/@eslint/config-array/node_modules/debug": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@eslint/config-array/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/@eslint/config-array/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-            "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+            "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^0.17.0"
+                "@eslint/core": "^1.2.1"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-            "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+            "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@types/json-schema": "^7.0.15"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
-        "node_modules/@eslint/eslintrc": {
-            "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-            "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+        "node_modules/@eslint/js": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+            "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "ajv": "^6.14.0",
-                "debug": "^4.3.2",
-                "espree": "^10.0.1",
-                "globals": "^14.0.0",
-                "ignore": "^5.2.0",
-                "import-fresh": "^3.2.1",
-                "js-yaml": "^4.1.1",
-                "minimatch": "^3.1.5",
-                "strip-json-comments": "^3.1.1"
-            },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             },
             "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/@eslint/eslintrc/node_modules/ajv": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
+                "url": "https://eslint.org/donate"
             },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/@eslint/eslintrc/node_modules/debug": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
+            "peerDependencies": {
+                "eslint": "^10.0.0"
             },
             "peerDependenciesMeta": {
-                "supports-color": {
+                "eslint": {
                     "optional": true
                 }
             }
         },
-        "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/@eslint/eslintrc/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@eslint/js": {
-            "version": "9.39.4",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-            "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "url": "https://eslint.org/donate"
-            }
-        },
         "node_modules/@eslint/object-schema": {
-            "version": "2.1.7",
-            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-            "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+            "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-            "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+            "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^0.17.0",
+                "@eslint/core": "^1.2.1",
                 "levn": "^0.4.1"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
         "node_modules/@exodus/schemasafe": {
@@ -1474,224 +1322,6 @@
                 }
             }
         },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
-            "version": "5.2.1",
-            "license": "MIT",
-            "dependencies": {
-                "accepts": "^2.0.0",
-                "body-parser": "^2.2.1",
-                "content-disposition": "^1.0.0",
-                "content-type": "^1.0.5",
-                "cookie": "^0.7.1",
-                "cookie-signature": "^1.2.1",
-                "debug": "^4.4.0",
-                "depd": "^2.0.0",
-                "encodeurl": "^2.0.0",
-                "escape-html": "^1.0.3",
-                "etag": "^1.8.1",
-                "finalhandler": "^2.1.0",
-                "fresh": "^2.0.0",
-                "http-errors": "^2.0.0",
-                "merge-descriptors": "^2.0.0",
-                "mime-types": "^3.0.0",
-                "on-finished": "^2.4.1",
-                "once": "^1.4.0",
-                "parseurl": "^1.3.3",
-                "proxy-addr": "^2.0.7",
-                "qs": "^6.14.0",
-                "range-parser": "^1.2.1",
-                "router": "^2.2.0",
-                "send": "^1.1.0",
-                "serve-static": "^2.2.0",
-                "statuses": "^2.0.1",
-                "type-is": "^2.0.1",
-                "vary": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 18"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/accepts": {
-            "version": "2.0.0",
-            "license": "MIT",
-            "dependencies": {
-                "mime-types": "^3.0.0",
-                "negotiator": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/accepts/node_modules/negotiator": {
-            "version": "1.0.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/body-parser": {
-            "version": "2.2.2",
-            "license": "MIT",
-            "dependencies": {
-                "bytes": "^3.1.2",
-                "content-type": "^1.0.5",
-                "debug": "^4.4.3",
-                "http-errors": "^2.0.0",
-                "iconv-lite": "^0.7.0",
-                "on-finished": "^2.4.1",
-                "qs": "^6.14.1",
-                "raw-body": "^3.0.1",
-                "type-is": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/content-disposition": {
-            "version": "1.0.1",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/cookie-signature": {
-            "version": "1.2.2",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.6.0"
-            }
-        },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/debug": {
-            "version": "4.4.3",
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/debug/node_modules/ms": {
-            "version": "2.1.3",
-            "license": "MIT"
-        },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/finalhandler": {
-            "version": "2.1.1",
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.4.0",
-                "encodeurl": "^2.0.0",
-                "escape-html": "^1.0.3",
-                "on-finished": "^2.4.1",
-                "parseurl": "^1.3.3",
-                "statuses": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/fresh": {
-            "version": "2.0.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/merge-descriptors": {
-            "version": "2.0.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/send": {
-            "version": "1.2.1",
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.4.3",
-                "encodeurl": "^2.0.0",
-                "escape-html": "^1.0.3",
-                "etag": "^1.8.1",
-                "fresh": "^2.0.0",
-                "http-errors": "^2.0.1",
-                "mime-types": "^3.0.2",
-                "ms": "^2.1.3",
-                "on-finished": "^2.4.1",
-                "range-parser": "^1.2.1",
-                "statuses": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 18"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/send/node_modules/ms": {
-            "version": "2.1.3",
-            "license": "MIT"
-        },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/serve-static": {
-            "version": "2.2.1",
-            "license": "MIT",
-            "dependencies": {
-                "encodeurl": "^2.0.0",
-                "escape-html": "^1.0.3",
-                "parseurl": "^1.3.3",
-                "send": "^1.2.0"
-            },
-            "engines": {
-                "node": ">= 18"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/type-is": {
-            "version": "2.0.1",
-            "license": "MIT",
-            "dependencies": {
-                "content-type": "^1.0.5",
-                "media-typer": "^1.1.0",
-                "mime-types": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/type-is/node_modules/media-typer": {
-            "version": "1.1.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/@napi-rs/wasm-runtime": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -2092,29 +1722,6 @@
                 "graphql": "^16.0.0"
             }
         },
-        "node_modules/@theguild/federation-composition/node_modules/debug": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@theguild/federation-composition/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "license": "MIT"
-        },
         "node_modules/@tybys/wasm-util": {
             "version": "0.10.1",
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2168,6 +1775,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/esrecurse": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+            "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2176,18 +1790,21 @@
             "license": "MIT"
         },
         "node_modules/@types/express": {
-            "version": "4.17.25",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+            "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/body-parser": "*",
-                "@types/express-serve-static-core": "^4.17.33",
-                "@types/qs": "*",
-                "@types/serve-static": "^1"
+                "@types/express-serve-static-core": "^5.0.0",
+                "@types/serve-static": "^2"
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "4.19.8",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+            "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2199,6 +1816,8 @@
         },
         "node_modules/@types/http-errors": {
             "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+            "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
             "dev": true,
             "license": "MIT"
         },
@@ -2209,13 +1828,10 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/mime": {
-            "version": "1.3.5",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/node": {
-            "version": "20.19.37",
+            "version": "22.19.17",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+            "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2236,31 +1852,37 @@
         },
         "node_modules/@types/qs": {
             "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+            "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/range-parser": {
             "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/send": {
-            "version": "0.17.6",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/mime": "^1",
                 "@types/node": "*"
             }
         },
         "node_modules/@types/serve-static": {
-            "version": "1.15.10",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+            "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/http-errors": "*",
-                "@types/node": "*",
-                "@types/send": "<1"
+                "@types/node": "*"
             }
         },
         "node_modules/@types/sql.js": {
@@ -2338,31 +1960,6 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@typescript-eslint/parser/node_modules/debug": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@typescript-eslint/project-service": {
             "version": "8.58.2",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
@@ -2384,31 +1981,6 @@
             "peerDependencies": {
                 "typescript": ">=4.8.4 <6.1.0"
             }
-        },
-        "node_modules/@typescript-eslint/project-service/node_modules/debug": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/project-service/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@typescript-eslint/scope-manager": {
             "version": "8.58.2",
@@ -2470,31 +2042,6 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/type-utils/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@typescript-eslint/types": {
             "version": "8.58.2",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
@@ -2537,31 +2084,6 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@typescript-eslint/utils": {
             "version": "8.58.2",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
@@ -2602,19 +2124,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/@vitest/coverage-v8": {
@@ -2815,29 +2324,14 @@
             }
         },
         "node_modules/accepts": {
-            "version": "1.3.8",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
             "license": "MIT",
             "dependencies": {
-                "mime-types": "~2.1.34",
-                "negotiator": "0.6.3"
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
             },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/accepts/node_modules/mime-types": {
-            "version": "2.1.35",
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/accepts/node_modules/mime-types/node_modules/mime-db": {
-            "version": "1.52.0",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -2920,10 +2414,6 @@
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "license": "Python-2.0"
         },
-        "node_modules/array-flatten": {
-            "version": "1.1.1",
-            "license": "MIT"
-        },
         "node_modules/assertion-error": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2956,48 +2446,27 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "1.20.4",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
             "license": "MIT",
             "dependencies": {
-                "bytes": "~3.1.2",
-                "content-type": "~1.0.5",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "~1.2.0",
-                "http-errors": "~2.0.1",
-                "iconv-lite": "~0.4.24",
-                "on-finished": "~2.4.1",
-                "qs": "~6.14.0",
-                "raw-body": "~2.5.3",
-                "type-is": "~1.6.18",
-                "unpipe": "~1.0.0"
+                "bytes": "^3.1.2",
+                "content-type": "^1.0.5",
+                "debug": "^4.4.3",
+                "http-errors": "^2.0.0",
+                "iconv-lite": "^0.7.0",
+                "on-finished": "^2.4.1",
+                "qs": "^6.14.1",
+                "raw-body": "^3.0.1",
+                "type-is": "^2.0.1"
             },
             "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
-        "node_modules/body-parser/node_modules/iconv-lite": {
-            "version": "0.4.24",
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3"
+                "node": ">=18"
             },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/body-parser/node_modules/raw-body": {
-            "version": "2.5.3",
-            "license": "MIT",
-            "dependencies": {
-                "bytes": "~3.1.2",
-                "http-errors": "~2.0.1",
-                "iconv-lite": "~0.4.24",
-                "unpipe": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/brace-expansion": {
@@ -3048,16 +2517,6 @@
             "version": "1.0.2",
             "license": "MIT"
         },
-        "node_modules/callsites": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/camel-case": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
@@ -3087,23 +2546,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/change-case": {
@@ -3152,13 +2594,6 @@
             "version": "1.1.4",
             "license": "MIT"
         },
-        "node_modules/concat-map": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/constant-case": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
@@ -3171,13 +2606,16 @@
             }
         },
         "node_modules/content-disposition": {
-            "version": "0.5.4",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+            "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
             "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "5.2.1"
-            },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/content-type": {
@@ -3202,8 +2640,13 @@
             }
         },
         "node_modules/cookie-signature": {
-            "version": "1.0.7",
-            "license": "MIT"
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.6.0"
+            }
         },
         "node_modules/cors": {
             "version": "2.8.6",
@@ -3264,10 +2707,20 @@
             "license": "MIT"
         },
         "node_modules/debug": {
-            "version": "2.6.9",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "license": "MIT",
             "dependencies": {
-                "ms": "2.0.0"
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
         },
         "node_modules/deep-is": {
@@ -3282,14 +2735,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/destroy": {
-            "version": "1.2.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
             }
         },
         "node_modules/detect-libc": {
@@ -3448,33 +2893,30 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.39.4",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-            "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
+            "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
-                "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.21.2",
-                "@eslint/config-helpers": "^0.4.2",
-                "@eslint/core": "^0.17.0",
-                "@eslint/eslintrc": "^3.3.5",
-                "@eslint/js": "9.39.4",
-                "@eslint/plugin-kit": "^0.4.1",
+                "@eslint-community/regexpp": "^4.12.2",
+                "@eslint/config-array": "^0.23.4",
+                "@eslint/config-helpers": "^0.5.4",
+                "@eslint/core": "^1.2.0",
+                "@eslint/plugin-kit": "^0.7.0",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
                 "@types/estree": "^1.0.6",
                 "ajv": "^6.14.0",
-                "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.6",
                 "debug": "^4.3.2",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^8.4.0",
-                "eslint-visitor-keys": "^4.2.1",
-                "espree": "^10.4.0",
-                "esquery": "^1.5.0",
+                "eslint-scope": "^9.1.2",
+                "eslint-visitor-keys": "^5.0.1",
+                "espree": "^11.2.0",
+                "esquery": "^1.7.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^8.0.0",
@@ -3484,8 +2926,7 @@
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
-                "lodash.merge": "^4.6.2",
-                "minimatch": "^3.1.5",
+                "minimatch": "^10.2.4",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.3"
             },
@@ -3493,7 +2934,7 @@
                 "eslint": "bin/eslint.js"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             },
             "funding": {
                 "url": "https://eslint.org/donate"
@@ -3508,30 +2949,32 @@
             }
         },
         "node_modules/eslint-scope": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-            "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+            "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
+                "@types/esrecurse": "^4.3.1",
+                "@types/estree": "^1.0.8",
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/eslint-visitor-keys": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
@@ -3554,42 +2997,6 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/eslint/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/eslint/node_modules/debug": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/eslint/node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3597,39 +3004,19 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/eslint/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/eslint/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/espree": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+            "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "acorn": "^8.15.0",
+                "acorn": "^8.16.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^4.2.1"
+                "eslint-visitor-keys": "^5.0.1"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
@@ -3726,43 +3113,42 @@
             }
         },
         "node_modules/express": {
-            "version": "4.22.1",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "license": "MIT",
             "dependencies": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "~1.20.3",
-                "content-disposition": "~0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "~0.7.1",
-                "cookie-signature": "~1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "~1.3.1",
-                "fresh": "~0.5.2",
-                "http-errors": "~2.0.0",
-                "merge-descriptors": "1.0.3",
-                "methods": "~1.1.2",
-                "on-finished": "~2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "~0.1.12",
-                "proxy-addr": "~2.0.7",
-                "qs": "~6.14.0",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "~0.19.0",
-                "serve-static": "~1.16.2",
-                "setprototypeof": "1.2.0",
-                "statuses": "~2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
+                "accepts": "^2.0.0",
+                "body-parser": "^2.2.1",
+                "content-disposition": "^1.0.0",
+                "content-type": "^1.0.5",
+                "cookie": "^0.7.1",
+                "cookie-signature": "^1.2.1",
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "finalhandler": "^2.1.0",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "merge-descriptors": "^2.0.0",
+                "mime-types": "^3.0.0",
+                "on-finished": "^2.4.1",
+                "once": "^1.4.0",
+                "parseurl": "^1.3.3",
+                "proxy-addr": "^2.0.7",
+                "qs": "^6.14.0",
+                "range-parser": "^1.2.1",
+                "router": "^2.2.0",
+                "send": "^1.1.0",
+                "serve-static": "^2.2.0",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
             },
             "engines": {
-                "node": ">= 0.10.0"
+                "node": ">= 18"
             },
             "funding": {
                 "type": "opencollective",
@@ -3874,19 +3260,24 @@
             }
         },
         "node_modules/finalhandler": {
-            "version": "1.3.2",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
             "license": "MIT",
             "dependencies": {
-                "debug": "2.6.9",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "on-finished": "~2.4.1",
-                "parseurl": "~1.3.3",
-                "statuses": "~2.0.2",
-                "unpipe": "~1.0.0"
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1"
             },
             "engines": {
-                "node": ">= 0.8"
+                "node": ">= 18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/find-up": {
@@ -3951,10 +3342,12 @@
             }
         },
         "node_modules/fresh": {
-            "version": "0.5.2",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
             "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 0.8"
             }
         },
         "node_modules/fsevents": {
@@ -4038,19 +3431,6 @@
             },
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/globals": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/gopd": {
@@ -4225,23 +3605,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
-            }
-        },
-        "node_modules/import-fresh": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "parent-module": "^1.0.0",
-                "resolve-from": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/imurmurhash": {
@@ -4847,34 +4210,24 @@
             }
         },
         "node_modules/media-typer": {
-            "version": "0.3.0",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
             "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 0.8"
             }
         },
         "node_modules/merge-descriptors": {
-            "version": "1.0.3",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
             "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/methods": {
-            "version": "1.1.2",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/mime": {
-            "version": "1.6.0",
-            "license": "MIT",
-            "bin": {
-                "mime": "cli.js"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/mime-db": {
@@ -4914,7 +4267,9 @@
             }
         },
         "node_modules/ms": {
-            "version": "2.0.0",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
         },
         "node_modules/nanoid": {
@@ -4944,7 +4299,9 @@
             "license": "MIT"
         },
         "node_modules/negotiator": {
-            "version": "0.6.3",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -5208,19 +4565,6 @@
                 "tslib": "^2.0.3"
             }
         },
-        "node_modules/parent-module": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "callsites": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/parseurl": {
             "version": "1.3.3",
             "license": "MIT",
@@ -5270,12 +4614,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/path-to-regexp": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-            "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-            "license": "MIT"
         },
         "node_modules/pathe": {
             "version": "2.0.3",
@@ -5488,9 +4826,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-            "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+            "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -5578,16 +4916,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/resolve-from": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/resolve-pkg-maps": {
             "version": "1.0.0",
             "dev": true,
@@ -5644,25 +4972,6 @@
                 "node": ">= 18"
             }
         },
-        "node_modules/router/node_modules/debug": {
-            "version": "4.4.3",
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/router/node_modules/debug/node_modules/ms": {
-            "version": "2.1.3",
-            "license": "MIT"
-        },
         "node_modules/router/node_modules/path-to-regexp": {
             "version": "8.4.2",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
@@ -5672,24 +4981,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
             }
-        },
-        "node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
@@ -5709,30 +5000,30 @@
             }
         },
         "node_modules/send": {
-            "version": "0.19.2",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
             "license": "MIT",
             "dependencies": {
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "fresh": "~0.5.2",
-                "http-errors": "~2.0.1",
-                "mime": "1.6.0",
-                "ms": "2.1.3",
-                "on-finished": "~2.4.1",
-                "range-parser": "~1.2.1",
-                "statuses": "~2.0.2"
+                "debug": "^4.4.3",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.2"
             },
             "engines": {
-                "node": ">= 0.8.0"
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
-        },
-        "node_modules/send/node_modules/ms": {
-            "version": "2.1.3",
-            "license": "MIT"
         },
         "node_modules/sentence-case": {
             "version": "3.0.4",
@@ -5746,16 +5037,22 @@
             }
         },
         "node_modules/serve-static": {
-            "version": "1.16.3",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
             "license": "MIT",
             "dependencies": {
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.3",
-                "send": "~0.19.1"
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
             },
             "engines": {
-                "node": ">= 0.8.0"
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/setprototypeof": {
@@ -5970,19 +5267,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/strip-json-comments": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6175,35 +5459,23 @@
             }
         },
         "node_modules/type-is": {
-            "version": "1.6.18",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
             "license": "MIT",
             "dependencies": {
-                "media-typer": "0.3.0",
-                "mime-types": "~2.1.24"
+                "content-type": "^1.0.5",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
             },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/type-is/node_modules/mime-types": {
-            "version": "2.1.35",
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/type-is/node_modules/mime-types/node_modules/mime-db": {
-            "version": "1.52.0",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+            "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -6289,13 +5561,6 @@
             "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
             "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
             "license": "MIT"
-        },
-        "node_modules/utils-merge": {
-            "version": "1.0.1",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4.0"
-            }
         },
         "node_modules/vary": {
             "version": "1.1.2",
@@ -6618,7 +5883,9 @@
             }
         },
         "node_modules/zod": {
-            "version": "3.25.76",
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+            "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -90,10 +90,10 @@
         "release:git-backfill-tags:push": "bash scripts/git-backfill-npm-release-tags.sh --push"
     },
     "dependencies": {
-        "@graphql-mesh/utils": "^0.104.29",
+        "@graphql-mesh/utils": "^0.104.35",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@omnigraph/openapi": "^0.109.41",
-        "express": "^4.18.2",
+        "express": "^5.2.1",
         "graphql": "^16.8.1",
         "graphql-http": "^1.22.0",
         "node-fetch": "^3.3.2",
@@ -101,19 +101,19 @@
         "sql.js": "^1.14.1",
         "swagger2openapi": "^7.0.8",
         "yaml": "^2.8.2",
-        "zod": "^3.22.4"
+        "zod": "^4.3.6"
     },
     "devDependencies": {
-        "@eslint/js": "^9.39.4",
-        "@types/express": "^4.17.21",
-        "@types/node": "^20.0.0",
+        "@eslint/js": "^10.0.1",
+        "@types/express": "^5.0.0",
+        "@types/node": "^22.0.0",
         "@types/pg": "^8.20.0",
         "@types/sql.js": "^1.4.11",
         "@vitest/coverage-v8": "^4.1.1",
-        "eslint": "^9.39.4",
-        "prettier": "^3.4.2",
+        "eslint": "^10.2.0",
+        "prettier": "^3.8.3",
         "tsx": "^4.7.0",
-        "typescript": "^5.3.0",
+        "typescript": "^6.0.2",
         "typescript-eslint": "^8.58.2",
         "vitest": "^4.1.1"
     }

--- a/src/memory-ingest.ts
+++ b/src/memory-ingest.ts
@@ -155,7 +155,7 @@ export async function runMemoryIngest(input: MemoryIngestInput): Promise<MemoryI
     try {
       existing = await readVaultTextFile(vault, rel);
     } catch {
-      existing = "";
+      // missing file → keep existing as ""
     }
 
     if (existing && extractIngestHashes(existing).has(hash)) {

--- a/src/spec-loader.ts
+++ b/src/spec-loader.ts
@@ -396,7 +396,8 @@ async function loadRawDocument(source: SpecSource): Promise<unknown> {
         if (bundledOfflineNoRemoteFetch()) {
           throw new Error(
             `Bundled spec file missing: ${abs}. ` +
-              `Run \`npm run fetch-provider-specs\` or clear CLAWQL_BUNDLED_OFFLINE.`
+              `Run \`npm run fetch-provider-specs\` or clear CLAWQL_BUNDLED_OFFLINE.`,
+            { cause: e }
           );
         }
         console.error(
@@ -404,7 +405,9 @@ async function loadRawDocument(source: SpecSource): Promise<unknown> {
         );
         const res = await fetch(source.entry.fallbackUrl);
         if (!res.ok) {
-          throw new Error(`Failed to fetch provider fallback (${source.entry.id}): ${res.status}`);
+          throw new Error(`Failed to fetch provider fallback (${source.entry.id}): ${res.status}`, {
+            cause: e,
+          });
         }
         return parseSpecText(await res.text());
       }
@@ -431,7 +434,8 @@ async function loadRawDocument(source: SpecSource): Promise<unknown> {
         if (bundledOfflineNoRemoteFetch()) {
           throw new Error(
             `Bundled spec file missing: ${abs}. ` +
-              `Run \`npm run fetch-provider-specs\` or clear CLAWQL_BUNDLED_OFFLINE.`
+              `Run \`npm run fetch-provider-specs\` or clear CLAWQL_BUNDLED_OFFLINE.`,
+            { cause: e }
           );
         }
         console.error(
@@ -439,7 +443,9 @@ async function loadRawDocument(source: SpecSource): Promise<unknown> {
         );
         const res = await fetch(entry.fallbackUrl);
         if (!res.ok) {
-          throw new Error(`Failed to fetch provider fallback (${entry.id}): ${res.status}`);
+          throw new Error(`Failed to fetch provider fallback (${entry.id}): ${res.status}`, {
+            cause: e,
+          });
         }
         return parseSpecText(await res.text());
       }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -252,7 +252,7 @@ export function registerTools(server: McpServer) {
             "E.g. 'run.projects.locations.services.list'."
         ),
       args: z
-        .record(z.unknown())
+        .record(z.string(), z.unknown())
         .describe(
           "Key/value map of parameters for the operation (path + query params). " +
             "E.g. { parent: 'projects/my-proj/locations/us-central1', pageSize: 10 }"

--- a/src/vault-config.ts
+++ b/src/vault-config.ts
@@ -37,7 +37,8 @@ export async function validateObsidianVaultAtStartup(): Promise<void> {
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
     throw new Error(
-      `CLAWQL_OBSIDIAN_VAULT_PATH: path does not exist or is inaccessible: ${vault} (${msg})`
+      `CLAWQL_OBSIDIAN_VAULT_PATH: path does not exist or is inaccessible: ${vault} (${msg})`,
+      { cause: e }
     );
   }
   if (!st.isDirectory()) {
@@ -47,7 +48,9 @@ export async function validateObsidianVaultAtStartup(): Promise<void> {
     await access(vault, constants.R_OK | constants.W_OK);
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
-    throw new Error(`CLAWQL_OBSIDIAN_VAULT_PATH: not readable/writable: ${vault} (${msg})`);
+    throw new Error(`CLAWQL_OBSIDIAN_VAULT_PATH: not readable/writable: ${vault} (${msg})`, {
+      cause: e,
+    });
   }
   console.error(`[clawql-mcp] Obsidian vault: ${vault}`);
 }


### PR DESCRIPTION
## Summary
Single PR that supersedes and closes the remaining open Dependabot PRs:

- **#49** `actions/setup-node` (pinned to v6.3.0 SHA)
- **#50** `actions/checkout` (pinned to v6.0.2 SHA)
- **#51** `github/codeql-action` (pinned to v4.35.2 commit SHA)
- **#52** `@types/node` — uses **^22** (LTS typings aligned with CI) instead of 25 to avoid Node-25-only API surface while keeping `engines: ">=20"`
- **#55** `@eslint/js` 10
- **#57** Prettier 3.8.x
- **#60** Zod 4
- **#61** ESLint 10
- **#62** TypeScript 6
- **#64** Express 5 + `@types/express` 5 (matches `@modelcontextprotocol/sdk` dependency on `express@^5.2.1`)

Also bumps `@graphql-mesh/utils` to ^0.104.35 (prior failed merge #54).

### Code changes
- Zod 4: `z.record(z.string(), z.unknown())` for `execute` tool `args`
- ESLint 10: `preserve-caught-error` and `no-useless-assignment` fixes in `spec-loader`, `vault-config`, `memory-ingest`
- Prettier: `README.md` formatting

### After merge
Close the above Dependabot PRs (or comment `@dependabot close`) so they do not rebase forever.

**CI:** wait for green checks before merge per branch protection.