### PR TITLE
fix(k8s): Vault bootstrap — root token vs ROOT collision + wait

### DIFF
--- a/.cursor/skills/clawql-audit-workflows/SKILL.md
+++ b/.cursor/skills/clawql-audit-workflows/SKILL.md
@@ -1,13 +1,16 @@
 ---
 name: clawql-audit-workflows
-description: Use the optional audit ring buffer for live operator breadcrumbs during workflows.
+description: >-
+  Workflow recipes for the ClawQL MCP audit tool. The audit tool is ClawQL Core
+  (always registered — no CLAWQL_ENABLE_AUDIT); this skill is optional guidance for
+  append/list/clear patterns during multi-step runs.
 ---
 
 # ClawQL audit workflows
 
 ## When to apply
 
-- You need lightweight in-run event traces.
+- You want structured **`audit.append`** / **`audit.list`** breadcrumbs during a workflow (the tool is already available on every ClawQL MCP server).
 
 ## Workflow
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 # Build context for `docker build -f docker/Dockerfile .`
 node_modules
+# Workspace installs under packages/* conflict with `COPY packages ./packages` in the Dockerfile.
+packages/**/node_modules
 dist
 .git
 .github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,6 +331,9 @@ jobs:
       - name: Typecheck & build
         run: npm run build
 
+      - name: Assert dist registers cache + audit (non-negotiable MCP)
+        run: bash scripts/ci/assert-dist-mcp-nonnegotiable-tools.sh
+
       - name: Unit tests + coverage
         run: npx vitest run --coverage
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deploy-cloud-run deploy-k8s deploy-docs local-k8s-up bootstrap-vault-eso local-k8s-mcp-delete local-docker-up helm-lint helm-ui-template-tests kustomize-local-lint lint-k8s-manifests smoke-grpcurl-istio-gateway-mcp smoke-mcp-http-istio-gateway smoke-localhost-uis verify-vault-policy
+.PHONY: deploy-cloud-run deploy-k8s deploy-docs local-k8s-up bootstrap-vault-eso local-k8s-mcp-delete local-docker-up helm-lint helm-ui-template-tests kustomize-local-lint lint-k8s-manifests smoke-grpcurl-istio-gateway-mcp smoke-mcp-http-istio-gateway smoke-localhost-uis verify-vault-policy verify-mcp-core-tools-local
 
 # Validate charts/clawql-mcp (requires helm on PATH)
 helm-lint:
@@ -65,6 +65,10 @@ smoke-grpcurl-istio-gateway-mcp:
 # Streamable HTTP POST /mcp initialize via Istio :80 (matches Cursor; default URL 127.0.0.1)
 smoke-mcp-http-istio-gateway:
 	@bash scripts/kubernetes/smoke-mcp-http-istio-gateway.sh
+
+# After local-k8s-up: assert tools/list includes ClawQL Core audit+cache (catches stale :latest digest — rollout restart MCP)
+verify-mcp-core-tools-local:
+	@npx tsx scripts/dev/verify-mcp-streamable-core-tools.ts
 
 # Localhost ingress UI smoke checks (docs, mcp, flink, onyx, paperless, tika, gotenberg, nats)
 smoke-localhost-uis:

--- a/charts/clawql-mcp/templates/deployment.yaml
+++ b/charts/clawql-mcp/templates/deployment.yaml
@@ -244,7 +244,14 @@ spec:
         - name: docker-sock
           hostPath:
             path: {{ .Values.sandboxDocker.hostSocketPath | quote }}
+            {{- /* Sprig `default` treats false as "empty" — use hasKey so explicit false omits type (Docker Desktop). */}}
+            {{- $enforceSocketType := true }}
+            {{- if hasKey .Values.sandboxDocker "enforceHostPathSocketType" }}
+            {{- $enforceSocketType = .Values.sandboxDocker.enforceHostPathSocketType }}
+            {{- end }}
+            {{- if $enforceSocketType }}
             type: Socket
