### PR TITLE
fix(ci): correct GitHub Pages deploy action SHAs

### DIFF
--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -46,7 +46,7 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@56afc609e60203658a72b9b32c0479be6a04d492
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
         with:
           path: landing-page/demo/out
 
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5e628ed4e8ac69b3d7bf06b669c0e
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e


### PR DESCRIPTION
## Summary
- Fixes invalid pinned SHAs for `upload-pages-artifact` and `deploy-pages` that caused the landing page deploy workflow to fail on merge.

## Test plan
- [ ] Merge and confirm `Deploy landing page (GitHub Pages)` succeeds on `main`