### PR TITLE
feat(core): Phase 0 — Turborepo, clawql-core, audit Effect port

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 COPY package.json package-lock.json ./
+COPY packages/clawql-core/package.json ./packages/clawql-core/
 COPY packages/mcp-grpc-transport/package.json ./packages/mcp-grpc-transport/
 COPY packages/clawql-ouroboros/package.json ./packages/clawql-ouroboros/
 # `workspace:*` deps (e.g. clawql-ouroboros) need every workspace package.json present before `npm ci`.

--- a/docker/panguard-mcp-bridge/Dockerfile
+++ b/docker/panguard-mcp-bridge/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 COPY package.json package-lock.json ./
+COPY packages/clawql-core/package.json ./packages/clawql-core/package.json
 COPY packages/clawql-ouroboros/package.json ./packages/clawql-ouroboros/package.json
 COPY packages/mcp-grpc-transport ./packages/mcp-grpc-transport
 COPY packages/panguard-mcp-bridge ./packages/panguard-mcp-bridge

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
                 "@opentelemetry/resources": "^2.7.1",
                 "@opentelemetry/sdk-trace-base": "^2.7.1",
                 "@opentelemetry/sdk-trace-node": "^2.7.1",
+                "clawql-core": "workspace:*",
                 "clawql-ouroboros": "workspace:*",
                 "dotenv": "^17.4.2",
                 "express": "^5.2.1",
@@ -51,6 +52,7 @@
                 "eslint": "^10.4.0",
                 "prettier": "^3.8.3",
                 "tsx": "^4.22.2",
+                "turbo": "^2.5.4",
                 "typescript": "^6.0.3",
                 "typescript-eslint": "^8.60.0",
                 "vitest": "^4.1.7"
