### PR TITLE
fix(landing): remove case studies section and nav links

### DIFF
--- a/landing-page/demo/src/app/layout.tsx
+++ b/landing-page/demo/src/app/layout.tsx
@@ -57,7 +57,6 @@ export default function RootLayout({
                   Workflows
                 </NavbarLink>
                 <NavbarLink href="/#idp">IDP</NavbarLink>
-                <NavbarLink href="/#case-studies">Case studies</NavbarLink>
                 <NavbarLink href={site.urls.pricing}>Pricing</NavbarLink>
                 <NavbarLink href={site.urls.docs}>Docs</NavbarLink>
                 <NavbarLink href={site.urls.signup} className="sm:hidden">
@@ -101,7 +100,6 @@ export default function RootLayout({
                 <FooterCategory title="Product">
                   <FooterLink href="/#tools">Tools</FooterLink>
                   <FooterLink href="/#workflows">Workflows</FooterLink>
-                  <FooterLink href="/#case-studies">Case studies</FooterLink>
                   <FooterLink href={site.urls.pricing}>Pricing</FooterLink>
                   <FooterLink href={site.urls.signup}>Sign up</FooterLink>
                   <FooterLink href={site.urls.docs}>Documentation</FooterLink>
@@ -110,7 +108,6 @@ export default function RootLayout({
                   <FooterLink href={site.urls.github}>GitHub</FooterLink>
                   <FooterLink href={site.urls.npm}>npm package</FooterLink>
                   <FooterLink href={`${site.urls.docs}/readme/getting-started`}>Quick start</FooterLink>
-                  <FooterLink href={`${site.urls.docs}/case-studies`}>Case studies</FooterLink>
                   <FooterLink href={`${site.urls.docs}/mcp/mcp-tools`}>MCP tools</FooterLink>
                 </FooterCategory>
                 <FooterCategory title="Company">

--- a/landing-page/demo/src/app/page.tsx
+++ b/landing-page/demo/src/app/page.tsx
@@ -6,8 +6,6 @@ import { Link } from '@/components/elements/link'
 import { ArrowNarrowRightIcon } from '@/components/icons/arrow-narrow-right-icon'
 import { CallToActionSimple } from '@/components/sections/call-to-action-simple'
 import {
-  CaseStudyCard,
-  CaseStudyGrid,
   IdpStageCard,
   ToolTierSection,
 } from '@/components/sections/clawql-marketing'
@@ -17,7 +15,7 @@ import { Plan, PricingMultiTier } from '@/components/sections/pricing-multi-tier
 import { Stat, StatsFourColumns } from '@/components/sections/stats-four-columns'
 import { Section } from '@/components/elements/section'
 import { WorkflowFeedSection } from '@/components/sections/workflow-feed'
-import { caseStudies, idpPipelineStages, mcpToolTiers, multiProviderBenchmark } from '@/lib/marketing'
+import { idpPipelineStages, mcpToolTiers, multiProviderBenchmark } from '@/lib/marketing'
 import { workflowFeeds } from '@/lib/workflow-feeds'
 import { managedPrice, pricing } from '@/lib/pricing'
 import { site } from '@/lib/site'
@@ -157,31 +155,6 @@ export default function Page() {
           ))}
         </div>
       </Section>
-
-      {/* Case studies */}
-      <CaseStudyGrid
-        id="case-studies"
-        eyebrow="Case studies"
-        headline="Published workflows — not marketing fiction."
-        subheadline={
-          <p>
-            Each study documents real tool traces, failures, fixes, and token measurements. Read the full narratives on{' '}
-            <a href={`${site.urls.docs}/case-studies`} className="underline">
-              docs.clawql.com
-            </a>
-            .
-          </p>
-        }
-        footer={
-          <Link href={`${site.urls.docs}/case-studies`} className="mt-6">
-            View all case studies <ArrowNarrowRightIcon />
-          </Link>
-        }
-      >
-        {caseStudies.map((study) => (
-          <CaseStudyCard key={study.slug} {...study} />
-        ))}
-      </CaseStudyGrid>
 
       {/* FAQs */}
       <FAQsTwoColumnAccordion id="faqs" headline="Questions & Answers">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the **Case studies** grid from the ClawQL landing page homepage and drops the related nav/footer links. Workflow feeds already surface the same stories with tool-call sequences and links to full case studies on docs.

## What changed

- Deleted `CaseStudyGrid` from `landing-page/demo/src/app/page.tsx`
- Removed **Case studies** from navbar and footer (Product `#case-studies` and Developers docs link)

## Note

This commit was pushed after #484 merged; it was not included in that PR.

## Verification

- `npm run build` in `landing-page/demo` — static export succeeds

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f269b-2a41-70f3-b7b6-2db2140b0d45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f269b-2a41-70f3-b7b6-2db2140b0d45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

