### PR TITLE
fix: restore npm ci on main (workspace lock sync)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5629,6 +5629,10 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/panguard-mcp-bridge": {
+            "resolved": "packages/panguard-mcp-bridge",
+            "link": true
+        },
         "node_modules/param-case": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -7891,7 +7895,6 @@
         },
         "packages/panguard-mcp-bridge": {
             "version": "0.1.0",
-            "extraneous": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.14.3",


### PR DESCRIPTION
## Summary
- regenerate `package-lock.json` using Node 25/npm 11 so the `panguard-mcp-bridge` workspace is represented as a link
- remove the stale `extraneous` workspace marker that causes `npm ci` to fail in CI
- verify in Node 25 container that `npm ci` now succeeds

## Test plan
- [x] `docker run --rm -v \"$PWD:/repo\" -w /repo node:25 bash -lc \"npm ci\"`
- [x] confirm only `package-lock.json` changed