### PR TITLE
feat(landing): industry pages for lending, real estate, healthcare

### DIFF
--- a/landing-page/demo/src/app/industries/healthcare/page.tsx
+++ b/landing-page/demo/src/app/industries/healthcare/page.tsx
@@ -1,0 +1,13 @@
+import { IndustryPage } from '@/components/sections/industry-page'
+import { industriesBySlug } from '@/lib/industries'
+
+const industry = industriesBySlug.healthcare
+
+export const metadata = {
+  title: `${industry.name} — ClawQL for clinical documents`,
+  description: industry.subheadline,
+}
+
+export default function Page() {
+  return <IndustryPage industry={industry} />
+}

--- a/landing-page/demo/src/app/industries/lending/page.tsx
+++ b/landing-page/demo/src/app/industries/lending/page.tsx
@@ -1,0 +1,13 @@
+import { IndustryPage } from '@/components/sections/industry-page'
+import { industriesBySlug } from '@/lib/industries'
+
+const industry = industriesBySlug.lending
+
+export const metadata = {
+  title: `${industry.name} — ClawQL for lending & mortgage`,
+  description: industry.subheadline,
+}
+
+export default function Page() {
+  return <IndustryPage industry={industry} />
+}

--- a/landing-page/demo/src/app/industries/page.tsx
+++ b/landing-page/demo/src/app/industries/page.tsx
@@ -1,0 +1,59 @@
+import { ButtonLink } from '@/components/elements/button'
+import { Link } from '@/components/elements/link'
+import { ArrowNarrowRightIcon } from '@/components/icons/arrow-narrow-right-icon'
+import { HeroSimpleCentered } from '@/components/sections/hero-simple-centered'
+import { Section } from '@/components/elements/section'
+import { industries } from '@/lib/industries'
+import { site } from '@/lib/site'
+
+export const metadata = {
+  title: 'Industries',
+  description:
+    'ClawQL vertical packages for lending, real estate, healthcare, and more — agent-native document and API workflows on one MCP gateway.',
+}
+
+export default function Page() {
+  return (
+    <>
+      <HeroSimpleCentered
+        id="hero"
+        eyebrow="Industry verticals"
+        headline="One gateway. Domain-specific workflows."
+        subheadline={
+          <p>
+            ClawQL modularization v2.1 defines opt-in vertical packages — lending, healthcare, legal, insurance, and
+            more — that share security, memory, audit, and the IDP pipeline. These pages explain the first industries we
+            are targeting.
+          </p>
+        }
+        cta={
+          <ButtonLink href={`${site.urls.docs}/vision/modularization`} size="lg">
+            Read modularization v2.1
+          </ButtonLink>
+        }
+      />
+
+      <Section id="industries" headline="Explore by industry">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {industries.map((industry) => (
+            <article
+              key={industry.slug}
+              className="flex flex-col justify-between gap-6 rounded-xl bg-mist-950/2.5 p-6 dark:bg-white/5"
+            >
+              <div className="flex flex-col gap-3">
+                <p className="text-xs font-medium tracking-wide text-mist-500 uppercase dark:text-mist-400">
+                  {industry.packageName}
+                </p>
+                <h2 className="text-base font-semibold text-mist-950 dark:text-white">{industry.name}</h2>
+                <p className="text-sm/7 text-mist-700 dark:text-mist-400">{industry.headline}</p>
+              </div>
+              <Link href={`/industries/${industry.slug}`}>
+                View use cases <ArrowNarrowRightIcon />
+              </Link>
+            </article>
+          ))}
+        </div>
+      </Section>
+    </>
+  )
+}

--- a/landing-page/demo/src/app/industries/real-estate/page.tsx
+++ b/landing-page/demo/src/app/industries/real-estate/page.tsx
@@ -1,0 +1,13 @@
+import { IndustryPage } from '@/components/sections/industry-page'
+import { industriesBySlug } from '@/lib/industries'
+
+const industry = industriesBySlug['real-estate']
+
+export const metadata = {
+  title: `${industry.name} — ClawQL for property transactions`,
+  description: industry.subheadline,
+}
+
+export default function Page() {
+  return <IndustryPage industry={industry} />
+}

