### PR TITLE
fix(ci): Prettier after #73; clarify merge-wait-ci rule

### DIFF
--- a/.cursor/rules/git-pr-merge-wait-ci.mdc
+++ b/.cursor/rules/git-pr-merge-wait-ci.mdc
@@ -9,7 +9,8 @@ When merging pull requests (GitHub / `gh pr merge`):
 
 - **Never** merge immediately after creating a PR or without verifying CI.
 - **Always** wait for required checks to finish and pass before merging.
-- Prefer: `gh pr merge <n> --merge --auto` (GitHub waits for branch protection + green checks).
-- Or: poll `gh pr checks <n>` until all required checks succeed (or stop on failure).
+- **`gh pr merge --auto` is not sufficient by itself:** if the repository does not require specific status checks in branch protection, GitHub may merge **immediately** when you use `--auto`, before workflows finish. **Do not rely on `--auto` alone.**
+- **Before merge, run:** `gh pr checks <n> --watch --fail-fast` and confirm it exits **0** (all checks finished and passed). Alternatively poll `gh pr checks <n> --json` until no check is pending and none failed.
+- **Only then** run `gh pr merge <n> --merge` (merge-after-green). Prefer this sequence over trusting `--auto` unless you have verified branch protection blocks merge until required checks pass.
 
 If branch protection blocks merge until green, do not bypass it. Do not assume checks are optional.

