### PR TITLE
test(workflow): Helm CI assertions and handler coverage for all operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deploy-cloud-run deploy-k8s deploy-docs local-k8s-up bootstrap-vault-eso local-k8s-mcp-delete local-docker-up helm-lint helm-ui-template-tests kustomize-local-lint lint-k8s-manifests smoke-grpcurl-istio-gateway-mcp smoke-mcp-http-istio-gateway smoke-localhost-uis verify-vault-policy verify-mcp-core-tools-local
+.PHONY: deploy-cloud-run deploy-k8s deploy-docs local-k8s-up bootstrap-vault-eso local-k8s-mcp-delete local-docker-up helm-lint helm-ui-template-tests helm-workflow-template-tests kustomize-local-lint lint-k8s-manifests smoke-grpcurl-istio-gateway-mcp smoke-mcp-http-istio-gateway smoke-localhost-uis verify-vault-policy verify-mcp-core-tools-local
 
 # Validate charts/clawql-mcp (requires helm on PATH)
 helm-lint:
@@ -56,7 +56,10 @@ kustomize-local-lint:
 helm-ui-template-tests:
 	@bash scripts/kubernetes/test-helm-ui-templates.sh
 
-lint-k8s-manifests: helm-lint helm-ui-template-tests kustomize-local-lint
+helm-workflow-template-tests:
+	@bash scripts/kubernetes/test-helm-workflow-templates.sh
+
+lint-k8s-manifests: helm-lint helm-ui-template-tests helm-workflow-template-tests kustomize-local-lint
 
 # Local desktop k8s: default Helm + Istio ambient + Gateway/VS + heavy observability; CLAWQL_LOCAL_K8S_ISTIO=0 skips mesh
 local-k8s-up:

