### PR TITLE
fix(supply-chain): hono 4.12.16 for OSV-Scanner on main

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -67,7 +67,7 @@
         "@grpc/proto-loader": "^0.8.0",
         "@grpc/reflection": "^1.0.4",
         "google-proto-files": "^4.2.0",
-        "protobufjs": "^8.0.1",
+        "protobufjs": "^8.0.3",
       },
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -87,8 +87,10 @@
         "clawql-panguard-bridge-shim": "./dist/shim-main.js",
       },
       "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "express": "^5.2.1",
+        "jose": "^6.1.3",
         "mcp-grpc-transport": "^0.1.2",
       },
     },
@@ -97,7 +99,7 @@
     "@hono/node-server": "1.19.13",
     "brace-expansion": "5.0.5",
     "esbuild": "0.28.0",
-    "hono": "4.12.14",
+    "hono": "4.12.16",
     "ip-address": "10.1.1",
     "path-to-regexp": "8.4.0",
     "picomatch": "4.0.4",
@@ -754,7 +756,7 @@
 
     "header-case": ["header-case@2.0.4", "", { "dependencies": { "capital-case": "^1.0.4", "tslib": "^2.0.3" } }, "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q=="],
 
-    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
+    "hono": ["hono@4.12.16", "", {}, "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "clawql-mcp",
-    "version": "6.0.0",
+    "version": "6.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "clawql-mcp",
-            "version": "6.0.0",
+            "version": "6.1.0",
             "license": "Apache-2.0",
             "workspaces": [
                 "packages/*"
@@ -4503,9 +4503,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.14",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-            "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+            "version": "4.12.16",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+            "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
             "license": "MIT",
             "engines": {
                 "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
         "brace-expansion": "5.0.5",
         "ip-address": "10.1.1",
         "esbuild": "0.28.0",
-        "hono": "4.12.14",
+        "hono": "4.12.16",
         "path-to-regexp": "8.4.0",
         "picomatch": "4.0.4",
         "postcss": "8.5.10",


### PR DESCRIPTION
Unblocks CI [Supply chain job](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/25468099996) after merge of #332.

OSV-Scanner reported **hono@4.12.14** ([GHSA-69xw-7hcm-h432](https://osv.dev/GHSA-69xw-7hcm-h432), [GHSA-9vqf-7f2p-gf9v](https://osv.dev/GHSA-9vqf-7f2p-gf9v)) in `package-lock.json` and `bun.lock`. Root `overrides.hono` is bumped to **4.12.16**; lockfiles refreshed.

Verified locally: `docker run ... osv-scanner:latest scan ...` exits 0.