--- a/docs/cursor-vault-memory.md
+++ b/docs/cursor-vault-memory.md
@@ -6,10 +6,10 @@ This document explains how **ClawQL’s Obsidian vault tools** (`memory_ingest`,
 
 ## Prerequisites
 
-| Requirement | Role |
-| ----------- | ---- |
-| **ClawQL MCP** configured in Cursor | The agent can call MCP tools (stdio or HTTP, per your setup). |
-| **`CLAWQL_OBSIDIAN_VAULT_PATH`** | Points the server at a writable vault directory. Without it, vault tools return an error; see **[README.md](../README.md)** and **[memory-obsidian.md](memory-obsidian.md)**. |
+| Requirement                         | Role                                                                                                                                                                          |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ClawQL MCP** configured in Cursor | The agent can call MCP tools (stdio or HTTP, per your setup).                                                                                                                 |
+| **`CLAWQL_OBSIDIAN_VAULT_PATH`**    | Points the server at a writable vault directory. Without it, vault tools return an error; see **[README.md](../README.md)** and **[memory-obsidian.md](memory-obsidian.md)**. |
 
 ---
 
@@ -24,21 +24,21 @@ These tools are **transport-agnostic**: any MCP client can call them. Cursor’s
 
 ### 2. Cursor rule (always on)
 
-| File | Purpose |
-| ---- | ------- |
+| File                                                                                    | Purpose                                                                                                                                                                      |
+| --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **[`.cursor/rules/clawql-vault-memory.mdc`](../.cursor/rules/clawql-vault-memory.mdc)** | **`alwaysApply: true`** — reminds the agent to use **`memory_recall`** early and **`memory_ingest`** after important outcomes, and points to the skill for **deep** ingests. |
 
 Rules live in the repo and apply to chats in this workspace (when Cursor loads project rules).
 
 ### 3. Cursor skill (deep playbook)
 
-| File | Purpose |
-| ---- | ------- |
+| File                                                                                                | Purpose                                                                                                                                                                               |
+| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **[`.cursor/skills/clawql-vault-memory/SKILL.md`](../.cursor/skills/clawql-vault-memory/SKILL.md)** | Skill **`clawql-vault-memory`**: field-by-field tool usage, structured **`insights`** templates, wikilink strategy, **`sessionId`** / **`append`**, recall parameters, anti-patterns. |
 
-Cursor uses the skill’s YAML **`description`** to decide when to attach it; you can also say explicitly: *“use the clawql-vault-memory skill for this ingest.”*
+Cursor uses the skill’s YAML **`description`** to decide when to attach it; you can also say explicitly: _“use the clawql-vault-memory skill for this ingest.”_
 
-**Rule vs skill:** the **rule** establishes the *habit* (recall + ingest). The **skill** holds the *procedure* for thorough notes.
+**Rule vs skill:** the **rule** establishes the _habit_ (recall + ingest). The **skill** holds the _procedure_ for thorough notes.
 
 ---
 
@@ -58,19 +58,19 @@ Cursor uses the skill’s YAML **`description`** to decide when to attach it; yo
 
 ## Related documentation
 
-| Doc | Topic |
-| --- | ----- |
-| **[memory-obsidian.md](memory-obsidian.md)** | Why a vault, `Memory/`, wikilinks, index pages. |
-| **[mcp-tools.md](mcp-tools.md)** | All MCP tools, JSON-shaped examples. |
-| **[memory-db-hybrid-implementation.md](memory-db-hybrid-implementation.md)** | `memory.db`, recall implementation. |
+| Doc                                                                          | Topic                                           |
+| ---------------------------------------------------------------------------- | ----------------------------------------------- |
+| **[memory-obsidian.md](memory-obsidian.md)**                                 | Why a vault, `Memory/`, wikilinks, index pages. |
+| **[mcp-tools.md](mcp-tools.md)**                                             | All MCP tools, JSON-shaped examples.            |
+| **[memory-db-hybrid-implementation.md](memory-db-hybrid-implementation.md)** | `memory.db`, recall implementation.             |
 
 ---
 
 ## Repo file reference
 
-| Path | Type |
-| ---- | ---- |
-| `.cursor/rules/clawql-vault-memory.mdc` | Cursor rule (always apply) |
+| Path                                          | Type                                |
+| --------------------------------------------- | ----------------------------------- |
+| `.cursor/rules/clawql-vault-memory.mdc`       | Cursor rule (always apply)          |
 | `.cursor/skills/clawql-vault-memory/SKILL.md` | Cursor skill (deep ingest + recall) |
-| `src/memory-ingest.ts` | `memory_ingest` implementation |
-| `src/memory-recall.ts` | `memory_recall` implementation |
+| `src/memory-ingest.ts`                        | `memory_ingest` implementation      |
+| `src/memory-recall.ts`                        | `memory_recall` implementation      |

--- a/packages/mcp-grpc-transport/src/mcp-protobuf-service.ts
+++ b/packages/mcp-grpc-transport/src/mcp-protobuf-service.ts
@@ -548,9 +548,7 @@ export function createMcpProtobufServiceImplementation(
             call.write(
               toolResultToCallToolResponse(
                 {
-                  content: [
-                    { type: "text", text: `Error executing tool ${inner.name}: ${msg}` },
-                  ],
+                  content: [{ type: "text", text: `Error executing tool ${inner.name}: ${msg}` }],
                   isError: true,
                 },
                 buildResponseCommon(bridge, undefined)

--- a/packages/mcp-grpc-transport/src/mcp-protobuf-struct.ts
+++ b/packages/mcp-grpc-transport/src/mcp-protobuf-struct.ts
@@ -49,7 +49,11 @@ export function defaultListTtlDuration(): { seconds: number; nanos: number } {
   return { seconds: 3600, nanos: 0 };
 }
 
-function pickValueField<T>(v: Record<string, unknown>, snake: string, camel: string): T | undefined {
+function pickValueField<T>(
+  v: Record<string, unknown>,
+  snake: string,
+  camel: string
+): T | undefined {
   const s = v[snake];
   if (s !== undefined) {
     return s as T;
@@ -78,7 +82,9 @@ export function valueToJson(v: Record<string, unknown> | undefined | null): unkn
   if (bool !== undefined) {
     return bool;
   }
-  const structVal = (v.struct_value ?? v.structValue) as { fields?: Record<string, unknown> } | undefined;
+  const structVal = (v.struct_value ?? v.structValue) as
+    | { fields?: Record<string, unknown> }
+    | undefined;
   if (structVal && typeof structVal === "object") {
     return structToJson(structVal);
   }
@@ -105,10 +111,7 @@ function structFieldEntries(
 
 /** Decode `google.protobuf.Struct` (proto-loader shape) to a plain object. */
 export function structToJson(
-  s:
-    | { fields?: Record<string, unknown> | Map<string, unknown> }
-    | undefined
-    | null
+  s: { fields?: Record<string, unknown> | Map<string, unknown> } | undefined | null
 ): Record<string, unknown> | undefined {
   if (s == null || typeof s !== "object") {
     return undefined;
@@ -118,7 +121,9 @@ export function structToJson(
     return undefined;
   }
   const out: Record<string, unknown> = {};
-  for (const [k, v] of structFieldEntries(fields as Record<string, unknown> | Map<string, unknown>)) {
+  for (const [k, v] of structFieldEntries(
+    fields as Record<string, unknown> | Map<string, unknown>
+  )) {
     out[k] = valueToJson(v as Record<string, unknown>);
   }
   return out;

--- a/src/grpc-memory-tools.test.ts
+++ b/src/grpc-memory-tools.test.ts
@@ -24,7 +24,10 @@ const protoRoot = join(root, "packages/mcp-grpc-transport/proto");
 
 const CALL_TOOL = "/model_context_protocol.Mcp/CallTool";
 
-type StructFields = Record<string, { stringValue?: string; numberValue?: number; boolValue?: boolean }>;
+type StructFields = Record<
+  string,
+  { stringValue?: string; numberValue?: number; boolValue?: boolean }
+>;
 
 function argsToStructFields(args: Record<string, unknown>): StructFields {
   const fields: StructFields = {};
@@ -65,9 +68,7 @@ function toObjectMessages(
 
 function lastNonEmptyToolText(messages: Record<string, unknown>[]): string {
   for (let i = messages.length - 1; i >= 0; i--) {
-    const content = messages[i]?.content as
-      | Array<{ text?: { text?: string } }>
-      | undefined;
+    const content = messages[i]?.content as Array<{ text?: { text?: string } }> | undefined;
     if (!content?.length) continue;
     const t = content[0]?.text?.text;
     if (typeof t === "string" && t.length > 0) return t;
@@ -102,13 +103,7 @@ async function callToolGrpc(
     Buffer.from(CallToolRequest.encode(CallToolRequest.create(req)).finish());
   const deserialize = (buf: Buffer) => CallToolResponse.decode(buf);
 
-  const stream = client.makeServerStreamRequest(
-    CALL_TOOL,
-    serialize,
-    deserialize,
-    payload,
-    md
-  );
+  const stream = client.makeServerStreamRequest(CALL_TOOL, serialize, deserialize, payload, md);
 
   const decoded: protobuf.Message[] = [];
   await new Promise<void>((resolve, reject) => {
@@ -142,59 +137,51 @@ describe("gRPC CallTool + memory_ingest / memory_recall", () => {
     resetSchemaFieldCache();
   });
 
-  it(
-    "memory_ingest succeeds with Struct args over CallTool",
-    async () => {
-      const started = await maybeStartGrpcMcpServer({
-        createMcpServer: createRegisteredMcpServer,
-        bindAddress: "127.0.0.1:0",
+  it("memory_ingest succeeds with Struct args over CallTool", async () => {
+    const started = await maybeStartGrpcMcpServer({
+      createMcpServer: createRegisteredMcpServer,
+      bindAddress: "127.0.0.1:0",
+    });
+    if (!started) throw new Error("expected gRPC server");
+
+    try {
+      const messages = await callToolGrpc(started.address, "memory_ingest", {
+        title: "Grpc Ingest Note",
+        insights: "grpc-memory-tools test body",
       });
-      if (!started) throw new Error("expected gRPC server");
+      const text = lastNonEmptyToolText(messages);
+      expect(text).toContain('"ok": true');
+      expect(text).toContain("Memory/");
+    } finally {
+      await started.shutdown();
+    }
+  }, 30_000);
 
-      try {
-        const messages = await callToolGrpc(started.address, "memory_ingest", {
-          title: "Grpc Ingest Note",
-          insights: "grpc-memory-tools test body",
-        });
-        const text = lastNonEmptyToolText(messages);
-        expect(text).toContain('"ok": true');
-        expect(text).toContain("Memory/");
-      } finally {
-        await started.shutdown();
-      }
-    },
-    30_000
-  );
+  it("memory_recall succeeds with Struct args over CallTool (after ingest)", async () => {
+    const token = `grpc-recall-${Date.now()}`;
+    const started = await maybeStartGrpcMcpServer({
+      createMcpServer: createRegisteredMcpServer,
+      bindAddress: "127.0.0.1:0",
+    });
+    if (!started) throw new Error("expected gRPC server");
 
-  it(
-    "memory_recall succeeds with Struct args over CallTool (after ingest)",
-    async () => {
-      const token = `grpc-recall-${Date.now()}`;
-      const started = await maybeStartGrpcMcpServer({
-        createMcpServer: createRegisteredMcpServer,
-        bindAddress: "127.0.0.1:0",
+    try {
+      const ingestMessages = await callToolGrpc(started.address, "memory_ingest", {
+        title: "Recall Seed",
+        insights: `unique ${token} content for recall`,
       });
-      if (!started) throw new Error("expected gRPC server");
+      const ingestText = lastNonEmptyToolText(ingestMessages);
+      expect(ingestText).toContain('"ok": true');
 
-      try {
-        const ingestMessages = await callToolGrpc(started.address, "memory_ingest", {
-          title: "Recall Seed",
-          insights: `unique ${token} content for recall`,
-        });
-        const ingestText = lastNonEmptyToolText(ingestMessages);
-        expect(ingestText).toContain('"ok": true');
-
-        const recallMessages = await callToolGrpc(started.address, "memory_recall", {
-          query: token,
-          limit: 10,
-        });
-        const recallText = lastNonEmptyToolText(recallMessages);
-        expect(recallText).toContain('"ok": true');
-        expect(recallText.toLowerCase()).toContain(token.toLowerCase());
-      } finally {
-        await started.shutdown();
-      }
-    },
-    30_000
-  );
+      const recallMessages = await callToolGrpc(started.address, "memory_recall", {
+        query: token,
+        limit: 10,
+      });
+      const recallText = lastNonEmptyToolText(recallMessages);
+      expect(recallText).toContain('"ok": true');
+      expect(recallText.toLowerCase()).toContain(token.toLowerCase());
+    } finally {
+      await started.shutdown();
+    }
+  }, 30_000);
 });


### PR DESCRIPTION
Repairs **main** CI: [run 24550611828](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/24550611828) failed **Prettier** on four paths introduced in #73.

Also updates **`.cursor/rules/git-pr-merge-wait-ci.mdc`** so agents do not treat `gh pr merge --auto` as sufficient when branch protection does not require checks (merge can happen before workflows finish).

**Verification:** `npm run format:check` and `npm test` pass locally.