### PR TITLE
docs: OpenClaw bootstrap + IDP profile; NATS JetStream conventions (#226 #227 #127)

### DIFF
--- a/charts/clawql-mcp/README.md
+++ b/charts/clawql-mcp/README.md
@@ -36,6 +36,15 @@ ClawQL exposes **OpenMetrics** on **`GET /metrics`** (native GraphQL/gRPC counte
 
 Issue [#127](https://github.com/danielsmithdevelopment/ClawQL/issues/127) adds optional in-cluster NATS JetStream as an event backbone for Ouroboros, agent orchestration, and edge synchronization.
 
+**Subject roots** (streams are app-owned; defaults in **`values.yaml`** → **`nats.subjectConvention`**):
+
+- `clawql.workflow` — workflow / Ouroboros checkpoints
+- `clawql.agent` — agent coordination
+- `clawql.document` — document pipeline events
+- `clawql.edge` — edge worker sync
+
+Deep dive (retention guidance, Prometheus notes, integration links): **[`docs/deployment/helm.md`](../../docs/deployment/helm.md#nats-jetstream-deep-dive)** (**Subject naming** → [`#subject-naming-deck-aligned`](../../docs/deployment/helm.md#subject-naming-deck-aligned)). Public site mirror: **`/nats-jetstream`** on [clawql.io](https://clawql.com).
+
 Enable:
 
 ```bash
@@ -45,10 +54,13 @@ helm upgrade --install clawql ./charts/clawql-mcp -n clawql --create-namespace \
   --set nats.persistence.size=20Gi
 ```
 
-Verify:
+Verify (resource names assume default **`fullnameOverride: clawql-mcp-http`**):
 
 ```bash
 kubectl -n clawql get deploy,svc,pvc | rg nats
 kubectl -n clawql logs deploy/clawql-mcp-http-nats
+kubectl -n clawql port-forward svc/clawql-mcp-http-nats 8222:8222
+curl -s http://127.0.0.1:8222/healthz
+curl -s http://127.0.0.1:8222/jsz | head -c 500
 kubectl -n clawql get deploy clawql-mcp-http -o yaml | rg "CLAWQL_NATS_URL|CLAWQL_NATS_JETSTREAM" -n
 ```

--- a/charts/clawql-mcp/templates/NOTES.txt
+++ b/charts/clawql-mcp/templates/NOTES.txt
@@ -15,7 +15,15 @@
 {{- end }}
 
 2. Optional gRPC (set enableGrpc: true): port {{ .Values.service.grpc.port }} on the same Service.
+{{- if .Values.nats.enabled }}
+
+3. NATS JetStream (optional backbone; GitHub issue #127):
+   kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "clawql-mcp.natsName" . }} 8222:{{ .Values.nats.service.monitorPort }}
+   curl -s http://127.0.0.1:8222/healthz && curl -s http://127.0.0.1:8222/jsz | head -c 400
+   Subject roots (see values `nats.subjectConvention`): {{ .Values.nats.subjectConvention.workflow }}, {{ .Values.nats.subjectConvention.agent }}, {{ .Values.nats.subjectConvention.document }}, {{ .Values.nats.subjectConvention.edge }}
+
+{{- end }}
 {{- if .Values.kyverno.imageSignaturePolicy.enabled }}
 
-3. Kyverno image signature policy is enabled: verify Kyverno is installed and `kubectl get clusterpolicy` shows the ClawQL GHCR Cosign policy. See `docs/security/image-signature-enforcement.md`.
+{{ if .Values.nats.enabled }}4{{ else }}3{{ end }}. Kyverno image signature policy is enabled: verify Kyverno is installed and `kubectl get clusterpolicy` shows the ClawQL GHCR Cosign policy. See `docs/security/image-signature-enforcement.md`.
 {{- end }}

--- a/charts/clawql-mcp/values.yaml
+++ b/charts/clawql-mcp/values.yaml
@@ -500,6 +500,13 @@ nats:
     limits:
       cpu: "1"
       memory: 1Gi
+  # Deck-aligned subject roots for JetStream publishers/consumers ([#127](https://github.com/danielsmithdevelopment/ClawQL/issues/127)).
+  # Helm deploys NATS only — streams/consumers are created by application workers (Ouroboros, agents, edge), not by templates.
+  subjectConvention:
+    workflow: clawql.workflow
+    agent: clawql.agent
+    document: clawql.document
+    edge: clawql.edge
 
 # Extra env (e.g. tokens from literal — prefer existing secrets for production).
 extraEnv: []

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,9 @@ This directory is organized by purpose so operational guides, product docs, and 
 
 ## Deployment and Platform Operations
 
+- `openclaw/clawql-bootstrap.md` — register ClawQL in OpenClaw, env matrix, smoke checklist ([#226](https://github.com/danielsmithdevelopment/ClawQL/issues/226))
+- `openclaw/openclaw-idp-skill-profile.md` — **OpenClaw IDP** canonical tools, provider matrix, workflow contract ([#227](https://github.com/danielsmithdevelopment/ClawQL/issues/227))
+- `deployment/helm.md` § **NATS JetStream deep dive** — optional in-cluster event backbone, subject conventions, ops ([#127](https://github.com/danielsmithdevelopment/ClawQL/issues/127)); website **`/nats-jetstream`**
 - `deployment/deploy-cloud-run.md`
 - `deployment/deploy-k8s.md`
 - `deployment/helm.md`

--- a/docs/clawql-ecosystem.md
+++ b/docs/clawql-ecosystem.md
@@ -892,7 +892,7 @@ The body of this doc describes a **target experience**. The bullets below are **
 
 **Separate products / repos**
 
-- **OpenClaw** — governance UI, audit explorer, “digital employee” console: **not** shipped inside this repository; track integration via [#128](https://github.com/danielsmithdevelopment/ClawQL/issues/128).
+- **OpenClaw** — governance UI, audit explorer, “digital employee” console: **not** shipped inside this repository; track integration via [#128](https://github.com/danielsmithdevelopment/ClawQL/issues/128). Phase 0 MCP wiring and smokes: [`docs/openclaw/clawql-bootstrap.md`](openclaw/clawql-bootstrap.md) ([#226](https://github.com/danielsmithdevelopment/ClawQL/issues/226)). Default IDP skill profile (tools + matrix): [`docs/openclaw/openclaw-idp-skill-profile.md`](openclaw/openclaw-idp-skill-profile.md) ([#227](https://github.com/danielsmithdevelopment/ClawQL/issues/227)).
 - **ClawQL-Agent** — LangGraph runtime, long-lived employees, LangFuse-heavy ops: **private / separate** from core MCP; same epic [#128](https://github.com/danielsmithdevelopment/ClawQL/issues/128).
 - **Edge Worker mode** — laptops as pooled workers: narrative only until [#129](https://github.com/danielsmithdevelopment/ClawQL/issues/129) (and related work) lands end-to-end.
 

--- a/docs/deployment/deploy-k8s.md
+++ b/docs/deployment/deploy-k8s.md
@@ -130,6 +130,7 @@ kubectl -n clawql get deploy,svc,pvc | rg nats
 kubectl -n clawql logs deploy/clawql-mcp-http-nats
 kubectl -n clawql port-forward svc/clawql-mcp-http-nats 8222:8222
 curl -s http://127.0.0.1:8222/healthz
+curl -s http://127.0.0.1:8222/jsz | head -c 800
 kubectl -n clawql get deploy clawql-mcp-http -o yaml | rg "CLAWQL_NATS_URL|CLAWQL_NATS_JETSTREAM" -n
 ```
 
@@ -138,5 +139,5 @@ kubectl -n clawql get deploy clawql-mcp-http -o yaml | rg "CLAWQL_NATS_URL|CLAWQ
 - Keep service type `ClusterIP` for private east-west traffic.
 - Always enable persistence if workflow replay/recovery matters.
 - Budget PV size and JetStream max file store together.
-- Add internal scrape for monitor endpoint (`8222`) and alert on health degradation.
-- Standardize subjects early (`clawql.workflow.*`, `clawql.agent.*`, `clawql.document.*`, `clawql.edge.*`) to avoid migration churn.
+- Add internal scrape for monitor endpoint (`8222`) and alert on health degradation (broker JSON — use NATS Prometheus exporter or probe **`/healthz`**; see [helm.md § NATS JetStream deep dive](helm.md#nats-jetstream-deep-dive)).
+- Standardize subjects early — **`nats.subjectConvention`** in **`charts/clawql-mcp/values.yaml`** (`clawql.workflow`, `clawql.agent`, `clawql.document`, `clawql.edge`) — to avoid migration churn ([#127](https://github.com/danielsmithdevelopment/ClawQL/issues/127)).

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -179,6 +179,29 @@ helm upgrade --install clawql ./charts/clawql-mcp -n clawql --create-namespace \
 - Restrict monitor port (`8222`) to trusted internal networks.
 - Document stream retention/consumer ack policy in the app layer so storage growth is predictable.
 
+### Subject naming (deck-aligned)
+
+Issue [#127](https://github.com/danielsmithdevelopment/ClawQL/issues/127) tracks Helm + docs for this convention.
+
+Helm deploys **only** the NATS server. **JetStream streams and consumers** are created by workers (Ouroboros, agents, edge jobs), not by chart templates — standardize **subject roots** early:
+
+| Root | Use |
+|------|-----|
+| `clawql.workflow.>` | Ouroboros phases, workflow checkpoints, structured loops ([#110](https://github.com/danielsmithdevelopment/ClawQL/issues/110)) |
+| `clawql.agent.>` | Agent coordination, LangGraph-related handoff ([ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)) |
+| `clawql.document.>` | Document pipeline hops (Tika → Gotenberg → Stirling → Paperless), provenance |
+| `clawql.edge.>` | Edge worker join/leave/status ([#129](https://github.com/danielsmithdevelopment/ClawQL/issues/129)) |
+
+Defaults live in chart **`values.yaml`** as **`nats.subjectConvention`** (`workflow` / `agent` / `document` / `edge` keys) for operators and downstream charts.
+
+**Related in-repo tracks:** Cuckoo/Merkle and audit publications ([#114](https://github.com/danielsmithdevelopment/ClawQL/issues/114), [#115](https://github.com/danielsmithdevelopment/ClawQL/issues/115), [#89](https://github.com/danielsmithdevelopment/ClawQL/issues/89)); full-stack service map ([#113](https://github.com/danielsmithdevelopment/ClawQL/issues/113)).
+
+**Retention / consumers:** choose per stream — for example **limits** retention with **`max_age`** for workflow telemetry vs **interest** for task queues. Set **ACK** policies explicitly on pull consumers so replay behavior matches compliance expectations. Configure streams in application init or GitOps — not in the NATS `ConfigMap` here.
+
+**Prometheus / Grafana:** the broker monitor port exposes **JSON** (`/healthz`, `/jsz`, `/varz`), not OpenMetrics. Use **[NATS Prometheus exporter](https://github.com/nats-io/prometheus-nats-exporter)** sidecar or HTTP probes for uptime; wire dashboards separately from ClawQL’s **`GET /metrics`** ([#210](https://github.com/danielsmithdevelopment/ClawQL/issues/210)).
+
+**Out of scope for v1:** multi-cluster NATS federation (deck “FUTURE”) — track when single-cluster JetStream is stable.
+
 ### Validate before/after deploy
 
 Template check:
@@ -194,6 +217,7 @@ kubectl -n clawql get deploy,svc,pvc | rg nats
 kubectl -n clawql logs deploy/clawql-mcp-http-nats
 kubectl -n clawql port-forward svc/clawql-mcp-http-nats 8222:8222
 curl -s http://127.0.0.1:8222/healthz
+curl -s http://127.0.0.1:8222/jsz | head -c 800
 kubectl -n clawql get deploy clawql-mcp-http -o yaml | rg "CLAWQL_NATS_URL|CLAWQL_NATS_JETSTREAM" -n
 ```
 

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -185,12 +185,12 @@ Issue [#127](https://github.com/danielsmithdevelopment/ClawQL/issues/127) tracks
 
 Helm deploys **only** the NATS server. **JetStream streams and consumers** are created by workers (Ouroboros, agents, edge jobs), not by chart templates — standardize **subject roots** early:
 
-| Root | Use |
-|------|-----|
+| Root                | Use                                                                                                                            |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `clawql.workflow.>` | Ouroboros phases, workflow checkpoints, structured loops ([#110](https://github.com/danielsmithdevelopment/ClawQL/issues/110)) |
-| `clawql.agent.>` | Agent coordination, LangGraph-related handoff ([ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent)) |
-| `clawql.document.>` | Document pipeline hops (Tika → Gotenberg → Stirling → Paperless), provenance |
-| `clawql.edge.>` | Edge worker join/leave/status ([#129](https://github.com/danielsmithdevelopment/ClawQL/issues/129)) |
+| `clawql.agent.>`    | Agent coordination, LangGraph-related handoff ([ClawQL-Agent](https://github.com/danielsmithdevelopment/ClawQL-Agent))         |
+| `clawql.document.>` | Document pipeline hops (Tika → Gotenberg → Stirling → Paperless), provenance                                                   |
+| `clawql.edge.>`     | Edge worker join/leave/status ([#129](https://github.com/danielsmithdevelopment/ClawQL/issues/129))                            |
 
 Defaults live in chart **`values.yaml`** as **`nats.subjectConvention`** (`workflow` / `agent` / `document` / `edge` keys) for operators and downstream charts.
 

--- a/docs/openclaw/clawql-bootstrap.md
+++ b/docs/openclaw/clawql-bootstrap.md
@@ -1,0 +1,104 @@
+# OpenClaw + ClawQL MCP — bootstrap and smoke tests
+
+This runbook supports **[#226](https://github.com/danielsmithdevelopment/ClawQL/issues/226)** (Phase 0 wiring). OpenClaw itself is **not** built in this repo; track the umbrella narrative in **[#128](https://github.com/danielsmithdevelopment/ClawQL/issues/128)**.
+
+**After this path is green:** comment on **[#128](https://github.com/danielsmithdevelopment/ClawQL/issues/128)** with a pointer here + PR link so Phase 0 stays traceable.
+
+**IDP skill profile (agents/operators):** **[`openclaw-idp-skill-profile.md`](openclaw-idp-skill-profile.md)** ([#227](https://github.com/danielsmithdevelopment/ClawQL/issues/227)) — canonical tools, provider matrix, and workflow contract.
+
+## What “green” means
+
+1. ClawQL MCP serves tools over **stdio** or **Streamable HTTP** with a documented env matrix.
+2. OpenClaw (or any MCP client) registers that server using the **same** command/URL shape as Cursor’s `mcp.json`.
+3. You complete the **smoke checklist** below (or run the repo script) with clear pass/fail.
+
+## Register ClawQL in OpenClaw
+
+Follow **your OpenClaw version’s** MCP docs for `mcp set` / UI equivalent. The ClawQL side mirrors **[`docs/readme/deployment.md`](../readme/deployment.md)**:
+
+| Mode | What you register |
+|------|-------------------|
+| **Stdio** | Command: `npx` (or `node` to `dist/server.js` after `npm run build`), args: `-y`, `clawql-mcp` — plus env vars below. Working directory: optional; use repo root if developing from source. |
+| **HTTP** | URL ending in **`/mcp`** (e.g. `http://localhost:8080/mcp`). Run **`npm run start:http`** or your Helm/K8s Service URL. |
+
+Cursor template: **`.cursor/mcp.json.example`** at repo root.
+
+**OpenClaw CLI-shaped registration (illustrative — align with your OpenClaw version):**
+
+```bash
+# Stdio from published package (adjust env file path)
+openclaw mcp set clawql -- \
+  env -i HOME="$HOME" PATH="$PATH" \
+  bash -lc 'set -a; [ -f ~/.config/clawql/idp.env ] && . ~/.config/clawql/idp.env; exec npx -y clawql-mcp'
+
+# HTTP MCP already listening on port 8080
+openclaw mcp set clawql-url --url 'http://localhost:8080/mcp'
+```
+
+**Private tailnets:** use MagicDNS or Tailscale Serve HTTPS URLs for **`/mcp`**, aligned with **`docs/deployment/tailscale-and-headscale-for-clawql.md`**.
+
+## Baseline env matrix (IDP-oriented)
+
+Unset typically means **on** for memory and documents; see **[`docs/readme/configuration.md`](../readme/configuration.md)**.
+
+| Goal | Variables (examples) |
+|------|----------------------|
+| Core **`search` / `execute`** | Default; optional **`CLAWQL_PROVIDER=all-providers`** |
+| Document pipeline tools (**`ingest_external_knowledge`**, bundled Tika/Gotenberg/Stirling/Paperless in index) | **`CLAWQL_ENABLE_DOCUMENTS=1`** (default). To hide: **`CLAWQL_ENABLE_DOCUMENTS=0`**. |
+| Onyx **`knowledge_search_onyx`** | **`CLAWQL_ENABLE_ONYX=1`** and documents still enabled; set **`ONYX_BASE_URL`** + auth per **[`docs/onyx-knowledge-tool.md`](../onyx-knowledge-tool.md)** |
+| Ouroboros **`ouroboros_*`** | **`CLAWQL_ENABLE_OUROBOROS=1`** |
+| Vault memory **`memory_*`** | Writable **`CLAWQL_OBSIDIAN_VAULT_PATH`** for real I/O |
+| External ingest (non-stub imports) | **`CLAWQL_EXTERNAL_INGEST=1`**; optional **`CLAWQL_EXTERNAL_INGEST_FETCH=1`** for URL fetch |
+| Privacy filter (deployment-specific) | If **your** stack defines **`CLAWQL_ENABLE_PRIVACY_FILTER=1`** (or equivalent), document it **beside** ClawQL — not in core **`.env.example`** today. |
+
+**Privacy / redaction:** Enterprise deployments may inject redaction or policy in front of the document stack (Helm values, sidecars). There is **no single** core-repo **`CLAWQL_ENABLE_*`** toggle for all “privacy filter” stories; validate against **your** chart and **[`docs/enterprise-mcp-tools.md`](../enterprise-mcp-tools.md#regulated-deployments)** for regulated environments.
+
+**Gotenberg / Stirling “transform” smokes:** Require reachable **`GOTENBERG_BASE_URL`**, **`STIRLING_PDF_BASE_URL`**, **`TIKA_BASE_URL`**, etc., when not using defaults from your environment. Without those services, skip extended smokes and stay on **core + ingest stub/preview** paths.
+
+## Automated smoke (CI-friendly)
+
+From repo root after a build:
+
+```bash
+npm run build
+npm run smoke:openclaw-bootstrap
+```
+
+This checks MCP **`listTools`** for **`search`** / **`execute`**, runs **`search` → `execute`** against the **bundled GitHub** provider (offline specs), and asserts **`ingest_external_knowledge`** is listed when documents are enabled.
+
+**Pass:** script exits **0** and prints **`OK`**.  
+**Fail:** non-zero exit; stderr shows the failing step.
+
+Optional env (same as **`scripts/workflows/smoke-github-commits.mjs`**): **`GITHUB_OWNER`**, **`GITHUB_REPO`**, **`CLAWQL_BEARER_TOKEN`** / **`gh auth login`**.
+
+To smoke **without** the GitHub execute step (tools-only):
+
+```bash
+CLAWQL_OPENCLAW_BOOTSTRAP_TOOLS_ONLY=1 npm run smoke:openclaw-bootstrap
+```
+
+## Manual checklist (OpenClaw → ClawQL)
+
+Use this when validating through the OpenClaw UI (mirrors what the script proves against stdio).
+
+| Step | Action | Pass |
+|------|--------|------|
+| 1 | In OpenClaw, send a prompt that triggers **`search`** for a GitHub operation (e.g. list commits) and then **`execute`** with lean **`fields`**. | JSON result; no MCP transport error. |
+| 2 | **Document path:** call **`ingest_external_knowledge`** per **[`docs/external-ingest.md`](../external-ingest.md)** (vault path + **`CLAWQL_EXTERNAL_INGEST=1`** as needed). | Success payload or documented preview when dry-run. |
+| 3 | **Privacy:** confirm your deployment’s redaction/policy behavior (if any) on a sample doc — align with ops runbooks. | Matches expected policy. |
+| 4 | **Transform (optional):** **`execute`** a Stirling/Gotenberg **`operationId`** only when those bases are up. | PDF/transform response as expected. |
+
+## Troubleshooting
+
+| Symptom | Check |
+|---------|--------|
+| OpenClaw cannot connect to MCP | Stdio: command on `PATH`, **`npx`** can resolve **`clawql-mcp`**. HTTP: firewall, **`PORT`**, URL includes **`/mcp`**. |
+| **`listTools`** missing document tools | **`CLAWQL_ENABLE_DOCUMENTS=0`** not set; rebuild/restart server. |
+| **`execute`** 401 from GitHub | **`CLAWQL_BEARER_TOKEN`** / **`gh auth token`** for private repos. |
+| gRPC native protocols | **[`ENABLE_GRPC=1`](../readme/deployment.md#optional-grpc-transport)** — separate from OpenClaw MCP bridge over HTTP/stdio. |
+
+## Related issues
+
+- **[#226](https://github.com/danielsmithdevelopment/ClawQL/issues/226)** — bootstrap acceptance (this doc + **`npm run smoke:openclaw-bootstrap`**).
+- **[#227](https://github.com/danielsmithdevelopment/ClawQL/issues/227)** — **[IDP skill profile](openclaw-idp-skill-profile.md)** (canonical matrix + workflow).
+- **[#128](https://github.com/danielsmithdevelopment/ClawQL/issues/128)** — ecosystem / OpenClaw + Agent umbrella (**cross-link Phase 0 here when closing #226**).

--- a/docs/openclaw/clawql-bootstrap.md
+++ b/docs/openclaw/clawql-bootstrap.md
@@ -16,10 +16,10 @@ This runbook supports **[#226](https://github.com/danielsmithdevelopment/ClawQL/
 
 Follow **your OpenClaw version’s** MCP docs for `mcp set` / UI equivalent. The ClawQL side mirrors **[`docs/readme/deployment.md`](../readme/deployment.md)**:
 
-| Mode | What you register |
-|------|-------------------|
+| Mode      | What you register                                                                                                                                                                           |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Stdio** | Command: `npx` (or `node` to `dist/server.js` after `npm run build`), args: `-y`, `clawql-mcp` — plus env vars below. Working directory: optional; use repo root if developing from source. |
-| **HTTP** | URL ending in **`/mcp`** (e.g. `http://localhost:8080/mcp`). Run **`npm run start:http`** or your Helm/K8s Service URL. |
+| **HTTP**  | URL ending in **`/mcp`** (e.g. `http://localhost:8080/mcp`). Run **`npm run start:http`** or your Helm/K8s Service URL.                                                                     |
 
 Cursor template: **`.cursor/mcp.json.example`** at repo root.
 
@@ -41,15 +41,15 @@ openclaw mcp set clawql-url --url 'http://localhost:8080/mcp'
 
 Unset typically means **on** for memory and documents; see **[`docs/readme/configuration.md`](../readme/configuration.md)**.
 
-| Goal | Variables (examples) |
-|------|----------------------|
-| Core **`search` / `execute`** | Default; optional **`CLAWQL_PROVIDER=all-providers`** |
-| Document pipeline tools (**`ingest_external_knowledge`**, bundled Tika/Gotenberg/Stirling/Paperless in index) | **`CLAWQL_ENABLE_DOCUMENTS=1`** (default). To hide: **`CLAWQL_ENABLE_DOCUMENTS=0`**. |
-| Onyx **`knowledge_search_onyx`** | **`CLAWQL_ENABLE_ONYX=1`** and documents still enabled; set **`ONYX_BASE_URL`** + auth per **[`docs/onyx-knowledge-tool.md`](../onyx-knowledge-tool.md)** |
-| Ouroboros **`ouroboros_*`** | **`CLAWQL_ENABLE_OUROBOROS=1`** |
-| Vault memory **`memory_*`** | Writable **`CLAWQL_OBSIDIAN_VAULT_PATH`** for real I/O |
-| External ingest (non-stub imports) | **`CLAWQL_EXTERNAL_INGEST=1`**; optional **`CLAWQL_EXTERNAL_INGEST_FETCH=1`** for URL fetch |
-| Privacy filter (deployment-specific) | If **your** stack defines **`CLAWQL_ENABLE_PRIVACY_FILTER=1`** (or equivalent), document it **beside** ClawQL — not in core **`.env.example`** today. |
+| Goal                                                                                                          | Variables (examples)                                                                                                                                      |
+| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Core **`search` / `execute`**                                                                                 | Default; optional **`CLAWQL_PROVIDER=all-providers`**                                                                                                     |
+| Document pipeline tools (**`ingest_external_knowledge`**, bundled Tika/Gotenberg/Stirling/Paperless in index) | **`CLAWQL_ENABLE_DOCUMENTS=1`** (default). To hide: **`CLAWQL_ENABLE_DOCUMENTS=0`**.                                                                      |
+| Onyx **`knowledge_search_onyx`**                                                                              | **`CLAWQL_ENABLE_ONYX=1`** and documents still enabled; set **`ONYX_BASE_URL`** + auth per **[`docs/onyx-knowledge-tool.md`](../onyx-knowledge-tool.md)** |
+| Ouroboros **`ouroboros_*`**                                                                                   | **`CLAWQL_ENABLE_OUROBOROS=1`**                                                                                                                           |
+| Vault memory **`memory_*`**                                                                                   | Writable **`CLAWQL_OBSIDIAN_VAULT_PATH`** for real I/O                                                                                                    |
+| External ingest (non-stub imports)                                                                            | **`CLAWQL_EXTERNAL_INGEST=1`**; optional **`CLAWQL_EXTERNAL_INGEST_FETCH=1`** for URL fetch                                                               |
+| Privacy filter (deployment-specific)                                                                          | If **your** stack defines **`CLAWQL_ENABLE_PRIVACY_FILTER=1`** (or equivalent), document it **beside** ClawQL — not in core **`.env.example`** today.     |
 
 **Privacy / redaction:** Enterprise deployments may inject redaction or policy in front of the document stack (Helm values, sidecars). There is **no single** core-repo **`CLAWQL_ENABLE_*`** toggle for all “privacy filter” stories; validate against **your** chart and **[`docs/enterprise-mcp-tools.md`](../enterprise-mcp-tools.md#regulated-deployments)** for regulated environments.
 
@@ -81,21 +81,21 @@ CLAWQL_OPENCLAW_BOOTSTRAP_TOOLS_ONLY=1 npm run smoke:openclaw-bootstrap
 
 Use this when validating through the OpenClaw UI (mirrors what the script proves against stdio).
 
-| Step | Action | Pass |
-|------|--------|------|
-| 1 | In OpenClaw, send a prompt that triggers **`search`** for a GitHub operation (e.g. list commits) and then **`execute`** with lean **`fields`**. | JSON result; no MCP transport error. |
-| 2 | **Document path:** call **`ingest_external_knowledge`** per **[`docs/external-ingest.md`](../external-ingest.md)** (vault path + **`CLAWQL_EXTERNAL_INGEST=1`** as needed). | Success payload or documented preview when dry-run. |
-| 3 | **Privacy:** confirm your deployment’s redaction/policy behavior (if any) on a sample doc — align with ops runbooks. | Matches expected policy. |
-| 4 | **Transform (optional):** **`execute`** a Stirling/Gotenberg **`operationId`** only when those bases are up. | PDF/transform response as expected. |
+| Step | Action                                                                                                                                                                      | Pass                                                |
+| ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| 1    | In OpenClaw, send a prompt that triggers **`search`** for a GitHub operation (e.g. list commits) and then **`execute`** with lean **`fields`**.                             | JSON result; no MCP transport error.                |
+| 2    | **Document path:** call **`ingest_external_knowledge`** per **[`docs/external-ingest.md`](../external-ingest.md)** (vault path + **`CLAWQL_EXTERNAL_INGEST=1`** as needed). | Success payload or documented preview when dry-run. |
+| 3    | **Privacy:** confirm your deployment’s redaction/policy behavior (if any) on a sample doc — align with ops runbooks.                                                        | Matches expected policy.                            |
+| 4    | **Transform (optional):** **`execute`** a Stirling/Gotenberg **`operationId`** only when those bases are up.                                                                | PDF/transform response as expected.                 |
 
 ## Troubleshooting
 
-| Symptom | Check |
-|---------|--------|
-| OpenClaw cannot connect to MCP | Stdio: command on `PATH`, **`npx`** can resolve **`clawql-mcp`**. HTTP: firewall, **`PORT`**, URL includes **`/mcp`**. |
-| **`listTools`** missing document tools | **`CLAWQL_ENABLE_DOCUMENTS=0`** not set; rebuild/restart server. |
-| **`execute`** 401 from GitHub | **`CLAWQL_BEARER_TOKEN`** / **`gh auth token`** for private repos. |
-| gRPC native protocols | **[`ENABLE_GRPC=1`](../readme/deployment.md#optional-grpc-transport)** — separate from OpenClaw MCP bridge over HTTP/stdio. |
+| Symptom                                | Check                                                                                                                       |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| OpenClaw cannot connect to MCP         | Stdio: command on `PATH`, **`npx`** can resolve **`clawql-mcp`**. HTTP: firewall, **`PORT`**, URL includes **`/mcp`**.      |
+| **`listTools`** missing document tools | **`CLAWQL_ENABLE_DOCUMENTS=0`** not set; rebuild/restart server.                                                            |
+| **`execute`** 401 from GitHub          | **`CLAWQL_BEARER_TOKEN`** / **`gh auth token`** for private repos.                                                          |
+| gRPC native protocols                  | **[`ENABLE_GRPC=1`](../readme/deployment.md#optional-grpc-transport)** — separate from OpenClaw MCP bridge over HTTP/stdio. |
 
 ## Related issues
 

--- a/docs/openclaw/openclaw-idp-skill-profile.md
+++ b/docs/openclaw/openclaw-idp-skill-profile.md
@@ -4,12 +4,12 @@ This is the **canonical** operator + agent contract for **OpenClaw-triggered int
 
 ## Profile summary
 
-| Field | Value |
-|-------|--------|
-| **Profile id** | `clawql-openclaw-idp` |
-| **MCP server** | `clawql-mcp` (stdio or Streamable HTTP `…/mcp`) |
-| **Default provider merge** | `all-providers` (or explicit **`CLAWQL_BUNDLED_PROVIDERS`** listing document vendors) |
-| **Primary tools** | **`search`** → **`execute`** on bundled REST/OpenAPI providers; **`ingest_external_knowledge`**; optional **`knowledge_search_onyx`**; vault **`memory_ingest`** / **`memory_recall`** |
+| Field                      | Value                                                                                                                                                                                  |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Profile id**             | `clawql-openclaw-idp`                                                                                                                                                                  |
+| **MCP server**             | `clawql-mcp` (stdio or Streamable HTTP `…/mcp`)                                                                                                                                        |
+| **Default provider merge** | `all-providers` (or explicit **`CLAWQL_BUNDLED_PROVIDERS`** listing document vendors)                                                                                                  |
+| **Primary tools**          | **`search`** → **`execute`** on bundled REST/OpenAPI providers; **`ingest_external_knowledge`**; optional **`knowledge_search_onyx`**; vault **`memory_ingest`** / **`memory_recall`** |
 
 Agents should **always** prefer **`search`** with a tight natural-language **`query`**, then **`execute`** with **`operationId`** + minimal **`fields`**. First-class wrappers (**`knowledge_search_onyx`**, **`ingest_external_knowledge`**) exist where documented — use them instead of re-discovering the same paths via raw **`execute`** when the workflow matches.
 
@@ -17,18 +17,18 @@ Agents should **always** prefer **`search`** with a tight natural-language **`qu
 
 Legend: **Ready** = shipped in this repo with bundled or refreshed OpenAPI; **Partial** = env-dependent or roadmap; **Not MCP** = outside MCP tool surface today.
 
-| Layer | Mechanism | Required env / base URLs | Status | Notes |
-|-------|-----------|---------------------------|--------|--------|
-| **Extract / parse** | **`execute`** on **`tika`** spec (`TIKA_BASE_URL`) | **`TIKA_BASE_URL`** | Ready | Discover ops with **`search`** (e.g. Tika put/post resources). |
-| **HTML → PDF / renders** | **`execute`** on **`gotenberg`** | **`GOTENBERG_BASE_URL`** | Ready | Chromium/Chromium routes per bundled spec. |
-| **PDF transforms / sign** | **`execute`** on **`stirling`** | **`STIRLING_BASE_URL`**, optional **`STIRLING_API_KEY`** | Ready | Minimal bundled spec; refresh from live `/v3/api-docs` when possible ([#125](https://github.com/danielsmithdevelopment/ClawQL/issues/125)). |
-| **Archive / metadata** | **`execute`** on **`paperless`** | **`PAPERLESS_BASE_URL`**, **`PAPERLESS_API_TOKEN`** | Ready | See **[`docs/providers/paperless-onboarding.md`](../providers/paperless-onboarding.md)**. |
-| **Enterprise search** | **`knowledge_search_onyx`** or **`execute`** on **`onyx`** | **`CLAWQL_ENABLE_ONYX=1`**, **`ONYX_BASE_URL`**, token | Ready | Wrapper vs raw **`execute`**: **[`docs/onyx-knowledge-tool.md`](../onyx-knowledge-tool.md)** ([#118](https://github.com/danielsmithdevelopment/ClawQL/issues/118)). |
-| **Post-Paperless → Onyx index** | **`execute`** (Onyx ingestion API) | Same as Onyx | Partial | Tracked as product glue ([#120](https://github.com/danielsmithdevelopment/ClawQL/issues/120)). |
-| **Bulk ingest + vault** | **`ingest_external_knowledge`** | **`CLAWQL_EXTERNAL_INGEST=1`**, vault path, optional fetch | Ready | **[`docs/external-ingest.md`](../external-ingest.md)**. |
-| **Privacy / redaction** | Policy **outside** a single MCP flag | Helm / sidecar / gateway | Partial | No **`CLAWQL_ENABLE_PRIVACY_FILTER`** in core **`.env.example`** — align with **[`docs/enterprise-mcp-tools.md`](../enterprise-mcp-tools.md#regulated-deployments)** and your deployment’s controls. |
-| **Structured workflows** | **`ouroboros_*`** MCP tools | **`CLAWQL_ENABLE_OUROBOROS=1`** | Ready | **[`docs/clawql-ouroboros.md`](../clawql-ouroboros.md)** — optional overlay on linear IDP chains. |
-| **LangExtract / Docling** | N/A in MCP catalog | — | Not MCP | Use **`execute`** only if you merge a **custom OpenAPI** for those services; not bundled as first-class providers today. |
+| Layer                           | Mechanism                                                  | Required env / base URLs                                   | Status  | Notes                                                                                                                                                                                                |
+| ------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Extract / parse**             | **`execute`** on **`tika`** spec (`TIKA_BASE_URL`)         | **`TIKA_BASE_URL`**                                        | Ready   | Discover ops with **`search`** (e.g. Tika put/post resources).                                                                                                                                       |
+| **HTML → PDF / renders**        | **`execute`** on **`gotenberg`**                           | **`GOTENBERG_BASE_URL`**                                   | Ready   | Chromium/Chromium routes per bundled spec.                                                                                                                                                           |
+| **PDF transforms / sign**       | **`execute`** on **`stirling`**                            | **`STIRLING_BASE_URL`**, optional **`STIRLING_API_KEY`**   | Ready   | Minimal bundled spec; refresh from live `/v3/api-docs` when possible ([#125](https://github.com/danielsmithdevelopment/ClawQL/issues/125)).                                                          |
+| **Archive / metadata**          | **`execute`** on **`paperless`**                           | **`PAPERLESS_BASE_URL`**, **`PAPERLESS_API_TOKEN`**        | Ready   | See **[`docs/providers/paperless-onboarding.md`](../providers/paperless-onboarding.md)**.                                                                                                            |
+| **Enterprise search**           | **`knowledge_search_onyx`** or **`execute`** on **`onyx`** | **`CLAWQL_ENABLE_ONYX=1`**, **`ONYX_BASE_URL`**, token     | Ready   | Wrapper vs raw **`execute`**: **[`docs/onyx-knowledge-tool.md`](../onyx-knowledge-tool.md)** ([#118](https://github.com/danielsmithdevelopment/ClawQL/issues/118)).                                  |
+| **Post-Paperless → Onyx index** | **`execute`** (Onyx ingestion API)                         | Same as Onyx                                               | Partial | Tracked as product glue ([#120](https://github.com/danielsmithdevelopment/ClawQL/issues/120)).                                                                                                       |
+| **Bulk ingest + vault**         | **`ingest_external_knowledge`**                            | **`CLAWQL_EXTERNAL_INGEST=1`**, vault path, optional fetch | Ready   | **[`docs/external-ingest.md`](../external-ingest.md)**.                                                                                                                                              |
+| **Privacy / redaction**         | Policy **outside** a single MCP flag                       | Helm / sidecar / gateway                                   | Partial | No **`CLAWQL_ENABLE_PRIVACY_FILTER`** in core **`.env.example`** — align with **[`docs/enterprise-mcp-tools.md`](../enterprise-mcp-tools.md#regulated-deployments)** and your deployment’s controls. |
+| **Structured workflows**        | **`ouroboros_*`** MCP tools                                | **`CLAWQL_ENABLE_OUROBOROS=1`**                            | Ready   | **[`docs/clawql-ouroboros.md`](../clawql-ouroboros.md)** — optional overlay on linear IDP chains.                                                                                                    |
+| **LangExtract / Docling**       | N/A in MCP catalog                                         | —                                                          | Not MCP | Use **`execute`** only if you merge a **custom OpenAPI** for those services; not bundled as first-class providers today.                                                                             |
 
 ## Reference workflow contract (chat-shaped)
 
@@ -45,11 +45,11 @@ Pair durable operator trails with **`memory_ingest`** / **`memory_recall`** when
 
 ## Missing / follow-up (explicit)
 
-| Gap | Track |
-|-----|--------|
+| Gap                                                   | Track                                                               |
+| ----------------------------------------------------- | ------------------------------------------------------------------- |
 | Pregenerated introspection for all document providers | [#125](https://github.com/danielsmithdevelopment/ClawQL/issues/125) |
-| Post-Paperless push to Onyx automation | [#120](https://github.com/danielsmithdevelopment/ClawQL/issues/120) |
-| Bundled LangExtract / Docling as providers | Not filed as default — merge custom specs if needed |
+| Post-Paperless push to Onyx automation                | [#120](https://github.com/danielsmithdevelopment/ClawQL/issues/120) |
+| Bundled LangExtract / Docling as providers            | Not filed as default — merge custom specs if needed                 |
 
 ## Where operators start
 

--- a/docs/openclaw/openclaw-idp-skill-profile.md
+++ b/docs/openclaw/openclaw-idp-skill-profile.md
@@ -1,0 +1,59 @@
+# OpenClaw IDP skill profile (ClawQL document pipeline)
+
+This is the **canonical** operator + agent contract for **OpenClaw-triggered intelligent document processing (IDP)** on ClawQL MCP. It satisfies **[#227](https://github.com/danielsmithdevelopment/ClawQL/issues/227)**. Bootstrap wiring and smokes: **[`clawql-bootstrap.md`](clawql-bootstrap.md)** ([#226](https://github.com/danielsmithdevelopment/ClawQL/issues/226)). Umbrella tracking: **[#128](https://github.com/danielsmithdevelopment/ClawQL/issues/128)**.
+
+## Profile summary
+
+| Field | Value |
+|-------|--------|
+| **Profile id** | `clawql-openclaw-idp` |
+| **MCP server** | `clawql-mcp` (stdio or Streamable HTTP `…/mcp`) |
+| **Default provider merge** | `all-providers` (or explicit **`CLAWQL_BUNDLED_PROVIDERS`** listing document vendors) |
+| **Primary tools** | **`search`** → **`execute`** on bundled REST/OpenAPI providers; **`ingest_external_knowledge`**; optional **`knowledge_search_onyx`**; vault **`memory_ingest`** / **`memory_recall`** |
+
+Agents should **always** prefer **`search`** with a tight natural-language **`query`**, then **`execute`** with **`operationId`** + minimal **`fields`**. First-class wrappers (**`knowledge_search_onyx`**, **`ingest_external_knowledge`**) exist where documented — use them instead of re-discovering the same paths via raw **`execute`** when the workflow matches.
+
+## Compatibility matrix (toolchain)
+
+Legend: **Ready** = shipped in this repo with bundled or refreshed OpenAPI; **Partial** = env-dependent or roadmap; **Not MCP** = outside MCP tool surface today.
+
+| Layer | Mechanism | Required env / base URLs | Status | Notes |
+|-------|-----------|---------------------------|--------|--------|
+| **Extract / parse** | **`execute`** on **`tika`** spec (`TIKA_BASE_URL`) | **`TIKA_BASE_URL`** | Ready | Discover ops with **`search`** (e.g. Tika put/post resources). |
+| **HTML → PDF / renders** | **`execute`** on **`gotenberg`** | **`GOTENBERG_BASE_URL`** | Ready | Chromium/Chromium routes per bundled spec. |
+| **PDF transforms / sign** | **`execute`** on **`stirling`** | **`STIRLING_BASE_URL`**, optional **`STIRLING_API_KEY`** | Ready | Minimal bundled spec; refresh from live `/v3/api-docs` when possible ([#125](https://github.com/danielsmithdevelopment/ClawQL/issues/125)). |
+| **Archive / metadata** | **`execute`** on **`paperless`** | **`PAPERLESS_BASE_URL`**, **`PAPERLESS_API_TOKEN`** | Ready | See **[`docs/providers/paperless-onboarding.md`](../providers/paperless-onboarding.md)**. |
+| **Enterprise search** | **`knowledge_search_onyx`** or **`execute`** on **`onyx`** | **`CLAWQL_ENABLE_ONYX=1`**, **`ONYX_BASE_URL`**, token | Ready | Wrapper vs raw **`execute`**: **[`docs/onyx-knowledge-tool.md`](../onyx-knowledge-tool.md)** ([#118](https://github.com/danielsmithdevelopment/ClawQL/issues/118)). |
+| **Post-Paperless → Onyx index** | **`execute`** (Onyx ingestion API) | Same as Onyx | Partial | Tracked as product glue ([#120](https://github.com/danielsmithdevelopment/ClawQL/issues/120)). |
+| **Bulk ingest + vault** | **`ingest_external_knowledge`** | **`CLAWQL_EXTERNAL_INGEST=1`**, vault path, optional fetch | Ready | **[`docs/external-ingest.md`](../external-ingest.md)**. |
+| **Privacy / redaction** | Policy **outside** a single MCP flag | Helm / sidecar / gateway | Partial | No **`CLAWQL_ENABLE_PRIVACY_FILTER`** in core **`.env.example`** — align with **[`docs/enterprise-mcp-tools.md`](../enterprise-mcp-tools.md#regulated-deployments)** and your deployment’s controls. |
+| **Structured workflows** | **`ouroboros_*`** MCP tools | **`CLAWQL_ENABLE_OUROBOROS=1`** | Ready | **[`docs/clawql-ouroboros.md`](../clawql-ouroboros.md)** — optional overlay on linear IDP chains. |
+| **LangExtract / Docling** | N/A in MCP catalog | — | Not MCP | Use **`execute`** only if you merge a **custom OpenAPI** for those services; not bundled as first-class providers today. |
+
+## Reference workflow contract (chat-shaped)
+
+Use this as the **default narrative** for OpenClaw system prompts and eval harnesses. Steps are **logical**; skip or reorder when data or policy requires it.
+
+1. **Ingest** — **`ingest_external_knowledge`** (Markdown bulk and/or URL fetch with **`CLAWQL_EXTERNAL_INGEST_FETCH`**) or **`execute`** on Paperless/Tika as appropriate.
+2. **Redact / policy** — apply **deployment-specific** redaction (sidecar, gateway, or human review); no single ClawQL env toggle documents “privacy filter” for all stacks.
+3. **Classify / route** — **`search`** for the right **`operationId`** across pipeline vendors; **`execute`** with lean **`fields`**.
+4. **Extract** — Tika/Stirling/Gotenberg **`execute`** paths for text/PDF/HTML transforms per spec.
+5. **Optional sign / seal** — Stirling/Paperless/Gotenberg routes where the OpenAPI exposes them; attest later via Merkle/Ouroboros ([#114](https://github.com/danielsmithdevelopment/ClawQL/issues/114)).
+6. **Archive / index** — Paperless **`execute`** for durable doc store; **`knowledge_search_onyx`** (or Onyx **`execute`**) for enterprise retrieval and citations.
+
+Pair durable operator trails with **`memory_ingest`** / **`memory_recall`** when using an Obsidian vault (**[#130](https://github.com/danielsmithdevelopment/ClawQL/issues/130)** citation patterns).
+
+## Missing / follow-up (explicit)
+
+| Gap | Track |
+|-----|--------|
+| Pregenerated introspection for all document providers | [#125](https://github.com/danielsmithdevelopment/ClawQL/issues/125) |
+| Post-Paperless push to Onyx automation | [#120](https://github.com/danielsmithdevelopment/ClawQL/issues/120) |
+| Bundled LangExtract / Docling as providers | Not filed as default — merge custom specs if needed |
+
+## Where operators start
+
+1. **[`clawql-bootstrap.md`](clawql-bootstrap.md)** — MCP registration + **`npm run smoke:openclaw-bootstrap`**.
+2. This page — **IDP** defaults and matrix.
+3. **[`docs/mcp-tools.md`](../mcp-tools.md)** — authoritative tool catalog.
+4. **[`providers/README.md`](../providers/README.md)** — bundled **`operationId`** sources.

--- a/docs/readme/deployment.md
+++ b/docs/readme/deployment.md
@@ -29,6 +29,13 @@ Endpoints:
 
 In **regulated** environments (HIPAA / SOC 2–style controls), treat **`/healthz`** and **`/metrics`** as **internal-only**: restrict routes with network policy, TLS, and mesh placement; never put identifiable patient data in **`sourceLabel`** or metric dimensions. See **[`docs/enterprise-mcp-tools.md` § Regulated deployments](../enterprise-mcp-tools.md#regulated-deployments)** ([#133](https://github.com/danielsmithdevelopment/ClawQL/issues/133)).
 
+## OpenClaw (MCP registration)
+
+OpenClaw acts as an MCP client toward ClawQL.
+
+- **Phase 0 — bootstrap:** **[`docs/openclaw/clawql-bootstrap.md`](../openclaw/clawql-bootstrap.md)** ([#226](https://github.com/danielsmithdevelopment/ClawQL/issues/226); umbrella [#128](https://github.com/danielsmithdevelopment/ClawQL/issues/128)) — registration, env matrix, **`npm run smoke:openclaw-bootstrap`**.
+- **IDP skill profile — default agent/operator contract:** **[`docs/openclaw/openclaw-idp-skill-profile.md`](../openclaw/openclaw-idp-skill-profile.md)** ([#227](https://github.com/danielsmithdevelopment/ClawQL/issues/227)) — document toolchain matrix, **`search`/`execute`** vs wrappers, reference ingest→index workflow.
+
 ## Cursor / Claude Configuration
 
 Use:

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
         "smoke:atlassian": "node scripts/workflows/smoke-atlassian.mjs",
         "smoke:cloudflare": "node scripts/workflows/smoke-cloudflare.mjs",
         "smoke:github-commits": "npm run build && node scripts/workflows/smoke-github-commits.mjs",
+        "smoke:openclaw-bootstrap": "npm run build && node scripts/workflows/smoke-openclaw-bootstrap.mjs",
         "grpc:memory-recall": "node scripts/dev/grpc-memory-recall.mjs",
         "clawql:github-repo-description": "npm run build && node scripts/dev/clawql-github-patch-repo-description.mjs",
         "benchmark:tokens": "npm run build && node scripts/workflows/benchmark-provider-tokens.mjs",

--- a/scripts/workflows/smoke-openclaw-bootstrap.mjs
+++ b/scripts/workflows/smoke-openclaw-bootstrap.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * MCP smoke for OpenClaw bootstrap (#226): listTools + search/execute (GitHub) + document tool visibility.
+ *
+ *   npm run build && npm run smoke:openclaw-bootstrap
+ *
+ * CLAWQL_OPENCLAW_BOOTSTRAP_TOOLS_ONLY=1 — skip search/execute (tools list only).
+ *
+ * GitHub execute auth: same as smoke-github-commits (CLAWQL_BEARER_TOKEN or gh auth token).
+ */
+
+import { execSync } from "node:child_process";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+function tokenFromGhCli() {
+  if (process.env.GITHUB_USE_GH_TOKEN === "0") return "";
+  try {
+    return execSync("gh auth token", {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 10_000,
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+async function main() {
+  const toolsOnly =
+    process.env.CLAWQL_OPENCLAW_BOOTSTRAP_TOOLS_ONLY === "1" ||
+    process.env.CLAWQL_OPENCLAW_BOOTSTRAP_TOOLS_ONLY === "true";
+
+  const fromEnv =
+    process.env.CLAWQL_BEARER_TOKEN?.trim() ||
+    process.env.GITHUB_TOKEN?.trim();
+  const fromGh = fromEnv ? "" : tokenFromGhCli();
+  const token = fromEnv || fromGh;
+
+  const childEnv = { ...process.env };
+  childEnv.CLAWQL_PROVIDER = process.env.CLAWQL_PROVIDER ?? "github";
+  childEnv.CLAWQL_BUNDLED_OFFLINE = process.env.CLAWQL_BUNDLED_OFFLINE ?? "1";
+  if (token) {
+    childEnv.CLAWQL_BEARER_TOKEN = token;
+    childEnv.GITHUB_TOKEN = token;
+  } else {
+    delete childEnv.CLAWQL_BEARER_TOKEN;
+    delete childEnv.GITHUB_TOKEN;
+  }
+  delete childEnv.CLAWQL_SPEC_URL;
+  delete childEnv.CLAWQL_SPEC_PATH;
+  delete childEnv.CLAWQL_DISCOVERY_URL;
+  delete childEnv.CLAWQL_GOOGLE_TOP50_SPECS;
+  delete childEnv.CLAWQL_SPEC_PATHS;
+  delete childEnv.CLAWQL_HTTP_HEADERS;
+
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [join(ROOT, "dist", "server.js")],
+    cwd: ROOT,
+    stderr: "inherit",
+    env: childEnv,
+  });
+
+  const client = new Client(
+    { name: "clawql-openclaw-bootstrap", version: "1.0.0" },
+    {}
+  );
+  await client.connect(transport);
+
+  const listed = await client.listTools();
+  const names = new Set((listed.tools ?? []).map((t) => t.name));
+
+  const required = ["search", "execute"];
+  for (const n of required) {
+    if (!names.has(n)) {
+      throw new Error(`listTools missing required tool: ${n}`);
+    }
+  }
+
+  const docsOn =
+    process.env.CLAWQL_ENABLE_DOCUMENTS === undefined ||
+    !/^(0|false|no)$/i.test(String(process.env.CLAWQL_ENABLE_DOCUMENTS));
+
+  if (docsOn && !names.has("ingest_external_knowledge")) {
+    throw new Error(
+      "listTools missing ingest_external_knowledge (documents enabled)"
+    );
+  }
+
+  console.error(
+    `[listTools] OK: search, execute${docsOn ? ", ingest_external_knowledge" : ""} (${listed.tools?.length ?? 0} tools)`
+  );
+
+  if (toolsOnly) {
+    await client.close();
+    console.error("\nOK (tools-only)");
+    return;
+  }
+
+  const owner = process.env.GITHUB_OWNER?.trim() || "github";
+  const repo = process.env.GITHUB_REPO?.trim() || "rest-api-description";
+  const perPage = Math.min(
+    5,
+    Math.max(1, Number(process.env.GITHUB_COMMIT_LIMIT ?? "3") || 3)
+  );
+  const operationId = "repos/list-commits";
+
+  await client.callTool({
+    name: "search",
+    arguments: {
+      query: "GitHub REST list commits for repository GET repos owner repo commits",
+      limit: 10,
+    },
+  });
+
+  const execRes = await client.callTool({
+    name: "execute",
+    arguments: {
+      operationId,
+      args: {
+        owner,
+        repo,
+        sha: "main",
+        per_page: perPage,
+      },
+      fields: ["sha", "commit"],
+    },
+  });
+
+  await client.close();
+
+  const execText = execRes.content?.find((b) => b.type === "text")?.text ?? "";
+  let parsed;
+  try {
+    parsed = JSON.parse(execText);
+  } catch {
+    console.error(execText);
+    throw new Error("execute did not return JSON");
+  }
+
+  if (execRes.isError) {
+    console.error(JSON.stringify(parsed, null, 2));
+    throw new Error("execute reported error");
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error("Expected JSON array from repos/list-commits");
+  }
+
+  console.log("=== OpenClaw bootstrap smoke (GitHub execute) ===\n");
+  console.log(`Repo: ${owner}/${repo}  operationId: ${operationId}`);
+  console.log(JSON.stringify(parsed.slice(0, 3), null, 2));
+  console.error("\nOK");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/website/src/app/deployment/page.mdx
+++ b/website/src/app/deployment/page.mdx
@@ -71,4 +71,8 @@ ENV=dev IMAGE=us-central1-docker.pkg.dev/<project>/<repo>/clawql-mcp TAG=<tag> m
 
 Or install with **Helm** from **`charts/clawql-mcp`**: **[Helm](/helm)** and [`docs/deployment/helm.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/deployment/helm.md).
 
+Optional **NATS JetStream** (event backbone for agents / Ouroboros / edge sync): **[NATS JetStream](/nats-jetstream)** ([#127](https://github.com/danielsmithdevelopment/ClawQL/issues/127)).
+
+**OpenClaw (MCP client to ClawQL):** bootstrap runbook [`docs/openclaw/clawql-bootstrap.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/openclaw/clawql-bootstrap.md) ([#226](https://github.com/danielsmithdevelopment/ClawQL/issues/226)); IDP skill profile [`docs/openclaw/openclaw-idp-skill-profile.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/openclaw/openclaw-idp-skill-profile.md) ([#227](https://github.com/danielsmithdevelopment/ClawQL/issues/227)); umbrella [#128](https://github.com/danielsmithdevelopment/ClawQL/issues/128).
+
 Details: [`docs/deployment/deploy-k8s.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/deployment/deploy-k8s.md). Extended container and manifest notes: [`docker/README.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docker/README.md).

--- a/website/src/app/nats-jetstream/page.mdx
+++ b/website/src/app/nats-jetstream/page.mdx
@@ -101,7 +101,7 @@ helm upgrade --install clawql ./charts/clawql-mcp -n clawql --create-namespace \
 
 ## Subject taxonomy suggestion
 
-Use stable subjects so multiple components can interoperate:
+Use stable subjects so multiple components can interoperate (mirrors **`nats.subjectConvention`** in **`charts/clawql-mcp/values.yaml`**):
 
 - `clawql.workflow.*` — workflow lifecycle and checkpoints
 - `clawql.agent.*` — agent state, assignment, and handoffs
@@ -110,13 +110,24 @@ Use stable subjects so multiple components can interoperate:
 
 If you need tenant isolation, append namespace/tenant segments (for example `clawql.workflow.team-a.*`).
 
+**Observability:** monitor **`8222`** JSON (`/jsz`, `/varz`) is not OpenMetrics — pair with the upstream **[NATS Prometheus exporter](https://github.com/nats-io/prometheus-nats-exporter)** or blackbox checks on **`/healthz`**; ClawQL app metrics remain on MCP **`GET /metrics`** ([#210](https://github.com/danielsmithdevelopment/ClawQL/issues/210)).
+
+**Scope:** single-cluster JetStream only here; global NATS federation stays future work (deck).
+
+## Integration points (in-repo)
+
+Ouroboros and workflow events ([#110](https://github.com/danielsmithdevelopment/ClawQL/issues/110)), Cuckoo/Merkle / audit ([#114](https://github.com/danielsmithdevelopment/ClawQL/issues/114), [#115](https://github.com/danielsmithdevelopment/ClawQL/issues/115), [#89](https://github.com/danielsmithdevelopment/ClawQL/issues/89)), and full-stack topology ([#113](https://github.com/danielsmithdevelopment/ClawQL/issues/113)). Chart **`values.yaml`** exposes **`nats.subjectConvention`** (`workflow`, `agent`, `document`, `edge`) for operators.
+
 ## Verify after rollout
+
+Default Helm **`fullnameOverride`** is **`clawql-mcp-http`** — NATS resources are named **`clawql-mcp-http-nats`**.
 
 ```bash
 kubectl -n clawql get deploy,svc | rg nats
 kubectl -n clawql logs deploy/clawql-mcp-http-nats
 kubectl -n clawql port-forward svc/clawql-mcp-http-nats 8222:8222
 curl -s http://127.0.0.1:8222/healthz
+curl -s http://127.0.0.1:8222/jsz | head -c 600
 ```
 
 Additional checks:


### PR DESCRIPTION
## Summary

- **OpenClaw (#226, #227):** Add `docs/openclaw/clawql-bootstrap.md` (MCP registration, env matrix, manual checklist) and `docs/openclaw/openclaw-idp-skill-profile.md` (canonical IDP tool/provider matrix and ingest→index workflow). Cross-links from deployment README, ecosystem appendix, and website deployment page.
- **Smoke:** `npm run smoke:openclaw-bootstrap` — listTools + GitHub `search`/`execute` path (`scripts/workflows/smoke-openclaw-bootstrap.mjs`).
- **NATS JetStream (#127):** `nats.subjectConvention` in Helm values, NOTES.txt ops hints, expanded `helm.md` subject naming + integration links, chart README + deploy-k8s + website nats-jetstream page.

## Issues

Closes nothing automatically; tracks **#226**, **#227**, **#127** acceptance toward docs/operator readiness.