@@ -2381,7 +2383,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
             "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@theguild/federation-composition": {
@@ -2401,6 +2402,90 @@
             "peerDependencies": {
                 "graphql": "^16.0.0"
             }
+        },
+        "node_modules/@turbo/darwin-64": {
+            "version": "2.9.16",
+            "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.16.tgz",
+            "integrity": "sha512-jLjApWTSNd7JZ5JaLYfelW1ytnGQOvB7ivl+2RD1xQvJTbi8I9gBjzcga7tDZVPyaxpl10YTfJt3BrYXR18KDw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@turbo/darwin-arm64": {
+            "version": "2.9.16",
+            "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.9.16.tgz",
+            "integrity": "sha512-YPgrn+5HIGzrx0O2a631SV4MBQUe4W/DafMFUuBVgaU32PW9/OTT0ehviF0QSxTXuRJlHvW2eUTemddF5/spmw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@turbo/linux-64": {
+            "version": "2.9.16",
+            "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.16.tgz",
+            "integrity": "sha512-vAEf1H6l26lTpl9FJ/peQo1NUB8RC0sbEJJz5mPcUhHA2bPDup2x3CZPgo/bH8S4cUcBLm4FN3UHd5iUO2RAew==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@turbo/linux-arm64": {
+            "version": "2.9.16",
+            "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.16.tgz",
+            "integrity": "sha512-xDBLR2PZg4BrQOchfG6svgpv5FCNJ2TOtT2psLdEJcdKo1BH+pnPs9Xj6pvUjgfkHbuvBOfeE4R6tvxMoQKDHQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@turbo/windows-64": {
+            "version": "2.9.16",
+            "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.16.tgz",
+            "integrity": "sha512-NBAJnaUiGdgkSzQwUIdOvkCkcpTSu58G/sBGa0mvBtzfvFOOgrQwepKOOQ8cp6sWM6OcKDNFj2p1dsZA1OWjPg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@turbo/windows-arm64": {
+            "version": "2.9.16",
+            "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.16.tgz",
+            "integrity": "sha512-Y7SJppD0Z8wjO3Ec0ZGd9KQ4Yv0BMnA8CIowj5Vp+OEVsosXDG2weK6/t1RRLfJmc2Ozrnd6y4DOgQys+mn3WQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/@tybys/wasm-util": {
             "version": "0.10.2",
@@ -3310,6 +3395,10 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/clawql-core": {
+            "resolved": "packages/clawql-core",
+            "link": true
+        },
         "node_modules/clawql-ouroboros": {
             "resolved": "packages/clawql-ouroboros",
             "link": true
@@ -3649,6 +3738,16 @@
         "node_modules/ee-first": {
             "version": "1.1.1",
             "license": "MIT"
+        },
+        "node_modules/effect": {
+            "version": "3.21.2",
+            "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.2.tgz",
+            "integrity": "sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==",
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "fast-check": "^3.23.1"
+            }
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -4051,6 +4150,28 @@
             },
             "peerDependencies": {
                 "express": ">= 4.11"
+            }
+        },
+        "node_modules/fast-check": {
+            "version": "3.23.2",
+            "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+            "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/dubzzz"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fast-check"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "pure-rand": "^6.1.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -5983,6 +6104,22 @@
                 "node": ">=6"
             }
         },
+        "node_modules/pure-rand": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+            "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/dubzzz"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fast-check"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/qs": {
             "version": "6.15.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
@@ -7256,6 +7393,24 @@
                 "fsevents": "~2.3.3"
             }
         },
+        "node_modules/turbo": {
+            "version": "2.9.16",
+            "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.16.tgz",
+            "integrity": "sha512-NqgRQy6j6dPYcdSdv0q1g9QsZg7SWg87RERM8otw/1AtKU2yTFVClOM7cbwKzOonZr/Ek1blTBucw64L9H0Bwg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "turbo": "bin/turbo"
+            },
+            "optionalDependencies": {
+                "@turbo/darwin-64": "2.9.16",
+                "@turbo/darwin-arm64": "2.9.16",
+                "@turbo/linux-64": "2.9.16",
+                "@turbo/linux-arm64": "2.9.16",
+                "@turbo/windows-64": "2.9.16",
+                "@turbo/windows-arm64": "2.9.16"
+            }
+        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7738,6 +7893,39 @@
             "peerDependencies": {
                 "zod": "^3.25 || ^4"
             }
+        },
+        "packages/clawql-core": {
+            "version": "0.0.1",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "effect": "3.21.2"
+            },
+            "devDependencies": {
+                "@types/node": "^22.0.0",
+                "tsup": "^8.3.0",
+                "typescript": "^6.0.2",
+                "vitest": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "packages/clawql-core/node_modules/@types/node": {
+            "version": "22.19.19",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+            "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
+        },
+        "packages/clawql-core/node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "packages/clawql-ouroboros": {
             "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,9 @@
         ".cursor/mcp.json.example"
     ],
     "scripts": {
-        "clean": "rm -rf dist packages/mcp-grpc-transport/dist packages/clawql-ouroboros/dist packages/panguard-mcp-bridge/dist",
-        "build": "npm run clean && npm run build -w mcp-grpc-transport && npm run build -w clawql-ouroboros && npm run build -w panguard-mcp-bridge && tsc",
+        "clean": "rm -rf dist packages/clawql-core/dist packages/mcp-grpc-transport/dist packages/clawql-ouroboros/dist packages/panguard-mcp-bridge/dist",
+        "build": "npm run clean && npm run build -w clawql-core && npm run build -w mcp-grpc-transport && npm run build -w clawql-ouroboros && npm run build -w panguard-mcp-bridge && tsc",
+        "build:turbo": "turbo run build",
         "prepublishOnly": "npm run build",
         "start": "node dist/server.js",
         "start:http": "node dist/server-http.js",
@@ -90,10 +91,10 @@
         "pretest": "npm run build",
         "test": "vitest run",
         "test:coverage": "npm run build && vitest run --coverage",
-        "lint": "eslint \"src/**/*.ts\" \"packages/mcp-grpc-transport/src/**/*.ts\" \"packages/clawql-ouroboros/src/**/*.ts\" \"packages/panguard-mcp-bridge/src/**/*.ts\" \"vitest.config.ts\" --max-warnings 0 --cache --cache-location .eslintcache",
-        "lint:fix": "eslint \"src/**/*.ts\" \"packages/mcp-grpc-transport/src/**/*.ts\" \"packages/clawql-ouroboros/src/**/*.ts\" \"packages/panguard-mcp-bridge/src/**/*.ts\" \"vitest.config.ts\" --fix --cache --cache-location .eslintcache",
-        "format": "prettier --write \"src/**/*.{ts,tsx}\" \"packages/mcp-grpc-transport/**/*.{ts,md,json}\" \"docs/**/*.md\" \".github/**/*.yml\" \"*.md\" \"vitest.config.ts\" \"eslint.config.js\" \"tsconfig.json\" \".prettierrc.json\" --cache --cache-location .prettier-cache && npm run format --prefix website",
-        "format:check": "prettier --check \"src/**/*.{ts,tsx}\" \"packages/mcp-grpc-transport/**/*.{ts,md,json}\" \"docs/**/*.md\" \".github/**/*.yml\" \"*.md\" \"vitest.config.ts\" \"eslint.config.js\" \"tsconfig.json\" \".prettierrc.json\" --cache --cache-location .prettier-cache && npm run format:check --prefix website",
+        "lint": "eslint \"src/**/*.ts\" \"packages/clawql-core/src/**/*.ts\" \"packages/mcp-grpc-transport/src/**/*.ts\" \"packages/clawql-ouroboros/src/**/*.ts\" \"packages/panguard-mcp-bridge/src/**/*.ts\" \"vitest.config.ts\" --max-warnings 0 --cache --cache-location .eslintcache",
+        "lint:fix": "eslint \"src/**/*.ts\" \"packages/clawql-core/src/**/*.ts\" \"packages/mcp-grpc-transport/src/**/*.ts\" \"packages/clawql-ouroboros/src/**/*.ts\" \"packages/panguard-mcp-bridge/src/**/*.ts\" \"vitest.config.ts\" --fix --cache --cache-location .eslintcache",
+        "format": "prettier --write \"src/**/*.{ts,tsx}\" \"packages/clawql-core/**/*.{ts,md,json}\" \"packages/mcp-grpc-transport/**/*.{ts,md,json}\" \"docs/**/*.md\" \".github/**/*.yml\" \"*.md\" \"vitest.config.ts\" \"eslint.config.js\" \"tsconfig.json\" \".prettierrc.json\" \"turbo.json\" --cache --cache-location .prettier-cache && npm run format --prefix website",
+        "format:check": "prettier --check \"src/**/*.{ts,tsx}\" \"packages/clawql-core/**/*.{ts,md,json}\" \"packages/mcp-grpc-transport/**/*.{ts,md,json}\" \"docs/**/*.md\" \".github/**/*.yml\" \"*.md\" \"vitest.config.ts\" \"eslint.config.js\" \"tsconfig.json\" \".prettierrc.json\" \"turbo.json\" --cache --cache-location .prettier-cache && npm run format:check --prefix website",
         "release:git-tag": "bash scripts/release/git-release-tag.sh",
         "release:git-tag:push": "bash scripts/release/git-release-tag.sh --push",
         "release:git-backfill-tags": "bash scripts/release/git-backfill-npm-release-tags.sh",
@@ -110,6 +111,7 @@
         "@opentelemetry/resources": "^2.7.1",
         "@opentelemetry/sdk-trace-base": "^2.7.1",
         "@opentelemetry/sdk-trace-node": "^2.7.1",
+        "clawql-core": "workspace:*",
         "clawql-ouroboros": "workspace:*",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
@@ -137,6 +139,7 @@
         "tsx": "^4.22.2",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.60.0",
+        "turbo": "^2.5.4",
         "vitest": "^4.1.7"
     },
     "overrides": {

--- a/packages/clawql-core/README.md
+++ b/packages/clawql-core/README.md
@@ -1,0 +1,11 @@
+# clawql-core
+
+Effect-TS foundation for ClawQL modularization ([#307](https://github.com/danielsmithdevelopment/ClawQL/issues/307), plan in [`docs/design/effect-ts-modularization-rearchitecture-plan.md`](../../docs/design/effect-ts-modularization-rearchitecture-plan.md)).
+
+**Phase 0:** `AuditService` + in-process audit ring buffer (MCP `audit` tool delegates here).
+
+**Planned modules (inside this package, not separate npm workspaces):**
+
+- `merkle/` — tamper-evident roots
+- `cuckoo/` — ingest deduplication filters
+- `utils/` — shared primitives

--- a/packages/clawql-core/package.json
+++ b/packages/clawql-core/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "clawql-core",
+  "version": "0.0.1",
+  "description": "ClawQL primitives: Effect-TS services, Merkle/Cuckoo modules, audit ring buffer — foundation for modular clawql-mcp",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "npm run clean && tsup",
+    "prepublishOnly": "npm run build",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "effect": "3.21.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsup": "^8.3.0",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.1"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danielsmithdevelopment/ClawQL.git",
+    "directory": "packages/clawql-core"
+  },
+  "keywords": [
+    "clawql",
+    "effect",
+    "mcp",
+    "audit",
+    "merkle"
+  ]
+}

--- a/packages/clawql-core/src/audit/audit-service.test.ts
+++ b/packages/clawql-core/src/audit/audit-service.test.ts
@@ -1,0 +1,53 @@
+import { Effect } from "effect";
+import { afterEach, describe, expect, it } from "vitest";
+import { AuditService, AuditTestLayer } from "./audit-service.js";
+import { getClawqlAuditMaxEntries } from "./config.js";
+import { resetDefaultAuditRingBufferForTests } from "./ring-buffer.js";
+
+const run = <A, E>(program: Effect.Effect<A, E, AuditService>) =>
+  Effect.runPromise(program.pipe(Effect.provide(AuditTestLayer)));
+
+describe("AuditService (Effect)", () => {
+  afterEach(() => {
+    resetDefaultAuditRingBufferForTests();
+  });
+
+  it("append and list via Effect Layer", async () => {
+    const list = await run(
+      Effect.gen(function* () {
+        const audit = yield* AuditService;
+        yield* audit.append({
+          category: "tool",
+          action: "execute",
+          summary: "petstore",
+          correlationId: "c1",
+        });
+        return yield* audit.list(10);
+      })
+    );
+    expect(list.total).toBe(1);
+    expect(list.entries[0]?.category).toBe("tool");
+    expect(list.entries[0]?.correlationId).toBe("c1");
+  });
+
+  it("clear via Effect Layer", async () => {
+    await run(
+      Effect.gen(function* () {
+        const audit = yield* AuditService;
+        yield* audit.append({ category: "x", action: "y", summary: "z" });
+        const cleared = yield* audit.clear();
+        expect(cleared.cleared).toBe(1);
+        const list = yield* audit.list(10);
+        expect(list.total).toBe(0);
+      })
+    );
+  });
+
+  it("getClawqlAuditMaxEntries respects env", () => {
+    const saved = process.env.CLAWQL_AUDIT_MAX_ENTRIES;
+    process.env.CLAWQL_AUDIT_MAX_ENTRIES = "42";
+    expect(getClawqlAuditMaxEntries()).toBe(42);
+    if (saved === undefined) delete process.env.CLAWQL_AUDIT_MAX_ENTRIES;
+    else process.env.CLAWQL_AUDIT_MAX_ENTRIES = saved;
+  });
+});

--- a/packages/clawql-core/src/audit/audit-service.ts
+++ b/packages/clawql-core/src/audit/audit-service.ts
@@ -1,0 +1,78 @@
+import { Context, Effect, Layer } from "effect";
+import { getClawqlAuditMaxEntries } from "./config.js";
+import {
+  createAuditRingBuffer,
+  getDefaultAuditRingBuffer,
+  type AuditRingBuffer,
+} from "./ring-buffer.js";
+import type {
+  AuditAppendResult,
+  AuditClearResult,
+  AuditListResult,
+  ClawqlAuditEntry,
+} from "./types.js";
+
+export type AuditAppendInput = {
+  readonly category: string;
+  readonly action: string;
+  readonly summary: string;
+  readonly correlationId?: string;
+};
+
+export class AuditService extends Context.Tag("clawql/AuditService")<
+  AuditService,
+  {
+    readonly getMaxEntries: () => number;
+    readonly append: (input: AuditAppendInput) => Effect.Effect<AuditAppendResult>;
+    readonly list: (limit: number) => Effect.Effect<AuditListResult>;
+    readonly clear: () => Effect.Effect<AuditClearResult>;
+    readonly resetForTests: () => Effect.Effect<void>;
+  }
+>() {}
+
+function serviceFromBuffer(
+  buffer: AuditRingBuffer,
+  getMaxEntries: () => number,
+  resetBuffer: () => void
+) {
+  return AuditService.of({
+    getMaxEntries,
+    append: (input) =>
+      Effect.sync(() => {
+        const entry: ClawqlAuditEntry = {
+          ts: new Date().toISOString(),
+          category: input.category,
+          action: input.action,
+          summary: input.summary,
+          correlationId: input.correlationId,
+        };
+        return buffer.append(entry);
+      }),
+    list: (limit) => Effect.sync(() => buffer.list(limit)),
+    clear: () => Effect.sync(() => buffer.clear()),
+    resetForTests: () => Effect.sync(() => resetBuffer()),
+  });
+}
+
+/** In-memory ring buffer backed by the process-wide default buffer (MCP bridge). */
+export const AuditLive = Layer.effect(
+  AuditService,
+  Effect.sync(() =>
+    serviceFromBuffer(getDefaultAuditRingBuffer(), getClawqlAuditMaxEntries, () =>
+      getDefaultAuditRingBuffer().reset()
+    )
+  )
+);
+
+/** Isolated buffer for unit tests (`Effect.provide(AuditTestLayer)`). */
+export const AuditTestLayer = Layer.effect(
+  AuditService,
+  Effect.sync(() => {
+    const buffer = createAuditRingBuffer(() => 500);
+    return serviceFromBuffer(
+      buffer,
+      () => 500,
+      () => buffer.reset()
+    );
+  })
+);

--- a/packages/clawql-core/src/audit/config.ts
+++ b/packages/clawql-core/src/audit/config.ts
@@ -1,0 +1,8 @@
+/** `CLAWQL_AUDIT_MAX_ENTRIES` (default 500, min 1, max 50_000). */
+export function getClawqlAuditMaxEntries(): number {
+  const v = process.env.CLAWQL_AUDIT_MAX_ENTRIES?.trim();
+  if (!v) return 500;
+  const n = Number.parseInt(v, 10);
+  if (!Number.isFinite(n)) return 500;
+  return Math.min(Math.max(n, 1), 50_000);
+}

--- a/packages/clawql-core/src/audit/index.ts
+++ b/packages/clawql-core/src/audit/index.ts
@@ -1,0 +1,4 @@
+export * from "./audit-service.js";
+export * from "./config.js";
+export * from "./ring-buffer.js";
+export * from "./types.js";

--- a/packages/clawql-core/src/audit/ring-buffer.test.ts
+++ b/packages/clawql-core/src/audit/ring-buffer.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getClawqlAuditMaxEntries } from "./config.js";
+import { createAuditRingBuffer } from "./ring-buffer.js";
+
+describe("audit ring buffer", () => {
+  const saved = process.env.CLAWQL_AUDIT_MAX_ENTRIES;
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env.CLAWQL_AUDIT_MAX_ENTRIES;
+    else process.env.CLAWQL_AUDIT_MAX_ENTRIES = saved;
+  });
+
+  it("evicts oldest when over max entries", () => {
+    process.env.CLAWQL_AUDIT_MAX_ENTRIES = "2";
+    expect(getClawqlAuditMaxEntries()).toBe(2);
+    const buffer = createAuditRingBuffer(getClawqlAuditMaxEntries);
+    const mk = (summary: string) => ({
+      ts: new Date().toISOString(),
+      category: "a",
+      action: "x",
+      summary,
+    });
+    buffer.append(mk("first"));
+    buffer.append(mk("second"));
+    const { dropped } = buffer.append(mk("third"));
+    expect(dropped).toBe(1);
+    const list = buffer.list(10);
+    expect(list.entries.map((e) => e.summary)).toEqual(["second", "third"]);
+  });
+});

