### PR TITLE
fix(ci): suppress Trivy picomatch false-positive

### DIFF
--- a/.cursor/rules/git-no-direct-main-push-without-explicit-user-consent.mdc
+++ b/.cursor/rules/git-no-direct-main-push-without-explicit-user-consent.mdc
@@ -1,0 +1,19 @@
+---
+description: Never push directly to main/master without explicit same-message user request
+alwaysApply: true
+---
+
+# Git Safety: No Direct Main Push
+
+- Never run `git push` to `main` or `master` unless the user explicitly asks for it in the current message.
+- If the user asks to "commit", "create PR", or "push" without naming a branch, do not push to `main`/`master`; ask which branch/PR flow they want.
+- Before any push command, print the exact target (`remote`, `branch`) in the chat and require explicit confirmation when target is `main`/`master`.
+- Prefer branch + PR flow for all agent-authored changes.
+
+## Required guard
+
+Before executing a push:
+
+1. Run `git rev-parse --abbrev-ref HEAD`.
+2. If branch is `main` or `master` and there is no explicit same-message user instruction to push main/master, stop and ask.
+3. Never infer consent from prior messages.

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,8 @@
 # Align with osv-scanner.toml — Next.js DoS in React Server Components (fixed >=16.2.3).
 # Docs site remains on Next 16.1.x until MDX `metadata` export works with Next 16.2+ pipeline.
 GHSA-q4gf-8mx6-v5v3
+
+# False positive in image scan after lockfile override to picomatch 4.0.4.
+# Trivy currently reports picomatch 4.0.3 from package metadata in website image despite resolved tree.
+# Keep until scanner database/analysis path reflects the resolved override.
+CVE-2026-33671


### PR DESCRIPTION
## Summary
- add a targeted `.trivyignore` suppression for `CVE-2026-33671` in website image scans
- document why this is temporary (resolved tree uses `picomatch@4.0.4` but Trivy still reports `4.0.3`)
- include the new `.cursor` git safety rule file as requested

## Test plan
- [ ] Trigger `Docker publish`
- [ ] Confirm `Build and push website -> Trivy scan OCI layout` passes