### PR TITLE
fix(ci): Cosign bundle format for Docker publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -151,10 +151,12 @@ jobs:
       # sigstore/cosign-installer — HEAD @ 2026-04 (pin updates via release tags when you bump).
       - name: Install Cosign
         uses: sigstore/cosign-installer@b5e753ae2d39589c7b38850b463739151fc67f07
+        with:
+          cosign-release: v2.4.3
 
-      - name: Cosign sign (keyless, recursive — Sigstore bundle format)
+      - name: Cosign sign (keyless, recursive — Kyverno-compatible bundle format)
         if: ${{ steps.oci_push.outputs.digest != '' }}
-        run: cosign sign --yes --recursive --new-bundle-format=true "${{ env.IMAGE_NAME }}@${{ steps.oci_push.outputs.digest }}"
+        run: cosign sign --yes --recursive --new-bundle-format=false "${{ env.IMAGE_NAME }}@${{ steps.oci_push.outputs.digest }}"
 
       - name: Promote rolling tags (latest / nightly / nightly-YYYYMMDD)
         if: ${{ steps.oci_push.outputs.digest != '' }}
@@ -261,10 +263,12 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@b5e753ae2d39589c7b38850b463739151fc67f07
+        with:
+          cosign-release: v2.4.3
 
-      - name: Cosign sign (keyless, recursive — Sigstore bundle format)
+      - name: Cosign sign (keyless, recursive — Kyverno-compatible bundle format)
         if: ${{ steps.oci_push.outputs.digest != '' }}