--- a/packages/clawql-core/src/audit/ring-buffer.ts
+++ b/packages/clawql-core/src/audit/ring-buffer.ts
@@ -1,0 +1,60 @@
+import { getClawqlAuditMaxEntries } from "./config.js";
+import type {
+  AuditAppendResult,
+  AuditClearResult,
+  AuditListResult,
+  ClawqlAuditEntry,
+} from "./types.js";
+
+export type AuditRingBuffer = {
+  readonly append: (entry: ClawqlAuditEntry) => AuditAppendResult;
+  readonly list: (limit: number) => AuditListResult;
+  readonly clear: () => AuditClearResult;
+  readonly reset: () => void;
+};
+
+export function createAuditRingBuffer(getMaxEntries: () => number): AuditRingBuffer {
+  const buffer: ClawqlAuditEntry[] = [];
+
+  return {
+    append(entry: ClawqlAuditEntry): AuditAppendResult {
+      buffer.push(entry);
+      const max = getMaxEntries();
+      let dropped = 0;
+      while (buffer.length > max) {
+        buffer.shift();
+        dropped++;
+      }
+      return { total: buffer.length, dropped };
+    },
+    list(limit: number): AuditListResult {
+      const max = getMaxEntries();
+      const slice = buffer.slice(-limit);
+      return { total: buffer.length, maxEntries: max, entries: slice };
+    },
+    clear(): AuditClearResult {
+      const cleared = buffer.length;
+      buffer.length = 0;
+      return { cleared };
+    },
+    reset(): void {
+      buffer.length = 0;
+    },
+  };
+}
+
+let defaultBuffer: AuditRingBuffer | undefined;
+
+/** Shared in-process buffer for `clawql-mcp` until full Layer bootstrap at API startup. */
+export function getDefaultAuditRingBuffer(): AuditRingBuffer {
+  if (!defaultBuffer) {
+    defaultBuffer = createAuditRingBuffer(getClawqlAuditMaxEntries);
+  }
+  return defaultBuffer;
+}
+
+/** Test helper — drops singleton so the next call creates a fresh buffer. */
+export function resetDefaultAuditRingBufferForTests(): void {
+  defaultBuffer?.reset();
+  defaultBuffer = undefined;
+}

