### PR TITLE
feat(landing): workflow feed section showing MCP tool sequences

### DIFF
--- a/landing-page/demo/src/app/layout.tsx
+++ b/landing-page/demo/src/app/layout.tsx
@@ -53,6 +53,9 @@ export default function RootLayout({
             links={
               <>
                 <NavbarLink href="/#tools">Tools</NavbarLink>
+                <NavbarLink href="/#workflows" className="max-lg:hidden">
+                  Workflows
+                </NavbarLink>
                 <NavbarLink href="/#idp">IDP</NavbarLink>
                 <NavbarLink href="/#case-studies">Case studies</NavbarLink>
                 <NavbarLink href={site.urls.pricing}>Pricing</NavbarLink>
@@ -97,6 +100,7 @@ export default function RootLayout({
               <>
                 <FooterCategory title="Product">
                   <FooterLink href="/#tools">Tools</FooterLink>
+                  <FooterLink href="/#workflows">Workflows</FooterLink>
                   <FooterLink href="/#case-studies">Case studies</FooterLink>
                   <FooterLink href={site.urls.pricing}>Pricing</FooterLink>
                   <FooterLink href={site.urls.signup}>Sign up</FooterLink>

--- a/landing-page/demo/src/app/page.tsx
+++ b/landing-page/demo/src/app/page.tsx
@@ -17,7 +17,9 @@ import { HeroTwoColumnWithPhoto } from '@/components/sections/hero-two-column-wi
 import { Plan, PricingMultiTier } from '@/components/sections/pricing-multi-tier'
 import { Stat, StatsFourColumns } from '@/components/sections/stats-four-columns'
 import { Section } from '@/components/elements/section'
+import { WorkflowFeedSection } from '@/components/sections/workflow-feed'
 import { caseStudies, idpPipelineStages, mcpToolTiers, multiProviderBenchmark } from '@/lib/marketing'
+import { workflowFeeds } from '@/lib/workflow-feeds'
 import { managedPrice, pricing } from '@/lib/pricing'
 import { site } from '@/lib/site'
 
@@ -113,6 +115,23 @@ export default function Page() {
           <ToolTierSection {...mcpToolTiers.idp} />
         </div>
       </Section>
+
+      {/* Workflow feeds — tool calling sequences from case studies */}
+      <WorkflowFeedSection
+        id="workflows"
+        eyebrow="Workflows in practice"
+        headline="What a real ClawQL session looks like."
+        subheadline={
+          <p>
+            Published case studies document the same pattern: agents call MCP tools in sequence — recall context,
+            discover operations with <code className="text-sm">search</code>, act with{' '}
+            <code className="text-sm">execute</code>, then persist outcomes with{' '}
+            <code className="text-sm">memory_ingest</code>. These feeds show the chronology without pasting specs into
+            the chat.
+          </p>
+        }
+        feeds={workflowFeeds}
+      />
 
       {/* IDP pipeline */}
       <Section

--- a/landing-page/demo/src/components/sections/workflow-feed.tsx
+++ b/landing-page/demo/src/components/sections/workflow-feed.tsx
@@ -1,0 +1,99 @@
+import { clsx } from 'clsx/lite'
+import type { ComponentProps, ReactNode } from 'react'
+import { Link } from '../elements/link'
+import { Section } from '../elements/section'
+import { ArrowNarrowRightIcon } from '../icons/arrow-narrow-right-icon'
+import { ChatBubbleCircleEllipsisIcon } from '../icons/chat-bubble-circle-ellipsis-icon'
+import { CheckmarkIcon } from '../icons/checkmark-icon'
+import { CodeSquareIcon } from '../icons/code-square-icon'
+import { TerminalIcon } from '../icons/terminal-icon'
+import type { WorkflowFeed, WorkflowFeedStep, WorkflowFeedStepKind } from '@/lib/workflow-feeds'
+
+const stepIcon: Record<WorkflowFeedStepKind, ReactNode> = {
+  agent: <ChatBubbleCircleEllipsisIcon className="size-3.5" />,
+  tool: <TerminalIcon className="size-3.5" />,
+  result: <CheckmarkIcon className="size-3.5" />,
+}
+
+const stepIconRing: Record<WorkflowFeedStepKind, string> = {
+  agent: 'bg-mist-950/5 text-mist-700 ring-mist-950/10 dark:bg-white/10 dark:text-mist-200 dark:ring-white/10',
+  tool: 'bg-mist-950/8 text-mist-950 ring-mist-950/15 dark:bg-white/15 dark:text-white dark:ring-white/15',
+  result: 'bg-emerald-500/10 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-400/10 dark:text-emerald-300 dark:ring-emerald-400/20',
+}
+
+function WorkflowFeedStepRow({ step, isLast }: { step: WorkflowFeedStep; isLast: boolean }) {
+  return (
+    <li className="relative flex gap-x-4 pb-8 last:pb-0">
+      {!isLast ? (
+        <div
+          aria-hidden="true"
+          className="absolute top-7 left-3 -bottom-1 w-px bg-mist-950/10 dark:bg-white/10"
+        />
+      ) : null}
+      <div
+        className={clsx(
+          'relative flex size-6 flex-none items-center justify-center rounded-full ring-1 ring-inset',
+          stepIconRing[step.kind],
+        )}
+      >
+        {stepIcon[step.kind]}
+      </div>
+      <div className="flex min-w-0 flex-auto flex-col gap-1.5 pt-0.5">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <p className="text-sm/6 font-medium text-mist-950 dark:text-white">{step.title}</p>
+          {step.tool ? (
+            <code className="rounded-md bg-mist-950/5 px-1.5 py-0.5 text-xs font-semibold text-mist-800 dark:bg-white/10 dark:text-mist-200">
+              {step.tool}()
+            </code>
+          ) : null}
+        </div>
+        <p className="text-sm/7 text-mist-600 dark:text-mist-400">{step.body}</p>
+      </div>
+    </li>
+  )
+}
+
+export function WorkflowFeedPanel({
+  feed,
+  className,
+  ...props
+}: { feed: WorkflowFeed } & ComponentProps<'article'>) {
+  return (
+    <article
+      className={clsx('flex flex-col gap-6 rounded-2xl bg-mist-950/2.5 p-6 sm:p-8 dark:bg-white/5', className)}
+      {...props}
+    >
+      <div className="flex flex-col gap-2">
+        <p className="text-xs font-medium tracking-wide text-mist-500 uppercase dark:text-mist-400">{feed.source}</p>
+        <h3 className="text-base font-semibold text-mist-950 dark:text-white">{feed.title}</h3>
+      </div>
+      <ol className="list-none">
+        {feed.steps.map((step, index) => (
+          <WorkflowFeedStepRow key={`${feed.slug}-${index}`} step={step} isLast={index === feed.steps.length - 1} />
+        ))}
+      </ol>
+      <Link href={feed.href}>
+        Read case study <ArrowNarrowRightIcon />
+      </Link>
+    </article>
+  )
+}
+
+export function WorkflowFeedSection({
+  feeds,
+  ...props
+}: ComponentProps<typeof Section> & { feeds: readonly WorkflowFeed[] }) {
+  return (
+    <Section {...props}>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 xl:grid-cols-3">
+        {feeds.map((feed) => (
+          <WorkflowFeedPanel key={feed.slug} feed={feed} />
+        ))}
+      </div>
+      <p className="mt-2 flex items-center gap-2 text-sm/7 text-mist-600 dark:text-mist-400">
+        <CodeSquareIcon className="size-3.5 shrink-0 text-mist-500" />
+        Sequences are abbreviated from published case studies — full tool traces, failures, and fixes are in the docs.
+      </p>
+    </Section>
+  )
+}

--- a/landing-page/demo/src/lib/workflow-feeds.ts
+++ b/landing-page/demo/src/lib/workflow-feeds.ts
@@ -1,0 +1,149 @@
+/** Chronological MCP tool sequences from published case studies. */
+export type WorkflowFeedStepKind = 'agent' | 'tool' | 'result'
+
+export type WorkflowFeedStep = {
+  kind: WorkflowFeedStepKind
+  /** MCP tool name when kind is `tool`. */
+  tool?: string
+  title: string
+  body: string
+}
+
+export type WorkflowFeed = {
+  slug: string
+  title: string
+  source: string
+  href: string
+  steps: readonly WorkflowFeedStep[]
+}
+
+export const workflowFeeds: readonly WorkflowFeed[] = [
+  {
+    slug: 'cloudflare-docs',
+    title: 'Ship docs.clawql.com',
+    source: 'Cloudflare docs MCP case study',
+    href: 'https://docs.clawql.com/case-studies/cloudflare-docs-mcp',
+    steps: [
+      {
+        kind: 'agent',
+        title: 'Agent intent',
+        body: 'Deploy the Next.js docs site to docs.clawql.com on Cloudflare Workers and verify custom-domain routing.',
+      },
+      {
+        kind: 'tool',
+        tool: 'memory_recall',
+        title: 'Recall prior context',
+        body: 'Query the vault for “Cloudflare docs deploy”, Workers 1101, and OpenNext fs failures — skip dead ends from earlier sessions.',
+      },
+      {
+        kind: 'tool',
+        tool: 'search',
+        title: 'Discover control-plane ops',
+        body: 'Rank Cloudflare REST operations for Workers custom domains and zone bindings — no multi‑MB OpenAPI in the prompt.',
+      },
+      {
+        kind: 'tool',
+        tool: 'execute',
+        title: 'Attach hostname',
+        body: 'workers.domains.update — bind docs.clawql.com to the clawql-docs Worker with account_id, zone_id, and service name.',
+      },
+      {
+        kind: 'result',
+        title: 'Deploy and verify',
+        body: 'OpenNext build via Wrangler; HTTP 200 on /; wrangler tail clean after fixing fs.readdir and MDX prerender crashes.',
+      },
+      {
+        kind: 'tool',
+        tool: 'memory_ingest',
+        title: 'Persist runbook',
+        body: 'Append deploy decisions and fixes to the vault with append: true and wikilinks — durable recall for the next incident.',
+      },
+    ],
+  },
+  {
+    slug: 'github-provider',
+    title: 'GitHub without a 9 MB spec dump',
+    source: 'GitHub provider case study',
+    href: 'https://docs.clawql.com/case-studies/github-provider-danielsmithdevelopment-clawql',
+    steps: [
+      {
+        kind: 'agent',
+        title: 'Agent intent',
+        body: 'List the latest commits on main and update the repository description from the README summary.',
+      },
+      {
+        kind: 'tool',
+        tool: 'search',
+        title: 'Find list-commits',
+        body: '“GitHub REST list commits GET repos owner repo” → repos/list-commits ranked #2 among 1,099 indexed operations.',
+      },
+      {
+        kind: 'tool',
+        tool: 'execute',
+        title: 'List commits',
+        body: 'repos/list-commits with owner, repo, sha: main, per_page: 5 — lean JSON response, not the bundled ~9 MB spec.',
+      },
+      {
+        kind: 'tool',
+        tool: 'search',
+        title: 'Find repos/update',
+        body: '“PATCH update repository repos owner” → repos/update surfaces in the top hits.',
+      },
+      {
+        kind: 'tool',
+        tool: 'execute',
+        title: 'Patch description',
+        body: 'repos/update with validated args — description within GitHub’s 350-character limit.',
+      },
+      {
+        kind: 'result',
+        title: 'Measured token savings',
+        body: 'Planning context drops from ~2.28M tokens (naive full-spec paste) to ~3.4K (search → execute workflow).',
+      },
+    ],
+  },
+  {
+    slug: 'vault-github-session',
+    title: 'Vault ingest → GitHub → audit',
+    source: 'Vault memory + GitHub session case study',
+    href: 'https://docs.clawql.com/case-studies/vault-memory-github-session-2026-04',
+    steps: [
+      {
+        kind: 'tool',
+        tool: 'memory_recall',
+        title: 'Ground on prior work',
+        body: 'Recall roadmap notes, vendor analysis, and open prioritization before triaging the backlog.',
+      },
+      {
+        kind: 'tool',
+        tool: 'memory_ingest',
+        title: 'Capture decisions',
+        body: 'Ingest structured insights with wikilinks — durable narrative, not ephemeral session cache.',
+      },
+      {
+        kind: 'tool',
+        tool: 'search',
+        title: 'Find GitHub issue APIs',
+        body: 'Discover issues/create and related operations from the bundled GitHub provider.',
+      },
+      {
+        kind: 'tool',
+        tool: 'execute',
+        title: 'Open tracking issues',
+        body: 'Create canonical GitHub issues for audit (#89), Helm wiring, and duplicate consolidation.',
+      },
+      {
+        kind: 'tool',
+        tool: 'audit',
+        title: 'Log MCP events',
+        body: 'Append structured breadcrumbs during the ship — correlate operator events with vault ingests later.',
+      },
+      {
+        kind: 'tool',
+        tool: 'memory_ingest',
+        title: 'Close the loop',
+        body: 'Append session outcomes so the next chat recalls what shipped and why.',
+      },
+    ],
+  },
+] as const


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Workflows in practice** section to the ClawQL landing page (`landing-page/demo`), placed immediately after the MCP tool tier list. The section uses Tailwind UI–style activity feeds (icon timeline with connecting lines) to show how ClawQL tools are called in sequence during real workflows.

## What changed

- **`workflow-feeds.ts`** — Three chronological sequences sourced from published case studies:
  - **Ship docs.clawql.com** — `memory_recall` → `search` → `execute` → deploy/verify → `memory_ingest` (Cloudflare docs MCP case study)
  - **GitHub without a 9 MB spec dump** — `search` → `execute` loop with measured token savings (GitHub provider case study)
  - **Vault ingest → GitHub → audit** — recall, ingest, GitHub issue creation, audit logging, close-the-loop ingest (vault memory + GitHub session case study)
- **`workflow-feed.tsx`** — Feed panel component with agent/tool/result step types, tool name badges, vertical timeline, and case study links
- **`page.tsx`** — New `#workflows` section between `#tools` and `#idp`
- **`layout.tsx`** — Nav/footer links to `#workflows`

## Verification

- `npm ci && npm run build` in `landing-page/demo` — static export succeeds

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f269b-2a41-70f3-b7b6-2db2140b0d45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f269b-2a41-70f3-b7b6-2db2140b0d45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

