### PR TITLE
feat(landing): legal, insurance, and education industry pages

### DIFF
--- a/landing-page/demo/src/app/industries/education/page.tsx
+++ b/landing-page/demo/src/app/industries/education/page.tsx
@@ -1,0 +1,13 @@
+import { IndustryPage } from '@/components/sections/industry-page'
+import { industriesBySlug } from '@/lib/industries'
+
+const industry = industriesBySlug.education
+
+export const metadata = {
+  title: `${industry.name} — ClawQL for faculty & LMS workflows`,
+  description: industry.subheadline,
+}
+
+export default function Page() {
+  return <IndustryPage industry={industry} />
+}

--- a/landing-page/demo/src/app/industries/insurance/page.tsx
+++ b/landing-page/demo/src/app/industries/insurance/page.tsx
@@ -1,0 +1,13 @@
+import { IndustryPage } from '@/components/sections/industry-page'
+import { industriesBySlug } from '@/lib/industries'
+
+const industry = industriesBySlug.insurance
+
+export const metadata = {
+  title: `${industry.name} — ClawQL for carriers & claims`,
+  description: industry.subheadline,
+}
+
+export default function Page() {
+  return <IndustryPage industry={industry} />
+}

--- a/landing-page/demo/src/app/industries/legal/page.tsx
+++ b/landing-page/demo/src/app/industries/legal/page.tsx
@@ -1,0 +1,13 @@
+import { IndustryPage } from '@/components/sections/industry-page'
+import { industriesBySlug } from '@/lib/industries'
+
+const industry = industriesBySlug.legal
+
+export const metadata = {
+  title: `${industry.name} — ClawQL for law firms & in-house counsel`,
+  description: industry.subheadline,
+}
+
+export default function Page() {
+  return <IndustryPage industry={industry} />
+}