+            {{- end }}
         {{- end }}
         {{- /* Volume "obsidian-vault": Obsidian Markdown memory (.Values.vault / persistence), not HashiCorp Vault — #161 */}}
         - name: obsidian-vault

--- a/charts/clawql-mcp/values-docker-desktop.yaml
+++ b/charts/clawql-mcp/values-docker-desktop.yaml
@@ -113,10 +113,10 @@ onyx:
     resources:
       requests:
         cpu: 100m
-        memory: 512Mi
+        memory: 768Mi
       limits:
-        cpu: "1"
-        memory: 1536Mi
+        cpu: "2"
+        memory: 3Gi
   minio:
     persistence:
       enabled: true
@@ -128,6 +128,10 @@ onyx:
         cpu: "1"
         memory: 1Gi
   dragonfly:
+    image:
+      repository: ghcr.io/dragonflydb/dragonfly
+      tag: v1.37.2
+      pullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 15m
@@ -166,6 +170,11 @@ ouroborosPostgres:
 
 nats:
   enabled: true
+  image:
+    # Google mirror of Docker Hub — fewer "short read" EOF pulls on Docker Desktop than registry-1.docker.io.
+    repository: mirror.gcr.io/library/nats
+    tag: "2.10.17-alpine"
+    pullPolicy: IfNotPresent
   resources:
     requests:
       cpu: 25m
@@ -176,6 +185,10 @@ nats:
 
 flink:
   enabled: true
+  image:
+    repository: mirror.gcr.io/library/flink
+    tag: "1.19.1-scala_2.12-java17"
+    pullPolicy: IfNotPresent
   # Flink 1.19+ enforces minimum JVM/network fractions; 768m TM process violates them (IllegalConfigurationException).
   # Config only via FLINK_PROPERTIES (no read-only flink-conf.yaml mount — entrypoint must rewrite conf).
   jobManagerMemoryProcessSize: "1024m"
@@ -337,6 +350,8 @@ hashicorpvault:
 sandboxDocker:
   enabled: true
   runAsRootForDockerSocket: true
+  # Docker Desktop kubelet often fails hostPath type: Socket on /var/run/docker.sock (false negative).
+  enforceHostPathSocketType: false
 
 documentPipeline:
   tika:
@@ -389,6 +404,10 @@ stores:
         cpu: 500m
         memory: 768Mi
   dragonfly:
+    image:
+      repository: ghcr.io/dragonflydb/dragonfly
+      tag: v1.37.2
+      pullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 15m

--- a/charts/clawql-mcp/values.yaml
+++ b/charts/clawql-mcp/values.yaml
@@ -149,6 +149,9 @@ enableSandbox: false
 sandboxDocker:
   enabled: false
   hostSocketPath: /var/run/docker.sock
+  # When true, docker-sock hostPath uses type: Socket (kubelet rejects if the path is not a socket). Docker Desktop
+  # Kubernetes sometimes fails this check even with a valid socket — set false in values-docker-desktop.yaml.
+  enforceHostPathSocketType: true
   # https://download.docker.com/linux/static/stable/<arch>/docker-<version>.tgz
   staticCliVersion: "27.4.1"
   initImage: curlimages/curl:8.11.1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,10 @@ RUN npm ci --ignore-scripts
 COPY tsconfig.json ./
 COPY src ./src
 COPY packages ./packages
-RUN npm run build && npm prune --omit=dev
+RUN npm run build \
+  && grep -qF 'server.tool("cache"' dist/tools.js \
+  && grep -qF 'server.tool("audit"' dist/tools.js \
+  && npm prune --omit=dev
 
 COPY providers ./providers
 COPY bin ./bin

