### PR TITLE
chore(release): clawql-mcp 6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.3.0] - 2026-06-02
+
+Minor release: **monorepo modularization phases 2–9** — workspace packages **`clawql-core`**, **`clawql-api`**, **`clawql-memory`**, **`clawql-documents`**, **`clawql-automation`** with thin **`src/`** shims; **`search`/`execute`** on Effect-TS via **`createClawQLApi()`**; **`PanguardProxyPlugin`**; plugin model + registry docs and **`/reference/plugins`** on docs.clawql.com. **No intentional MCP tool or env-flag breaks** — same **`search`**, **`execute`**, **`memory_*`**, optional tools behind existing **`CLAWQL_ENABLE_*`** gates. **`charts/clawql-mcp`** **Chart.version** **0.6.6** with **`appVersion` `6.3.0`**. Release notes: **[`RELEASE_NOTES_v6.3.0.md`](RELEASE_NOTES_v6.3.0.md)**.
+
+### Added
+
+- **Workspace packages (phases 2–9, [#306](https://github.com/danielsmithdevelopment/ClawQL/issues/306)):** **`clawql-core`** (audit, Merkle, Cuckoo, `Plugin` types), **`clawql-api`** (spec load/search, REST/GraphQL/gRPC execute, `createClawQLApi()`, provider registry), **`clawql-memory`** (vault, `memory.db`, ingest/recall, embeddings), **`clawql-documents`** (external ingest scaffold), **`clawql-automation`** (schedule worker + Slack notify). Ground truth: [`docs/design/modularization-implementation-status.md`](docs/design/modularization-implementation-status.md).
+- **Effect-TS gateway path:** MCP **`search`** / **`execute`** delegate through **`getClawqlApi().run(Effect…)`** (`SearchService` / `ExecuteService` Layers) — [#401](https://github.com/danielsmithdevelopment/ClawQL/pull/401), [#423](https://github.com/danielsmithdevelopment/ClawQL/pull/423)–[#430](https://github.com/danielsmithdevelopment/ClawQL/pull/430).
+- **`PanguardProxyPlugin`:** first-class **`mcp-proxy`** plugin with **`beforeCallTool`** chokepoint ([#308](https://github.com/danielsmithdevelopment/ClawQL/issues/308), [#272](https://github.com/danielsmithdevelopment/ClawQL/issues/272)).
+- **Turborepo:** `turbo.json` + workspace build order for extracted packages.
+- **Documentation:** plugin model, plugin registry, implementation-status sync across vision docs; docs site **[`/reference/plugins`](https://docs.clawql.com/reference/plugins)** ([#431](https://github.com/danielsmithdevelopment/ClawQL/pull/431)).
+
+### Changed
+
+- **Internal layout:** business logic moved into **`packages/*`**; **`src/tools.ts`** remains MCP registration transport; **`configureNotifyDeps`** wires automation notify from transport ([#430](https://github.com/danielsmithdevelopment/ClawQL/pull/430)).
+- **Docker:** Dockerfiles copy workspace **`package.json`** files before **`npm ci`** for modularization builds.
+- **Docs site:** information architecture revamp, hub pages, synced vision/enablement/modularization bodies ([#420](https://github.com/danielsmithdevelopment/ClawQL/pull/420)).
+
+### Documentation
+
+- **[`docs/design/clawql-plugin-model.md`](docs/design/clawql-plugin-model.md)** — horizontal packages becoming plugins.
+- **[`docs/reference/clawql-plugin-registry.md`](docs/reference/clawql-plugin-registry.md)** — shipped vs planned plugin registry.
+- Deployment guide, package READMEs, contributor spec, and memory docs aligned with phases 1–9 shipped state.
+
 ## [6.2.1] - 2026-05-19
 
 Patch release: **`fetch-provider-specs`** hardening (Paperless `/api/schema/` validation, **Paperless-ngx ≥ 2.15** guidance, in-cluster HTTP diagnostics, **Gotenberg** pinned upstream OpenAPI when `/openapi.json` is absent), **Helm** Paperless default image **2.15.0** and removal of ineffective **`PAPERLESS_API_TOKEN`** injection into the Paperless container, **full bundled** **Tika**/**Gotenberg** OpenAPI surfaces, refreshed pinned public and live-fetched provider specs (**Onyx** `operationId` alignment for **`knowledge_search_onyx`** / Ouroboros ingest), **Istio** `*.localhost` provider VirtualServices when Stirling exists (not gated on full stack), **`execute`** multipart **`fileEncoding: base64`**, consolidated **dependency** and **OSV** updates, and **OpenTelemetry** **2.7.x** + OTLP exporter **0.218**. **`charts/clawql-mcp`** **Chart.version** **0.6.5** with **`appVersion` `6.2.1`**. Release notes: **[`RELEASE_NOTES_v6.2.1.md`](RELEASE_NOTES_v6.2.1.md)**.

--- a/RELEASE_NOTES_v6.3.0.md
+++ b/RELEASE_NOTES_v6.3.0.md
@@ -1,0 +1,29 @@
+## clawql-mcp 6.3.0
+
+**npm:** [clawql-mcp@6.3.0](https://www.npmjs.com/package/clawql-mcp)  
+**Full changelog:** [CHANGELOG.md#630---2026-06-02](https://github.com/danielsmithdevelopment/ClawQL/blob/main/CHANGELOG.md#630---2026-06-02)
+
+### Highlights
+
+- **Modularization phases 2–9** ([#306](https://github.com/danielsmithdevelopment/ClawQL/issues/306)): workspace packages **`clawql-core`**, **`clawql-api`**, **`clawql-memory`**, **`clawql-documents`**, **`clawql-automation`** — logic extracted from the monolith with thin **`src/`** shims for backward-compatible imports.
+- **Effect-TS gateway:** MCP **`search`** and **`execute`** run through **`createClawQLApi()`** + Effect Layers (`SearchService` / `ExecuteService`).
+- **`PanguardProxyPlugin`:** policy chokepoint as a first-class **`mcp-proxy`** plugin ([#272](https://github.com/danielsmithdevelopment/ClawQL/issues/272)).
+- **Docs:** [modularization implementation status](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/design/modularization-implementation-status.md), [plugin model](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/design/clawql-plugin-model.md), [plugin registry](https://docs.clawql.com/reference/plugins) on docs.clawql.com.
+
+### Upgrade notes (6.2.x → 6.3.0)
+
+- **MCP tools and env flags are unchanged** for normal consumers (`search`, `execute`, `memory_*`, `CLAWQL_ENABLE_*`, etc.).
+- **Not a semver-major break** — internal refactor only; report regressions on [GitHub Issues](https://github.com/danielsmithdevelopment/ClawQL/issues).
+- If you **deep-imported** private `src/` modules (unsupported), switch to supported MCP tools or wait for published **`clawql-*`** packages ([#306](https://github.com/danielsmithdevelopment/ClawQL/issues/306)).
+
+### Helm chart
+
+- **`charts/clawql-mcp`:** **Chart.version `0.6.6`**, **`appVersion` `6.3.0`** (aligns with npm).
+
+### Install
+
+```bash
+npm install clawql-mcp@6.3.0
+```
+
+**Node:** `>=22` (see `package.json` `engines`).

--- a/charts/clawql-mcp/Chart.yaml
+++ b/charts/clawql-mcp/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: clawql-mcp
 description: ClawQL MCP server (Streamable HTTP, optional gRPC) for Kubernetes
 type: application
-version: 0.6.5
+version: 0.6.6
 # Align with npm package when cutting chart releases; image tag is separate (values.image.tag).
-appVersion: "6.2.1"
+appVersion: "6.3.0"
 dependencies:
   - name: vault
     # Lowercase RFC 1123-safe alias (Kubernetes resource names derive from Helm release prefix + alias).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "clawql-mcp",
-    "version": "6.2.1",
+    "version": "6.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "clawql-mcp",
-            "version": "6.2.1",
+            "version": "6.3.0",
             "license": "Apache-2.0",
             "workspaces": [
                 "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "clawql-mcp",
-    "version": "6.2.1",
+    "version": "6.3.0",
     "description": "MCP server: search + execute OpenAPI/Discovery APIs (internal GraphQL projection), optional native GraphQL HTTP and gRPC unary sources",
     "license": "Apache-2.0",
     "type": "module",


### PR DESCRIPTION
## Summary

- Bump **`clawql-mcp`** to **6.3.0** (minor — modularization phases 2–9, no intentional MCP/env breaks).
- **`CHANGELOG.md`** + **`RELEASE_NOTES_v6.3.0.md`**
- Helm **`charts/clawql-mcp`**: Chart **0.6.6**, **appVersion 6.3.0**

## After merge

1. `git checkout main && git pull`
2. `npm run release:git-tag:push` → **v6.3.0**
3. `npm publish --provenance` (trusted publishing)
4. `gh release create v6.3.0 --title "clawql-mcp 6.3.0" --notes-file RELEASE_NOTES_v6.3.0.md`

## Test plan

- [x] `npm run build && npm test` — 420 passed locally
- [ ] CI green on this PR