### PR TITLE
fix(website): unblock docs deploy (brace-expansion)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -3923,9 +3923,9 @@
       }
     },
     "node_modules/@node-minify/core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -3922,6 +3922,16 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@node-minify/core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/@node-minify/core/node_modules/glob": {
       "version": "9.3.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
@@ -7468,6 +7478,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bare-events": {
       "version": "2.8.2",

--- a/website/package.json
+++ b/website/package.json
@@ -74,7 +74,7 @@
     "@node-minify/core": {
       "glob": {
         "minimatch": {
-          "brace-expansion": "2.0.2"
+          "brace-expansion": "2.0.3"
         }
       }
     },

--- a/website/package.json
+++ b/website/package.json
@@ -71,6 +71,13 @@
   },
   "overrides": {
     "brace-expansion": "5.0.6",
+    "@node-minify/core": {
+      "glob": {
+        "minimatch": {
+          "brace-expansion": "2.0.2"
+        }
+      }
+    },
     "ws": "8.20.1",
     "basic-ftp": "5.3.1",
     "ip-address": "10.1.1",


### PR DESCRIPTION
## Summary

Fixes failed **Deploy docs (Cloudflare)** on main after #370 ([run 26206560208](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/26206560208/job/77107591564)).

`opennextjs-cloudflare` pulls `@node-minify/core` → `minimatch@8`, which does `import expand from 'brace-expansion'`. The repo-wide npm override to **brace-expansion@5.0.6** (OSV) removed the default ESM export that minimatch expects, so deploy died immediately with:

`SyntaxError: The requested module 'brace-expansion' does not provide an export named 'default'`

Keep **5.0.6** globally for supply-chain/OSV, but pin **2.0.2** only under `@node-minify/core` → `glob` → `minimatch`.

## Test plan

- [x] `cd website && npx opennextjs-cloudflare build` completes locally
- [ ] Merge and confirm **Deploy docs (Cloudflare)** succeeds on `main`
- [ ] https://docs.clawql.com/vision/technical-enablement loads after deploy