--- a/landing-page/demo/src/app/layout.tsx
+++ b/landing-page/demo/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { ClawQLLogo } from '@/components/elements/clawql-logo'
 import { Main } from '@/components/elements/main'
 import { GitHubIcon } from '@/components/icons/social/github-icon'
 import { XIcon } from '@/components/icons/social/x-icon'
+import { NavbarIndustriesMenu } from '@/components/elements/navbar-industries-menu'
 import {
   FooterCategory,
   FooterLink,
@@ -57,6 +58,7 @@ export default function RootLayout({
                   Workflows
                 </NavbarLink>
                 <NavbarLink href="/#idp">IDP</NavbarLink>
+                <NavbarIndustriesMenu />
                 <NavbarLink href="/#security">Security</NavbarLink>
                 <NavbarLink href={site.urls.pricing}>Pricing</NavbarLink>
                 <NavbarLink href={site.urls.docs}>Docs</NavbarLink>
@@ -105,6 +107,12 @@ export default function RootLayout({
                   <FooterLink href={site.urls.pricing}>Pricing</FooterLink>
                   <FooterLink href={site.urls.signup}>Sign up</FooterLink>
                   <FooterLink href={site.urls.docs}>Documentation</FooterLink>
+                </FooterCategory>
+                <FooterCategory title="Industries">
+                  <FooterLink href="/industries/lending">Lending</FooterLink>
+                  <FooterLink href="/industries/real-estate">Real estate</FooterLink>
+                  <FooterLink href="/industries/healthcare">Healthcare</FooterLink>
+                  <FooterLink href="/industries">All industries</FooterLink>
                 </FooterCategory>
                 <FooterCategory title="Developers">
                   <FooterLink href={site.urls.github}>GitHub</FooterLink>

--- a/landing-page/demo/src/components/elements/navbar-industries-menu.tsx
+++ b/landing-page/demo/src/components/elements/navbar-industries-menu.tsx
@@ -1,0 +1,71 @@
+import Link from 'next/link'
+
+import { clsx } from 'clsx/lite'
+import type { ReactNode } from 'react'
+import { industries } from '@/lib/industries'
+
+function IndustryMenuLink({
+  href,
+  children,
+  className,
+}: {
+  href: string
+  children: ReactNode
+  className?: string
+}) {
+  return (
+    <Link
+      href={href}
+      className={clsx(
+        'block rounded-lg px-3 py-2 text-sm font-medium text-mist-700 hover:bg-mist-950/5 hover:text-mist-950 dark:text-mist-300 dark:hover:bg-white/10 dark:hover:text-white',
+        className,
+      )}
+    >
+      {children}
+    </Link>
+  )
+}
+
+export function NavbarIndustriesMenu() {
+  return (
+    <>
+      {/* Desktop dropdown */}
+      <div className="group relative hidden lg:block">
+        <button
+          type="button"
+          className="inline-flex items-center gap-1.5 text-sm/7 font-medium text-mist-950 dark:text-white"
+          aria-haspopup="true"
+        >
+          Industries
+          <svg viewBox="0 0 8 5" fill="currentColor" className="size-2 opacity-60" aria-hidden>
+            <path d="M.22.22a.75.75 0 0 1 1.06 0L4 2.94 7.72.22a.75.75 0 1 1 1.06 1.06L4.53 4.53a.75.75 0 0 1-1.06 0L.22 1.28a.75.75 0 0 1 0-1.06Z" />
+          </svg>
+        </button>
+        <div className="pointer-events-none absolute top-full left-1/2 z-20 mt-2 w-52 -translate-x-1/2 rounded-xl border border-mist-950/10 bg-mist-100 p-2 opacity-0 shadow-lg transition group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 dark:border-white/10 dark:bg-mist-900">
+          {industries.map((industry) => (
+            <IndustryMenuLink key={industry.slug} href={`/industries/${industry.slug}`}>
+              {industry.name}
+            </IndustryMenuLink>
+          ))}
+          <IndustryMenuLink href="/industries" className="text-mist-500 dark:text-mist-400">
+            All industries
+          </IndustryMenuLink>
+        </div>
+      </div>
+
+      {/* Mobile — nested links */}
+      <div className="flex flex-col gap-3 lg:hidden">
+        <span className="text-3xl/10 font-medium text-mist-950 dark:text-white">Industries</span>
+        {industries.map((industry) => (
+          <Link
+            key={industry.slug}
+            href={`/industries/${industry.slug}`}
+            className="pl-4 text-2xl/10 font-medium text-mist-600 dark:text-mist-300"
+          >
+            {industry.name}
+          </Link>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/landing-page/demo/src/components/sections/industry-page.tsx
+++ b/landing-page/demo/src/components/sections/industry-page.tsx
@@ -1,0 +1,143 @@
+import { ButtonLink, PlainButtonLink } from '@/components/elements/button'
+import { Link } from '@/components/elements/link'
+import { Section } from '@/components/elements/section'
+import { ArrowNarrowRightIcon } from '@/components/icons/arrow-narrow-right-icon'
+import { CallToActionSimple } from '@/components/sections/call-to-action-simple'
+import { HeroSimpleCentered } from '@/components/sections/hero-simple-centered'
+import type { Industry } from '@/lib/industries'
+import { site } from '@/lib/site'
+
+function StatusBadge({ status }: { status: Industry['status'] }) {
+  const label =
+    status === 'shipped' ? 'Shipped samples' : status === 'partial' ? 'Partial — samples shipping' : 'Planned vertical'
+  return (
+    <span className="inline-flex rounded-full bg-mist-950/5 px-3 py-1 text-xs font-medium tracking-wide text-mist-600 uppercase dark:bg-white/10 dark:text-mist-300">
+      {label}
+    </span>
+  )
+}
+
+export function IndustryPage({ industry }: { industry: Industry }) {
+  return (
+    <>
+      <HeroSimpleCentered
+        id="hero"
+        eyebrow={<StatusBadge status={industry.status} />}
+        headline={industry.headline}
+        subheadline={<p>{industry.subheadline}</p>}
+        cta={
+          <div className="flex flex-col items-center gap-4 sm:flex-row">
+            <ButtonLink href={site.urls.signup} size="lg">
+              Talk to us about {industry.name.toLowerCase()}
+            </ButtonLink>
+            <PlainButtonLink href={industry.docsHref} size="lg">
+              Technical docs <ArrowNarrowRightIcon />
+            </PlainButtonLink>
+          </div>
+        }
+      />
+
+      <Section
+        id="use-cases"
+        eyebrow="Use cases"
+        headline={`Why ClawQL for ${industry.name.toLowerCase()}`}
+        subheadline={
+          <p>
+            Vertical packages extend the same MCP gateway — search, execute, memory, IDP, audit — with domain tools from{' '}
+            <code className="text-sm">{industry.packageName}</code> in{' '}
+            <Link href="https://docs.clawql.com/vision/modularization">modularization v2.1</Link>.
+          </p>
+        }
+      >
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {industry.useCases.map((useCase) => (
+            <div key={useCase.title} className="flex flex-col gap-3 rounded-xl bg-mist-950/2.5 p-6 dark:bg-white/5">
+              <h3 className="text-base font-semibold text-mist-950 dark:text-white">{useCase.title}</h3>
+              <p className="text-sm/7 text-mist-700 dark:text-mist-400">{useCase.body}</p>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section
+        id="examples"
+        eyebrow="Examples"
+        headline="Example agent workflows"
+        subheadline={
+          <p>
+            Representative MCP tool sequences — production deployments add tenant classifiers, RBAC, and your compliance
+            policies on top.
+          </p>
+        }
+      >
+        <div className="flex flex-col gap-4">
+          {industry.examples.map((example) => (
+            <article
+              key={example.title}
+              className="flex flex-col gap-4 rounded-xl bg-mist-950/2.5 p-6 sm:p-8 dark:bg-white/5"
+            >
+              <h3 className="text-base font-semibold text-mist-950 dark:text-white">{example.title}</h3>
+              <p className="text-sm/7 text-mist-700 dark:text-mist-400">{example.body}</p>
+              <div className="flex flex-wrap gap-2">
+                {example.tools.map((tool) => (
+                  <code
+                    key={tool}
+                    className="rounded-md bg-mist-950/5 px-2 py-1 text-xs font-semibold text-mist-800 dark:bg-white/10 dark:text-mist-200"
+                  >
+                    {tool}()
+                  </code>
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+      </Section>
+
+      <Section
+        id="compliance"
+        eyebrow="Security & compliance"
+        headline="Built for regulated workflows"
+        subheadline={
+          <p>
+            Industry pages summarize platform capabilities — your legal, compliance, and security teams should review{' '}
+            <Link href={`${site.urls.docs}/security`}>docs.clawql.com/security</Link> before production PHI or lending
+            data.
+          </p>
+        }
+      >
+        <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {industry.compliance.map((item) => (
+            <li
+              key={item}
+              className="flex gap-3 rounded-xl bg-mist-950/2.5 p-4 text-sm/7 text-mist-700 dark:bg-white/5 dark:text-mist-400"
+            >
+              <span className="mt-1.5 size-1.5 shrink-0 rounded-full bg-mist-400 dark:bg-mist-500" aria-hidden />
+              {item}
+            </li>
+          ))}
+        </ul>
+        {industry.disclaimer ? (
+          <p className="mt-6 text-sm/7 text-mist-500 dark:text-mist-400">{industry.disclaimer}</p>
+        ) : null}
+      </Section>
+
+      <CallToActionSimple
+        id="cta"
+        headline={`Ready to pilot ClawQL in ${industry.name.toLowerCase()}?`}
+        subheadline={
+          <p>Self-host the lending compose stack today, or join the managed waitlist for hosted MCP, vault, and IDP.</p>
+        }
+        cta={
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+            <ButtonLink href={site.urls.signup} size="lg">
+              Join waitlist
+            </ButtonLink>
+            <PlainButtonLink href={`${site.urls.docs}/vision/modularization`} size="lg">
+              Modularization roadmap <ArrowNarrowRightIcon />
+            </PlainButtonLink>
+          </div>
+        }
+      />
+    </>
+  )
+}

--- a/landing-page/demo/src/lib/industries.ts
+++ b/landing-page/demo/src/lib/industries.ts
@@ -1,0 +1,179 @@
+export type IndustryExample = {
+  title: string
+  body: string
+  tools: readonly string[]
+}
+
+export type Industry = {
+  slug: string
+  name: string
+  headline: string
+  subheadline: string
+  /** Planned package name from modularization v2.1 */
+  packageName: string
+  status: 'shipped' | 'partial' | 'planned'
+  useCases: readonly { title: string; body: string }[]
+  examples: readonly IndustryExample[]
+  compliance: readonly string[]
+  docsHref: string
+  disclaimer?: string
+}
+
+export const industries: readonly Industry[] = [
+  {
+    slug: 'lending',
+    name: 'Lending',
+    headline: 'Agent-native lending and mortgage operations.',
+    subheadline:
+      'ClawQL’s lending vertical (clawql-lending) composes the IDP pipeline, vault memory, HITL review, and workflow automation for loan origination — W-2s, income docs, and underwriting packages without pasting specs or losing audit trails.',
+    packageName: 'clawql-lending',
+    status: 'partial',
+    useCases: [
+      {
+        title: 'Income document ingestion',
+        body: 'Parse W-2s and pay stubs with Docling, classify by document type, route low-confidence extractions to Label Studio, and archive tagged outcomes for underwriters.',
+      },
+      {
+        title: 'Underwriting memory across sessions',
+        body: 'memory_recall surfaces prior borrower conditions, cleared stipulations, and vendor notes — underwriters do not re-derive context every time a loan file reopens.',
+      },
+      {
+        title: 'Compliance-aware automation',
+        body: 'Shared compliance plugins target Reg Z, ECOA, and fair-lending guardrails. audit logs structured MCP events; dedicated managed hosting isolates tenant workloads.',
+      },
+    ],
+    examples: [
+      {
+        title: 'W-2 intake with confidence routing',
+        body: 'Agent executes docling_convert_file on a synthetic W-2, calls classify_document, and enqueues hitl_enqueue_label_studio when confidence is below threshold. Label Studio webhook persists the reviewer decision via memory_ingest.',
+        tools: ['execute', 'classify_document', 'hitl_enqueue_label_studio', 'memory_ingest'],
+      },
+      {
+        title: 'Argo suspend / resume for HITL',
+        body: 'workflow submits clawql-lending-w2-ingest; the template suspends on low confidence. After human review, workflow resume continues the pipeline — same pattern as the shipped lending W-2 reference pack.',
+        tools: ['workflow', 'hitl_enqueue_label_studio', 'memory_recall'],
+      },
+      {
+        title: 'One-command local lending stack',
+        body: 'docker compose -f lending.compose.yml brings up MCP, Docling, classifier, LangExtract demo, and Label Studio CE for POC underwriting flows — documented in the repo compose README.',
+        tools: ['search', 'execute', 'audit'],
+      },
+    ],
+    compliance: [
+      'PII redaction via Stirling in the IDP pipeline before archive',
+      'Structured audit ring buffer plus optional vault postmortems',
+      'Vertical RLS and ATR scoping planned via clawql-auth (modularization v2.1)',
+      'Cosign-signed images and Kyverno admission on self-hosted Helm',
+    ],
+    docsHref: 'https://docs.clawql.com/vision/modularization',
+    disclaimer:
+      'Lending compose stacks and W-2 samples use synthetic data only — not tax, legal, or underwriting advice. Train tenant-specific models before production.',
+  },
+  {
+    slug: 'real-estate',
+    name: 'Real estate',
+    headline: 'Document intelligence for property transactions.',
+    subheadline:
+      'Real estate workflows map to ClawQL’s mortgage module plus the eight-vendor IDP pipeline: title packages, purchase agreements, disclosures, and deal-room distribution — agents search, execute, redact, archive, and share without bespoke integrations per vendor.',
+    packageName: 'clawql-lending (mortgage)',
+    status: 'planned',
+    useCases: [
+      {
+        title: 'Transaction document packages',
+        body: 'Ingest deeds, title reports, appraisals, and disclosure PDFs through run_idp_pipeline — normalize to PDF, redact PII, archive with metadata, and index for hybrid search.',
+      },
+      {
+        title: 'Grounded field extraction',
+        body: 'extract_document returns purchase-price, closing-date, and party fields with char_interval provenance — grounded extraction for contracts and leases, not free-form LLM guesses.',
+      },
+      {
+        title: 'Secure deal-room distribution',
+        body: 'Coneshare VDR share links and viewer webhooks close the loop — agents notify Slack when external parties open sensitive transaction documents.',
+      },
+    ],
+    examples: [
+      {
+        title: 'Purchase agreement → archive → search',
+        body: 'Nextcloud intake triggers classify_document routing; Gotenberg normalizes Office exhibits; Stirling redacts borrower PII; Onyx indexes content for knowledge_search_onyx during diligence.',
+        tools: ['run_idp_pipeline', 'classify_document', 'knowledge_search_onyx'],
+      },
+      {
+        title: 'Multi-doc closing package',
+        body: 'Agents search bundled vendor APIs for the right operationId per hop instead of pasting OpenAPI — the same search → execute pattern used in production case studies, applied to title and escrow APIs in the merge.',
+        tools: ['search', 'execute', 'memory_ingest'],
+      },
+      {
+        title: 'Transaction room with notify',
+        body: 'After archive, agents create a Coneshare share link and post a notify milestone to the deal channel with Paperless and Onyx links for the closing team.',
+        tools: ['execute', 'notify', 'audit'],
+      },
+    ],
+    compliance: [
+      'PII redaction before documents enter archive or search indexes',
+      'Immutable audit breadcrumbs for agent actions on sensitive files',
+      'Self-hosted option keeps transaction docs on your infrastructure',
+      'VDR viewer activity can trigger webhook-driven review workflows',
+    ],
+    docsHref: 'https://docs.clawql.com/providers/idp-pipeline',
+    disclaimer:
+      'Real estate examples describe target workflows from modularization v2.1 — not legal or title advice. Verify recording and disclosure rules for your jurisdiction.',
+  },
+  {
+    slug: 'healthcare',
+    name: 'Healthcare',
+    headline: 'HIPAA-aware clinical document processing.',
+    subheadline:
+      'The planned clawql-healthcare vertical extends ClawQL’s document pipeline for FHIR bundles, HL7 messages, DICOM imaging, and clinical notes — PHI de-identification, structured extraction, and audit trails on the same MCP gateway as the rest of your stack.',
+    packageName: 'clawql-healthcare',
+    status: 'planned',
+    useCases: [
+      {
+        title: 'Clinical document structuring',
+        body: 'Parse discharge summaries and referral letters with Docling/Tika, de-identify PHI before persistence, and archive with correspondent and document-type metadata agents can query later.',
+      },
+      {
+        title: 'Interop without spec dumps',
+        body: 'search surfaces FHIR and HL7 operations from bundled providers; execute calls run with validated args — keeping planning context lean when agents touch EHR or imaging APIs.',
+      },
+      {
+        title: 'Human review on low confidence',
+        body: 'hitl_enqueue_label_studio routes ambiguous extractions — for example diagnosis coding or medication fields — to clinical reviewers before results enter the vault or downstream systems.',
+      },
+    ],
+    examples: [
+      {
+        title: 'Clinical PDF → redact → archive',
+        body: 'run_idp_pipeline chains intake through Stirling PII redaction and the archive layer; agents recall prior patient-context runbooks from the vault without storing PHI in the chat transcript.',
+        tools: ['run_idp_pipeline', 'memory_recall', 'audit'],
+      },
+      {
+        title: 'FHIR bundle extraction',
+        body: 'Agent searches for FHIR read/search operations, executes with scoped credentials, and ingests a de-identified summary to the vault with wikilinks — durable context for care-coordination workflows.',
+        tools: ['search', 'execute', 'memory_ingest'],
+      },
+      {
+        title: 'Radiology metadata (planned)',
+        body: 'dicom_analyze and medical_image_analyze tools from clawql-healthcare will expose imaging metadata to agents under HIPAA-friendly redaction policies — documented in modularization v2.1.',
+        tools: ['search', 'execute', 'deidentify'],
+      },
+    ],
+    compliance: [
+      'HIPAA-oriented de-identification via IDP redaction stage (Stirling)',
+      '6-year audit retention targets for PHI-handling tenants (security curriculum)',
+      'Dedicated managed hosting for workload isolation',
+      '32-module security curriculum maps controls to HIPAA evidence collection',
+    ],
+    docsHref: 'https://docs.clawql.com/security',
+    disclaimer:
+      'Healthcare vertical tools are planned — not medical advice. BAAs, BRA processes, and production PHI handling require your compliance review.',
+  },
+] as const
+
+export const industriesBySlug = Object.fromEntries(industries.map((industry) => [industry.slug, industry])) as Record<
+  string,
+  Industry
+>
+
+export function getIndustry(slug: string): Industry | undefined {
+  return industriesBySlug[slug]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds industry-targeted marketing pages to clawql.com with a dropdown **Industries** menu in the navbar, grounded in [modularization v2.1](https://docs.clawql.com/vision/modularization) and shipped lending samples.

## New routes

| Route | Focus |
| ----- | ----- |
| `/industries` | Index of all industry verticals |
| `/industries/lending` | W-2 intake, HITL, Argo workflows, lending compose stack |
| `/industries/real-estate` | Transaction packages, IDP pipeline, Coneshare VDR (mortgage module) |
| `/industries/healthcare` | FHIR/HL7, PHI de-identification, clinical docs (planned vertical) |

## Page structure (each industry)

- Hero with shipped/partial/planned status badge
- **Use cases** — 3 cards explaining why ClawQL fits the vertical
- **Example workflows** — MCP tool sequences with tool name badges
- **Security & compliance** — platform controls + industry disclaimer
- CTA to waitlist and modularization docs

## Navigation

- Desktop: **Industries** hover dropdown (Lending, Real estate, Healthcare, All industries)
- Mobile: nested industry links in the menu drawer
- Footer: new **Industries** category

## Honesty notes

- Lending marked **partial** (compose + W-2 sample shipped; full `clawql-lending` package planned)
- Real estate and healthcare marked **planned** where appropriate, with disclaimers

## Verification

- `npm run build` in `landing-page/demo` — 13 static routes export successfully

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f269b-2a41-70f3-b7b6-2db2140b0d45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f269b-2a41-70f3-b7b6-2db2140b0d45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