--- a/packages/clawql-core/src/audit/types.ts
+++ b/packages/clawql-core/src/audit/types.ts
@@ -1,0 +1,22 @@
+export type ClawqlAuditEntry = {
+  ts: string;
+  category: string;
+  action: string;
+  summary: string;
+  correlationId?: string;
+};
+
+export type AuditAppendResult = {
+  readonly total: number;
+  readonly dropped: number;
+};
+
+export type AuditListResult = {
+  readonly total: number;
+  readonly maxEntries: number;
+  readonly entries: readonly ClawqlAuditEntry[];
+};
+
+export type AuditClearResult = {
+  readonly cleared: number;
+};

--- a/packages/clawql-core/src/cuckoo/README.md
+++ b/packages/clawql-core/src/cuckoo/README.md
@@ -1,0 +1,3 @@
+# Cuckoo (planned)
+
+Ingest deduplication / filters — migrate from `src/memory-cuckoo-metrics.ts` and related code in a follow-up PR.

--- a/packages/clawql-core/src/index.ts
+++ b/packages/clawql-core/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./audit/index.js";

--- a/packages/clawql-core/src/merkle/README.md
+++ b/packages/clawql-core/src/merkle/README.md
@@ -1,0 +1,3 @@
+# Merkle (planned)
+
+Tamper-evident roots — migrate from `src/merkle-tree.ts` in a follow-up PR.