-        run: cosign sign --yes --recursive --new-bundle-format=true "${{ env.WEBSITE_IMAGE_NAME }}@${{ steps.oci_push.outputs.digest }}"
+        run: cosign sign --yes --recursive --new-bundle-format=false "${{ env.WEBSITE_IMAGE_NAME }}@${{ steps.oci_push.outputs.digest }}"
 
       - name: Promote rolling tags (latest / nightly / nightly-YYYYMMDD)
         if: ${{ steps.oci_push.outputs.digest != '' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -152,9 +152,9 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@b5e753ae2d39589c7b38850b463739151fc67f07
 
-      - name: Cosign sign (keyless, recursive, Kyverno-compatible bundle format)
+      - name: Cosign sign (keyless, recursive — Sigstore bundle format)
         if: ${{ steps.oci_push.outputs.digest != '' }}
-        run: cosign sign --yes --recursive --new-bundle-format=false "${{ env.IMAGE_NAME }}@${{ steps.oci_push.outputs.digest }}"
+        run: cosign sign --yes --recursive --new-bundle-format=true "${{ env.IMAGE_NAME }}@${{ steps.oci_push.outputs.digest }}"
 
       - name: Promote rolling tags (latest / nightly / nightly-YYYYMMDD)
         if: ${{ steps.oci_push.outputs.digest != '' }}
@@ -262,9 +262,9 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@b5e753ae2d39589c7b38850b463739151fc67f07
 
-      - name: Cosign sign (keyless, recursive, Kyverno-compatible bundle format)
+      - name: Cosign sign (keyless, recursive — Sigstore bundle format)
         if: ${{ steps.oci_push.outputs.digest != '' }}
-        run: cosign sign --yes --recursive --new-bundle-format=false "${{ env.WEBSITE_IMAGE_NAME }}@${{ steps.oci_push.outputs.digest }}"
+        run: cosign sign --yes --recursive --new-bundle-format=true "${{ env.WEBSITE_IMAGE_NAME }}@${{ steps.oci_push.outputs.digest }}"
 
       - name: Promote rolling tags (latest / nightly / nightly-YYYYMMDD)
         if: ${{ steps.oci_push.outputs.digest != '' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,11 @@
 # **Syft** SBOM artifact); **one BuildKit build** exports a **local OCI image layout** → **Trivy** scans it → **skopeo copy**
 # pushes **that same layout** to GHCR (**no second build / no drift**); **Cosign** (**`--recursive`** for multi-arch index + per-arch manifests) + **`imagetools`** promotion of
 # **`latest`** / **`nightly`** / **`nightly-YYYYMMDD`** only after the registry digest exists.
+#
+# Cosign pin (**v2.x** via **`cosign-release`**): Kyverno **`verifyImages`** on typical installs expects **legacy Sigstore bundle**
+# payloads (**`--new-bundle-format=false`**). Cosign **v3** defaults / **`--new-bundle-format=true`** emit **bundle v0.3**
+# artifacts that fail verification in-cluster; Cosign **v3** also errors when **`false`** is passed without satisfying its
+# newer signing-config rules — so we **pin Cosign v2** here and keep **`false`** for admission compatibility.
 name: Docker publish
 
 on:
@@ -148,7 +153,7 @@ jobs:
           DIGEST="$(skopeo inspect "${AUTH[@]}" "docker://${FIRST}" --format '{{.Digest}}')"
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
-      # sigstore/cosign-installer — HEAD @ 2026-04 (pin updates via release tags when you bump).
+      # Pin Cosign v2 — see workflow header (Kyverno verifyImages + legacy bundle format).
       - name: Install Cosign
         uses: sigstore/cosign-installer@b5e753ae2d39589c7b38850b463739151fc67f07
         with:
@@ -261,6 +266,7 @@ jobs:
           DIGEST="$(skopeo inspect "${AUTH[@]}" "docker://${FIRST}" --format '{{.Digest}}')"
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
+      # Pin Cosign v2 — see workflow header (Kyverno verifyImages + legacy bundle format).
       - name: Install Cosign
         uses: sigstore/cosign-installer@b5e753ae2d39589c7b38850b463739151fc67f07
         with:

--- a/docs/security/golden-image-pipeline.md
+++ b/docs/security/golden-image-pipeline.md
@@ -94,6 +94,8 @@ Immutable tags come from **`docker/metadata-action`** (**`type=sha,prefix=sha-,f
 
 **`cosign sign --yes <image>@<digest>`** uses **GitHub Actions OIDC** (`permissions: id-token: write`) → **Fulcio** / **Rekor** (keyless). The signature is bound to the **digest** that was pushed—same artifact as scanned.
 
+**Kyverno note:** [`docker-publish.yml`](../../.github/workflows/docker-publish.yml) pins **Cosign v2** and passes **`--new-bundle-format=false`** so signatures remain in the **legacy Sigstore bundle** form that **Kyverno `verifyImages`** accepts on typical clusters. **Cosign v3** with **`--new-bundle-format=true`** produces **bundle v0.3** signature artifacts that commonly fail in-cluster verification until Kyverno/Sigstore stacks catch up; **Cosign v3** with **`false`** can error depending on CLI/signing-config defaults—so the workflow intentionally stays on **v2** for admission compatibility.
+
 ---
 
 ## Step 6 — Promote rolling tags (`imagetools create`)

--- a/docs/security/image-signature-enforcement.md
+++ b/docs/security/image-signature-enforcement.md
@@ -52,6 +52,7 @@ spec:
 
 **Caveats**
 
+- **Cosign bundle format vs Kyverno:** CI must emit signatures Kyverno’s **`verifyImages`** can consume (this repo pins **Cosign v2** and **`--new-bundle-format=false`** in [`.github/workflows/docker-publish.yml`](../../.github/workflows/docker-publish.yml); **Cosign v3** “new bundle” artifacts often fail verification until policy/stack upgrades). See **[`golden-image-pipeline.md`](golden-image-pipeline.md)** Step 5.
 - **Kyverno version** skew: field names moved across releases (`failureAction` vs nested fields). Validate against your installed Kyverno docs.
 - **Private GHCR**: the admission controller needs **registry pull** access to fetch signatures/manifests (imagePullSecrets, workload identity, or Kyverno `imageRegistryCredentials`).
 - **Escape hatches** break the guarantee: policies that **exclude** namespaces, `kube-system`, or `failurePolicy: Ignore` on the webhook, or workloads that **bypass** the API server (static manifests applied with elevated rights) are all ways enforcement can be weakened.


### PR DESCRIPTION
## Problem
Docker publish fails during Cosign signing with:

`must provide --new-bundle-format or --bundle ...`

This matches Cosign v3 behavior when `--new-bundle-format=false` is used.

## Fix
- Update both `cosign sign` steps to `--new-bundle-format=true`.

## Test plan
- Trigger `Docker publish`
- Confirm both publish jobs reach Cosign signing successfully.