--- a/landing-page/demo/src/app/layout.tsx
+++ b/landing-page/demo/src/app/layout.tsx
@@ -112,6 +112,9 @@ export default function RootLayout({
                   <FooterLink href="/industries/lending">Lending</FooterLink>
                   <FooterLink href="/industries/real-estate">Real estate</FooterLink>
                   <FooterLink href="/industries/healthcare">Healthcare</FooterLink>
+                  <FooterLink href="/industries/legal">Legal</FooterLink>
+                  <FooterLink href="/industries/insurance">Insurance</FooterLink>
+                  <FooterLink href="/industries/education">Education</FooterLink>
                   <FooterLink href="/industries">All industries</FooterLink>
                 </FooterCategory>
                 <FooterCategory title="Developers">

--- a/landing-page/demo/src/lib/industries.ts
+++ b/landing-page/demo/src/lib/industries.ts
@@ -167,6 +167,153 @@ export const industries: readonly Industry[] = [
     disclaimer:
       'Healthcare vertical tools are planned — not medical advice. BAAs, BRA processes, and production PHI handling require your compliance review.',
   },
+  {
+    slug: 'legal',
+    name: 'Legal',
+    headline: 'Contract intelligence with privilege-aware automation.',
+    subheadline:
+      'The planned clawql-legal vertical adds clause extraction, precedent search, privilege redaction, and filing validation on ClawQL’s IDP pipeline — agents handle due diligence and litigation support without leaking attorney-client material into prompts or vault notes.',
+    packageName: 'clawql-legal',
+    status: 'planned',
+    useCases: [
+      {
+        title: 'Due diligence at scale',
+        body: 'Ingest data-room PDFs, extract clauses and risk flags with provenance, and recall prior deal patterns from the vault — associates start from indexed precedent instead of re-reading every exhibit.',
+      },
+      {
+        title: 'Privilege-safe redaction',
+        body: 'redact_privilege and Stirling PII stages strip sensitive content before documents enter archive or enterprise search — ethical walls enforced by vertical RLS and ATR scoping (modularization v2.1).',
+      },
+      {
+        title: 'Litigation timelines and drafts',
+        body: 'timeline_generate and brief_draft tools compose structured outputs from ingested discovery — human attorneys review; agents handle retrieval, citation gathering, and first-pass organization.',
+      },
+    ],
+    examples: [
+      {
+        title: 'M&A data room intake',
+        body: 'run_idp_pipeline normalizes seller disclosures; classify_document routes contracts vs financials; extract_document returns party and indemnity fields with char_interval citations for associate review.',
+        tools: ['run_idp_pipeline', 'classify_document', 'extract_document'],
+      },
+      {
+        title: 'Precedent search across matters',
+        body: 'memory_recall with elevated graph depth surfaces prior vault notes on similar clauses; knowledge_search_onyx queries the firm index — agents cite paths and snippets, not model improvisation.',
+        tools: ['memory_recall', 'knowledge_search_onyx', 'audit'],
+      },
+      {
+        title: 'Privilege review queue',
+        body: 'Low-confidence privilege calls route to hitl_enqueue_label_studio; reviewer decisions append to the vault via memory_ingest with wikilinks to the matter file.',
+        tools: ['hitl_enqueue_label_studio', 'memory_ingest', 'audit'],
+      },
+    ],
+    compliance: [
+      'Attorney-client privilege redaction before archive and search',
+      'Ethical-wall and matter-scoping via planned vertical RLS',
+      'Immutable audit trails for agent actions on client documents',
+      'Self-hosted deployment keeps matter files on firm-controlled infrastructure',
+    ],
+    docsHref: 'https://docs.clawql.com/vision/modularization',
+    disclaimer:
+      'Legal workflows are planned — not legal advice. Privilege, ethical-wall, and e-discovery rules require qualified counsel and tenant configuration.',
+  },
+  {
+    slug: 'insurance',
+    name: 'Insurance',
+    headline: 'Claims and policy intelligence on one MCP surface.',
+    subheadline:
+      'The planned clawql-insurance vertical targets carriers, brokers, and MGAs: claim extraction, policy analysis, loss-run reconciliation, and fraud signals — with HIPAA/SOC2-friendly redaction and Merkle audit trails on the same gateway as lending and healthcare.',
+    packageName: 'clawql-insurance',
+    status: 'planned',
+    useCases: [
+      {
+        title: 'First notice of loss automation',
+        body: 'Agents parse FNOL packets and supporting photos through the IDP pipeline, extract_document returns grounded policy and claimant fields, and classify_document routes health vs P&C vs commercial lines.',
+      },
+      {
+        title: 'Loss run reconciliation',
+        body: 'loss_run_reconcile compares carrier statements against internal policy systems — search discovers the right API operations; execute runs validated calls without pasting multi-megabyte carrier specs.',
+      },
+      {
+        title: 'Fraud and coverage checks',
+        body: 'fraud_flag and coverage_check tools compose with memory_recall of prior claim patterns — cross-vertical recall stays explicit and permissioned via ATR claims.',
+      },
+    ],
+    examples: [
+      {
+        title: 'Claim packet → extract → adjudicate',
+        body: 'Docling parses adjuster reports; extract_document surfaces injury and policy limits; agents execute carrier APIs for reserve updates and post notify milestones to the claims Slack channel.',
+        tools: ['execute', 'extract_document', 'notify', 'audit'],
+      },
+      {
+        title: 'Policy endorsement review',
+        body: 'policy_analyze compares endorsement PDFs against master policy text indexed in Onyx; memory_ingest captures underwriter decisions for the next renewal cycle.',
+        tools: ['knowledge_search_onyx', 'memory_ingest', 'search'],
+      },
+      {
+        title: 'SIU referral on fraud signals',
+        body: 'fraud_flag raises a score; hitl_enqueue_label_studio routes high-risk claims to SIU; workflow suspends until review completes — same Argo HITL pattern as lending.',
+        tools: ['workflow', 'hitl_enqueue_label_studio', 'memory_recall'],
+      },
+    ],
+    compliance: [
+      'HIPAA and SOC2-oriented redaction paths in the IDP pipeline',
+      'Merkle audit trails for claim-processing provenance (modularization v2.1)',
+      'Dedicated managed hosting for carrier workload isolation',
+      '32-module security curriculum for SOC 2 evidence collection',
+    ],
+    docsHref: 'https://docs.clawql.com/security',
+    disclaimer:
+      'Insurance tools are planned — not underwriting or claims-handling advice. State filing and licensing requirements remain the carrier’s responsibility.',
+  },
+  {
+    slug: 'education',
+    name: 'Education',
+    headline: 'Faculty productivity and LMS-connected agents.',
+    subheadline:
+      'The planned clawql-education vertical connects Canvas, Moodle, and Blackboard with syllabus generation, rubric scaffolding, and progress analysis — course content and student data stay behind the same MCP gateway, audit, and vault policies as the rest of ClawQL.',
+    packageName: 'clawql-education',
+    status: 'planned',
+    useCases: [
+      {
+        title: 'Course content scaffolding',
+        body: 'syllabus_generate and content_scaffold produce draft outlines from department templates; faculty edit and memory_ingest approved versions so the next semester recalls institutional style guides.',
+      },
+      {
+        title: 'LMS sync without bespoke scripts',
+        body: 'lms_sync and search → execute against bundled LMS APIs publish assignments and rubrics — agents discover operationIds instead of pasting entire OpenAPI exports into chat.',
+      },
+      {
+        title: 'Adaptive learning signals',
+        body: 'progress_analyze aggregates anonymized outcomes; agents recall prior intervention notes from the vault when TAs pick up mid-semester without full handoff meetings.',
+      },
+    ],
+    examples: [
+      {
+        title: 'Syllabus → Canvas publish',
+        body: 'Agent drafts syllabus sections, ingests the approved version to the vault, searches Canvas REST operations, and executes course-module creates with validated args.',
+        tools: ['memory_ingest', 'search', 'execute'],
+      },
+      {
+        title: 'Rubric generation with HITL',
+        body: 'rubric_create proposes criteria; instructor reviews in Label Studio via hitl_enqueue_label_studio; finalized rubric syncs through lms_sync.',
+        tools: ['hitl_enqueue_label_studio', 'execute', 'audit'],
+      },
+      {
+        title: 'Cross-semester recall',
+        body: 'memory_recall surfaces prior course postmortems and accommodation notes — a new TA thread inherits department context without copying last year’s chat logs.',
+        tools: ['memory_recall', 'memory_ingest', 'cache'],
+      },
+    ],
+    compliance: [
+      'FERPA-aware handling — student PII redacted before vault persistence',
+      'Self-hosted option for institutions that cannot send LMS data to third-party SaaS',
+      'Role-scoped ATR for faculty vs student-facing agent tools (planned)',
+      'Audit breadcrumbs for agent-published gradebook or content changes',
+    ],
+    docsHref: 'https://docs.clawql.com/vision/modularization',
+    disclaimer:
+      'Education vertical tools are planned — not academic policy advice. FERPA, accessibility, and institutional review requirements vary by jurisdiction and school.',
+  },
 ] as const
 
 export const industriesBySlug = Object.fromEntries(industries.map((industry) => [industry.slug, industry])) as Record<


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Legal**, **Insurance**, and **Education** industry pages to clawql.com — extending the Industries dropdown and footer from PR #487.

## New routes

| Route | Package (modularization v2.1) |
| ----- | ----------------------------- |
| `/industries/legal` | `clawql-legal` — privilege-aware due diligence, precedent search |
| `/industries/insurance` | `clawql-insurance` — claims, policy analysis, fraud signals |
| `/industries/education` | `clawql-education` — LMS sync, syllabus/rubric scaffolding |

Each page follows the same structure as lending/healthcare: use cases, MCP workflow examples, compliance notes, and disclaimers.

## Navigation

- Industries dropdown auto-includes all six verticals (data-driven from `industries.ts`)
- Footer Industries section updated with Legal, Insurance, Education links

## Verification

- `npm run build` in `landing-page/demo` — 16 static routes export successfully

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f269b-2a41-70f3-b7b6-2db2140b0d45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f269b-2a41-70f3-b7b6-2db2140b0d45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

