### PR TITLE
feat: Helm chart, GHCR local K8s, multi-arch Docker publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,14 @@ jobs:
 
       - uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca
 
+      # azure/setup-helm@v4.3.0
+      - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112
+        with:
+          version: v3.17.0
+
+      - name: Helm chart lint
+        run: make helm-lint
+
   # Wave 2 — only if fast gates pass (fail early: no matrix work when lint/scripts fail)
   test:
     name: Test (Node ${{ matrix.node-version }})

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,6 +60,8 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: true
+          # Apple Silicon Docker Desktop (linux/arm64) + typical Linux nodes (amd64)
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### CI
 
-- **Docker publish** (`.github/workflows/docker-publish.yml`): **daily** at **06:00 UTC** and **`workflow_dispatch`** — builds `docker/Dockerfile`, pushes to **`ghcr.io/danielsmithdevelopment/clawql-mcp`** with tags **`latest`**, **`nightly`**, **`sha-*`**, and **`nightly-YYYYMMDD`** on scheduled runs; GHA BuildKit cache enabled.
+- **Docker publish** (`.github/workflows/docker-publish.yml`): **daily** at **06:00 UTC** and **`workflow_dispatch`** — builds `docker/Dockerfile`, pushes to **`ghcr.io/danielsmithdevelopment/clawql-mcp`** with tags **`latest`**, **`nightly`**, **`sha-*`**, and **`nightly-YYYYMMDD`** on scheduled runs; GHA BuildKit cache enabled; **multi-platform** **`linux/amd64`** + **`linux/arm64`** (Docker Desktop on Apple Silicon).
 
 - **Prettier autofix** job on **same-repo pull requests**: when the **Lint & format** job fails, applies **`npm run format`** and pushes a single commit **`style: apply Prettier [prettier-autofix]`** if there are diffs. **Loop guards:** job runs only when `lint` failed; skips if the actor is **`github-actions[bot]`**; skips if **`[prettier-autofix]`** is already in **HEAD**; does not commit when Prettier makes no changes. **Fork PRs** are excluded (token cannot push to forks).
 
 ### Changed
 
