### PR TITLE
feat(landing): security section marketing docs.clawql.com/security

### DIFF
--- a/landing-page/demo/src/app/layout.tsx
+++ b/landing-page/demo/src/app/layout.tsx
@@ -57,7 +57,7 @@ export default function RootLayout({
                   Workflows
                 </NavbarLink>
                 <NavbarLink href="/#idp">IDP</NavbarLink>
-                <NavbarLink href="/#case-studies">Case studies</NavbarLink>
+                <NavbarLink href="/#security">Security</NavbarLink>
                 <NavbarLink href={site.urls.pricing}>Pricing</NavbarLink>
                 <NavbarLink href={site.urls.docs}>Docs</NavbarLink>
                 <NavbarLink href={site.urls.signup} className="sm:hidden">
@@ -101,7 +101,7 @@ export default function RootLayout({
                 <FooterCategory title="Product">
                   <FooterLink href="/#tools">Tools</FooterLink>
                   <FooterLink href="/#workflows">Workflows</FooterLink>
-                  <FooterLink href="/#case-studies">Case studies</FooterLink>
+                  <FooterLink href="/#security">Security</FooterLink>
                   <FooterLink href={site.urls.pricing}>Pricing</FooterLink>
                   <FooterLink href={site.urls.signup}>Sign up</FooterLink>
                   <FooterLink href={site.urls.docs}>Documentation</FooterLink>
@@ -110,7 +110,7 @@ export default function RootLayout({
                   <FooterLink href={site.urls.github}>GitHub</FooterLink>
                   <FooterLink href={site.urls.npm}>npm package</FooterLink>
                   <FooterLink href={`${site.urls.docs}/readme/getting-started`}>Quick start</FooterLink>
-                  <FooterLink href={`${site.urls.docs}/case-studies`}>Case studies</FooterLink>
+                  <FooterLink href={`${site.urls.docs}/security`}>Security</FooterLink>
                   <FooterLink href={`${site.urls.docs}/mcp/mcp-tools`}>MCP tools</FooterLink>
                 </FooterCategory>
                 <FooterCategory title="Company">

--- a/landing-page/demo/src/app/page.tsx
+++ b/landing-page/demo/src/app/page.tsx
@@ -16,8 +16,10 @@ import { HeroTwoColumnWithPhoto } from '@/components/sections/hero-two-column-wi
 import { Plan, PricingMultiTier } from '@/components/sections/pricing-multi-tier'
 import { Stat, StatsFourColumns } from '@/components/sections/stats-four-columns'
 import { Section } from '@/components/elements/section'
+import { SecuritySection } from '@/components/sections/security-section'
 import { WorkflowFeedSection } from '@/components/sections/workflow-feed'
 import { caseStudies, idpPipelineStages, mcpToolTiers, multiProviderBenchmark } from '@/lib/marketing'
+import { securityEnforcementLayers, securityPillars } from '@/lib/security-marketing'
 import { workflowFeeds } from '@/lib/workflow-feeds'
 import { managedPrice, pricing } from '@/lib/pricing'
 import { site } from '@/lib/site'
@@ -158,6 +160,27 @@ export default function Page() {
         </div>
       </Section>
 
+      {/* Security */}
+      <SecuritySection
+        id="security"
+        eyebrow="Security"
+        headline="Built to prove, not just claim."
+        subheadline={
+          <p>
+            ClawQL documents how container images are scanned, signed, and enforced from CI through Kubernetes
+            admission — plus a 32-module curriculum for agentic AI deployments. Same controls on self-hosted Helm and
+            dedicated managed accounts.
+          </p>
+        }
+        cta={
+          <Link href={`${site.urls.docs}/security`}>
+            Read the security hub <ArrowNarrowRightIcon />
+          </Link>
+        }
+        pillars={securityPillars}
+        enforcementLayers={securityEnforcementLayers}
+      />
+
       {/* Case studies */}
       <CaseStudyGrid
         id="case-studies"
@@ -204,6 +227,11 @@ export default function Page() {
           id="faq-4"
           question="Do you offer enterprise contracts?"
           answer="Yes — for very high volume, custom SLAs, and on-call support. We don't list a fixed enterprise price; contracts are scoped individually and typically start around $3,000/month. Contact sales to discuss."
+        />
+        <Faq
+          id="faq-5"
+          question="How does ClawQL handle supply chain and runtime security?"
+          answer="Container images pass OSV, Trivy, and SBOM gates in CI, are Cosign-signed, and Kyverno verifyImages rejects unsigned digests at deploy time by default. Runtime layers — MCP ATR scoping, audit, sandbox isolation, PII redaction in the IDP pipeline — are documented in the 32-module security curriculum and defense-in-depth guide on docs.clawql.com/security."
         />
       </FAQsTwoColumnAccordion>
 

--- a/landing-page/demo/src/components/sections/security-section.tsx
+++ b/landing-page/demo/src/components/sections/security-section.tsx
@@ -1,0 +1,92 @@
+import { clsx } from 'clsx/lite'
+import type { ComponentProps } from 'react'
+import { Link } from '../elements/link'
+import { Section } from '../elements/section'
+import { ArrowNarrowRightIcon } from '../icons/arrow-narrow-right-icon'
+import type { securityEnforcementLayers, securityPillars } from '@/lib/security-marketing'
+
+export function SecurityPillarCard({
+  title,
+  body,
+  href,
+  linkLabel,
+  className,
+  ...props
+}: {
+  title: string
+  body: string
+  href: string
+  linkLabel: string
+} & ComponentProps<'article'>) {
+  return (
+    <article
+      className={clsx('flex flex-col justify-between gap-6 rounded-xl bg-mist-950/2.5 p-6 dark:bg-white/5', className)}
+      {...props}
+    >
+      <div className="flex flex-col gap-3">
+        <h3 className="text-base font-semibold text-mist-950 dark:text-white">{title}</h3>
+        <p className="text-sm/7 text-mist-700 dark:text-mist-400">{body}</p>
+      </div>
+      <Link href={href}>
+        {linkLabel} <ArrowNarrowRightIcon />
+      </Link>
+    </article>
+  )
+}
+
+export function SecurityEnforcementTable({
+  layers,
+  className,
+  ...props
+}: {
+  layers: typeof securityEnforcementLayers
+} & ComponentProps<'div'>) {
+  return (
+    <div
+      className={clsx('overflow-hidden rounded-xl border border-mist-950/10 dark:border-white/10', className)}
+      {...props}
+    >
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-mist-950/10 bg-mist-950/2.5 dark:border-white/10 dark:bg-white/5">
+            <th className="px-4 py-3 font-semibold text-mist-950 dark:text-white">Layer</th>
+            <th className="px-4 py-3 font-semibold text-mist-950 dark:text-white">What happens</th>
+          </tr>
+        </thead>
+        <tbody>
+          {layers.map((row) => (
+            <tr key={row.layer} className="border-b border-mist-950/5 last:border-0 dark:border-white/5">
+              <td className="px-4 py-3 font-medium text-mist-950 dark:text-white">{row.layer}</td>
+              <td className="px-4 py-3 text-mist-700 dark:text-mist-400">{row.outcome}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export function SecuritySection({
+  pillars,
+  enforcementLayers,
+  ...props
+}: ComponentProps<typeof Section> & {
+  pillars: typeof securityPillars
+  enforcementLayers: typeof securityEnforcementLayers
+}) {
+  return (
+    <Section {...props}>
+      <div className="flex flex-col gap-10">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {pillars.map((pillar) => (
+            <SecurityPillarCard key={pillar.slug} {...pillar} />
+          ))}
+        </div>
+        <div className="flex flex-col gap-4">
+          <h3 className="text-sm font-semibold text-mist-950 dark:text-white">Build → registry → cluster</h3>
+          <SecurityEnforcementTable layers={enforcementLayers} />
+        </div>
+      </div>
+    </Section>
+  )
+}

--- a/landing-page/demo/src/lib/security-marketing.ts
+++ b/landing-page/demo/src/lib/security-marketing.ts
@@ -1,0 +1,37 @@
+/** Client-facing security pillars — aligned with docs.clawql.com/security. */
+export const securityPillars = [
+  {
+    slug: 'golden-image',
+    title: 'Golden image pipeline',
+    body: 'OSV-Scanner, Trivy, and Syft SBOM gates run before any image publishes. One BuildKit build per image — the exact OCI layout scanned is what Cosign signs and pushes to GHCR. Failed scans block push, sign, and tag promotion.',
+    href: 'https://docs.clawql.com/security',
+    linkLabel: 'Pipeline overview',
+  },
+  {
+    slug: 'admission',
+    title: 'Admission enforcement',
+    body: 'The Helm chart defaults Kyverno verifyImages for clawql-mcp and clawql-website. Unsigned or unverified digests do not schedule — deployed ClawQL images tie back to the signed artifacts from CI, not ad-hoc kubectl.',
+    href: 'https://docs.clawql.com/security/defense-in-depth',
+    linkLabel: 'Defense in depth',
+  },
+  {
+    slug: 'agentic-ai',
+    title: 'Built for agentic AI',
+    body: '32-module security curriculum from supply chain through runtime. MCP gateway ATR scoping limits what agents can do regardless of prompt injection; audit trails, sandbox isolation, and distroless images are documented for self-hosted k3s.',
+    href: 'https://docs.clawql.com/security/best-practices',
+    linkLabel: '32-module curriculum',
+  },
+  {
+    slug: 'verify-yourself',
+    title: 'Prove it yourself',
+    body: 'Security documentation is public: golden-image walkthroughs, deliverables matrix, npm supply-chain hardening, and cosign verify instructions. Operators and reviewers can reproduce CI gates — we document limits as clearly as controls.',
+    href: 'https://docs.clawql.com/security',
+    linkLabel: 'Full security hub',
+  },
+] as const
+
+export const securityEnforcementLayers = [
+  { layer: 'GitHub Actions', outcome: 'Failed OSV/Trivy/SBOM or image scan → no push, no sign' },
+  { layer: 'GHCR + Sigstore', outcome: 'Cosign keyless signatures bind to the digest that passed CI' },
+  { layer: 'Kubernetes', outcome: 'Kyverno verifyImages rejects unsigned ClawQL images at admission' },
+] as const


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Security** section to clawql.com, grounded in [docs.clawql.com/security](https://docs.clawql.com/security), to reassure enterprise and self-hosted clients that security is documented and enforced — not hand-waved.

## What was added

### Homepage `#security` section
- **Headline:** "Built to prove, not just claim."
- **Four pillars** (2×2 card grid):
  1. **Golden image pipeline** — OSV, Trivy, Syft SBOM gates; single build → scan → Cosign sign → push
  2. **Admission enforcement** — Kyverno `verifyImages` enabled by default in Helm
  3. **Built for agentic AI** — 32-module curriculum, MCP ATR scoping, audit, sandbox isolation
  4. **Prove it yourself** — public docs, deliverables matrix, `cosign verify` instructions
- **Enforcement table** — CI → GHCR/Sigstore → Kubernetes (mirrors docs security page)
- CTA to full security hub on docs

### Navigation & FAQ
- Navbar and footer links to `#security` and `docs.clawql.com/security`
- New FAQ on supply chain and runtime security

## Source material

Content distilled from the docs security hub: golden image pipeline, build vs cluster enforcement table, defense-in-depth guide, and 32-module best-practices curriculum.

## Verification

- `npm run build` in `landing-page/demo` — static export succeeds

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f269b-2a41-70f3-b7b6-2db2140b0d45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f269b-2a41-70f3-b7b6-2db2140b0d45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

