### PR TITLE
perf(website): Cloudflare Worker cost — leaner RSC, lazy search, edge cache

### DIFF
--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -37,6 +37,14 @@ const nextConfig = {
   outputFileTracingIncludes: {
     '/**/*': ['./src/app/**/*.mdx'],
   },
+  // Tree-shake heavy barrel imports — smaller RSC + client bundle (helps Workers + hydration).
+  experimental: {
+    optimizePackageImports: [
+      'framer-motion',
+      '@headlessui/react',
+      '@algolia/autocomplete-core',
+    ],
+  },
   /**
    * Edge / browser caching for docs.clawql.com (Cloudflare CDN honors `s-maxage` / `stale-while-revalidate`).
    * Later rules override earlier ones for the same header (Next.js merge behavior).
@@ -65,8 +73,9 @@ const nextConfig = {
         headers: [
           {
             key: 'Cache-Control',
+            // Longer shared edge TTL → fewer fresh HTML generations on the Worker (10ms CPU budget on Free).
             value:
-              'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400',
+              'public, max-age=0, s-maxage=86400, stale-while-revalidate=604800',
           },
           {
             key: 'Referrer-Policy',

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -2,33 +2,11 @@ import { type Metadata, type Viewport } from 'next'
 
 import { Providers } from '@/app/providers'
 import { Layout } from '@/components/Layout'
-import { type Section } from '@/components/SectionProvider'
 import { SiteStructuredData } from '@/components/SiteStructuredData'
 import { WebMcpRegister } from '@/components/WebMcpRegister'
 import { getSiteOrigin } from '@/lib/site-url'
 
-import { caseStudyCloudflareDocsSections } from '@/lib/case-study-cloudflare-docs-sections'
-import { caseStudyCrossThreadVaultRecallSections } from '@/lib/case-study-cross-thread-vault-recall-sections'
-import { caseStudyTruenasCorgicaveSections } from '@/lib/case-study-truenas-corgicave-sections'
-import { caseStudyVaultMemorySessionSections } from '@/lib/case-study-vault-memory-session-sections'
-import { caseStudyWorker1102McpMemorySections } from '@/lib/case-study-worker-1102-mcp-memory-sections'
-import { homePageSections } from '@/lib/home-page-sections'
-
 import '@/styles/tailwind.css'
-
-/** No runtime filesystem reads — Cloudflare Workers does not implement `fs.readdir`. */
-const allSections: Record<string, Array<Section>> = {
-  '/': homePageSections,
-  '/case-studies/cloudflare-docs-mcp': caseStudyCloudflareDocsSections,
-  '/case-studies/vault-memory-github-session-2026-04':
-    caseStudyVaultMemorySessionSections,
-  '/case-studies/cross-thread-vault-recall':
-    caseStudyCrossThreadVaultRecallSections,
-  '/case-studies/truenas-scale-corgicave-homelab':
-    caseStudyTruenasCorgicaveSections,
-  '/case-studies/docs-clawql-worker-1102-mcp-memory-2026-04':
-    caseStudyWorker1102McpMemorySections,
-}
 
 export const metadata: Metadata = {
   metadataBase: getSiteOrigin(),
@@ -102,7 +80,7 @@ export default function RootLayout({
         <Providers>
           <WebMcpRegister />
           <div className="w-full">
-            <Layout allSections={allSections}>{children}</Layout>
+            <Layout>{children}</Layout>
           </div>
         </Providers>
       </body>

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -30,7 +30,10 @@ const Search = dynamic(
 const MobileSearch = dynamic(
   () =>
     import('@/components/Search').then((m) => ({ default: m.MobileSearch })),
-  { ssr: false, loading: () => <div className="size-6 shrink-0 lg:hidden" aria-hidden /> },
+  {
+    ssr: false,
+    loading: () => <div className="size-6 shrink-0 lg:hidden" aria-hidden />,
+  },
 )
 
 function TopLevelNavItem({

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx'
 import { motion, useScroll, useTransform } from 'framer-motion'
+import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { forwardRef } from 'react'
 
@@ -10,9 +11,27 @@ import {
   useIsInsideMobileNavigation,
   useMobileNavigationStore,
 } from '@/components/MobileNavigation'
-import { MobileSearch, Search } from '@/components/Search'
 import { ThemeToggle } from '@/components/ThemeToggle'
 import { CloseButton } from '@headlessui/react'
+
+const Search = dynamic(
+  () => import('@/components/Search').then((m) => ({ default: m.Search })),
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        className="hidden h-8 w-full max-w-md lg:block lg:max-w-md lg:flex-auto"
+        aria-hidden
+      />
+    ),
+  },
+)
+
+const MobileSearch = dynamic(
+  () =>
+    import('@/components/Search').then((m) => ({ default: m.MobileSearch })),
+  { ssr: false, loading: () => <div className="size-6 shrink-0 lg:hidden" aria-hidden /> },
+)
 
 function TopLevelNavItem({
   href,

--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { motion } from 'framer-motion'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 
@@ -8,24 +7,16 @@ import { Footer } from '@/components/Footer'
 import { Header } from '@/components/Header'
 import { Logo } from '@/components/Logo'
 import { Navigation } from '@/components/Navigation'
-import { SectionProvider, type Section } from '@/components/SectionProvider'
+import { SectionProvider } from '@/components/SectionProvider'
+import { DOC_LAYOUT_SECTIONS_BY_PATH } from '@/lib/doc-layout-sections'
 
-export function Layout({
-  children,
-  allSections,
-}: {
-  children: React.ReactNode
-  allSections: Record<string, Array<Section>>
-}) {
+export function Layout({ children }: { children: React.ReactNode }) {
   let pathname = usePathname()
 
   return (
-    <SectionProvider sections={allSections[pathname] ?? []}>
+    <SectionProvider sections={DOC_LAYOUT_SECTIONS_BY_PATH[pathname] ?? []}>
       <div className="h-full lg:ml-72 xl:ml-80">
-        <motion.header
-          layoutScroll
-          className="contents lg:pointer-events-none lg:fixed lg:inset-0 lg:z-40 lg:flex"
-        >
+        <header className="contents lg:pointer-events-none lg:fixed lg:inset-0 lg:z-40 lg:flex">
           <div className="contents lg:pointer-events-auto lg:block lg:w-72 lg:overflow-y-auto lg:border-r lg:border-zinc-900/10 lg:px-6 lg:pt-4 lg:pb-8 xl:w-80 lg:dark:border-claw-graph/40">
             <div className="hidden lg:flex">
               <Link href="/" aria-label="Home">
@@ -35,7 +26,7 @@ export function Layout({
             <Header />
             <Navigation className="hidden lg:mt-10 lg:block" />
           </div>
-        </motion.header>
+        </header>
         <div className="relative flex h-full flex-col px-4 pt-14 sm:px-6 lg:px-8">
           <main id="main-content" className="flex-auto" tabIndex={-1}>
             {children}

--- a/website/src/lib/doc-layout-sections.ts
+++ b/website/src/lib/doc-layout-sections.ts
@@ -16,8 +16,10 @@ export const DOC_LAYOUT_SECTIONS_BY_PATH: Record<string, Array<Section>> = {
   '/case-studies/cloudflare-docs-mcp': caseStudyCloudflareDocsSections,
   '/case-studies/vault-memory-github-session-2026-04':
     caseStudyVaultMemorySessionSections,
-  '/case-studies/cross-thread-vault-recall': caseStudyCrossThreadVaultRecallSections,
-  '/case-studies/truenas-scale-corgicave-homelab': caseStudyTruenasCorgicaveSections,
+  '/case-studies/cross-thread-vault-recall':
+    caseStudyCrossThreadVaultRecallSections,
+  '/case-studies/truenas-scale-corgicave-homelab':
+    caseStudyTruenasCorgicaveSections,
   '/case-studies/docs-clawql-worker-1102-mcp-memory-2026-04':
     caseStudyWorker1102McpMemorySections,
 }

--- a/website/src/lib/doc-layout-sections.ts
+++ b/website/src/lib/doc-layout-sections.ts
@@ -1,0 +1,23 @@
+import type { Section } from '@/components/SectionProvider'
+
+import { caseStudyCloudflareDocsSections } from '@/lib/case-study-cloudflare-docs-sections'
+import { caseStudyCrossThreadVaultRecallSections } from '@/lib/case-study-cross-thread-vault-recall-sections'
+import { caseStudyTruenasCorgicaveSections } from '@/lib/case-study-truenas-corgicave-sections'
+import { caseStudyVaultMemorySessionSections } from '@/lib/case-study-vault-memory-session-sections'
+import { caseStudyWorker1102McpMemorySections } from '@/lib/case-study-worker-1102-mcp-memory-sections'
+import { homePageSections } from '@/lib/home-page-sections'
+
+/**
+ * In-page section nav (TOC) keyed by path. Kept in a **client** module so the
+ * root RSC does not embed this map in the RSC flight payload for every page.
+ */
+export const DOC_LAYOUT_SECTIONS_BY_PATH: Record<string, Array<Section>> = {
+  '/': homePageSections,
+  '/case-studies/cloudflare-docs-mcp': caseStudyCloudflareDocsSections,
+  '/case-studies/vault-memory-github-session-2026-04':
+    caseStudyVaultMemorySessionSections,
+  '/case-studies/cross-thread-vault-recall': caseStudyCrossThreadVaultRecallSections,
+  '/case-studies/truenas-scale-corgicave-homelab': caseStudyTruenasCorgicaveSections,
+  '/case-studies/docs-clawql-worker-1102-mcp-memory-2026-04':
+    caseStudyWorker1102McpMemorySections,
+}


### PR DESCRIPTION
## Summary
Reduces per-request and repeat-traffic cost for **docs.clawql.com** (Next + OpenNext on Cloudflare Workers) to stay within tight **Free** CPU limits and avoid **Error 1102** (`Worker exceeded resource limits`).

## Changes
- **RSC payload:** move the in-page TOC section map from the root `layout` server prop into `website/src/lib/doc-layout-sections.ts` and read it in the client `Layout` via `usePathname()` (no longer ship the full map through RSC for every page).
- **Search:** `next/dynamic` + `ssr: false` for `Search` / `MobileSearch` in `Header` (small layout placeholders). FlexSearch remains deferred until a query (existing dynamic `import` in `Search.tsx`).
- **Layout:** replace `motion.header` with a plain `header` in the shell; `Header` still uses framer for the sticky bar.
- **next.config:** `experimental.optimizePackageImports` for `framer-motion`, `@headlessui/react`, `@algolia/autocomplete-core`.
- **Cache-Control** for `/:path*`: `s-maxage` 1h → 24h, `stale-while-revalidate` 24h → 7d (fewer fresh HTML generations at the edge; browser `max-age=0` unchanged).

## Notes
- Did **not** add root `dynamic = 'force-static'` (can conflict with `app/api` route handlers that use `searchParams`).
- Optional follow-up: align the table in `docs/website-caching.md` with the new headers.

## Test plan
- [x] `cd website && npm run build`
- [x] `npx opennextjs-cloudflare build`