--- a/docs/design/workflow-tool-argo.md
+++ b/docs/design/workflow-tool-argo.md
@@ -251,7 +251,8 @@ if (flags.enableSchedule || flags.enableNotify || flags.enableWorkflow) {
 
 | Layer       | Approach                                                                                        |
 | ----------- | ----------------------------------------------------------------------------------------------- |
-| Unit        | Mock `CustomObjectsApi` / mapper fixture CRDs                                                   |
+| Unit        | Mock `CustomObjectsApi` / mapper fixture CRDs; handler tests for all Phase A operations         |
+| Helm CI     | `scripts/kubernetes/test-helm-workflow-templates.sh` (`enableWorkflow` render + RBAC assertions) |
 | Schema      | zod superRefine (missing template, disallowed namespace)                                        |
 | Plugin      | `automation-plugin.test.ts` — registers `workflow` when `enableWorkflow`                        |
 | Integration | Optional CI: **kind** + **Argo Workflows ≥ 3.4.0**, submit minimal template, assert `get` phase |

--- a/docs/design/workflow-tool-argo.md
+++ b/docs/design/workflow-tool-argo.md
@@ -249,13 +249,13 @@ if (flags.enableSchedule || flags.enableNotify || flags.enableWorkflow) {
 
 ## Testing
 
-| Layer       | Approach                                                                                        |
-| ----------- | ----------------------------------------------------------------------------------------------- |
-| Unit        | Mock `CustomObjectsApi` / mapper fixture CRDs; handler tests for all Phase A operations         |
+| Layer       | Approach                                                                                         |
+| ----------- | ------------------------------------------------------------------------------------------------ |
+| Unit        | Mock `CustomObjectsApi` / mapper fixture CRDs; handler tests for all Phase A operations          |
 | Helm CI     | `scripts/kubernetes/test-helm-workflow-templates.sh` (`enableWorkflow` render + RBAC assertions) |
-| Schema      | zod superRefine (missing template, disallowed namespace)                                        |
-| Plugin      | `automation-plugin.test.ts` — registers `workflow` when `enableWorkflow`                        |
-| Integration | Optional CI: **kind** + **Argo Workflows ≥ 3.4.0**, submit minimal template, assert `get` phase |
+| Schema      | zod superRefine (missing template, disallowed namespace)                                         |
+| Plugin      | `automation-plugin.test.ts` — registers `workflow` when `enableWorkflow`                         |
+| Integration | Optional CI: **kind** + **Argo Workflows ≥ 3.4.0**, submit minimal template, assert `get` phase  |
 
 ---
 

--- a/packages/clawql-automation/src/workflow/workflow.test.ts
+++ b/packages/clawql-automation/src/workflow/workflow.test.ts
@@ -1,11 +1,92 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { resetDefaultAuditRingBufferForTests, getDefaultAuditRingBuffer } from "clawql-core";
+import { getDefaultAuditRingBuffer, resetDefaultAuditRingBufferForTests } from "clawql-core";
 import { buildSubmitWorkflowBody, mapWorkflowToSummary } from "./argo-mapper.js";
 import {
   configureWorkflowK8sFactory,
   resetWorkflowK8sClientsForTests,
   type ArgoWorkflowObject,
+  type WorkflowK8sClients,
 } from "./k8s-client.js";
+
+function enableWorkflowEnv(): void {
+  process.env.CLAWQL_ENABLE_WORKFLOW = "1";
+  process.env.CLAWQL_WORKFLOW_NAMESPACE_ALLOWLIST = "clawql";
+  process.env.CLAWQL_WORKFLOW_DEFAULT_NAMESPACE = "clawql";
+}
+
+function clearWorkflowEnv(): void {
+  delete process.env.CLAWQL_ENABLE_WORKFLOW;
+  delete process.env.CLAWQL_WORKFLOW_NAMESPACE_ALLOWLIST;
+  delete process.env.CLAWQL_WORKFLOW_DEFAULT_NAMESPACE;
+  delete process.env.CLAWQL_WORKFLOW_ALLOW_DELETE;
+  delete process.env.CLAWQL_WORKFLOW_NOTIFY_ON_TERMINAL;
+  delete process.env.CLAWQL_WORKFLOW_NOTIFY_CHANNEL;
+}
+
+function mockClients(handlers: {
+  get?: () => Promise<ArgoWorkflowObject>;
+  list?: () => Promise<{ items?: ArgoWorkflowObject[] }>;
+  listTemplates?: () => Promise<{ items?: { metadata?: { name?: string; namespace?: string } }[] }>;
+  listClusterTemplates?: () => Promise<{ items?: { metadata?: { name?: string } }[] }>;
+  create?: () => Promise<ArgoWorkflowObject>;
+  delete?: () => Promise<void>;
+  logs?: () => Promise<string>;
+}): void {
+  configureWorkflowK8sFactory(async () => {
+    const clients: WorkflowK8sClients = {
+      customObjects: {
+        getNamespacedCustomObject: async () => {
+          if (!handlers.get) throw new Error("get not mocked");
+          return handlers.get();
+        },
+        listNamespacedCustomObject: async (params: { plural?: string }) => {
+          if (params.plural === "workflowtemplates") {
+            if (!handlers.listTemplates) throw new Error("listTemplates not mocked");
+            return handlers.listTemplates();
+          }
+          if (!handlers.list) throw new Error("list not mocked");
+          return handlers.list();
+        },
+        listClusterCustomObject: async () => {
+          if (!handlers.listClusterTemplates) throw new Error("listClusterTemplates not mocked");
+          return handlers.listClusterTemplates();
+        },
+        createNamespacedCustomObject: async () => {
+          if (!handlers.create) throw new Error("create not mocked");
+          return handlers.create();
+        },
+        deleteNamespacedCustomObject: async () => {
+          if (!handlers.delete) throw new Error("delete not mocked");
+          await handlers.delete();
+        },
+      } as never,
+      coreV1: {
+        readNamespacedPodLog: async () => handlers.logs?.() ?? "log line\n",
+      } as never,
+    };
+    return clients;
+  });
+}
+
+const sampleWorkflow = (phase: string): ArgoWorkflowObject => ({
+  metadata: {
+    name: "clawql-xyz",
+    namespace: "clawql",
+    labels: { "clawql.dev/correlation-id": "corr-1" },
+  },
+  status: {
+    phase,
+    nodes: {
+      "1": {
+        displayName: "vault-digest",
+        phase,
+        type: "Pod",
+        podName: "clawql-xyz-vault-digest-1",
+      },
+    },
+  },
+  spec: { workflowTemplateRef: { name: "clawql-vault-daily-digest" } },
+});
 
 describe("buildSubmitWorkflowBody", () => {
   it("builds template-ref workflow with managed labels", () => {
@@ -82,9 +163,7 @@ describe("handleWorkflowToolInput", () => {
   afterEach(() => {
     resetWorkflowK8sClientsForTests();
     resetDefaultAuditRingBufferForTests();
-    delete process.env.CLAWQL_ENABLE_WORKFLOW;
-    delete process.env.CLAWQL_WORKFLOW_NAMESPACE_ALLOWLIST;
-    delete process.env.CLAWQL_WORKFLOW_DEFAULT_NAMESPACE;
+    clearWorkflowEnv();
   });
 
   it("returns disabled when flag off", async () => {
@@ -96,9 +175,7 @@ describe("handleWorkflowToolInput", () => {
   });
 
   it("submits workflow when mocked k8s client is configured", async () => {
-    process.env.CLAWQL_ENABLE_WORKFLOW = "1";
-    process.env.CLAWQL_WORKFLOW_NAMESPACE_ALLOWLIST = "clawql";
-    process.env.CLAWQL_WORKFLOW_DEFAULT_NAMESPACE = "clawql";
+    enableWorkflowEnv();
 
     const created: ArgoWorkflowObject = {
       metadata: { name: "clawql-xyz", namespace: "clawql" },
@@ -106,12 +183,7 @@ describe("handleWorkflowToolInput", () => {
       spec: { workflowTemplateRef: { name: "clawql-vault-daily-digest" } },
     };
 
-    configureWorkflowK8sFactory(async () => ({
-      customObjects: {
-        createNamespacedCustomObject: async () => created,
-      } as never,
-      coreV1: {} as never,
-    }));
+    mockClients({ create: async () => created });
 
     const { handleWorkflowToolInput } = await import("./workflow.js");
     const res = await handleWorkflowToolInput({
@@ -131,25 +203,16 @@ describe("handleWorkflowToolInput", () => {
   });
 
   it("waits until workflow reaches terminal phase", async () => {
-    process.env.CLAWQL_ENABLE_WORKFLOW = "1";
-    process.env.CLAWQL_WORKFLOW_NAMESPACE_ALLOWLIST = "clawql";
-    process.env.CLAWQL_WORKFLOW_DEFAULT_NAMESPACE = "clawql";
+    enableWorkflowEnv();
 
     let polls = 0;
-    configureWorkflowK8sFactory(async () => ({
-      customObjects: {
-        getNamespacedCustomObject: async () => {
-          polls++;
-          const phase = polls < 2 ? "Running" : "Succeeded";
-          return {
-            metadata: { name: "clawql-xyz", namespace: "clawql" },
-            status: { phase },
-            spec: { workflowTemplateRef: { name: "clawql-vault-daily-digest" } },
-          } satisfies ArgoWorkflowObject;
-        },
-      } as never,
-      coreV1: {} as never,
-    }));
+    mockClients({
+      get: async () => {
+        polls++;
+        const phase = polls < 2 ? "Running" : "Succeeded";
+        return sampleWorkflow(phase);
+      },
+    });
 
     const { handleWorkflowToolInput } = await import("./workflow.js");
     const res = await handleWorkflowToolInput({
@@ -166,5 +229,148 @@ describe("handleWorkflowToolInput", () => {
     expect(body.polls).toBe(2);
     const audit = getDefaultAuditRingBuffer().list(5).entries;
     expect(audit.some((e) => e.action === "terminal" && e.category === "workflow")).toBe(true);
+  });
+
+  it("get appends audit when phase is terminal", async () => {
+    enableWorkflowEnv();
+    mockClients({ get: async () => sampleWorkflow("Succeeded") });
+
+    const { handleWorkflowToolInput } = await import("./workflow.js");
+    const res = await handleWorkflowToolInput({ operation: "get", name: "clawql-xyz" });
+    const body = JSON.parse(res.content[0]!.text);
+    expect(body.ok).toBe(true);
+    expect(body.workflow.phase).toBe("Succeeded");
+    const audit = getDefaultAuditRingBuffer().list(5).entries;
+    expect(audit.some((e) => e.action === "terminal")).toBe(true);
+  });
+
+  it("get does not audit when phase is non-terminal", async () => {
+    enableWorkflowEnv();
+    mockClients({ get: async () => sampleWorkflow("Running") });
+
+    const { handleWorkflowToolInput } = await import("./workflow.js");
+    await handleWorkflowToolInput({ operation: "get", name: "clawql-xyz" });
+    const audit = getDefaultAuditRingBuffer().list(5).entries;
+    expect(audit).toHaveLength(0);
+  });
+
+  it("lists workflows with optional phase filter", async () => {
+    enableWorkflowEnv();
+    mockClients({
+      list: async () => ({
+        items: [sampleWorkflow("Running"), sampleWorkflow("Succeeded")],
+      }),
+    });
+
+    const { handleWorkflowToolInput } = await import("./workflow.js");
+    const res = await handleWorkflowToolInput({
+      operation: "list",
+      phase: "Succeeded",
+    });
+    const body = JSON.parse(res.content[0]!.text);
+    expect(body.ok).toBe(true);
+    expect(body.workflows).toHaveLength(1);
+    expect(body.workflows[0].phase).toBe("Succeeded");
+  });
+
+  it("list_templates returns namespace and cluster templates", async () => {
+    enableWorkflowEnv();
+    mockClients({
+      listTemplates: async () => ({
+        items: [{ metadata: { name: "clawql-vault-daily-digest", namespace: "clawql" } }],
+      }),
+      listClusterTemplates: async () => ({
+        items: [{ metadata: { name: "global-digest" } }],
+      }),
+    });
+
+    const { handleWorkflowToolInput } = await import("./workflow.js");
+    const res = await handleWorkflowToolInput({ operation: "list_templates" });
+    const body = JSON.parse(res.content[0]!.text);
+    expect(body.ok).toBe(true);
+    expect(body.templates).toHaveLength(2);
+    expect(body.templates.map((t: { name: string }) => t.name).sort()).toEqual([
+      "clawql-vault-daily-digest",
+      "global-digest",
+    ]);
+  });
+
+  it("rejects delete when CLAWQL_WORKFLOW_ALLOW_DELETE is off", async () => {
+    enableWorkflowEnv();
+    mockClients({ delete: async () => {} });
+
+    const { handleWorkflowToolInput } = await import("./workflow.js");
+    const res = await handleWorkflowToolInput({ operation: "delete", name: "clawql-xyz" });
+    const body = JSON.parse(res.content[0]!.text);
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/delete is disabled/i);
+  });
+
+  it("deletes workflow when delete is allowed", async () => {
+    enableWorkflowEnv();
+    process.env.CLAWQL_WORKFLOW_ALLOW_DELETE = "1";
+    let deleted = false;
+    mockClients({
+      delete: async () => {
+        deleted = true;
+      },
+    });
+
+    const { handleWorkflowToolInput } = await import("./workflow.js");
+    const res = await handleWorkflowToolInput({ operation: "delete", name: "clawql-xyz" });
+    const body = JSON.parse(res.content[0]!.text);
+    expect(body.ok).toBe(true);
+    expect(body.deleted).toBe(true);
+    expect(deleted).toBe(true);
+  });
+
+  it("returns pod logs for a workflow node", async () => {
+    enableWorkflowEnv();
+    mockClients({
+      get: async () => sampleWorkflow("Succeeded"),
+      logs: async () => "digest complete\n",
+    });
+
+    const { handleWorkflowToolInput } = await import("./workflow.js");
+    const res = await handleWorkflowToolInput({
+      operation: "logs",
+      name: "clawql-xyz",
+      node_name: "vault-digest",
+    });
+    const body = JSON.parse(res.content[0]!.text);
+    expect(body.ok).toBe(true);
+    expect(body.logs).toBe("digest complete\n");
+    expect(body.pod_name).toBe("clawql-xyz-vault-digest-1");
+  });
+
+  it("rejects disallowed namespace", async () => {
+    enableWorkflowEnv();
+    process.env.CLAWQL_WORKFLOW_NAMESPACE_ALLOWLIST = "other-ns";
+
+    const { handleWorkflowToolInput } = await import("./workflow.js");
+    const res = await handleWorkflowToolInput({ operation: "get", name: "clawql-xyz" });
+    const body = JSON.parse(res.content[0]!.text);
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/not in CLAWQL_WORKFLOW_NAMESPACE_ALLOWLIST/i);
+  });
+
+  it("rejects submit without template_ref", async () => {
+    enableWorkflowEnv();
+    const { handleWorkflowToolInput } = await import("./workflow.js");
+    await expect(handleWorkflowToolInput({ operation: "submit" })).rejects.toThrow();
+  });
+
+  it("rejects wait without name", async () => {
+    enableWorkflowEnv();
+    const { handleWorkflowToolInput } = await import("./workflow.js");
+    await expect(handleWorkflowToolInput({ operation: "wait" })).rejects.toThrow();
+  });
+
+  it("rejects logs without node_name", async () => {
+    enableWorkflowEnv();
+    const { handleWorkflowToolInput } = await import("./workflow.js");
+    await expect(
+      handleWorkflowToolInput({ operation: "logs", name: "clawql-xyz" })
+    ).rejects.toThrow();
   });
 });

--- a/scripts/kubernetes/test-helm-workflow-templates.sh
+++ b/scripts/kubernetes/test-helm-workflow-templates.sh
@@ -54,7 +54,7 @@ checks = [
         r"name: CLAWQL_WORKFLOW_ALLOW_DELETE\n\s+value: \"1\"",
         "allow delete env",
     ),
-    (r"name: test-clawql-mcp-workflow", "workflow Role name"),
+    (r"name: clawql-mcp-http-workflow", "workflow Role name"),
     (r"clusterworkflowtemplates", "ClusterWorkflowTemplate read RBAC"),
 ]
 
@@ -66,7 +66,7 @@ for pattern, message in checks:
 if "CLAWQL_ENABLE_WORKFLOW" in disabled:
     print("ERROR: workflow env rendered when enableWorkflow=false")
     sys.exit(1)
-if "test-clawql-mcp-workflow" in disabled:
+if "clawql-mcp-http-workflow" in disabled:
     print("ERROR: workflow RBAC rendered when enableWorkflow=false")
     sys.exit(1)
 PY

--- a/scripts/kubernetes/test-helm-workflow-templates.sh
+++ b/scripts/kubernetes/test-helm-workflow-templates.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT}"
+
+TMP_ENABLED="$(mktemp)"
+TMP_DISABLED="$(mktemp)"
+trap 'rm -f "${TMP_ENABLED}" "${TMP_DISABLED}"' EXIT
+
+_LINT_SECRET=(--set envFromSecret=clawql-lint-provider-env)
+
+helm template test charts/clawql-mcp --namespace clawql \
+  "${_LINT_SECRET[@]}" \
+  --set kyverno.imageSignaturePolicy.enabled=false \
+  --set enableWorkflow=true \
+  --set 'workflow.namespaceAllowlist={clawql,pipelines}' \
+  --set workflow.defaultNamespace=clawql \
+  --set workflow.notifyOnTerminal=true \
+  --set workflow.notifyChannel=CTEST \
+  --set workflow.allowDelete=true >"${TMP_ENABLED}"
+
+helm template test charts/clawql-mcp --namespace clawql \
+  "${_LINT_SECRET[@]}" \
+  --set kyverno.imageSignaturePolicy.enabled=false >"${TMP_DISABLED}"
+
+python3 - "${TMP_ENABLED}" "${TMP_DISABLED}" <<'PY'
+import re
+import sys
+
+enabled_path, disabled_path = sys.argv[1], sys.argv[2]
+enabled = open(enabled_path, "r", encoding="utf-8").read()
+disabled = open(disabled_path, "r", encoding="utf-8").read()
+
+checks = [
+    (r"name: CLAWQL_ENABLE_WORKFLOW\n\s+value: \"1\"", "CLAWQL_ENABLE_WORKFLOW env"),
+    (
+        r"name: CLAWQL_WORKFLOW_NAMESPACE_ALLOWLIST\n\s+value: \"clawql,pipelines\"",
+        "namespace allowlist env",
+    ),
+    (
+        r"name: CLAWQL_WORKFLOW_DEFAULT_NAMESPACE\n\s+value: \"clawql\"",
+        "default namespace env",
+    ),
+    (
+        r"name: CLAWQL_WORKFLOW_NOTIFY_ON_TERMINAL\n\s+value: \"1\"",
+        "notify on terminal env",
+    ),
+    (
+        r"name: CLAWQL_WORKFLOW_NOTIFY_CHANNEL\n\s+value: \"CTEST\"",
+        "notify channel env",
+    ),
+    (
+        r"name: CLAWQL_WORKFLOW_ALLOW_DELETE\n\s+value: \"1\"",
+        "allow delete env",
+    ),
+    (r"name: test-clawql-mcp-workflow", "workflow Role name"),
+    (r"clusterworkflowtemplates", "ClusterWorkflowTemplate read RBAC"),
+]
+
+for pattern, message in checks:
+    if re.search(pattern, enabled, flags=re.MULTILINE) is None:
+        print(f"ERROR: missing {message}")
+        sys.exit(1)
+
+if "CLAWQL_ENABLE_WORKFLOW" in disabled:
+    print("ERROR: workflow env rendered when enableWorkflow=false")
+    sys.exit(1)
+if "test-clawql-mcp-workflow" in disabled:
+    print("ERROR: workflow RBAC rendered when enableWorkflow=false")
+    sys.exit(1)
+PY
+
+echo "helm-workflow-template-tests OK"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens CI and unit-test coverage for the Phase A workflow tool (post-#453–#455).

- **`scripts/kubernetes/test-helm-workflow-templates.sh`** — templates chart with `enableWorkflow=true` and asserts env vars + RBAC; wired into `make lint-k8s-manifests` / `workflow-scripts` CI job.
- **`packages/clawql-automation/src/workflow/workflow.test.ts`** — expanded handler coverage (list, delete, logs, list_templates, namespace guard, audit on terminal get, zod validation).
- **`docs/design/workflow-tool-argo.md`** — testing table updated.

## Fix

Helm assertions now use `clawql-mcp-http-workflow` (chart `fullnameOverride`) instead of `test-clawql-mcp-workflow`.

## Deferred (Phase B)

HITL + `suspend`/`resume`, Argo CD, kind integration — tracked separately ([#254](https://github.com/danielsmithdevelopment/ClawQL/issues/254)).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1711-824f-7aa5-afbd-2d81edc7c0fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1711-824f-7aa5-afbd-2d81edc7c0fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