--- a/packages/clawql-core/src/utils/README.md
+++ b/packages/clawql-core/src/utils/README.md
@@ -1,0 +1,3 @@
+# Utils (planned)
+
+Shared primitives (`normalizeOperationId`, IDs, etc.) — extracted from `clawql-mcp` incrementally.

--- a/packages/clawql-core/tsconfig.json
+++ b/packages/clawql-core/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "noEmit": true,
+    "ignoreDeprecations": "6.0",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/clawql-core/tsup.config.ts
+++ b/packages/clawql-core/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+});

--- a/packages/clawql-core/vitest.config.ts
+++ b/packages/clawql-core/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/src/clawql-audit.ts
+++ b/src/clawql-audit.ts
@@ -1,8 +1,16 @@
 /**
  * In-process audit ring buffer for MCP `audit` tool (GitHub #89).
  * **Not durable** — restart clears buffer; use `memory_ingest` for compliance-grade trails.
+ *
+ * Ring buffer + config live in `clawql-core`; this module adds MCP/Zod, Loki, and Prometheus.
  */
 
+import {
+  getClawqlAuditMaxEntries,
+  getDefaultAuditRingBuffer,
+  resetDefaultAuditRingBufferForTests,
+  type ClawqlAuditEntry,
+} from "clawql-core";
 import { z } from "zod";
 import { maybePushAuditEntryToLoki } from "./clawql-audit-loki.js";
 import { logMcpToolShape } from "./mcp-tool-log.js";