--- a/docs/deployment/external-secrets-vault-cluster-secret-store.yaml
+++ b/docs/deployment/external-secrets-vault-cluster-secret-store.yaml
@@ -28,3 +28,6 @@ spec:
           serviceAccountRef:
             name: "external-secrets"
             namespace: "external-secrets"
+            # Required with Vault 1.21+ when the Vault role sets audience=vault (see bootstrap script).
+            audiences:
+              - vault

--- a/scripts/ci/assert-dist-mcp-nonnegotiable-tools.sh
+++ b/scripts/ci/assert-dist-mcp-nonnegotiable-tools.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Fail CI / local release if bundled dist drops cache/audit registration literals.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FILE="${ROOT}/dist/tools.js"
+if [[ ! -f "${FILE}" ]]; then
+  echo "ERROR: ${FILE} not found (run npm run build first)" >&2
+  exit 1
+fi
+for needle in 'server.tool("cache"' 'server.tool("audit"'; do
+  if ! grep -qF "${needle}" "${FILE}"; then
+    echo "ERROR: dist/tools.js must contain ${needle} — non-negotiable MCP tools (#75 #89)" >&2
+    exit 1
+  fi
+done
+echo "OK: dist/tools.js contains cache + audit registration."

--- a/scripts/dev/verify-mcp-streamable-core-tools.ts
+++ b/scripts/dev/verify-mcp-streamable-core-tools.ts
@@ -1,0 +1,64 @@
+/**
+ * Verify Streamable HTTP MCP exposes ClawQL Core tools (audit + cache) and audit.call works.
+ * Use after local-k8s-up when Cursor shows a thin tool list — often a stale :latest digest on the node.
+ *
+ * Usage (repo root):
+ *   npx tsx scripts/dev/verify-mcp-streamable-core-tools.ts
+ *   CLAWQL_MCP_HTTP_URL=http://clawql-mcp.localhost/mcp npx tsx scripts/dev/verify-mcp-streamable-core-tools.ts
+ */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { CLAWQL_NONNEGOTIABLE_MCP_TOOL_NAMES } from "../../src/mcp-nonnegotiable-tools.js";
+
+const url = (process.argv[2] || process.env.CLAWQL_MCP_HTTP_URL || "http://127.0.0.1/mcp").trim();
+
+async function main() {
+  const transport = new StreamableHTTPClientTransport(new URL(url));
+  const client = new Client({ name: "verify-mcp-core-tools", version: "1.0.0" }, {});
+  await client.connect(transport);
+  try {
+    const { tools } = await client.listTools();
+    const names = new Set(tools.map((t) => t.name));
+    const missing: string[] = [];
+    for (const required of CLAWQL_NONNEGOTIABLE_MCP_TOOL_NAMES) {
+      if (!names.has(required)) missing.push(required);
+    }
+    if (missing.length) {
+      console.error(
+        `FAIL: ${url} tools/list missing Core tool(s): ${missing.join(", ")}. ` +
+          `Got ${tools.length} tools: ${[...names].sort().join(", ")}. ` +
+          `Try: kubectl -n clawql rollout restart deployment/clawql-mcp-http`
+      );
+      process.exit(1);
+    }
+    const append = await client.callTool({
+      name: "audit",
+      arguments: {
+        operation: "append",
+        category: "verify",
+        action: "verify_mcp_streamable_core_tools",
+        summary: "scripts/dev/verify-mcp-streamable-core-tools.ts",
+      },
+    });
+    if (append.isError) {
+      console.error("FAIL: audit append returned isError", append);
+      process.exit(1);
+    }
+    const listed = await client.callTool({
+      name: "audit",
+      arguments: { operation: "list", limit: 5 },
+    });
+    if (listed.isError) {
+      console.error("FAIL: audit list returned isError", listed);
+      process.exit(1);
+    }
+    console.log(`OK: ${url} — Core tools present (${tools.length} total); audit append/list succeeded.`);
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/kubernetes/bootstrap-local-vault-and-eso.sh
+++ b/scripts/kubernetes/bootstrap-local-vault-and-eso.sh
@@ -49,10 +49,24 @@ helm_ctx() {
   fi
 }
 
-echo "==> Wait for Vault StatefulSet / pod (${NS}/${VAULT_STS})"
-if ! kubectl_ctx rollout status "statefulset/${VAULT_STS}" -n "${NS}" --timeout=300s; then
-  echo "    rollout status unavailable for this strategy; waiting on pod readiness instead"
-  kubectl_ctx wait --for=condition=Ready "pod/${VAULT_STS}-0" -n "${NS}" --timeout=300s
+echo "==> Wait for Vault pod (${NS}/${VAULT_STS}-0)"
+if kubectl_ctx rollout status "statefulset/${VAULT_STS}" -n "${NS}" --timeout=300s 2>/dev/null; then
+  :
+else
+  echo "    rollout status unavailable for this strategy; waiting for pod phase Running (not Ready — Vault may be sealed)"
+  vault_phase=""
+  for _ in $(seq 1 60); do
+    vault_phase="$(kubectl_ctx get pod "${VAULT_STS}-0" -n "${NS}" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+    if [[ "${vault_phase}" == "Running" ]]; then
+      echo "    Vault pod is Running (may still be sealed — continuing to init/unseal)."
+      break
+    fi
+    sleep 5
+  done
+  if [[ "${vault_phase}" != "Running" ]]; then
+    echo "ERROR: Vault pod ${VAULT_STS}-0 did not reach Running in time (last phase: '${vault_phase:-unknown}')"
+    exit 1
+  fi
 fi
 
 if [[ "${SKIP_ESO_INSTALL:-0}" != "1" ]]; then
@@ -107,14 +121,14 @@ sealed="$(echo "${STATUS_JSON}" | python3 -c "import json,sys; print(json.load(s
 if [[ "${initialized}" == "False" ]]; then
   echo "    Initializing Vault (1 unseal key) and recording bootstrap Secret/${NS}/${BOOTSTRAP_SECRET}"
   INIT_JSON="$(vault_exec sh -ec "export VAULT_ADDR=http://127.0.0.1:8200; vault operator init -key-shares=1 -key-threshold=1 -format=json")"
-  ROOT="$(echo "${INIT_JSON}" | python3 -c "import json,sys; print(json.load(sys.stdin)['root_token'])")"
+  VAULT_INIT_ROOT_TOKEN="$(echo "${INIT_JSON}" | python3 -c "import json,sys; print(json.load(sys.stdin)['root_token'])")"
   UNSEAL_HEX="$(echo "${INIT_JSON}" | python3 -c "import json,sys; print(json.load(sys.stdin)['unseal_keys_hex'][0])")"
   kubectl_ctx create secret generic "${BOOTSTRAP_SECRET}" -n "${NS}" \
-    --from-literal=root-token="${ROOT}" \
+    --from-literal=root-token="${VAULT_INIT_ROOT_TOKEN}" \
     --from-literal=unseal-key="${UNSEAL_HEX}" \
     --dry-run=client -o yaml | kubectl_ctx apply -f -
   vault_exec env VAULT_ADDR=http://127.0.0.1:8200 vault operator unseal "${UNSEAL_HEX}"
-  TOKEN="${ROOT}"
+  TOKEN="${VAULT_INIT_ROOT_TOKEN}"
 elif [[ "${sealed}" == "True" ]]; then
   echo "    Unsealing Vault using Secret/${NS}/${BOOTSTRAP_SECRET}"
   if ! kubectl_ctx get secret "${BOOTSTRAP_SECRET}" -n "${NS}" >/dev/null 2>&1; then

--- a/scripts/kubernetes/bootstrap-local-vault-and-eso.sh
+++ b/scripts/kubernetes/bootstrap-local-vault-and-eso.sh
@@ -16,6 +16,7 @@
 #   VAULT_LOCAL_BOOTSTRAP_SECRET  default clawql-vault-local-bootstrap — holds root-token + unseal-key for standalone PVC (Docker Desktop)
 #   SKIP_ESO_INSTALL    set to 1 if external-secrets is already installed
 #   SKIP_VAULT_SEED     set to 1 to skip KV placeholder write (policy/auth still applied)
+#   SKIP_ESO_AMBIENT_ENFORCE  set to 1 to skip labeling ESO namespace for Istio ambient when HELM_NAMESPACE uses ambient dataplane
 
 set -euo pipefail
 
@@ -85,6 +86,24 @@ if [[ "${SKIP_ESO_INSTALL:-0}" != "1" ]]; then
   fi
 else
   echo "==> SKIP_ESO_INSTALL=1 — assume External Secrets is installed"
+fi
+
+# Istio ambient: if Vault's namespace is in the mesh but ESO's namespace is not, ztunnel resets plain TCP to Vault
+# (ClusterSecretStore stays InvalidProviderConfig / connection reset; ExternalSecret never syncs).
+if [[ "${SKIP_ESO_AMBIENT_ENFORCE:-0}" != "1" ]]; then
+  ns_dataplane_mode() {
+    kubectl_ctx get namespace "$1" -o json 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin).get('metadata',{}).get('labels') or {}; print(d.get('istio.io/dataplane-mode',''))" || true
+  }
+  clawql_dp="$(ns_dataplane_mode "${NS}")"
+  eso_dp="$(ns_dataplane_mode "${ESO_NS}")"
+  if [[ "${clawql_dp}" == "ambient" && "${eso_dp}" != "ambient" ]]; then
+    echo "==> Istio ambient on ${NS}: label namespace ${ESO_NS} with istio.io/dataplane-mode=ambient (ESO → Vault)"
+    kubectl_ctx label namespace "${ESO_NS}" istio.io/dataplane-mode=ambient --overwrite
+    if kubectl_ctx get deploy external-secrets -n "${ESO_NS}" >/dev/null 2>&1; then
+      kubectl_ctx rollout restart deployment/external-secrets -n "${ESO_NS}" || true
+      kubectl_ctx rollout status deployment/external-secrets -n "${ESO_NS}" --timeout=180s || true
+    fi
+  fi
 fi
 
 echo "==> TokenReview RBAC for Vault server ServiceAccount"

--- a/scripts/kubernetes/bootstrap-local-vault-and-eso.sh
+++ b/scripts/kubernetes/bootstrap-local-vault-and-eso.sh
@@ -31,6 +31,7 @@ NS="${HELM_NAMESPACE:-clawql}"
 ESO_NS="${EXTERNAL_SECRETS_NAMESPACE:-external-secrets}"
 TOKEN="${VAULT_DEV_ROOT_TOKEN:-root}"
 VAULT_STS="${REL}-hashicorpvault"
+vault_pod="${VAULT_STS}-0"
 POLICY_FILE="${ROOT}/docs/deployment/vault-policy-clawql-eso-read.hcl"
 
 kubectl_ctx() {
@@ -49,10 +50,28 @@ helm_ctx() {
   fi
 }
 
-echo "==> Wait for Vault StatefulSet / pod (${NS}/${VAULT_STS})"
-if ! kubectl_ctx rollout status "statefulset/${VAULT_STS}" -n "${NS}" --timeout=300s; then
-  echo "    rollout status unavailable for this strategy; waiting on pod readiness instead"
-  kubectl_ctx wait --for=condition=Ready "pod/${VAULT_STS}-0" -n "${NS}" --timeout=300s
+echo "==> Wait for Vault pod (${NS}/${vault_pod})"
+# Vault Helm StatefulSet often uses updateStrategy.type=OnDelete — `kubectl rollout status` is not supported.
+# Do not wait for condition=Ready: readiness stays false while Vault is sealed; this script unseals next.
+_deadline=$((SECONDS + 300))
+_vault_phase=""
+while [[ "${SECONDS}" -lt "${_deadline}" ]]; do
+  _vault_phase="$(kubectl_ctx get pod "${vault_pod}" -n "${NS}" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+  if [[ "${_vault_phase}" == "Running" ]]; then
+    echo "    Vault pod is Running (may still be sealed — continuing to init/unseal)."
+    break
+  fi
+  if [[ "${_vault_phase}" == "Failed" ]]; then
+    echo "ERROR: Vault pod ${vault_pod} is Failed"
+    kubectl_ctx describe pod "${vault_pod}" -n "${NS}" | tail -40 || true
+    exit 1
+  fi
+  sleep 2
+done
+if [[ "${_vault_phase}" != "Running" ]]; then
+  echo "ERROR: Vault pod ${vault_pod} did not reach Running within 300s (last phase: ${_vault_phase:-missing})"
+  kubectl_ctx get pods -n "${NS}" -l "app.kubernetes.io/name=vault" -o wide 2>/dev/null || kubectl_ctx get pod -n "${NS}" "${vault_pod}" -o wide 2>/dev/null || true
+  exit 1
 fi
 
 if [[ "${SKIP_ESO_INSTALL:-0}" != "1" ]]; then
@@ -75,8 +94,6 @@ fi
 
 echo "==> TokenReview RBAC for Vault server ServiceAccount"
 kubectl_ctx apply -f "${ROOT}/docs/deployment/vault-kubernetes-auth-tokenreview-rbac.yaml"
-
-vault_pod="${VAULT_STS}-0"
 
 vault_exec() {
   kubectl_ctx exec -n "${NS}" "${vault_pod}" -c vault -- "$@"
@@ -107,14 +124,15 @@ sealed="$(echo "${STATUS_JSON}" | python3 -c "import json,sys; print(json.load(s
 if [[ "${initialized}" == "False" ]]; then
   echo "    Initializing Vault (1 unseal key) and recording bootstrap Secret/${NS}/${BOOTSTRAP_SECRET}"
   INIT_JSON="$(vault_exec sh -ec "export VAULT_ADDR=http://127.0.0.1:8200; vault operator init -key-shares=1 -key-threshold=1 -format=json")"
-  ROOT="$(echo "${INIT_JSON}" | python3 -c "import json,sys; print(json.load(sys.stdin)['root_token'])")"
+  # Never assign Vault's root token to ROOT — ROOT is the repo path for kubectl apply -f "${ROOT}/docs/..." below.
+  VAULT_INIT_ROOT_TOKEN="$(echo "${INIT_JSON}" | python3 -c "import json,sys; print(json.load(sys.stdin)['root_token'])")"
   UNSEAL_HEX="$(echo "${INIT_JSON}" | python3 -c "import json,sys; print(json.load(sys.stdin)['unseal_keys_hex'][0])")"
   kubectl_ctx create secret generic "${BOOTSTRAP_SECRET}" -n "${NS}" \
-    --from-literal=root-token="${ROOT}" \
+    --from-literal=root-token="${VAULT_INIT_ROOT_TOKEN}" \
     --from-literal=unseal-key="${UNSEAL_HEX}" \
     --dry-run=client -o yaml | kubectl_ctx apply -f -
   vault_exec env VAULT_ADDR=http://127.0.0.1:8200 vault operator unseal "${UNSEAL_HEX}"
-  TOKEN="${ROOT}"
+  TOKEN="${VAULT_INIT_ROOT_TOKEN}"
 elif [[ "${sealed}" == "True" ]]; then
   echo "    Unsealing Vault using Secret/${NS}/${BOOTSTRAP_SECRET}"
   if ! kubectl_ctx get secret "${BOOTSTRAP_SECRET}" -n "${NS}" >/dev/null 2>&1; then

--- a/src/mcp-nonnegotiable-tools.ts
+++ b/src/mcp-nonnegotiable-tools.ts
@@ -1,0 +1,38 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+/**
+ * MCP tools that must always be registered and enabled for every transport
+ * (stdio, Streamable HTTP, gRPC). Used at server construction and in release gates.
+ *
+ * Keep in sync with {@link registerTools} in tools.ts (cache + audit immediately after search/execute).
+ */
+export const CLAWQL_NONNEGOTIABLE_MCP_TOOL_NAMES = ["search", "execute", "cache", "audit"] as const;
+export type ClawqlNonnegotiableMcpToolName = (typeof CLAWQL_NONNEGOTIABLE_MCP_TOOL_NAMES)[number];
+
+type ToolRegistry = Record<string, { enabled?: boolean } | undefined>;
+
+/**
+ * Runtime guard: {@link McpServer} keeps registered tools in `_registeredTools` (SDK implementation detail).
+ * If the SDK renames this, this function fails closed so we notice immediately.
+ */
+export function assertNonnegotiableMcpToolsRegistered(server: McpServer): void {
+  const registry = (server as unknown as { _registeredTools?: ToolRegistry })._registeredTools;
+  if (!registry || typeof registry !== "object") {
+    throw new Error(
+      "ClawQL invariant: McpServer has no _registeredTools map — MCP SDK may have changed; cannot verify audit/cache."
+    );
+  }
+  const missing: string[] = [];
+  const disabled: string[] = [];
+  for (const name of CLAWQL_NONNEGOTIABLE_MCP_TOOL_NAMES) {
+    const entry = registry[name];
+    if (!entry) missing.push(name);
+    else if (entry.enabled === false) disabled.push(name);
+  }
+  if (missing.length > 0 || disabled.length > 0) {
+    throw new Error(
+      "ClawQL invariant violated: non-negotiable MCP tools must always be registered and enabled. " +
+        `missing=[${missing.join(", ")}] disabled=[${disabled.join(", ")}]`
+    );
+  }
+}

--- a/src/mcp-server-factory.test.ts
+++ b/src/mcp-server-factory.test.ts
@@ -5,8 +5,9 @@ import { createRegisteredMcpServer } from "./mcp-server-factory.js";
 describe("createRegisteredMcpServer", () => {
   it("registers every non-negotiable MCP tool (cache + audit cannot be skipped)", () => {
     const server = createRegisteredMcpServer();
-    const registry = (server as unknown as { _registeredTools: Record<string, { enabled?: boolean }> })
-      ._registeredTools;
+    const registry = (
+      server as unknown as { _registeredTools: Record<string, { enabled?: boolean }> }
+    )._registeredTools;
     for (const name of CLAWQL_NONNEGOTIABLE_MCP_TOOL_NAMES) {
       expect(registry[name], `expected tool ${name}`).toBeDefined();
       expect(registry[name]?.enabled, `${name} must not be disabled`).not.toBe(false);

--- a/src/mcp-server-factory.test.ts
+++ b/src/mcp-server-factory.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { CLAWQL_NONNEGOTIABLE_MCP_TOOL_NAMES } from "./mcp-nonnegotiable-tools.js";
+import { createRegisteredMcpServer } from "./mcp-server-factory.js";
+
+describe("createRegisteredMcpServer", () => {
+  it("registers every non-negotiable MCP tool (cache + audit cannot be skipped)", () => {
+    const server = createRegisteredMcpServer();
+    const registry = (server as unknown as { _registeredTools: Record<string, { enabled?: boolean }> })
+      ._registeredTools;
+    for (const name of CLAWQL_NONNEGOTIABLE_MCP_TOOL_NAMES) {
+      expect(registry[name], `expected tool ${name}`).toBeDefined();
+      expect(registry[name]?.enabled, `${name} must not be disabled`).not.toBe(false);
+    }
+  });
+});

--- a/src/mcp-server-factory.ts
+++ b/src/mcp-server-factory.ts
@@ -1,5 +1,6 @@
 import type { Implementation } from "@modelcontextprotocol/sdk/types.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { assertNonnegotiableMcpToolsRegistered } from "./mcp-nonnegotiable-tools.js";
 import { NPM_PACKAGE_VERSION } from "./npm-version.js";
 import { registerTools } from "./tools.js";
 
@@ -14,5 +15,6 @@ const DEFAULT_INFO: Implementation = {
 export function createRegisteredMcpServer(serverInfo: Implementation = DEFAULT_INFO): McpServer {
   const server = new McpServer(serverInfo);
   registerTools(server);
+  assertNonnegotiableMcpToolsRegistered(server);
   return server;
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,7 +1,7 @@
 /**
  * tools.ts
  *
- * Core tools: search (spec discovery), execute (GraphQL-backed REST call), audit (in-process ring buffer; GitHub #89 — not durable; use memory_ingest for compliance trails), cache (in-process LRU KV; GitHub #75 — not persisted; use memory_* for vault).
+ * Core tools: search, execute, then immediately cache + audit (non-negotiable; must not follow optional branches that could throw). audit = in-process ring buffer (#89); cache = in-process LRU KV (#75).
  * Optional: **`sandbox_exec`** when **`CLAWQL_ENABLE_SANDBOX=1`** — bridge / Seatbelt / Docker (`CLAWQL_SANDBOX_BACKEND`).
  * memory_ingest / memory_recall — Obsidian vault notes (default on; set CLAWQL_ENABLE_MEMORY=0 to hide; writable vault).
  * Optional: ingest_external_knowledge — bulk Markdown + optional URL fetch (GitHub #40); default on; **`CLAWQL_ENABLE_DOCUMENTS=0`** to hide.
@@ -461,6 +461,11 @@ export function registerTools(server: McpServer) {
     wrapMcpToolHandler("execute", handleClawqlExecuteToolInput)
   );
 
+  // Non-negotiable Core tools: register immediately after search/execute so optional branches
+  // below cannot throw and skip cache/audit (#89 #75).
+  server.tool("cache", cacheToolSchema, wrapMcpToolHandler("cache", handleCacheToolInput));
+  server.tool("audit", auditToolSchema, wrapMcpToolHandler("audit", handleAuditToolInput));
+
   if (getClawqlOptionalToolFlags().enableSandbox) {
     const sandboxCodeSchema = {
       code: z
@@ -637,10 +642,6 @@ export function registerTools(server: McpServer) {
       wrapMcpToolHandler("ingest_external_knowledge", handleIngestExternalKnowledgeToolInput)
     );
   }
-
-  server.tool("cache", cacheToolSchema, wrapMcpToolHandler("cache", handleCacheToolInput));
-
-  server.tool("audit", auditToolSchema, wrapMcpToolHandler("audit", handleAuditToolInput));
 
   if (getClawqlOptionalToolFlags().enableSchedule) {
     server.tool(


### PR DESCRIPTION
## What broke
After `vault operator init`, the script assigned the **root token** to `ROOT`, overwriting the **repository directory** used for `kubectl apply -f "${ROOT}/docs/..."`. That produced the bogus path (`hvs....../docs/deployment/...`) and failed after a successful init.

## Fix
- Capture init root token in `VAULT_INIT_ROOT_TOKEN` only; **never** reuse `ROOT` for Vault tokens.
- Wait for Vault pod **phase Running** (no `rollout status` on OnDelete StatefulSets; do not wait **Ready** while sealed).

## Validation
- `bash -n scripts/kubernetes/bootstrap-local-vault-and-eso.sh`

Re-run: `make bootstrap-vault-eso` (if Vault was already initialized, the apply step should succeed; if you hit duplicate-init, use existing bootstrap secret / PVC per script messages).