### PR TITLE
release: clawql-mcp 6.4.1

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,128 @@
+# Publish clawql-mcp to npmjs.com after supply-chain gates on the exact tarball users install.
+# Trigger: annotated tag v<package.json version> (e.g. v6.4.1) or manual workflow_dispatch.
+# Requires npm trusted publishing (OIDC) and/or NPM_TOKEN secret on the repo.
+name: npm publish
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+concurrency:
+  group: npm-publish-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  TRIVY_SCAN_IMAGE: ghcr.io/aquasecurity/trivy:0.59.1
+
+jobs:
+  repo-supply-chain:
+    name: Repo supply chain (OSV + Trivy fs + Syft SBOM)
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: OSV-Scanner (lockfiles + manifests)
+        run: docker run --rm -v "$PWD:/repo" -w /repo ghcr.io/google/osv-scanner:latest scan --recursive --config osv-scanner.toml .
+
+      - name: Trivy filesystem (HIGH / CRITICAL)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: fs
+          scan-ref: "."
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          exit-code: "1"
+          trivyignores: .trivyignore
+          skip-dirs: node_modules,website/node_modules,dashboard/node_modules,dist,packages/mcp-grpc-transport/dist,packages/clawql-ouroboros/dist,packages/panguard-mcp-bridge/dist,.git
+
+      - name: CycloneDX SBOM (Syft)
+        run: |
+          docker run --rm -v "$PWD:/repo" -w /repo anchore/syft:v1.19.0 \
+            scan . -o "cyclonedx-json=sbom-cyclonedx-npm-publish.cdx.json"
+
+      - name: Upload repository SBOM
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom-cyclonedx-npm-publish
+          path: sbom-cyclonedx-npm-publish.cdx.json
+          if-no-files-found: error
+
+  publish:
+    name: Pack, scan, and publish clawql-mcp
+    needs: [repo-supply-chain]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Verify tag matches package.json (tag releases only)
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if [[ "${VERSION}" != "${PKG_VERSION}" ]]; then
+            echo "ERROR: tag ${TAG} does not match package.json version ${PKG_VERSION}" >&2
+            exit 1
+          fi
+          echo "Publishing clawql-mcp@${PKG_VERSION} for tag ${TAG}"
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "25"
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: npm pack install smoke
+        run: bash scripts/dev/test-npm-pack-install.sh
+
+      - name: Pack release tarball
+        id: pack
+        run: |
+          set -euo pipefail
+          PACK_DIR="${RUNNER_TEMP}/clawql-mcp-pack"
+          rm -rf "${PACK_DIR}"
+          mkdir -p "${PACK_DIR}"
+          npm pack --pack-destination "${PACK_DIR}" >/dev/null
+          TARBALL="$(find "${PACK_DIR}" -maxdepth 1 -name 'clawql-mcp-*.tgz' -print -quit)"
+          if [[ -z "${TARBALL}" || ! -f "${TARBALL}" ]]; then
+            echo "ERROR: npm pack did not produce clawql-mcp-*.tgz" >&2
+            exit 1
+          fi
+          echo "tarball=${TARBALL}" >> "$GITHUB_OUTPUT"
+          echo "Packed ${TARBALL}"
+
+      - name: Trivy scan packed tarball root (HIGH / CRITICAL)
+        run: |
+          set -euo pipefail
+          UNPACK="${RUNNER_TEMP}/clawql-mcp-unpack"
+          rm -rf "${UNPACK}"
+          mkdir -p "${UNPACK}"
+          tar -xzf "${{ steps.pack.outputs.tarball }}" -C "${UNPACK}"
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/repo:ro" \
+            -v "${UNPACK}:/work/unpack:ro" \
+            "${{ env.TRIVY_SCAN_IMAGE }}" \
+            fs \
+            --scanners vuln \
+            --severity HIGH,CRITICAL \
+            --ignore-unfixed \
+            --exit-code 1 \
+            --ignorefile /repo/.trivyignore \
+            /work/unpack/package
+
+      - name: Publish to npm (provenance)
+        run: npm publish "${{ steps.pack.outputs.tarball }}" --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-> **Note:** Items below are on **`main`** (post-**6.4.0** npm tag) and documented in release notes / IDP wave guides; they will appear in the next semver release entry when tagged.
-
-### Fixed
-
-- **npm + Docker distribution**: **`clawql-mcp`** npm tarball now **bundles** all **`clawql-*`** workspace packages (no broken **`workspace:*`** / **`file:../packages`** on install); **`docker/Dockerfile`** runtime copies the full **`packages/`** tree so **`node_modules`** symlinks resolve; CI smokes **`scripts/dev/test-npm-pack-install.sh`** and **`scripts/dev/test-docker-mcp-workspace-deps.sh`**.
+> **Note:** Items below are on **`main`** (post-**6.4.1** npm tag) and documented in release notes / IDP wave guides; they will appear in the next semver release entry when tagged.
 
 ### Added
 