@@ -11,29 +19,12 @@ import {
   prometheusRecordAuditClear,
 } from "./native-protocol-prometheus.js";
 
-export type ClawqlAuditEntry = {
-  ts: string;
-  category: string;
-  action: string;
-  summary: string;
-  correlationId?: string;
+export type { ClawqlAuditEntry };
+
+export {
+  getClawqlAuditMaxEntries,
+  resetDefaultAuditRingBufferForTests as resetClawqlAuditBufferForTests,
 };
-
-const buffer: ClawqlAuditEntry[] = [];
-
-/** Exported for tests — `CLAWQL_AUDIT_MAX_ENTRIES` (default 500, min 1, max 50_000). */
-export function getClawqlAuditMaxEntries(): number {
-  const v = process.env.CLAWQL_AUDIT_MAX_ENTRIES?.trim();
-  if (!v) return 500;
-  const n = Number.parseInt(v, 10);
-  if (!Number.isFinite(n)) return 500;
-  return Math.min(Math.max(n, 1), 50_000);
-}
-
-/** Test helper — clears buffer. */
-export function resetClawqlAuditBufferForTests(): void {
-  buffer.length = 0;
-}
 
 export const auditToolSchema = {
   operation: z
@@ -95,7 +86,7 @@ export async function handleAuditToolInput(
   params: unknown
 ): Promise<{ content: { type: "text"; text: string }[] }> {
   const parsed = auditInputSchema.parse(params);
-  const max = getClawqlAuditMaxEntries();
+  const buffer = getDefaultAuditRingBuffer();
 
   logMcpToolShape("audit", {
     operation: parsed.operation,
@@ -114,31 +105,25 @@ export async function handleAuditToolInput(
         summary: parsed.summary!.trim(),
         correlationId: parsed.correlationId?.trim() || undefined,
       };
-      buffer.push(entry);
-      let dropped = 0;
-      while (buffer.length > max) {
-        buffer.shift();
-        dropped++;
-      }
-      prometheusRecordAuditAppend(buffer.length, dropped);
+      const { total, dropped } = buffer.append(entry);
+      prometheusRecordAuditAppend(total, dropped);
       maybePushAuditEntryToLoki(entry);
-      return jsonResponse({ ok: true, total: buffer.length, dropped });
+      return jsonResponse({ ok: true, total, dropped });
     }
     case "list": {
       const limit = parsed.limit ?? 20;
-      const slice = buffer.slice(-limit);
+      const { total, maxEntries, entries } = buffer.list(limit);
       return jsonResponse({
         ok: true,
-        total: buffer.length,
-        maxEntries: max,
-        entries: slice,
+        total,
+        maxEntries: maxEntries,
+        entries,
       });
     }
     case "clear": {
-      const n = buffer.length;
-      buffer.length = 0;
+      const { cleared } = buffer.clear();
       prometheusRecordAuditClear();
-      return jsonResponse({ ok: true, cleared: n });
+      return jsonResponse({ ok: true, cleared });
     }
     default:
       return jsonResponse({ ok: false, error: "unsupported operation" });

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "test": {
+      "dependsOn": ["build"],
+      "outputs": []
+    },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "lint": {
+      "outputs": []
+    }
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     include: [
       "src/**/*.test.ts",
       "packages/mcp-grpc-transport/src/**/*.test.ts",
+      "packages/clawql-core/src/**/*.test.ts",
       "packages/clawql-ouroboros/src/**/*.test.ts",
       "packages/panguard-mcp-bridge/src/**/*.test.ts",
     ],
@@ -33,12 +34,14 @@ export default defineConfig({
       include: [
         "src/**/*.ts",
         "packages/mcp-grpc-transport/src/**/*.ts",
+        "packages/clawql-core/src/**/*.ts",
         "packages/clawql-ouroboros/src/**/*.ts",
         "packages/panguard-mcp-bridge/src/**/*.ts",
       ],
       exclude: [
         "src/**/*.test.ts",
         "packages/mcp-grpc-transport/src/**/*.test.ts",
+        "packages/clawql-core/src/**/*.test.ts",
         "packages/clawql-ouroboros/src/**/*.test.ts",
         "packages/panguard-mcp-bridge/src/**/*.test.ts",
         "src/test-utils/**",


### PR DESCRIPTION
## Summary

- Add **`packages/clawql-core`** (Effect 3.21): audit ring buffer, `AuditService` + `AuditLive` / `AuditTestLayer`, env config for `CLAWQL_AUDIT_MAX_ENTRIES`.
- **`clawql-mcp`** `audit` tool delegates buffer ops to `clawql-core` (MCP/Zod/Loki/Prometheus unchanged).
- **`turbo.json`** + root `build:turbo`; build order includes `clawql-core` before `tsc`.
- Scaffold **`merkle/`**, **`cuckoo/`**, **`utils/`** inside core (per locked architecture).

## Test plan

- [x] `npm run build`
- [x] `npm test` (409 passed; +4 in clawql-core)
- [x] `npm run lint` / `format:check`

## Tracking

- Closes **Phase 0** checklist in [#397](https://github.com/danielsmithdevelopment/ClawQL/issues/397)
- Progress on [#307](https://github.com/danielsmithdevelopment/ClawQL/issues/307) (`clawql-core` package)

## Next (Phase 1)

- `clawql-api` skeleton + `execute`/`search` Effect pipeline
- Move `merkle-tree.ts` into `clawql-core/merkle/`