+- **Docker Desktop local Kustomize overlay** (`docker/kustomize/overlays/local`): default image is **`ghcr.io/danielsmithdevelopment/clawql-mcp:latest`** with **`imagePullPolicy: Always`**. **`scripts/local-k8s-docker-desktop.sh`** no longer builds by default; set **`CLAWQL_LOCAL_K8S_BUILD_IMAGE=1`** to build **`clawql-mcp:latest`** locally and patch the Deployment (previous behavior).
 - **`memory_recall`:** when **`CLAWQL_MERKLE_ENABLED=1`**, JSON includes **`merkleSnapshot`**; when **`CLAWQL_CUCKOO_ENABLED=1`** and embeddings run, vector-ranked chunks are filtered by the Cuckoo membership filter with **`cuckooVectorChunksDropped`** ([#81](https://github.com/danielsmithdevelopment/ClawQL/issues/81)).
 - **Developer tooling:** root **`npm run format`** / **`format:check`** now includes the docs site: **`npm run format --prefix website`** (Prettier on **`website/`** `mdx`/`ts`/`tsx`). **`.prettierignore`** no longer skips all of **`website/`**—only build artifacts (**`.next/`**, **`node_modules/`**, etc.). CI runs **`npm ci --prefix website`** before **`format:check`** so site Prettier plugins resolve.
 - **Codegen:** **`pregenerate-graphql`** and **`pregenerate-google-top50-graphql`** use **`tsx`** (not Bun). Added **`npm run graphql`** → **`tsx src/graphql-proxy.ts`** for the standalone GraphQL proxy documented in the README.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### CI
 
+- **Helm:** **`workflow-scripts`** installs Helm **v3.17.0** and runs **`make helm-lint`** (`helm lint` + `helm template` for **`charts/clawql-mcp`**).
+
 - **Docker publish** (`.github/workflows/docker-publish.yml`): **daily** at **06:00 UTC** and **`workflow_dispatch`** — builds `docker/Dockerfile`, pushes to **`ghcr.io/danielsmithdevelopment/clawql-mcp`** with tags **`latest`**, **`nightly`**, **`sha-*`**, and **`nightly-YYYYMMDD`** on scheduled runs; GHA BuildKit cache enabled; **multi-platform** **`linux/amd64`** + **`linux/arm64`** (Docker Desktop on Apple Silicon).
 
 - **Prettier autofix** job on **same-repo pull requests**: when the **Lint & format** job fails, applies **`npm run format`** and pushes a single commit **`style: apply Prettier [prettier-autofix]`** if there are diffs. **Loop guards:** job runs only when `lint` failed; skips if the actor is **`github-actions[bot]`**; skips if **`[prettier-autofix]`** is already in **HEAD**; does not commit when Prettier makes no changes. **Fork PRs** are excluded (token cannot push to forks).
@@ -24,12 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Helm chart** **`charts/clawql-mcp`**: deploy **`clawql-mcp-http`** with configurable image (**GHCR** by default), Service (**LoadBalancer** / **ClusterIP**), optional **Ingress**, **`/vault`** PVC, gRPC env toggles; **`make helm-lint`**. Docs: **`docs/helm.md`**; site: **`/helm`**.
 - **Cuckoo filter + Merkle snapshot** for hybrid `memory.db` ([#25](https://github.com/danielsmithdevelopment/ClawQL/issues/25), [#37](https://github.com/danielsmithdevelopment/ClawQL/issues/37)): enable with **`CLAWQL_CUCKOO_ENABLED=1`** and **`CLAWQL_MERKLE_ENABLED=1`**; modules **`src/cuckoo-filter.ts`**, **`src/merkle-tree.ts`**, **`src/memory-artifacts.ts`**; helpers **`chunkIdMaybeInMemoryIndex`**, **`loadVaultMerkleSnapshotFromDb`**. Postgres migration **2** adds **`clawql_cuckoo_chunk_membership`** and **`clawql_vault_merkle`** when using **`CLAWQL_VECTOR_DATABASE_URL`**.
 - **`cache` MCP tool** ([#75](https://github.com/danielsmithdevelopment/ClawQL/issues/75)): opt-in via **`CLAWQL_ENABLE_CACHE`**; operations **`set` / `get` / `delete` / `list` / `search`**; **in-process `Map` only** (not persisted — use **`memory_ingest`** / **`memory_recall`** for vault); **`CLAWQL_CACHE_MAX_VALUE_BYTES`** per value (default **1 MiB**). Implementation: [`src/clawql-cache.ts`](src/clawql-cache.ts).
 - **`src/clawql-optional-flags.ts`**: Zod-validated optional feature flags (`ENABLE_GRPC`, `CLAWQL_EXTERNAL_INGEST`, planned **`CLAWQL_ENABLE_*`** for cache/schedule/notify/vision); **`src/external-ingest.ts`** uses the shared parser for **`CLAWQL_EXTERNAL_INGEST`**. See [#79](https://github.com/danielsmithdevelopment/ClawQL/issues/79).
 
 ### Documentation
 
+- **`docs/helm.md`**: Helm install, values table, relationship to Kustomize.
 - **`docs/benchmarks/archive/`**: short summaries + script links for archived workflow runs (formerly root `gcp-multi-test.md`, `multi-provider-test.md`, `TEST_RESULTS_2026-03-19.md`, and **`docs/JIRA_WORKFLOW_TOKEN_RESULTS_2026-03-19.md`**); benchmark stats JSON **`workflowOutput.source`** now points at the archive note.
 - **`docs/cache-tool.md`**: canonical **`cache`** vs **`memory_*`**, LRU semantics, env vars, multi-replica; cross-links from **`docs/mcp-tools.md`**, **`docs/memory-obsidian.md`**, **`docs/cursor-vault-memory.md`**, **`docs/deploy-k8s.md`**; website routes **`/cache`** and **`/tools`** (`website/src/app/cache`, `website/src/app/tools`) and nav/sitemap updated.
 - **`docs/deploy-k8s.md`**: TLS/mTLS/mesh and observability notes for port **50051**; gRPC tracking remains on [#67](https://github.com/danielsmithdevelopment/ClawQL/issues/67).

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-.PHONY: deploy-cloud-run deploy-k8s local-k8s-up local-docker-up
+.PHONY: deploy-cloud-run deploy-k8s local-k8s-up local-docker-up helm-lint
+
+# Validate charts/clawql-mcp (requires helm on PATH)
+helm-lint:
+	@helm lint charts/clawql-mcp
+	@helm template test charts/clawql-mcp --namespace clawql >/dev/null
+	@echo "helm-lint OK"
 
 # Docker Desktop Kubernetes: build image + kubectl apply -k docker/kustomize/overlays/local
 local-k8s-up:

--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ Run **MCP Streamable HTTP** in a local cluster so clients can use a fixed URL (t
    # or: bash scripts/local-k8s-docker-desktop.sh
    ```
 
-   This builds **`clawql-mcp:latest`**, applies **`docker/kustomize/overlays/local`**, and waits for rollouts. The script uses the **`docker-desktop`** kubectl context when present.
+   This applies **`docker/kustomize/overlays/local`**, pulls **`ghcr.io/danielsmithdevelopment/clawql-mcp:latest`**, and waits for rollouts. Use **`CLAWQL_LOCAL_K8S_BUILD_IMAGE=1`** with the same commands to build **`clawql-mcp:latest`** locally instead. The script uses the **`docker-desktop`** kubectl context when present.
 
 3. **Health:** `curl -s http://localhost:8080/healthz` should return `{"status":"ok",...}` before connecting the client.
 4. **GitHub + Cloudflare + Google auth:** `bash scripts/k8s-docker-desktop-set-github-token.sh` (optional `CLAWQL_CLOUDFLARE_API_TOKEN` and `GOOGLE_ACCESS_TOKEN` / `CLAWQL_GOOGLE_ACCESS_TOKEN` in the environment). See [`docker/README.md`](docker/README.md).
@@ -655,7 +655,7 @@ Longer-form docs for operators: [`website/src/app/kubernetes/page.mdx`](website/
 ENV=dev IMAGE=us-central1-docker.pkg.dev/<project>/<repo>/clawql-mcp TAG=<tag> make deploy-k8s
 ```
 
-See [`docs/deploy-k8s.md`](docs/deploy-k8s.md).
+See [`docs/deploy-k8s.md`](docs/deploy-k8s.md). **Helm:** [`docs/helm.md`](docs/helm.md) (`charts/clawql-mcp`).
 
 ---
 

--- a/charts/clawql-mcp/.helmignore
+++ b/charts/clawql-mcp/.helmignore
@@ -1,0 +1,3 @@
+# Patterns to ignore when packaging the chart.
+.DS_Store
+.git

--- a/charts/clawql-mcp/Chart.yaml
+++ b/charts/clawql-mcp/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: clawql-mcp
+description: ClawQL MCP server (Streamable HTTP, optional gRPC) for Kubernetes
+type: application
+version: 0.1.0
+# Align with npm package when cutting chart releases; image tag is separate (values.image.tag).
+appVersion: "3.2.3"

--- a/charts/clawql-mcp/README.md
+++ b/charts/clawql-mcp/README.md
@@ -1,0 +1,19 @@
+# `clawql-mcp` Helm chart
+
+Deploys **ClawQL** as **`clawql-mcp-http`**: Streamable HTTP MCP (`/mcp`), health (`/healthz`), GraphQL (`/graphql`), optional gRPC on **50051**.
+
+## Documentation
+
+- **Full guide:** [`docs/helm.md`](../../docs/helm.md) in this repository
+- **Kustomize alternative:** [`docs/deploy-k8s.md`](../../docs/deploy-k8s.md)
+
+## Quick install
+
+```bash
+helm upgrade --install clawql ./charts/clawql-mcp \
+  --namespace clawql \
+  --create-namespace \
+  --wait
+```
+
+Configure via **`values.yaml`** or **`--set`**. Defaults pull **`ghcr.io/danielsmithdevelopment/clawql-mcp:latest`**.

--- a/charts/clawql-mcp/templates/NOTES.txt
+++ b/charts/clawql-mcp/templates/NOTES.txt
@@ -1,0 +1,17 @@
+1. Get the application URL (depends on Service type):
+
+{{- if contains "LoadBalancer" .Values.service.type }}
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "clawql-mcp.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo "MCP Streamable HTTP: http://${SERVICE_IP}:{{ .Values.service.http.port }}{{ .Values.mcpPath }}"
+  echo "Health:              http://${SERVICE_IP}:{{ .Values.service.http.port }}/healthz"
+{{- else if contains "ClusterIP" .Values.service.type }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "clawql-mcp.fullname" . }} 8080:{{ .Values.service.http.port }}
+  echo "Then: http://localhost:8080{{ .Values.mcpPath }}"
+{{- end }}
+{{- if .Values.ingress.enabled }}
+  {{- range .Values.ingress.hosts }}
+  echo "Ingress host: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}{{ $.Values.mcpPath }}"
+  {{- end }}
+{{- end }}
+
+2. Optional gRPC (set enableGrpc: true): port {{ .Values.service.grpc.port }} on the same Service.

--- a/charts/clawql-mcp/templates/_helpers.tpl
+++ b/charts/clawql-mcp/templates/_helpers.tpl
@@ -1,0 +1,34 @@
+{{- define "clawql-mcp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "clawql-mcp.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name (include "clawql-mcp.name" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{- define "clawql-mcp.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "clawql-mcp.labels" -}}
+helm.sh/chart: {{ include "clawql-mcp.chart" . }}
+{{ include "clawql-mcp.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "clawql-mcp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "clawql-mcp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "clawql-mcp.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "clawql-mcp.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/clawql-mcp/templates/deployment.yaml
+++ b/charts/clawql-mcp/templates/deployment.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "clawql-mcp.fullname" . }}
+  labels:
+    {{- include "clawql-mcp.labels" . | nindent 4 }}
+    app: {{ include "clawql-mcp.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "clawql-mcp.selectorLabels" . | nindent 6 }}
+      app: {{ include "clawql-mcp.fullname" . }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "clawql-mcp.selectorLabels" . | nindent 8 }}
+        app: {{ include "clawql-mcp.fullname" . }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "clawql-mcp.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "clawql-mcp.fullname" . }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.http.targetPort | int }}
+              protocol: TCP
+            - name: grpc
+              containerPort: {{ .Values.service.grpc.targetPort | int }}
+              protocol: TCP
+          env:
+            - name: CLAWQL_PROVIDER
+              value: {{ .Values.provider | quote }}
+            - name: CLAWQL_OBSIDIAN_VAULT_PATH
+              value: {{ .Values.obsidianVaultPath | quote }}
+            - name: PORT
+              value: {{ .Values.port | quote }}
+            - name: MCP_PATH
+              value: {{ .Values.mcpPath | quote }}
+            - name: CLAWQL_BUNDLED_OFFLINE
+              value: {{ .Values.bundledOffline | quote }}
+            - name: NODE_OPTIONS
+              value: {{ .Values.nodeOptions | quote }}
+            {{- if .Values.enableGrpc }}
+            - name: ENABLE_GRPC
+              value: "1"
+            {{- end }}
+            {{- if .Values.enableGrpcReflection }}
+            - name: ENABLE_GRPC_REFLECTION
+              value: "1"
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.envFromSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.envFromSecret }}
+          {{- end }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: obsidian-vault
+              mountPath: {{ .Values.obsidianVaultPath }}
+      volumes:
+        - name: obsidian-vault
+          {{- if .Values.persistence.enabled }}
+          {{- if .Values.persistence.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim }}
+          {{- else }}
+          persistentVolumeClaim:
+            claimName: {{ include "clawql-mcp.fullname" . }}-vault
+          {{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/clawql-mcp/templates/ingress.yaml
+++ b/charts/clawql-mcp/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "clawql-mcp.fullname" . }}
+  labels:
+    {{- include "clawql-mcp.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "clawql-mcp.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.http.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/clawql-mcp/templates/pvc.yaml
+++ b/charts/clawql-mcp/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "clawql-mcp.fullname" . }}-vault
+  labels:
+    {{- include "clawql-mcp.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/clawql-mcp/templates/service.yaml
+++ b/charts/clawql-mcp/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clawql-mcp.fullname" . }}
+  labels:
+    {{- include "clawql-mcp.labels" . | nindent 4 }}
+    app: {{ include "clawql-mcp.fullname" . }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "clawql-mcp.selectorLabels" . | nindent 4 }}
+    app: {{ include "clawql-mcp.fullname" . }}
+  ports:
+    - name: http
+      port: {{ .Values.service.http.port }}
+      targetPort: http
+      protocol: TCP
+    - name: grpc
+      port: {{ .Values.service.grpc.port }}
+      targetPort: grpc
+      protocol: TCP

--- a/charts/clawql-mcp/templates/serviceaccount.yaml
+++ b/charts/clawql-mcp/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "clawql-mcp.serviceAccountName" . }}
+  labels:
+    {{- include "clawql-mcp.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/clawql-mcp/values.yaml
+++ b/charts/clawql-mcp/values.yaml
@@ -1,0 +1,105 @@
+# Default resource names match Kustomize (`clawql-mcp-http`) so kubectl snippets in docs stay familiar.
+fullnameOverride: clawql-mcp-http
+nameOverride: ""
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/danielsmithdevelopment/clawql-mcp
+  tag: latest
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+serviceAccount:
+  create: false
+  automount: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+securityContext: {}
+
+service:
+  type: LoadBalancer
+  # Service port for HTTP (MCP + health + GraphQL). Base Kustomize uses 80 → container 8080.
+  http:
+    port: 80
+    targetPort: 8080
+  grpc:
+    port: 50051
+    targetPort: 50051
+
+# Mirrors docker/kustomize/base/deployment-mcp-http.yaml
+provider: google-top50
+bundledOffline: "1"
+obsidianVaultPath: /vault
+port: "8080"
+mcpPath: /mcp
+nodeOptions: "--max-old-space-size=1536"
+
+enableGrpc: false
+enableGrpcReflection: false
+
+# Extra env (e.g. tokens from literal — prefer existing secrets for production).
+extraEnv: []
+
+# Optional: load env vars from an existing Secret (keys become env var names).
+envFromSecret: ""
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 1Gi
+  limits:
+    cpu: "2"
+    memory: 2Gi
+
+startupProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  periodSeconds: 10
+  failureThreshold: 36
+  timeoutSeconds: 5
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+persistence:
+  enabled: false
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
+  existingClaim: ""
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: clawql.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/docker/README.md
+++ b/docker/README.md
@@ -67,7 +67,7 @@ docker run -i --rm --entrypoint node clawql-mcp dist/server.js
 | `docker/docker-compose.yml`      | Local stack (`clawql-mcp-http` only)                              |
 | `docker/kubernetes-starter.yaml` | Starter K8s namespace + Deployments + Services                    |
 
-Future Compose / Kubernetes / Helm manifests can live under `docker/` (or split to `deploy/`) without changing this image.
+**Helm:** a maintained chart lives at **`charts/clawql-mcp`** — see **[`docs/helm.md`](../docs/helm.md)**. Kustomize overlays remain under **`docker/kustomize/`**.
 
 ## Docker Compose (local)
 
@@ -93,17 +93,19 @@ Endpoints:
 
 **Cursor MCP:** use a Streamable HTTP server whose URL points at your MCP endpoint (default for this compose/K8s setup: `http://localhost:8080/mcp`). Do not assume everyone uses the same URL — copy `.cursor/mcp.json.example` to `.cursor/mcp.json` (gitignored) and set `url` to localhost, a tunnel, or your cluster ingress. You can also set **`${env:VAR}`** in `url` via [Cursor config interpolation](https://cursor.com/docs/context/mcp) if you prefer env-based URLs.
 
-## Kubernetes on Docker Desktop (local image)
+## Kubernetes on Docker Desktop (GHCR image)
 
 1. Enable **Kubernetes** in Docker Desktop (Settings → Kubernetes → Enable cluster).
-2. Build the image and apply the **`local`** overlay (LoadBalancer on **8080** for MCP):
+2. Apply the **`local`** overlay (LoadBalancer on **8080** for MCP). The Deployment pulls **`ghcr.io/danielsmithdevelopment/clawql-mcp:latest`** (`imagePullPolicy: Always`).
 
 ```bash
 make local-k8s-up
 # or: bash scripts/local-k8s-docker-desktop.sh
 ```
 
-This tags **`clawql-mcp:latest`** (same daemon as Docker Desktop; no registry push). The overlay lives at `docker/kustomize/overlays/local`.
+The overlay lives at `docker/kustomize/overlays/local`. To **build the image locally** instead (same as before), run **`CLAWQL_LOCAL_K8S_BUILD_IMAGE=1 make local-k8s-up`** — the script builds `clawql-mcp:latest` and patches the Deployment to use it.
+
+If the GHCR package is **private**, add an **`imagePullSecret`** for `ghcr.io` on the Deployment or service account (same as any private registry).
 
 - **`CLAWQL_PROVIDER`:** The **local** overlay sets **`default-multi-provider`** (Google top50 + Cloudflare + GitHub, same as bare `npx clawql-mcp`). Edit `docker/kustomize/overlays/local/patch-local-provider-env.yaml` to **`all-providers`** when you need the full merge for multi-vendor MCP or **`workflow:complex-release-stack:mcp`** over HTTP. The **base** manifest defaults to **`google-top50`** when no overlay patch applies.
 - **`kubectl` context:** The script targets **`docker-desktop`** when that context exists (so your default context can stay on EKS or another cluster).

--- a/docker/kustomize/overlays/grpc-enabled/kustomization.yaml
+++ b/docker/kustomize/overlays/grpc-enabled/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 # Opt-in stack: HTTP + gRPC MCP with kubelet gRPC health checks (no in-image grpc_health_probe).
-# Build: docker build -f docker/Dockerfile -t clawql-mcp:latest .
+# Image: same as base (override with kustomize `images` or use ghcr.io/danielsmithdevelopment/clawql-mcp:latest).
 # Apply: kubectl apply -k docker/kustomize/overlays/grpc-enabled
 resources:
   - ../../base

--- a/docker/kustomize/overlays/local/kustomization.yaml
+++ b/docker/kustomize/overlays/local/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# Docker Desktop Kubernetes: use local image `clawql-mcp:latest` and expose MCP on localhost:8080.
-# Build first: docker build -f docker/Dockerfile -t clawql-mcp:latest .
+# Docker Desktop Kubernetes: pull the prebuilt image from GHCR (default tag: latest).
+# Optional local build: CLAWQL_LOCAL_K8S_BUILD_IMAGE=1 with scripts/local-k8s-docker-desktop.sh
 resources:
   - ../../base
 
@@ -20,5 +20,5 @@ patches:
 
 images:
   - name: clawql-mcp
-    newName: clawql-mcp
+    newName: ghcr.io/danielsmithdevelopment/clawql-mcp
     newTag: latest

--- a/docker/kustomize/overlays/local/patch-mcp-deployment.yaml
+++ b/docker/kustomize/overlays/local/patch-mcp-deployment.yaml
@@ -9,6 +9,7 @@ spec:
     spec:
       containers:
         - name: clawql-mcp-http
+          imagePullPolicy: Always
           env:
             - name: NODE_OPTIONS
               value: "--max-old-space-size=768"

--- a/docs/deploy-k8s.md
+++ b/docs/deploy-k8s.md
@@ -1,8 +1,18 @@
-# Deploy ClawQL on Kubernetes (Kustomize)
+# Deploy ClawQL on Kubernetes (Kustomize or Helm)
 
 This deploy pattern runs ClawQL as **one** workload (**`clawql-mcp-http`**): MCP at **`/mcp`**, GraphQL at **`/graphql`** on the same service.
 
-## Prerequisites
+## Helm chart (alternative)
+
+For **`helm install` / `helm upgrade`**, use the maintained chart at **`charts/clawql-mcp`**. See **[`docs/helm.md`](helm.md)** for install examples, values, private registry pull secrets, Ingress, and persistence.
+
+Quick start from repo root:
+
+```bash
+helm upgrade --install clawql ./charts/clawql-mcp --namespace clawql --create-namespace --wait
+```
+
+## Prerequisites (Kustomize)
 
 - `kubectl` configured for your target cluster
 - image pushed to a registry your cluster can pull from

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -1,0 +1,118 @@
+# Helm chart (`charts/clawql-mcp`)
+
+The repository ships a **Helm 3** chart that deploys the same workload as Kustomize (**`clawql-mcp-http`**): Streamable HTTP MCP (and optional gRPC) behind a Kubernetes **Service**.
+
+Use this when you prefer **`helm install` / `helm upgrade`** over **`kubectl apply -k`** (see also [`deploy-k8s.md`](deploy-k8s.md) for Kustomize).
+
+## Prerequisites
+
+- Kubernetes 1.24+ (typical for `networking.k8s.io/v1` Ingress)
+- [Helm 3](https://helm.sh/)
+- An image your cluster can pull (default: **`ghcr.io/danielsmithdevelopment/clawql-mcp`**, multi-arch **amd64** / **arm64** when published from CI)
+
+Private GHCR: create a pull secret and set **`imagePullSecrets`** (see [values](../charts/clawql-mcp/values.yaml)).
+
+## Install from a repo clone
+
+From the **repository root**:
+
+```bash
+helm upgrade --install clawql ./charts/clawql-mcp \
+  --namespace clawql \
+  --create-namespace \
+  --wait
+```
+
+Defaults use **`fullnameOverride: clawql-mcp-http`** so resource names match the Kustomize docs (**`kubectl -n clawql get deploy clawql-mcp-http`**).
+
+### Examples
+
+**ClusterIP** (in-cluster only, no cloud LoadBalancer cost):
+
+```bash
+helm upgrade --install clawql ./charts/clawql-mcp -n clawql --create-namespace \
+  --set service.type=ClusterIP \
+  --set service.http.port=8080
+```
+
+**Enable gRPC** (port **50051** on the Service; HTTP unchanged):
+
+```bash
+helm upgrade --install clawql ./charts/clawql-mcp -n clawql --create-namespace \
+  --set enableGrpc=true
+```
+
+**Image tag** (pin a digest or release tag):
+
+```bash
+helm upgrade --install clawql ./charts/clawql-mcp -n clawql --create-namespace \
+  --set image.tag=sha-abc1234
+```
+
+**Tokens via existing Secret** (keys become env vars in the pod):
+
+```bash
+kubectl -n clawql create secret generic clawql-env --from-literal=CLAWQL_GITHUB_TOKEN="$(gh auth token)"
+helm upgrade --install clawql ./charts/clawql-mcp -n clawql \
+  --set envFromSecret=clawql-env
+```
+
+**Persistent vault** (`memory_ingest` / `memory_recall` survive pod restarts):
+
+```bash
+helm upgrade --install clawql ./charts/clawql-mcp -n clawql --create-namespace \
+  --set persistence.enabled=true \
+  --set persistence.size=20Gi
+```
+
+**Ingress** (optional): set **`ingress.enabled=true`** and edit **`ingress.hosts`** / **`ingress.tls`** in a small values file; backend targets the HTTP **`service.http.port`**.
+
+## Values
+
+See **[`charts/clawql-mcp/values.yaml`](../charts/clawql-mcp/values.yaml)**. Common keys:
+
+| Key                                                 | Purpose                                        |
+| --------------------------------------------------- | ---------------------------------------------- |
+| `image.repository`, `image.tag`, `image.pullPolicy` | Container image                                |
+| `service.type`, `service.http.port`                 | `LoadBalancer` vs `ClusterIP`, front port      |
+| `provider`                                          | **`CLAWQL_PROVIDER`** (e.g. `google-top50`)    |
+| `enableGrpc` / `enableGrpcReflection`               | gRPC listener on **50051**                     |
+| `extraEnv`                                          | Additional container env entries               |
+| `envFromSecret`                                     | **`envFrom`** from an existing Secret          |
+| `persistence`                                       | PVC for **`/vault`** instead of **`emptyDir`** |
+| `ingress`                                           | Optional HTTP(S) Ingress                       |
+
+## Lint and template (CI / local)
+
+```bash
+make helm-lint
+```
+
+Or:
+
+```bash
+helm lint charts/clawql-mcp
+helm template test charts/clawql-mcp --namespace clawql
+```
+
+## Uninstall
+
+```bash
+helm uninstall clawql -n clawql
+```
+
+If you used persistence with a chart-managed PVC, remove the PVC separately if you no longer need the data.
+
+## Relationship to Kustomize
+
+|                          | Kustomize (`docker/kustomize/`)                | Helm (`charts/clawql-mcp`)                                                            |
+| ------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------------- |
+| **Naming**               | Overlays **`dev`**, **`prod`**, **`local`**    | **`values.yaml`** + **`--set`**                                                       |
+| **Image**                | Rewritten by **`scripts/deploy-k8s.sh`**       | **`image.repository`** / **`image.tag`**                                              |
+| **Local Docker Desktop** | **`make local-k8s-up`** (hostPath vault patch) | Use Helm with overrides or stay on Kustomize **`local`** for the scripted vault patch |
+
+For **Docker Desktop** with a **host bind** vault at **`~/.ClawQL`**, the **`local`** Kustomize flow (`scripts/local-k8s-docker-desktop.sh`) is still the most turnkey; Helm can do the same with a custom **`extraVolumes` / `extraVolumeMounts`** patch in a fork, or **`persistence`** with a suitable storage class.
+
+## Chart version
+
+**`Chart.version`** in **`Chart.yaml`** is the chart release; **`appVersion`** tracks the app loosely. The running software version is always the **container image** you deploy.

--- a/scripts/local-k8s-docker-desktop.sh
+++ b/scripts/local-k8s-docker-desktop.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Build the ClawQL image and apply the Kustomize "local" overlay to Docker Desktop Kubernetes.
+# Apply the Kustomize "local" overlay to Docker Desktop Kubernetes using the prebuilt
+# GHCR image (default: ghcr.io/danielsmithdevelopment/clawql-mcp:latest).
+#
+# Optional: CLAWQL_LOCAL_K8S_BUILD_IMAGE=1 — docker build locally and patch the Deployment
+# to use image clawql-mcp:latest (IfNotPresent) instead of pulling from GHCR.
+#
 # Requires: Docker Desktop with Kubernetes enabled, kubectl, docker.
 #
 # Uses kubectl context `docker-desktop` when present (avoids accidentally targeting EKS/other clusters).
@@ -73,11 +78,24 @@ if ! kubectl "${KUBECTL_FLAG[@]}" cluster-info >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "==> Building image clawql-mcp:latest"
-docker build -f docker/Dockerfile -t clawql-mcp:latest .
+if [[ "${CLAWQL_LOCAL_K8S_BUILD_IMAGE:-}" == "1" ]]; then
+  echo "==> Building local image clawql-mcp:latest (CLAWQL_LOCAL_K8S_BUILD_IMAGE=1)"
+  docker build -f docker/Dockerfile -t clawql-mcp:latest .
+else
+  echo "==> Using registry image (see docker/kustomize/overlays/local/kustomization.yaml)"
+  echo "    ghcr.io/danielsmithdevelopment/clawql-mcp:latest"
+fi
 
 echo "==> Applying ${OVERLAY}"
 kubectl "${KUBECTL_FLAG[@]}" apply -k "${OVERLAY}"
+
+if [[ "${CLAWQL_LOCAL_K8S_BUILD_IMAGE:-}" == "1" ]]; then
+  echo "==> Patching Deployment to use local image clawql-mcp:latest"
+  kubectl "${KUBECTL_FLAG[@]}" -n clawql patch deployment clawql-mcp-http --type=json -p='[
+    {"op":"replace","path":"/spec/template/spec/containers/0/image","value":"clawql-mcp:latest"},
+    {"op":"replace","path":"/spec/template/spec/containers/0/imagePullPolicy","value":"IfNotPresent"}
+  ]'
+fi
 
 echo "==> Waiting for rollouts (namespace clawql)"
 kubectl "${KUBECTL_FLAG[@]}" -n clawql rollout status deployment/clawql-mcp-http --timeout=300s

--- a/website/src/app/deployment/page.mdx
+++ b/website/src/app/deployment/page.mdx
@@ -1,7 +1,7 @@
 export const metadata = {
   title: 'Deployment',
   description:
-    'Deploy ClawQL: Docker Distroless image, Streamable HTTP /mcp, ENABLE_GRPC and GRPC_PORT, Google Cloud Run script, Kubernetes overlays and production notes.',
+    'Deploy ClawQL: Docker Distroless image, Streamable HTTP /mcp, ENABLE_GRPC and GRPC_PORT, Google Cloud Run script, Kubernetes Kustomize or Helm chart, production notes.',
 }
 
 # Deployment
@@ -48,12 +48,14 @@ After deploy, agents use **`https://<mcp-service-url>/mcp`**. Full options: [`do
 
 ## Kubernetes
 
-**Local MCP on Docker Desktop** (build `clawql-mcp:latest`, namespace `clawql`, **`http://localhost:8080/mcp`**) is covered on the dedicated guide: **[Kubernetes](/kubernetes)**.
+**Local MCP on Docker Desktop** (namespace `clawql`, **`http://localhost:8080/mcp`**, GHCR image or optional local build) is covered on **[Kubernetes](/kubernetes)**.
 
-For **remote** clusters, overlays for `dev` / `prod` with image tag injection:
+For **remote** clusters, use Kustomize overlays with image tag injection:
 
 ```bash
 ENV=dev IMAGE=us-central1-docker.pkg.dev/<project>/<repo>/clawql-mcp TAG=<tag> make deploy-k8s
 ```
+
+Or install with **Helm** from **`charts/clawql-mcp`**: **[Helm](/helm)** and [`docs/helm.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/helm.md).
 
 Details: [`docs/deploy-k8s.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/deploy-k8s.md). Extended container and manifest notes: [`docker/README.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docker/README.md).

--- a/website/src/app/helm/page.mdx
+++ b/website/src/app/helm/page.mdx
@@ -1,0 +1,42 @@
+export const metadata = {
+  title: 'Helm',
+  description:
+    'Install ClawQL on Kubernetes with the charts/clawql-mcp Helm chart: image, Service, optional Ingress and persistence.',
+}
+
+# Helm
+
+The repository includes a **Helm 3** chart at **`charts/clawql-mcp`** that deploys **`clawql-mcp-http`**: Streamable HTTP MCP on **`/mcp`**, health on **`/healthz`**, GraphQL on **`/graphql`**, and (optionally) gRPC on port **50051**—matching the [Kustomize](/kubernetes) layout.
+
+## Install
+
+From a **clone** of the repo (chart path is relative):
+
+```bash
+helm upgrade --install clawql ./charts/clawql-mcp \
+  --namespace clawql \
+  --create-namespace \
+  --wait
+```
+
+The default image is **`ghcr.io/danielsmithdevelopment/clawql-mcp:latest`**. Override **`image.tag`** or **`image.repository`** for your registry.
+
+## Docs and values
+
+- **Full guide** (examples: ClusterIP, gRPC, tokens, Ingress, persistence): **[`docs/helm.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/helm.md)** on GitHub
+- **Default values:** [`charts/clawql-mcp/values.yaml`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/charts/clawql-mcp/values.yaml)
+
+## Helm vs Kustomize
+
+|             | [Kubernetes / Kustomize](/kubernetes)                      | Helm (this page)          |
+| ----------- | ---------------------------------------------------------- | ------------------------- |
+| **Install** | `kubectl apply -k`, `make deploy-k8s`, `make local-k8s-up` | `helm upgrade --install`  |
+| **Config**  | Overlays under `docker/kustomize/overlays/`                | `values.yaml` and `--set` |
+
+Docker Desktop with a **host-mounted** vault is still easiest with **`make local-k8s-up`**; use Helm when you want chart-driven upgrades and values files on shared clusters.
+
+## Validate the chart locally
+
+```bash
+make helm-lint
+```

--- a/website/src/app/kubernetes/page.mdx
+++ b/website/src/app/kubernetes/page.mdx
@@ -1,12 +1,12 @@
 export const metadata = {
   title: 'Kubernetes',
   description:
-    'ClawQL on Kubernetes: Kustomize overlays, Streamable HTTP localhost:8080/mcp, optional gRPC 50051, Docker Desktop LoadBalancer, dev and prod deploy.',
+    'ClawQL on Kubernetes: Kustomize overlays or Helm chart, Streamable HTTP localhost:8080/mcp, optional gRPC 50051, Docker Desktop LoadBalancer, dev and prod deploy.',
 }
 
 # Kubernetes
 
-ClawQL is usually deployed as **`clawql-mcp-http`**: **Streamable HTTP** MCP on **`/mcp`**, **GraphQL** on **`/graphql`**, and (when **`ENABLE_GRPC=1`**) **gRPC** protobuf MCP on port **50051**—all in one pod. The Kustomize **Service** exposes **both** HTTP and **gRPC** ports so clients can use **`localhost:50051`** (Docker Desktop) or **`<LoadBalancer-ip>:50051`** without **`kubectl port-forward`**. {{ className: 'lead' }}
+ClawQL is usually deployed as **`clawql-mcp-http`**: **Streamable HTTP** MCP on **`/mcp`**, **GraphQL** on **`/graphql`**, and (when **`ENABLE_GRPC=1`**) **gRPC** protobuf MCP on port **50051**—all in one pod. The **Service** exposes **both** HTTP and **gRPC** ports so clients can use **`localhost:50051`** (Docker Desktop) or **`<LoadBalancer-ip>:50051`** without **`kubectl port-forward`**. Use **Kustomize** (below) or the **[Helm](/helm)** chart at **`charts/clawql-mcp`**. {{ className: 'lead' }}
 
 ## Local MCP on Docker Desktop
 
@@ -32,7 +32,7 @@ Or:
 bash scripts/local-k8s-docker-desktop.sh
 ```
 
-This **builds** the image as **`clawql-mcp:latest`** in the same Docker daemon Kubernetes uses, **applies** the Kustomize overlay at **`docker/kustomize/overlays/local`**, and waits for rollouts.
+This **applies** the Kustomize overlay at **`docker/kustomize/overlays/local`**, which deploys **`ghcr.io/danielsmithdevelopment/clawql-mcp:latest`** (prebuilt on GHCR), and waits for rollouts. To **build locally** instead, run **`CLAWQL_LOCAL_K8S_BUILD_IMAGE=1 make local-k8s-up`** (or the same env with **`bash scripts/local-k8s-docker-desktop.sh`**).
 
 ### Endpoints and client config
 

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -12,6 +12,7 @@ const PATHS = [
   '/troubleshooting',
   '/deployment',
   '/kubernetes',
+  '/helm',
   '/tools',
   '/cache',
   '/graphql-proxy',

--- a/website/src/components/Guides.tsx
+++ b/website/src/components/Guides.tsx
@@ -32,6 +32,12 @@ const guides = [
     description:
       'Local MCP on Docker Desktop K8s (localhost:8080/mcp), auth, rebuilds, and remote overlays.',
   },
+  {
+    href: '/helm',
+    name: 'Helm',
+    description:
+      'Helm chart at charts/clawql-mcp: install, values, GHCR image, optional Ingress and PVC.',
+  },
 ]
 
 export function Guides() {

--- a/website/src/components/Navigation.tsx
+++ b/website/src/components/Navigation.tsx
@@ -244,6 +244,7 @@ export const navigation: Array<NavGroup> = [
       { title: 'Troubleshooting', href: '/troubleshooting' },
       { title: 'Deployment', href: '/deployment' },
       { title: 'Kubernetes', href: '/kubernetes' },
+      { title: 'Helm', href: '/helm' },
     ],
   },
   {


### PR DESCRIPTION
## Summary

Adds a maintained **Helm 3** chart at `charts/clawql-mcp` (Deployment, Service, optional Ingress/PVC, GHCR image defaults) with **`docs/helm.md`** and the **`/helm`** docs site page.

**Docker Desktop local Kustomize** (`docker/kustomize/overlays/local`) now defaults to **`ghcr.io/danielsmithdevelopment/clawql-mcp:latest`** with `imagePullPolicy: Always`. Use **`CLAWQL_LOCAL_K8S_BUILD_IMAGE=1`** with `make local-k8s-up` to keep the previous local `docker build` flow.

**CI:** `azure/setup-helm` + `make helm-lint` in the workflow-scripts job. Root **Makefile** `helm-lint` target.

**Docker publish:** multi-platform **linux/amd64** + **linux/arm64** so Apple Silicon clusters can pull from GHCR.

## Files

- Chart: `charts/clawql-mcp/**`
- Docs: `docs/helm.md`, updates to `docs/deploy-k8s.md`, `docker/README.md`, `README.md`
- Website: `website/src/app/helm/page.mdx`, nav/sitemap/guides
- `.github/workflows/ci.yml`, `Makefile`, `CHANGELOG.md`