@@ -33,6 +29,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`docs/deployment/nats-keda-worker.md`**, Helm `nats.worker` / `nats.keda` values, IDP matrix #257 → Shipped.
 - **`docs/mcp/idp-pipeline-runner.md`**, IDP matrix #307 → Shipped, plugin registry + **`mcp-tools.md`** **`run_idp_pipeline`** row.
 - HITL + workflow tool guides: NATS dual-path (sync webhook vs async consumer); `.env.example` NATS block.
+
+## [6.4.1] - 2026-07-03
+
+Patch release: fixes **broken npm and Docker distribution** for **`clawql-mcp@6.4.0`** — fresh **`npm install`** and **`docker pull`** failed without cloning and building from source. **`charts/clawql-mcp`** **Chart.version** **0.6.8** with **`appVersion` `6.4.1`**. Release notes: **[`RELEASE_NOTES_v6.4.1.md`](RELEASE_NOTES_v6.4.1.md)**.
+
+### Fixed
+
+- **npm + Docker distribution** ([#477](https://github.com/danielsmithdevelopment/ClawQL/pull/477)): **`clawql-mcp`** npm tarball **bundles** all **`clawql-*`** workspace packages with compiled **`dist/`**; **`prepack`** runs **`npm run build`** before pack; **`docker/Dockerfile`** runtime copies the full **`packages/`** tree; CI smokes **`scripts/dev/test-npm-pack-install.sh`** and **`scripts/dev/test-docker-mcp-workspace-deps.sh`**.
 
 ## [6.4.0] - 2026-07-01
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Feature tiers (aligned with the [architecture diagram](docs/readme/images/clawql
 - Stdio and HTTP MCP server modes
 - Bundled provider specs for offline lookup and multi-provider workflows
 
-Primary package: `clawql-mcp` (current release: **6.4.0** — [`RELEASE_NOTES_v6.4.0.md`](RELEASE_NOTES_v6.4.0.md))  
+Primary package: `clawql-mcp` (current release: **6.4.1** — [`RELEASE_NOTES_v6.4.1.md`](RELEASE_NOTES_v6.4.1.md))  
 Repo: https://github.com/danielsmithdevelopment/ClawQL
 
 ### Container images on GHCR (Docker / Helm)

--- a/RELEASE_NOTES_v6.4.1.md
+++ b/RELEASE_NOTES_v6.4.1.md
@@ -1,0 +1,29 @@
+## clawql-mcp 6.4.1
+
+**npm:** [clawql-mcp@6.4.1](https://www.npmjs.com/package/clawql-mcp)  
+**Full changelog:** [CHANGELOG.md#641---2026-07-03](https://github.com/danielsmithdevelopment/ClawQL/blob/main/CHANGELOG.md#641---2026-07-03)
+
+### Highlights
+
+- **Distribution fix** ([#477](https://github.com/danielsmithdevelopment/ClawQL/pull/477)): **`npm install clawql-mcp`** and **`docker pull ghcr.io/danielsmithdevelopment/clawql-mcp`** work on a fresh machine without cloning the monorepo.
+- **npm tarball** bundles all **`clawql-*`** workspace packages (`clawql-core`, `clawql-api`, `clawql-memory`, etc.) with compiled **`dist/`**.
+- **Docker image** copies the full **`packages/`** tree so **`node_modules`** workspace symlinks resolve in the distroless runtime.
+
+### Upgrade notes (6.4.0 → 6.4.1)
+
+- **Required if 6.4.0 failed to start** — same MCP surface; no new env flags or tool renames.
+- Prefer **`npm install clawql-mcp@6.4.1`** (or **`npx clawql-mcp-http`**) over **`@6.4.0`**.
+- Re-pull the MCP container image after **`docker-publish`** promotes **`latest`** / **`nightly`**.
+
+### Helm chart
+
+- **`charts/clawql-mcp`:** **Chart.version `0.6.8`**, **`appVersion` `6.4.1`**.
+
+### Install
+
+```bash
+npm install clawql-mcp@6.4.1
+npx clawql-mcp-http
+
+docker pull ghcr.io/danielsmithdevelopment/clawql-mcp:latest
+```

--- a/charts/clawql-idp/Chart.yaml
+++ b/charts/clawql-idp/Chart.yaml
@@ -3,8 +3,8 @@ name: clawql-idp
 description: Umbrella Helm chart for a k3s-friendly ClawQL IDP stack (MCP + document pipeline + OpenClaw + Argo hooks)
 type: application
 version: 0.1.0
-appVersion: "6.4.0"
+appVersion: "6.4.1"
 dependencies:
   - name: clawql-mcp
-    version: 0.6.7
+    version: 0.6.8
     repository: file://../clawql-mcp

--- a/charts/clawql-mcp/Chart.yaml
+++ b/charts/clawql-mcp/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: clawql-mcp
 description: ClawQL MCP server (Streamable HTTP, optional gRPC) for Kubernetes
 type: application
-version: 0.6.7
+version: 0.6.8
 # Align with npm package when cutting chart releases; image tag is separate (values.image.tag).
-appVersion: "6.4.0"
+appVersion: "6.4.1"
 dependencies:
   - name: vault
     # Lowercase RFC 1123-safe alias (Kubernetes resource names derive from Helm release prefix + alias).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "clawql-mcp",
-    "version": "6.4.0",
+    "version": "6.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "clawql-mcp",
-            "version": "6.4.0",
+            "version": "6.4.1",
             "bundleDependencies": [
                 "clawql-api",
                 "clawql-automation",
@@ -31,13 +31,13 @@
                 "@opentelemetry/resources": "^2.7.1",
                 "@opentelemetry/sdk-trace-base": "^2.7.1",
                 "@opentelemetry/sdk-trace-node": "^2.7.1",
-                "clawql-api": "workspace:*",
-                "clawql-automation": "workspace:*",
-                "clawql-core": "workspace:*",
-                "clawql-documents": "workspace:*",
-                "clawql-memory": "workspace:*",
-                "clawql-ouroboros": "workspace:*",
-                "clawql-sandbox": "workspace:*",
+                "clawql-api": "0.0.1",
+                "clawql-automation": "0.0.1",
+                "clawql-core": "0.0.1",
+                "clawql-documents": "0.0.1",
+                "clawql-memory": "0.0.1",
+                "clawql-ouroboros": "0.1.1",
+                "clawql-sandbox": "0.0.1",
                 "dotenv": "^17.4.2",
                 "express": "^5.2.1",
                 "express-rate-limit": "^8.5.2",
@@ -8352,7 +8352,6 @@
                 "@grpc/proto-loader": "^0.8.1",
                 "@omnigraph/openapi": "^0.109.51",
                 "clawql-core": "file:../clawql-core",
-                "clawql-memory": "file:../clawql-memory",
                 "effect": "3.21.2",
                 "graphql": "^16.14.0",
                 "node-fetch": "^3.3.2",
@@ -8505,9 +8504,12 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
+                "clawql-api": "file:../clawql-api",
                 "clawql-core": "file:../clawql-core",
+                "effect": "3.21.2",
                 "pg": "^8.21.0",
-                "sql.js": "^1.14.1"
+                "sql.js": "^1.14.1",
+                "zod": "4.3.6"
             },
             "devDependencies": {
                 "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "clawql-mcp",
-    "version": "6.4.0",
+    "version": "6.4.1",
     "description": "MCP server: search + execute OpenAPI/Discovery APIs (internal GraphQL projection), optional native GraphQL HTTP and gRPC unary sources",
     "license": "Apache-2.0",
     "type": "module",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Release: clawql-mcp 6.4.1

Patch release fixing broken **npm** and **Docker** distribution ([#477](https://github.com/danielsmithdevelopment/ClawQL/pull/477)).

### Version bumps

| Artifact | Version |
|----------|---------|
| `clawql-mcp` (npm) | **6.4.1** |
| `charts/clawql-mcp` | **0.6.8** / appVersion **6.4.1** |
| `charts/clawql-idp` | appVersion **6.4.1**, dep **clawql-mcp 0.6.8** |

### New workflow

**`.github/workflows/npm-publish.yml`** — triggered by **`v*`** tags or **`workflow_dispatch`**:

1. OSV + Trivy fs + Syft SBOM
2. `test-npm-pack-install.sh` smoke
3. `npm pack` → Trivy on unpacked tarball → `npm publish --provenance`

### After merge

1. `git tag -a v6.4.1 -m 'clawql-mcp 6.4.1'` and push tag → npm publish
2. Run **`docker-publish`** workflow_dispatch (or wait for daily schedule) for GHCR image

Requires **`NPM_TOKEN`** secret and/or npm **trusted publishing** (OIDC) configured for this repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1711-824f-7aa5-afbd-2d81edc7c0fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1711-824f-7aa5-afbd-2d81edc7c0fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

