### PR TITLE
fix(ci): Cosign v2 signing — remove invalid --new-bundle-format flag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,9 +7,9 @@
 # **`latest`** / **`nightly`** / **`nightly-YYYYMMDD`** only after the registry digest exists.
 #
 # Cosign pin (**v2.x** via **`cosign-release`**): Kyverno **`verifyImages`** on typical installs expects **legacy Sigstore bundle**
-# payloads (**`--new-bundle-format=false`**). Cosign **v3** defaults / **`--new-bundle-format=true`** emit **bundle v0.3**
-# artifacts that fail verification in-cluster; Cosign **v3** also errors when **`false`** is passed without satisfying its
-# newer signing-config rules — so we **pin Cosign v2** here and keep **`false`** for admission compatibility.
+# payloads; **Cosign v2** emits those by default (**no** **`--new-bundle-format`** flag — that exists only in **v3**).
+# Cosign **v3** defaults / **`--new-bundle-format=true`** emit **bundle v0.3** artifacts that often fail verification in-cluster,
+# and mixing **v3** CLI with **`--new-bundle-format=false`** tripped signing-config checks — so we **pin Cosign v2** and sign with **`cosign sign --recursive`** only.
 name: Docker publish
 
 on:
@@ -159,9 +159,9 @@ jobs:
         with:
           cosign-release: v2.4.3
 
-      - name: Cosign sign (keyless, recursive — Kyverno-compatible bundle format)
+      - name: Cosign sign (keyless, recursive — Kyverno-compatible legacy bundles)
         if: ${{ steps.oci_push.outputs.digest != '' }}
-        run: cosign sign --yes --recursive --new-bundle-format=false "${{ env.IMAGE_NAME }}@${{ steps.oci_push.outputs.digest }}"
+        run: cosign sign --yes --recursive "${{ env.IMAGE_NAME }}@${{ steps.oci_push.outputs.digest }}"
 
       - name: Promote rolling tags (latest / nightly / nightly-YYYYMMDD)
         if: ${{ steps.oci_push.outputs.digest != '' }}
@@ -272,9 +272,9 @@ jobs:
         with:
           cosign-release: v2.4.3
 
-      - name: Cosign sign (keyless, recursive — Kyverno-compatible bundle format)
+      - name: Cosign sign (keyless, recursive — Kyverno-compatible legacy bundles)
         if: ${{ steps.oci_push.outputs.digest != '' }}
-        run: cosign sign --yes --recursive --new-bundle-format=false "${{ env.WEBSITE_IMAGE_NAME }}@${{ steps.oci_push.outputs.digest }}"
+        run: cosign sign --yes --recursive "${{ env.WEBSITE_IMAGE_NAME }}@${{ steps.oci_push.outputs.digest }}"
 
       - name: Promote rolling tags (latest / nightly / nightly-YYYYMMDD)
         if: ${{ steps.oci_push.outputs.digest != '' }}

--- a/docs/security/golden-image-pipeline.md
+++ b/docs/security/golden-image-pipeline.md
@@ -94,7 +94,7 @@ Immutable tags come from **`docker/metadata-action`** (**`type=sha,prefix=sha-,f
 
 **`cosign sign --yes <image>@<digest>`** uses **GitHub Actions OIDC** (`permissions: id-token: write`) → **Fulcio** / **Rekor** (keyless). The signature is bound to the **digest** that was pushed—same artifact as scanned.
 
-**Kyverno note:** [`docker-publish.yml`](../../.github/workflows/docker-publish.yml) pins **Cosign v2** and passes **`--new-bundle-format=false`** so signatures remain in the **legacy Sigstore bundle** form that **Kyverno `verifyImages`** accepts on typical clusters. **Cosign v3** with **`--new-bundle-format=true`** produces **bundle v0.3** signature artifacts that commonly fail in-cluster verification until Kyverno/Sigstore stacks catch up; **Cosign v3** with **`false`** can error depending on CLI/signing-config defaults—so the workflow intentionally stays on **v2** for admission compatibility.
+**Kyverno note:** [`docker-publish.yml`](../../.github/workflows/docker-publish.yml) pins **Cosign v2**, whose default signatures use the **legacy Sigstore bundle** form that **Kyverno `verifyImages`** accepts on typical clusters (**v2 has no** **`--new-bundle-format`** flag — that is **v3** only). **Cosign v3** with **`--new-bundle-format=true`** produces **bundle v0.3** signature artifacts that commonly fail in-cluster verification until Kyverno/Sigstore stacks catch up; **Cosign v3** signing paths also diverged — so the workflow intentionally stays on **v2** for admission compatibility.
 
 ---
 

--- a/docs/security/image-signature-enforcement.md
+++ b/docs/security/image-signature-enforcement.md
@@ -52,7 +52,7 @@ spec:
 
 **Caveats**
 
-- **Cosign bundle format vs Kyverno:** CI must emit signatures Kyverno’s **`verifyImages`** can consume (this repo pins **Cosign v2** and **`--new-bundle-format=false`** in [`.github/workflows/docker-publish.yml`](../../.github/workflows/docker-publish.yml); **Cosign v3** “new bundle” artifacts often fail verification until policy/stack upgrades). See **[`golden-image-pipeline.md`](golden-image-pipeline.md)** Step 5.
+- **Cosign bundle format vs Kyverno:** CI must emit signatures Kyverno’s **`verifyImages`** can consume (this repo pins **Cosign v2** in [`.github/workflows/docker-publish.yml`](../../.github/workflows/docker-publish.yml); **v2** defaults to legacy bundles; **`--new-bundle-format`** is **v3** only). **Cosign v3** “new bundle” artifacts often fail verification until policy/stack upgrades. See **[`golden-image-pipeline.md`](golden-image-pipeline.md)** Step 5.
 - **Kyverno version** skew: field names moved across releases (`failureAction` vs nested fields). Validate against your installed Kyverno docs.
 - **Private GHCR**: the admission controller needs **registry pull** access to fetch signatures/manifests (imagePullSecrets, workload identity, or Kyverno `imageRegistryCredentials`).
 - **Escape hatches** break the guarantee: policies that **exclude** namespaces, `kube-system`, or `failurePolicy: Ignore` on the webhook, or workloads that **bypass** the API server (static manifests applied with elevated rights) are all ways enforcement can be weakened.


### PR DESCRIPTION
## Problem
Run 25128732904 failed at **Cosign sign** with:

```
Error: unknown flag: --new-bundle-format
```

**`--new-bundle-format` is Cosign v3 only.** PR #233 pinned Cosign **v2.4.3** but left that flag on the `cosign sign` command.

## Change
- Sign with `cosign sign --yes --recursive` only (Cosign v2 default bundle shape matches Kyverno expectations).
- Update workflow header and security docs so they describe v2 vs v3 accurately.

## Verification
Merge then run **Docker publish** workflow on `main`; Cosign step should proceed past install/sign.