### PR TITLE
fix(ci): TruffleHog scheduled scan exclude-paths file

### DIFF
--- a/.github/trufflehog-exclude-paths.txt
+++ b/.github/trufflehog-exclude-paths.txt
@@ -1,0 +1,1 @@
+^providers/

--- a/.github/workflows/trufflehog-scheduled.yml
+++ b/.github/workflows/trufflehog-scheduled.yml
@@ -1,5 +1,6 @@
 # Historical secret scan — weekly + manual; complements mandatory Gitleaks in CI (#283).
 # Excludes bundled upstream specs under providers/ (vendor examples / placeholders).
+# TruffleHog --exclude-paths expects a file of newline-separated regexes, not an inline pattern.
 name: TruffleHog
 
 on:
@@ -26,4 +27,4 @@ jobs:
         uses: trufflesecurity/trufflehog@853e1e8d249fd1e29d0fcc7280d29b03df3d643d
         with:
           path: ./
-          extra_args: --exclude-paths=^providers/
+          extra_args: --exclude-paths=.github/trufflehog-exclude-paths.txt


### PR DESCRIPTION
## Summary
Scheduled **TruffleHog** failed because `--exclude-paths=^providers/` is treated as a **filter file path**, not an inline regex (`open ^providers/: no such file or directory`).

## Changes
- Add **`.github/trufflehog-exclude-paths.txt`** with the same regex (`^providers/`).
- Point **`trufflehog-scheduled.yml`** `extra_args` at that file.

## Other overnight failure
**Docker publish** schedule run **25425011872** failed with *"The job was not acquired by Runner of type hosted"* — GitHub runner capacity, not a repo defect; re-run the workflow if needed.

## Test plan
- [x] Local smoke: `docker run ... trufflehog git file:///tmp/ ... --exclude-paths=.github/trufflehog-exclude-paths.txt` (starts and completes without filter-file error)