### PR TITLE
fix(ci): npm publish OIDC when NPM_TOKEN secret is unset

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -123,6 +123,11 @@ jobs:
             /work/unpack/package
 
       - name: Publish to npm (provenance)
-        run: npm publish "${{ steps.pack.outputs.tarball }}" --provenance --access public
+        run: |
+          set -euo pipefail
+          if [[ -n "${NPM_TOKEN:-}" ]]; then
+            export NODE_AUTH_TOKEN="${NPM_TOKEN}"
+          fi
+          npm publish "${{ steps.pack.outputs.tarball }}" --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes `ENEEDAUTH` on v6.4.1 npm publish: empty `NODE_AUTH_TOKEN` from unset `NPM_TOKEN` secret blocked OIDC trusted publishing.

- Use `NPM_TOKEN` when the secret is set
- Otherwise publish via OIDC (no `NODE_AUTH_TOKEN` env)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1711-824f-7aa5-afbd-2d81edc7c0fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1711-824f-7aa5-afbd-2d81edc7c0fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

