### PR TITLE
feat(landing): competitive pricing landscape + GTM tiers

### DIFF
--- a/landing-page/demo/src/app/about/page.tsx
+++ b/landing-page/demo/src/app/about/page.tsx
@@ -53,8 +53,8 @@ export default function Page() {
           <div className="rounded-xl bg-mist-950/2.5 p-6 dark:bg-white/5">
             <h3 className="font-semibold text-mist-950 dark:text-white">Early access, founder-led</h3>
             <p className="mt-2">
-              Managed hosting is in early access — onboarding the first Dedicated and Shared tenants with founder-led
-              setup, not a self-serve checkout. The open-source core is production-ready today; hosted slots are limited
+              Managed hosting is in early access — onboarding the first Professional and shared-tenancy tenants with
+              founder-led setup, not a self-serve checkout. The open-source core is production-ready today; hosted slots are limited
               while we validate pipeline reliability under real workloads.
             </p>
           </div>

--- a/landing-page/demo/src/app/page.tsx
+++ b/landing-page/demo/src/app/page.tsx
@@ -202,8 +202,8 @@ export default function Page() {
         />
         <Faq
           id="faq-2"
-          question="What's the difference between Starter, Business, and Dedicated?"
-          answer="Starter ($149/mo) and Business ($299/mo) are shared multi-tenant plans with 5,000 and 25,000 documents/month respectively. Dedicated ($599/mo) gives your organization an isolated namespace with unlimited documents and 99.9% uptime SLA. All managed tiers are in early access — join the waitlist for founder-led onboarding."
+          question="What's the difference between Starter, Business, and Professional?"
+          answer={`Starter (${pricing.starter.monthlyPrice}/mo) and Business (${pricing.business.monthlyPrice}/mo) are shared multi-tenant plans with 5,000 and 25,000 documents/month respectively. Professional (${pricing.professional.monthlyPrice}/mo) gives your organization a dedicated namespace, one vertical fine-tune adapter, SSO/SAML, and 99.9% uptime SLA. All managed tiers are in early access — join the waitlist for founder-led onboarding.`}
         />
         <Faq
           id="faq-3"
@@ -213,12 +213,12 @@ export default function Page() {
         <Faq
           id="faq-4"
           question="Do you offer enterprise contracts?"
-          answer="Yes — for very high volume, custom SLAs, and on-call support. We don't list a fixed enterprise price; contracts are scoped individually and typically start around $3,000/month. Contact sales to discuss."
+          answer={`Yes — Enterprise starts from ${pricing.enterprise.priceFrom}${pricing.enterprise.period} for dedicated nodes, custom fine-tuning, EU multi-region, DPA/BAA, and a dedicated CSM. Contact sales to scope annual terms.`}
         />
         <Faq
           id="faq-5"
           question="Is managed hosting available today?"
-          answer="Self-hosting is available now — npm, Helm, and the full open-source stack. Managed Free, Starter, Business, and Dedicated hosting is in early access: limited tenant slots, founder-led onboarding, and personal replies to waitlist signups."
+          answer="Self-hosting is available now — npm, Helm, and the full open-source stack. Managed Free, Starter, Business, Professional, and Enterprise hosting is in early access: limited tenant slots, founder-led onboarding, and personal replies to waitlist signups."
         />
         <Faq
           id="faq-6"
@@ -230,7 +230,7 @@ export default function Page() {
       {/* Pricing teaser — full grid on /pricing */}
       <PricingMultiTier
         id="pricing"
-        headline="Self-host free. Managed tiers from $149/mo — early access."
+        headline={`Self-host free. Managed tiers from ${pricing.starter.monthlyPrice}/mo — early access.`}
         subheadline={<p className="text-center text-sm/7 text-mist-600 dark:text-mist-400">{site.earlyAccess.pricingNote}</p>}
         plans={
           <>
@@ -273,12 +273,12 @@ export default function Page() {
               }
             />
             <Plan
-              name={pricing.dedicated.name}
-              price={pricing.dedicated.monthlyPrice}
-              period={pricing.dedicated.period}
-              subheadline={<p>{pricing.dedicated.subheadline}</p>}
-              badge={pricing.dedicated.badge}
-              features={pricing.dedicated.features.slice(0, 4)}
+              name={pricing.professional.name}
+              price={pricing.professional.monthlyPrice}
+              period={pricing.professional.period}
+              subheadline={<p>{pricing.professional.subheadline}</p>}
+              badge={pricing.professional.badge}
+              features={pricing.professional.features.slice(0, 4)}
               cta={
                 <PlainButtonLink href={site.urls.pricing} size="lg">
                   All tiers & limits <ArrowNarrowRightIcon />

--- a/landing-page/demo/src/app/page.tsx
+++ b/landing-page/demo/src/app/page.tsx
@@ -19,7 +19,7 @@ import { WorkflowFeedSection } from '@/components/sections/workflow-feed'
 import { idpPipelineStages, mcpToolTiers, multiProviderBenchmark } from '@/lib/marketing'
 import { securityEnforcementLayers, securityPillars } from '@/lib/security-marketing'
 import { workflowFeeds } from '@/lib/workflow-feeds'
-import { managedPrice, pricing } from '@/lib/pricing'
+import { pricing } from '@/lib/pricing'
 import { site } from '@/lib/site'
 
 export default function Page() {
@@ -202,8 +202,8 @@ export default function Page() {
         />
         <Faq
           id="faq-2"
-          question="What's the difference between shared and dedicated managed hosting?"
-          answer="Shared managed hosting is multi-tenant — cost-effective at $299/month ($250/month on annual billing) but may see reduced performance during bursts and is not fully isolated for strict compliance. Dedicated managed hosting runs on hardware for your organization only at $599/month ($500/month annual) — full isolation, no neighbor tenants. Both tiers are in early access with founder-led onboarding — join the waitlist for a slot."
+          question="What's the difference between Starter, Business, and Dedicated?"
+          answer="Starter ($149/mo) and Business ($299/mo) are shared multi-tenant plans with 5,000 and 25,000 documents/month respectively. Dedicated ($599/mo) gives your organization an isolated namespace with unlimited documents and 99.9% uptime SLA. All managed tiers are in early access — join the waitlist for founder-led onboarding."
         />
         <Faq
           id="faq-3"
@@ -218,7 +218,7 @@ export default function Page() {
         <Faq
           id="faq-5"
           question="Is managed hosting available today?"
-          answer="Self-hosting is available now — npm, Helm, and the full open-source stack. Managed Shared and Dedicated hosting is in early access: limited tenant slots, founder-led onboarding, and personal replies to waitlist signups. Join the waitlist or contact sales for Dedicated and Enterprise requirements."
+          answer="Self-hosting is available now — npm, Helm, and the full open-source stack. Managed Free, Starter, Business, and Dedicated hosting is in early access: limited tenant slots, founder-led onboarding, and personal replies to waitlist signups."
         />
         <Faq
           id="faq-6"
@@ -227,10 +227,10 @@ export default function Page() {
         />
       </FAQsTwoColumnAccordion>
 
-      {/* Pricing */}
+      {/* Pricing teaser — full grid on /pricing */}
       <PricingMultiTier
         id="pricing"
-        headline="Self-host free today. Managed hosting — early access waitlist."
+        headline="Self-host free. Managed tiers from $149/mo — early access."
         subheadline={<p className="text-center text-sm/7 text-mist-600 dark:text-mist-400">{site.earlyAccess.pricingNote}</p>}
         plans={
           <>
@@ -239,7 +239,7 @@ export default function Page() {
               price={pricing.selfHosted.price}
               period={pricing.selfHosted.period}
               subheadline={<p>{pricing.selfHosted.subheadline}</p>}
-              features={[...pricing.selfHosted.features]}
+              features={pricing.selfHosted.features.slice(0, 4)}
               cta={
                 <ButtonLink href={`${site.urls.docs}/readme/getting-started`} size="lg">
                   Quick start
@@ -247,12 +247,25 @@ export default function Page() {
               }
             />
             <Plan
-              name={pricing.shared.name}
-              price={managedPrice('shared', 'Monthly')}
-              period={pricing.shared.period}
-              subheadline={<p>{pricing.shared.subheadline}</p>}
-              badge={pricing.shared.badge}
-              features={[...pricing.shared.features]}
+              name={pricing.starter.name}
+              price={pricing.starter.monthlyPrice}
+              period={pricing.starter.period}
+              subheadline={<p>{pricing.starter.subheadline}</p>}
+              badge={pricing.starter.badge}
+              features={pricing.starter.features.slice(0, 4)}
+              cta={
+                <ButtonLink href={site.urls.signup} size="lg">
+                  Join early access
+                </ButtonLink>
+              }
+            />
+            <Plan
+              name={pricing.business.name}
+              price={pricing.business.monthlyPrice}
+              period={pricing.business.period}
+              subheadline={<p>{pricing.business.subheadline}</p>}
+              badge={pricing.business.badge}
+              features={pricing.business.features.slice(0, 4)}
               cta={
                 <ButtonLink href={site.urls.signup} size="lg">
                   Join early access
@@ -261,15 +274,15 @@ export default function Page() {
             />
             <Plan
               name={pricing.dedicated.name}
-              price={managedPrice('dedicated', 'Monthly')}
+              price={pricing.dedicated.monthlyPrice}
               period={pricing.dedicated.period}
               subheadline={<p>{pricing.dedicated.subheadline}</p>}
               badge={pricing.dedicated.badge}
-              features={[...pricing.dedicated.features]}
+              features={pricing.dedicated.features.slice(0, 4)}
               cta={
-                <ButtonLink href={site.urls.signup} size="lg">
-                  Join early access
-                </ButtonLink>
+                <PlainButtonLink href={site.urls.pricing} size="lg">
+                  All tiers & limits <ArrowNarrowRightIcon />
+                </PlainButtonLink>
               }
             />
           </>

--- a/landing-page/demo/src/app/pricing/page.tsx
+++ b/landing-page/demo/src/app/pricing/page.tsx
@@ -5,44 +5,64 @@ import { FAQsAccordion, Faq } from '@/components/sections/faqs-accordion'
 import { PlanComparisonTable } from '@/components/sections/plan-comparison-table'
 import { Plan, PricingHeroMultiTier } from '@/components/sections/pricing-hero-multi-tier'
 import { Section } from '@/components/elements/section'
-import { managedPrice, annualBillingSavingsLabel, pricing, pricingPlanNames, type BillingPeriod } from '@/lib/pricing'
+import {
+  annualBillingNoteText,
+  annualBillingSavingsLabel,
+  managedPrice,
+  pricing,
+  pricingPlanNames,
+  type BillingPeriod,
+} from '@/lib/pricing'
 import { site } from '@/lib/site'
 
-function plans(billing: BillingPeriod) {
-  const annualNote =
-    billing === 'Yearly' ? (
-      <span className="block text-mist-500">
-        {' '}
-        Billed annually ($3,000/yr shared · $6,000/yr dedicated) — {annualBillingSavingsLabel} vs monthly billing.
-      </span>
-    ) : null
+function managedPlans(billing: BillingPeriod) {
+  const annualNote = annualBillingNoteText(billing)
 
   return (
     <>
       <Plan
-        name={pricing.selfHosted.name}
-        price={pricing.selfHosted.price}
-        period={pricing.selfHosted.period}
-        subheadline={<p>{pricing.selfHosted.subheadline}</p>}
-        features={[...pricing.selfHosted.features]}
+        name={pricing.managedFree.name}
+        price={pricing.managedFree.monthlyPrice}
+        period={pricing.managedFree.period}
+        subheadline={<p>{pricing.managedFree.subheadline}</p>}
+        badge={pricing.managedFree.badge}
+        features={[...pricing.managedFree.features]}
         cta={
-          <ButtonLink href={`${site.urls.docs}/readme/getting-started`} size="lg">
-            Quick start
+          <ButtonLink href={site.urls.signup} size="lg">
+            Join early access
           </ButtonLink>
         }
       />
       <Plan
-        name={pricing.shared.name}
-        price={managedPrice('shared', billing)}
-        period={pricing.shared.period}
+        name={pricing.starter.name}
+        price={managedPrice('starter', billing)}
+        period={pricing.starter.period}
         subheadline={
           <p>
-            {pricing.shared.subheadline}
-            {annualNote}
+            {pricing.starter.subheadline}
+            {annualNote ? <span className="block text-mist-500">{annualNote}</span> : null}
           </p>
         }
-        badge={pricing.shared.badge}
-        features={[...pricing.shared.features]}
+        badge={pricing.starter.badge}
+        features={[...pricing.starter.features]}
+        cta={
+          <ButtonLink href={site.urls.signup} size="lg">
+            Join early access
+          </ButtonLink>
+        }
+      />
+      <Plan
+        name={pricing.business.name}
+        price={managedPrice('business', billing)}
+        period={pricing.business.period}
+        subheadline={
+          <p>
+            {pricing.business.subheadline}
+            {annualNote ? <span className="block text-mist-500">{annualNote}</span> : null}
+          </p>
+        }
+        badge={pricing.business.badge}
+        features={[...pricing.business.features]}
         cta={
           <ButtonLink href={site.urls.signup} size="lg">
             Join early access
@@ -56,7 +76,7 @@ function plans(billing: BillingPeriod) {
         subheadline={
           <p>
             {pricing.dedicated.subheadline}
-            {annualNote}
+            {annualNote ? <span className="block text-mist-500">{annualNote}</span> : null}
           </p>
         }
         badge={pricing.dedicated.badge}
@@ -78,18 +98,34 @@ export const metadata = {
 export default function Page() {
   return (
     <>
+      <Section id="self-hosted" eyebrow="Open source" headline="Self-host free on your hardware">
+        <div className="flex flex-col gap-6 rounded-xl bg-mist-950/2.5 p-6 sm:flex-row sm:items-center sm:justify-between dark:bg-white/5">
+          <div className="max-w-2xl">
+            <p className="text-sm/7 text-mist-700 dark:text-mist-400">{pricing.selfHosted.subheadline}</p>
+            <ul className="mt-4 space-y-1 text-sm/7 text-mist-600 dark:text-mist-500">
+              {pricing.selfHosted.features.map((feature) => (
+                <li key={feature}>· {feature}</li>
+              ))}
+            </ul>
+          </div>
+          <ButtonLink href={`${site.urls.docs}/readme/getting-started`} size="lg" className="shrink-0">
+            Quick start
+          </ButtonLink>
+        </div>
+      </Section>
+
       <PricingHeroMultiTier
         id="pricing"
-        headline="Pricing"
+        headline="Managed hosting"
         subheadline={
           <p>
-            {site.earlyAccess.summary} Self-host the full stack free on your hardware today. Shared and dedicated
-            managed tiers are in early access — join the waitlist for founder-led onboarding.
+            {site.earlyAccess.summary} Document volume and storage limits apply per tier; storage overage billed at
+            $0.02/GB on Starter and Business ($0.015/GB pass-through on Dedicated).
           </p>
         }
         options={['Monthly', 'Yearly']}
         annualSavingsLabel={annualBillingSavingsLabel}
-        plans={{ Monthly: plans('Monthly'), Yearly: plans('Yearly') }}
+        plans={{ Monthly: managedPlans('Monthly'), Yearly: managedPlans('Yearly') }}
       />
 
       <Section id="early-access" eyebrow="Early access" headline="Managed hosting is onboarding its first tenants">
@@ -102,48 +138,125 @@ export default function Page() {
         plans={[...pricingPlanNames]}
         features={[
           {
-            title: 'Hosting model',
+            title: 'Usage & storage',
             features: [
-              { name: 'Your own hardware', value: { 'Self-hosted': true, Shared: false, Dedicated: false } },
               {
-                name: 'Multi-tenant shared infra',
-                value: { 'Self-hosted': false, Shared: true, Dedicated: false },
+                name: 'Documents / month',
+                value: {
+                  'Self-hosted': 'Unlimited (your infra)',
+                  Free: '500',
+                  Starter: '5,000',
+                  Business: '25,000',
+                  Dedicated: 'Unlimited',
+                },
               },
               {
-                name: 'Dedicated hardware (single-tenant)',
-                value: { 'Self-hosted': false, Shared: false, Dedicated: true },
+                name: 'Users',
+                value: {
+                  'Self-hosted': 'Unlimited',
+                  Free: '1',
+                  Starter: '5',
+                  Business: '25',
+                  Dedicated: 'Unlimited',
+                },
               },
               {
-                name: 'Full isolation for compliance',
-                value: { 'Self-hosted': true, Shared: false, Dedicated: true },
+                name: 'Storage included',
+                value: {
+                  'Self-hosted': 'Your choice',
+                  Free: '5 GB',
+                  Starter: '50 GB',
+                  Business: '500 GB',
+                  Dedicated: '1 TB',
+                },
+              },
+              {
+                name: 'Storage overage',
+                value: {
+                  'Self-hosted': 'N/A',
+                  Free: 'N/A',
+                  Starter: '$0.02/GB',
+                  Business: '$0.02/GB',
+                  Dedicated: '$0.015/GB',
+                },
               },
             ],
           },
           {
-            title: 'Core MCP',
+            title: 'Document intelligence',
             features: [
-              { name: 'search & execute', value: true },
-              { name: 'audit & cache', value: true },
-              { name: 'Bundled providers', value: true },
-              { name: 'Stdio MCP', value: true },
               {
-                name: 'Hosted HTTP MCP',
-                value: { 'Self-hosted': false, Shared: true, Dedicated: true },
+                name: 'Coneshare VDR',
+                value: {
+                  'Self-hosted': 'Self-deploy optional',
+                  Free: false,
+                  Starter: true,
+                  Business: true,
+                  Dedicated: 'Full + analytics',
+                },
               },
-            ],
-          },
-          {
-            title: 'IDP document pipeline',
-            features: [
-              { name: 'Eight bundled vendors', value: true },
-              { name: 'run_idp_pipeline', value: true },
-              { name: 'classify_document', value: true },
-              { name: 'extract_document', value: true },
+              {
+                name: 'Onyx semantic search',
+                value: {
+                  'Self-hosted': 'Self-managed',
+                  Free: 'Basic',
+                  Starter: 'Full',
+                  Business: 'Full',
+                  Dedicated: 'Full',
+                },
+              },
+              {
+                name: 'Processing priority',
+                value: {
+                  'Self-hosted': '—',
+                  Free: 'Low',
+                  Starter: 'Standard',
+                  Business: 'Priority',
+                  Dedicated: 'Priority',
+                },
+              },
               {
                 name: 'ClawQL Archive Layer (managed)',
                 value: {
                   'Self-hosted': 'Paperless-ngx optional',
-                  Shared: true,
+                  Free: true,
+                  Starter: true,
+                  Business: true,
+                  Dedicated: true,
+                },
+              },
+            ],
+          },
+          {
+            title: 'Platform',
+            features: [
+              {
+                name: 'Hosted HTTP MCP',
+                value: {
+                  'Self-hosted': false,
+                  Free: true,
+                  Starter: true,
+                  Business: true,
+                  Dedicated: true,
+                },
+              },
+              {
+                name: 'Tenant isolation',
+                value: {
+                  'Self-hosted': 'Your hardware',
+                  Free: 'Shared',
+                  Starter: 'Shared',
+                  Business: 'Shared',
+                  Dedicated: 'Dedicated namespace',
+                },
+              },
+              {
+                name: 'Sovereign inference (no external LLM APIs)',
+                value: {
+                  'Self-hosted': 'Your deployment',
+                  Free: true,
+                  Starter: true,
+                  Business: true,
                   Dedicated: true,
                 },
               },
@@ -151,37 +264,36 @@ export default function Page() {
                 name: 'hitl_enqueue_label_studio',
                 value: {
                   'Self-hosted': 'Self-deploy Label Studio',
-                  Shared: false,
+                  Free: false,
+                  Starter: false,
+                  Business: false,
                   Dedicated: false,
                 },
               },
             ],
           },
           {
-            title: 'Memory & knowledge',
+            title: 'Support & SLA',
             features: [
               {
-                name: 'Vault memory (memory_recall)',
-                value: { 'Self-hosted': 'Self-managed', Shared: true, Dedicated: true },
-              },
-              { name: 'Document ingest', value: true },
-              {
-                name: 'Onyx enterprise search',
-                value: { 'Self-hosted': 'Self-managed', Shared: true, Dedicated: true },
-              },
-            ],
-          },
-          {
-            title: 'Support',
-            features: [
-              { name: 'Community support', value: { 'Self-hosted': true, Shared: true, Dedicated: true } },
-              {
-                name: 'Email support',
-                value: { 'Self-hosted': false, Shared: true, Dedicated: 'Priority' },
+                name: 'SLA',
+                value: {
+                  'Self-hosted': '—',
+                  Free: 'None',
+                  Starter: '99% uptime',
+                  Business: '99.5% uptime',
+                  Dedicated: '99.9% uptime',
+                },
               },
               {
-                name: 'SSO / RBAC',
-                value: { 'Self-hosted': false, Shared: false, Dedicated: true },
+                name: 'Support',
+                value: {
+                  'Self-hosted': 'Community',
+                  Free: 'Community',
+                  Starter: 'Email (48 hr)',
+                  Business: 'Email (24 hr)',
+                  Dedicated: 'Priority + Slack',
+                },
               },
             ],
           },
@@ -191,8 +303,13 @@ export default function Page() {
       <Section
         id="enterprise"
         eyebrow="Enterprise"
-        headline="High volume, custom SLAs, and on-call support"
-        subheadline={<p>{pricing.enterprise.subheadline} Enterprise includes managed HITL via hitl_enqueue_label_studio.</p>}
+        headline="Custom contracts for SSO, EU residency, and on-call support"
+        subheadline={
+          <p>
+            {pricing.enterprise.subheadline} Enterprise adds managed HITL via hitl_enqueue_label_studio, dedicated CSM,
+            and custom SLAs beyond the $599/mo Dedicated tier.
+          </p>
+        }
       >
         <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
           {pricing.enterprise.features.map((feature) => (
@@ -213,29 +330,39 @@ export default function Page() {
         <Faq
           id="faq-1"
           question="Is self-hosted really free?"
-          answer="Yes. ClawQL is open source. You pay only for the compute and storage on your own hardware. All core MCP tools are included with no license fee."
+          answer="Yes. ClawQL is open source. You pay only for compute and storage on your hardware. All core MCP tools and the full IDP pipeline are included with no license fee."
         />
         <Faq
           id="faq-2"
-          question="What's the difference between shared and dedicated managed hosting?"
-          answer="Shared managed hosting is multi-tenant — your workload runs alongside other customers on the same infrastructure. It's more affordable but may see reduced performance during burst periods and does not provide complete isolation if regulators or compliance require it. Dedicated managed hosting deploys onto hardware reserved for your organization only — no other customers, full isolation."
+          question="What's the difference between Starter, Business, and Dedicated?"
+          answer="Starter ($149/mo) and Business ($299/mo) run on shared multi-tenant infrastructure with document volume limits (5,000 and 25,000 documents/month). Dedicated ($599/mo) gives your organization a dedicated namespace with full resource allocation, unlimited documents, and 99.9% uptime SLA. All managed tiers are in early access with founder-led onboarding."
         />
         <Faq
           id="faq-3"
-          question="Can I switch from shared to dedicated later?"
-          answer="Yes. Vault exports, provider auth, and pipeline configuration can migrate between tiers. Contact us when your compliance or performance requirements outgrow shared hosting."
+          question="What is the managed Free tier?"
+          answer="Free ($0/mo) lets you process up to 500 documents/month on hosted infrastructure with basic Onyx search — a way to try the real pipeline before upgrading to Starter for Coneshare VDR and higher limits. It is not the same as self-hosting, which has no document cap enforced by ClawQL."
         />
         <Faq
           id="faq-4"
+          question="Can I switch tiers later?"
+          answer="Yes. Vault exports, provider auth, and pipeline configuration can migrate between tiers. Upgrade when you hit document quotas or need Dedicated isolation for compliance."
+        />
+        <Faq
+          id="faq-5"
           question="Do you publish enterprise pricing?"
-          answer="Enterprise contracts are custom-scoped for very high volume, dedicated SLAs, and on-call support. We don't list a fixed price — engagements typically start around $3,000/month depending on requirements. Contact sales to discuss."
+          answer="Enterprise contracts are custom-scoped for SSO/SAML, EU data residency, on-call support, and very high volume. Contact sales to discuss annual terms."
         />
       </FAQsAccordion>
 
       <CallToActionSimpleCentered
         id="call-to-action"
-        headline="Start free or join early access"
-        subheadline={<p>Install clawql-mcp on your hardware, or join the waitlist for managed Shared and Dedicated hosting.</p>}
+        headline="Self-host free or join early access"
+        subheadline={
+          <p>
+            Install clawql-mcp on your hardware, or join the waitlist for managed Free, Starter, Business, or Dedicated
+            hosting.
+          </p>
+        }
         cta={
           <div className="flex items-center gap-4">
             <ButtonLink href={site.urls.signup} size="lg">

--- a/landing-page/demo/src/app/pricing/page.tsx
+++ b/landing-page/demo/src/app/pricing/page.tsx
@@ -1,5 +1,6 @@
 import { ButtonLink, PlainButtonLink } from '@/components/elements/button'
 import { ChevronIcon } from '@/components/icons/chevron-icon'
+import { CompetitivePricingSection } from '@/components/sections/competitive-pricing-section'
 import { CallToActionSimpleCentered } from '@/components/sections/call-to-action-simple-centered'
 import { FAQsAccordion, Faq } from '@/components/sections/faqs-accordion'
 import { PlanComparisonTable } from '@/components/sections/plan-comparison-table'
@@ -133,6 +134,8 @@ export default function Page() {
         <p className="mt-4 max-w-3xl text-sm/7 text-mist-600 dark:text-mist-500">{site.waitlistPromise}</p>
       </Section>
 
+      <CompetitivePricingSection />
+
       <PlanComparisonTable
         id="pricing-compare"
         plans={[...pricingPlanNames]}
@@ -251,23 +254,37 @@ export default function Page() {
                 },
               },
               {
+                name: 'Merkle cryptographic audit trail',
+                value: true,
+              },
+              {
                 name: 'Sovereign inference (no external LLM APIs)',
                 value: {
                   'Self-hosted': 'Your deployment',
-                  Free: true,
+                  Free: false,
                   Starter: true,
                   Business: true,
                   Dedicated: true,
                 },
               },
               {
-                name: 'hitl_enqueue_label_studio',
+                name: 'HITL review (Label Studio)',
                 value: {
-                  'Self-hosted': 'Self-deploy Label Studio',
+                  'Self-hosted': 'Self-deploy',
                   Free: false,
-                  Starter: false,
-                  Business: false,
-                  Dedicated: false,
+                  Starter: true,
+                  Business: true,
+                  Dedicated: true,
+                },
+              },
+              {
+                name: 'Pre-trained document skill library',
+                value: {
+                  'Self-hosted': 'Vertical adapters',
+                  Free: 'Vertical adapters',
+                  Starter: 'Vertical adapters',
+                  Business: 'Vertical adapters',
+                  Dedicated: 'Vertical adapters',
                 },
               },
             ],
@@ -295,6 +312,16 @@ export default function Page() {
                   Dedicated: 'Priority + Slack',
                 },
               },
+              {
+                name: 'SSO / SAML',
+                value: {
+                  'Self-hosted': false,
+                  Free: false,
+                  Starter: false,
+                  Business: false,
+                  Dedicated: true,
+                },
+              },
             ],
           },
         ]}
@@ -306,8 +333,8 @@ export default function Page() {
         headline="Custom contracts for SSO, EU residency, and on-call support"
         subheadline={
           <p>
-            {pricing.enterprise.subheadline} Enterprise adds managed HITL via hitl_enqueue_label_studio, dedicated CSM,
-            and custom SLAs beyond the $599/mo Dedicated tier.
+            {pricing.enterprise.subheadline} Enterprise adds multi-reviewer HITL RBAC, dedicated CSM, and custom SLAs
+            beyond the $599/mo Dedicated tier.
           </p>
         }
       >
@@ -349,6 +376,21 @@ export default function Page() {
         />
         <Faq
           id="faq-5"
+          question="How does ClawQL pricing compare to Hyperscience or ABBYY?"
+          answer="Incumbent IDP vendors often charge per page ($0.02–$1.50+) or $40K–$100K+/year in enterprise contracts. A Business customer processing 25,000 documents/month at ~5 pages each would pay tens of thousands per month at per-page IDP rates. ClawQL Business is $299/month flat with IDP, VDR, semantic search, and agent orchestration bundled — see the competitive section above for illustrative TCO math."
+        />
+        <Faq
+          id="faq-6"
+          question="Why is ClawQL so much cheaper than legacy VDR tools?"
+          answer="Intralinks, Datasite, and similar vendors price per deal, per page, or $10K–$200K+/year with storage overages and setup fees. Starter at $149/month includes Coneshare VDR in the subscription. The trade-off: we are early-stage with founder-led onboarding, not a decades-old vendor with a global services army."
+        />
+        <Faq
+          id="faq-7"
+          question="Do you match ABBYY's pre-trained document skills?"
+          answer="Not on day one. ABBYY Vantage ships 150+ pre-built skills for common document types. ClawQL composes classify, extract, and HITL per vertical — lending W-2 samples ship today; broader skill libraries build with vertical packages. We state this openly in competitive evaluations rather than overclaiming."
+        />
+        <Faq
+          id="faq-8"
           question="Do you publish enterprise pricing?"
           answer="Enterprise contracts are custom-scoped for SSO/SAML, EU data residency, on-call support, and very high volume. Contact sales to discuss annual terms."
         />

--- a/landing-page/demo/src/app/pricing/page.tsx
+++ b/landing-page/demo/src/app/pricing/page.tsx
@@ -12,6 +12,7 @@ import {
   managedPrice,
   pricing,
   pricingPlanNames,
+  sovereignSecurityPack,
   type BillingPeriod,
 } from '@/lib/pricing'
 import { site } from '@/lib/site'
@@ -71,17 +72,17 @@ function managedPlans(billing: BillingPeriod) {
         }
       />
       <Plan
-        name={pricing.dedicated.name}
-        price={managedPrice('dedicated', billing)}
-        period={pricing.dedicated.period}
+        name={pricing.professional.name}
+        price={managedPrice('professional', billing)}
+        period={pricing.professional.period}
         subheadline={
           <p>
-            {pricing.dedicated.subheadline}
+            {pricing.professional.subheadline}
             {annualNote ? <span className="block text-mist-500">{annualNote}</span> : null}
           </p>
         }
-        badge={pricing.dedicated.badge}
-        features={[...pricing.dedicated.features]}
+        badge={pricing.professional.badge}
+        features={[...pricing.professional.features]}
         cta={
           <ButtonLink href={site.urls.signup} size="lg">
             Join early access
@@ -121,7 +122,7 @@ export default function Page() {
         subheadline={
           <p>
             {site.earlyAccess.summary} Document volume and storage limits apply per tier; storage overage billed at
-            $0.02/GB on Starter and Business ($0.015/GB pass-through on Dedicated).
+            $0.02/GB on Starter and Business, $0.015/GB pass-through on Professional.
           </p>
         }
         options={['Monthly', 'Yearly']}
@@ -147,10 +148,10 @@ export default function Page() {
                 name: 'Documents / month',
                 value: {
                   'Self-hosted': 'Unlimited (your infra)',
-                  Free: '500',
+                  Free: '200',
                   Starter: '5,000',
                   Business: '25,000',
-                  Dedicated: 'Unlimited',
+                  Professional: '75,000',
                 },
               },
               {
@@ -160,7 +161,7 @@ export default function Page() {
                   Free: '1',
                   Starter: '5',
                   Business: '25',
-                  Dedicated: 'Unlimited',
+                  Professional: 'Unlimited',
                 },
               },
               {
@@ -170,7 +171,7 @@ export default function Page() {
                   Free: '5 GB',
                   Starter: '50 GB',
                   Business: '500 GB',
-                  Dedicated: '1 TB',
+                  Professional: '2 TB',
                 },
               },
               {
@@ -180,7 +181,7 @@ export default function Page() {
                   Free: 'N/A',
                   Starter: '$0.02/GB',
                   Business: '$0.02/GB',
-                  Dedicated: '$0.015/GB',
+                  Professional: '$0.015/GB',
                 },
               },
             ],
@@ -195,7 +196,7 @@ export default function Page() {
                   Free: false,
                   Starter: true,
                   Business: true,
-                  Dedicated: 'Full + analytics',
+                  Professional: 'Full + advanced analytics',
                 },
               },
               {
@@ -204,8 +205,8 @@ export default function Page() {
                   'Self-hosted': 'Self-managed',
                   Free: 'Basic',
                   Starter: 'Full',
-                  Business: 'Full',
-                  Dedicated: 'Full',
+                  Business: 'Full + cross-doc',
+                  Professional: 'Full + cross-doc',
                 },
               },
               {
@@ -215,7 +216,27 @@ export default function Page() {
                   Free: 'Low',
                   Starter: 'Standard',
                   Business: 'Priority',
-                  Dedicated: 'Priority',
+                  Professional: 'Dedicated queue',
+                },
+              },
+              {
+                name: 'Obsidian memory vault',
+                value: {
+                  'Self-hosted': 'Self-managed',
+                  Free: false,
+                  Starter: true,
+                  Business: true,
+                  Professional: true,
+                },
+              },
+              {
+                name: 'Dynamic watermarking (VDR)',
+                value: {
+                  'Self-hosted': 'Self-deploy optional',
+                  Free: false,
+                  Starter: true,
+                  Business: true,
+                  Professional: true,
                 },
               },
               {
@@ -225,7 +246,7 @@ export default function Page() {
                   Free: true,
                   Starter: true,
                   Business: true,
-                  Dedicated: true,
+                  Professional: true,
                 },
               },
             ],
@@ -240,7 +261,7 @@ export default function Page() {
                   Free: true,
                   Starter: true,
                   Business: true,
-                  Dedicated: true,
+                  Professional: true,
                 },
               },
               {
@@ -250,7 +271,7 @@ export default function Page() {
                   Free: 'Shared',
                   Starter: 'Shared',
                   Business: 'Shared',
-                  Dedicated: 'Dedicated namespace',
+                  Professional: 'Dedicated namespace',
                 },
               },
               {
@@ -264,7 +285,7 @@ export default function Page() {
                   Free: false,
                   Starter: true,
                   Business: true,
-                  Dedicated: true,
+                  Professional: true,
                 },
               },
               {
@@ -274,7 +295,7 @@ export default function Page() {
                   Free: false,
                   Starter: true,
                   Business: true,
-                  Dedicated: true,
+                  Professional: true,
                 },
               },
               {
@@ -284,7 +305,7 @@ export default function Page() {
                   Free: 'Vertical adapters',
                   Starter: 'Vertical adapters',
                   Business: 'Vertical adapters',
-                  Dedicated: 'Vertical adapters',
+                  Professional: 'One vertical fine-tune included',
                 },
               },
             ],
@@ -299,7 +320,7 @@ export default function Page() {
                   Free: 'None',
                   Starter: '99% uptime',
                   Business: '99.5% uptime',
-                  Dedicated: '99.9% uptime',
+                  Professional: '99.9% uptime',
                 },
               },
               {
@@ -309,7 +330,7 @@ export default function Page() {
                   Free: 'Community',
                   Starter: 'Email (48 hr)',
                   Business: 'Email (24 hr)',
-                  Dedicated: 'Priority + Slack',
+                  Professional: 'Slack Connect + email',
                 },
               },
               {
@@ -319,7 +340,7 @@ export default function Page() {
                   Free: false,
                   Starter: false,
                   Business: false,
-                  Dedicated: true,
+                  Professional: true,
                 },
               },
             ],
@@ -328,13 +349,31 @@ export default function Page() {
       />
 
       <Section
+        id="sovereign-security-pack"
+        eyebrow="Add-on"
+        headline={`${sovereignSecurityPack.name} — ${sovereignSecurityPack.monthlyPrice}${sovereignSecurityPack.period}`}
+        subheadline={<p>{sovereignSecurityPack.subheadline}</p>}
+      >
+        <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {sovereignSecurityPack.features.map((feature) => (
+            <li
+              key={feature}
+              className="rounded-xl bg-mist-950/2.5 px-4 py-3 text-sm/7 text-mist-700 dark:bg-white/5 dark:text-mist-400"
+            >
+              {feature}
+            </li>
+          ))}
+        </ul>
+      </Section>
+
+      <Section
         id="enterprise"
         eyebrow="Enterprise"
-        headline="Custom contracts for SSO, EU residency, and on-call support"
+        headline={`Enterprise from ${pricing.enterprise.priceFrom}${pricing.enterprise.period}`}
         subheadline={
           <p>
-            {pricing.enterprise.subheadline} Enterprise adds multi-reviewer HITL RBAC, dedicated CSM, and custom SLAs
-            beyond the $599/mo Dedicated tier.
+            {pricing.enterprise.subheadline} Contact sales for annual terms, EU residency, and custom SLAs beyond
+            Professional.
           </p>
         }
       >
@@ -361,28 +400,28 @@ export default function Page() {
         />
         <Faq
           id="faq-2"
-          question="What's the difference between Starter, Business, and Dedicated?"
-          answer="Starter ($149/mo) and Business ($299/mo) run on shared multi-tenant infrastructure with document volume limits (5,000 and 25,000 documents/month). Dedicated ($599/mo) gives your organization a dedicated namespace with full resource allocation, unlimited documents, and 99.9% uptime SLA. All managed tiers are in early access with founder-led onboarding."
+          question="What's the difference between Starter, Business, and Professional?"
+          answer={`Starter (${pricing.starter.monthlyPrice}/mo) and Business (${pricing.business.monthlyPrice}/mo) run on shared multi-tenant infrastructure with document volume limits (5,000 and 25,000 documents/month). Professional (${pricing.professional.monthlyPrice}/mo) gives your organization a dedicated namespace, one vertical fine-tune adapter, SSO/SAML, and 99.9% uptime SLA. All managed tiers are in early access with founder-led onboarding.`}
         />
         <Faq
           id="faq-3"
           question="What is the managed Free tier?"
-          answer="Free ($0/mo) lets you process up to 500 documents/month on hosted infrastructure with basic Onyx search — a way to try the real pipeline before upgrading to Starter for Coneshare VDR and higher limits. It is not the same as self-hosting, which has no document cap enforced by ClawQL."
+          answer="Free ($0/mo) lets you process up to 200 documents/month on hosted infrastructure with basic Onyx search — a way to try the real pipeline before upgrading to Starter for Coneshare VDR, sovereign inference, and higher limits. It is not the same as self-hosting, which has no document cap enforced by ClawQL."
         />
         <Faq
           id="faq-4"
           question="Can I switch tiers later?"
-          answer="Yes. Vault exports, provider auth, and pipeline configuration can migrate between tiers. Upgrade when you hit document quotas or need Dedicated isolation for compliance."
+          answer="Yes. Vault exports, provider auth, and pipeline configuration can migrate between tiers. Upgrade when you hit document quotas or need Professional isolation and vertical fine-tuning for compliance."
         />
         <Faq
           id="faq-5"
           question="How does ClawQL pricing compare to Hyperscience or ABBYY?"
-          answer="Incumbent IDP vendors often charge per page ($0.02–$1.50+) or $40K–$100K+/year in enterprise contracts. A Business customer processing 25,000 documents/month at ~5 pages each would pay tens of thousands per month at per-page IDP rates. ClawQL Business is $299/month flat with IDP, VDR, semantic search, and agent orchestration bundled — see the competitive section above for illustrative TCO math."
+          answer={`Incumbent IDP vendors often charge per page ($0.02–$1.50+) or $40K–$100K+/year in enterprise contracts. A Business customer processing 25,000 documents/month at ~5 pages each would pay tens of thousands per month at per-page IDP rates. ClawQL Business is ${pricing.business.monthlyPrice}/month flat with IDP, VDR, semantic search, and agent orchestration bundled — see the competitive section above for illustrative TCO math.`}
         />
         <Faq
           id="faq-6"
-          question="Why is ClawQL so much cheaper than legacy VDR tools?"
-          answer="Intralinks, Datasite, and similar vendors price per deal, per page, or $10K–$200K+/year with storage overages and setup fees. Starter at $149/month includes Coneshare VDR in the subscription. The trade-off: we are early-stage with founder-led onboarding, not a decades-old vendor with a global services army."
+          question="Why is ClawQL priced below legacy VDR and IDP stacks?"
+          answer={`Intralinks, Datasite, and similar vendors price per deal, per page, or $10K–$200K+/year with storage overages and setup fees. Starter at ${pricing.starter.monthlyPrice}/month includes Coneshare VDR in the subscription. Pricing is anchored to replacement value — still 6–20× below the incumbent stack — while remaining credible to enterprise procurement teams.`}
         />
         <Faq
           id="faq-7"
@@ -391,8 +430,13 @@ export default function Page() {
         />
         <Faq
           id="faq-8"
+          question="What is the Sovereign Security Pack?"
+          answer={`The Sovereign Security Pack (${sovereignSecurityPack.monthlyPrice}${sovereignSecurityPack.period}) is an optional add-on on Starter, Business, and Professional. It bundles Kata VM isolation, model weight integrity verification, WORM Merkle audit logs, Panguard fail-closed ATR, and monthly posture reports. Enterprise includes it by default.`}
+        />
+        <Faq
+          id="faq-9"
           question="Do you publish enterprise pricing?"
-          answer="Enterprise contracts are custom-scoped for SSO/SAML, EU data residency, on-call support, and very high volume. Contact sales to discuss annual terms."
+          answer={`Enterprise contracts start from ${pricing.enterprise.priceFrom}${pricing.enterprise.period} for dedicated nodes, custom fine-tuning with retraining, EU multi-region, DPA/BAA, and a dedicated CSM. Contact sales to discuss annual terms.`}
         />
       </FAQsAccordion>
 
@@ -401,7 +445,7 @@ export default function Page() {
         headline="Self-host free or join early access"
         subheadline={
           <p>
-            Install clawql-mcp on your hardware, or join the waitlist for managed Free, Starter, Business, or Dedicated
+            Install clawql-mcp on your hardware, or join the waitlist for managed Free, Starter, Business, or Professional
             hosting.
           </p>
         }

--- a/landing-page/demo/src/app/signup/page.tsx
+++ b/landing-page/demo/src/app/signup/page.tsx
@@ -22,8 +22,8 @@ export default function Page() {
         headline="Join early access for managed ClawQL"
         subheadline={
           <p>
-            {site.earlyAccess.summary} Shared from $299/month ($250/month annual) or dedicated single-tenant from
-            $599/month ($500/month annual). {site.waitlistPromise}
+            {site.earlyAccess.summary} Managed Free ($0), Starter ($149/mo), Business ($299/mo), and Dedicated
+            ($599/mo) — join the waitlist for founder-led onboarding. {site.waitlistPromise}
           </p>
         }
         cta={<WaitlistSignupForm className="mx-auto" />}

--- a/landing-page/demo/src/app/signup/page.tsx
+++ b/landing-page/demo/src/app/signup/page.tsx
@@ -8,6 +8,7 @@ import { Feature, FeaturesThreeColumn } from '@/components/sections/features-thr
 import { HeroSimpleCentered } from '@/components/sections/hero-simple-centered'
 import { Section } from '@/components/elements/section'
 import { idpPipelineStages, mcpToolTiers } from '@/lib/marketing'
+import { pricing } from '@/lib/pricing'
 import { site } from '@/lib/site'
 
 export const metadata = {
@@ -22,8 +23,9 @@ export default function Page() {
         headline="Join early access for managed ClawQL"
         subheadline={
           <p>
-            {site.earlyAccess.summary} Managed Free ($0), Starter ($149/mo), Business ($299/mo), and Dedicated
-            ($599/mo) — join the waitlist for founder-led onboarding. {site.waitlistPromise}
+            {site.earlyAccess.summary} Managed Free ($0), Starter ({pricing.starter.monthlyPrice}/mo), Business (
+            {pricing.business.monthlyPrice}/mo), and Professional ({pricing.professional.monthlyPrice}/mo) — join the
+            waitlist for founder-led onboarding. {site.waitlistPromise}
           </p>
         }
         cta={<WaitlistSignupForm className="mx-auto" />}
@@ -113,7 +115,8 @@ export default function Page() {
       <section className="pb-24">
         <div className="mx-auto flex max-w-xl flex-col items-center gap-4 px-6 text-center">
           <p className="text-sm/7 text-mist-700 dark:text-mist-400">
-            Enterprise: custom SLAs, on-call support, and very high volume — typically from ~$3,000/month.{' '}
+            Enterprise: dedicated node, custom fine-tuning, EU multi-region — from {pricing.enterprise.priceFrom}
+            {pricing.enterprise.period}.{' '}
             <a href={site.urls.contact} className="underline">
               Contact sales
             </a>{' '}

--- a/landing-page/demo/src/components/sections/competitive-pricing-section.tsx
+++ b/landing-page/demo/src/components/sections/competitive-pricing-section.tsx
@@ -9,6 +9,7 @@ import {
   competitiveHeadline,
   competitiveHonestyNotes,
   competitiveSummary,
+  stackReplacementSummary,
   tcoBenchmarks,
 } from '@/lib/competitive-pricing'
 
@@ -39,7 +40,11 @@ export function CompetitivePricingSection({ className, ...props }: ComponentProp
         id="competitive"
         eyebrow="Competitive landscape"
         headline={competitiveHeadline}
-        subheadline={<p>{competitiveSummary}</p>}
+        subheadline={
+          <p>
+            {competitiveSummary}
+          </p>
+        }
       >
         <div className="grid grid-cols-1 gap-2 lg:grid-cols-3">
           {tcoBenchmarks.map((benchmark) => (
@@ -62,6 +67,31 @@ export function CompetitivePricingSection({ className, ...props }: ComponentProp
             </div>
           ))}
         </div>
+        <div className="mt-10 rounded-xl border border-mist-950/10 bg-mist-950/2.5 p-6 sm:p-8 dark:border-white/10 dark:bg-white/5">
+          <h3 className="text-xl font-semibold text-mist-950 dark:text-white">{stackReplacementSummary.headline}</h3>
+          <p className="mt-2 text-sm/7 text-mist-600 dark:text-mist-400">{stackReplacementSummary.profile}</p>
+          <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+              <p className="text-xs font-medium tracking-wide text-mist-500 uppercase">Incumbent stack</p>
+              <p className="mt-1 text-lg font-semibold text-mist-950 dark:text-white">
+                {stackReplacementSummary.incumbentRange}
+              </p>
+              <p className="mt-2 text-sm/7 text-mist-700 dark:text-mist-400">
+                {stackReplacementSummary.incumbentDetail}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-medium tracking-wide text-mist-500 uppercase">ClawQL Business</p>
+              <p className="mt-1 text-lg font-semibold text-mist-950 dark:text-white">
+                {stackReplacementSummary.clawqlBusiness}
+              </p>
+              <p className="mt-1 text-sm/7 text-mist-600 dark:text-mist-400">
+                Up to {stackReplacementSummary.clawqlBusinessMax}
+              </p>
+              <p className="mt-2 text-sm/7 text-mist-700 dark:text-mist-400">{stackReplacementSummary.savingsNote}</p>
+            </div>
+          </div>
+        </div>
         <p className="mt-6 text-xs/6 text-mist-500 dark:text-mist-400">
           Illustrative benchmarks from published competitor pricing bands (July 2026). Your volume and contract terms
           will differ — use these for order-of-magnitude comparison, not procurement quotes.
@@ -71,7 +101,7 @@ export function CompetitivePricingSection({ className, ...props }: ComponentProp
       <Section
         id="competitor-features"
         eyebrow="Feature comparison"
-        headline="ClawQL Business ($299/mo) vs IDP and VDR incumbents"
+        headline="ClawQL Business ($599/mo) vs IDP and VDR incumbents"
         subheadline={
           <p>
             Competitors typically sell IDP <em>or</em> VDR. ClawQL bundles both plus semantic search and MCP agent

--- a/landing-page/demo/src/components/sections/competitive-pricing-section.tsx
+++ b/landing-page/demo/src/components/sections/competitive-pricing-section.tsx
@@ -1,0 +1,140 @@
+import { clsx } from 'clsx/lite'
+import type { ComponentProps } from 'react'
+import { Section } from '../elements/section'
+import { CheckmarkIcon } from '../icons/checkmark-icon'
+import { MinusIcon } from '../icons/minus-icon'
+import {
+  competitorColumns,
+  competitorFeatureRows,
+  competitiveHeadline,
+  competitiveHonestyNotes,
+  competitiveSummary,
+  tcoBenchmarks,
+} from '@/lib/competitive-pricing'
+
+function CellValue({ value }: { value: string | boolean }) {
+  if (value === true) {
+    return (
+      <span className="inline-flex items-center justify-center gap-1.5 font-medium text-mist-950 dark:text-white">
+        <CheckmarkIcon aria-hidden className="stroke-mist-950 dark:stroke-white" />
+        <span>Included</span>
+      </span>
+    )
+  }
+  if (value === false) {
+    return (
+      <span className="inline-flex items-center justify-center gap-1.5 text-mist-500">
+        <MinusIcon aria-hidden className="stroke-mist-500" />
+        <span>—</span>
+      </span>
+    )
+  }
+  return <span>{value}</span>
+}
+
+export function CompetitivePricingSection({ className, ...props }: ComponentProps<'div'>) {
+  return (
+    <div className={clsx('flex flex-col gap-16', className)} {...props}>
+      <Section
+        id="competitive"
+        eyebrow="Competitive landscape"
+        headline={competitiveHeadline}
+        subheadline={<p>{competitiveSummary}</p>}
+      >
+        <div className="grid grid-cols-1 gap-2 lg:grid-cols-3">
+          {tcoBenchmarks.map((benchmark) => (
+            <div key={benchmark.label} className="flex flex-col gap-3 rounded-xl bg-mist-950/2.5 p-6 dark:bg-white/5">
+              <p className="text-xs font-medium tracking-wide text-mist-500 uppercase dark:text-mist-400">
+                {benchmark.label}
+              </p>
+              <p className="text-sm/7 text-mist-700 dark:text-mist-400">{benchmark.scenario}</p>
+              <div className="flex flex-col gap-1 text-sm/7">
+                <p>
+                  <span className="text-mist-500">Incumbent: </span>
+                  <span className="font-medium text-mist-950 dark:text-white">{benchmark.incumbent}</span>
+                </p>
+                <p>
+                  <span className="text-mist-500">ClawQL: </span>
+                  <span className="font-semibold text-mist-950 dark:text-white">{benchmark.clawql}</span>
+                </p>
+              </div>
+              <p className="text-xs/6 text-mist-500 dark:text-mist-400">{benchmark.note}</p>
+            </div>
+          ))}
+        </div>
+        <p className="mt-6 text-xs/6 text-mist-500 dark:text-mist-400">
+          Illustrative benchmarks from published competitor pricing bands (July 2026). Your volume and contract terms
+          will differ — use these for order-of-magnitude comparison, not procurement quotes.
+        </p>
+      </Section>
+
+      <Section
+        id="competitor-features"
+        eyebrow="Feature comparison"
+        headline="ClawQL Business ($299/mo) vs IDP and VDR incumbents"
+        subheadline={
+          <p>
+            Competitors typically sell IDP <em>or</em> VDR. ClawQL bundles both plus semantic search and MCP agent
+            orchestration. Compare at the Business tier — our mid-market managed plan.
+          </p>
+        }
+      >
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[720px] border-collapse text-left text-sm/5">
+            <thead>
+              <tr>
+                <th className="sticky top-(--scroll-padding-top) bg-mist-100 py-4 pr-4 font-medium text-mist-950 dark:bg-mist-950 dark:text-white">
+                  Feature
+                </th>
+                {competitorColumns.map((col) => (
+                  <th
+                    key={col}
+                    className="sticky top-(--scroll-padding-top) bg-mist-100 px-3 py-4 text-center font-semibold text-mist-950 dark:bg-mist-950 dark:text-white"
+                  >
+                    {col}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {competitorFeatureRows.map((row) => (
+                <tr key={row.feature} className="group border-t border-mist-950/5 dark:border-white/10">
+                  <th
+                    scope="row"
+                    className="py-4 pr-4 font-normal text-mist-700 dark:text-mist-400"
+                  >
+                    <div className="flex flex-col gap-1">
+                      <span>{row.feature}</span>
+                      {row.footnote ? (
+                        <span className="text-xs/6 font-normal text-mist-500 dark:text-mist-500">{row.footnote}</span>
+                      ) : null}
+                    </div>
+                  </th>
+                  {competitorColumns.map((col) => (
+                    <td
+                      key={col}
+                      className="px-3 py-4 text-center text-mist-700 dark:text-mist-400"
+                    >
+                      <CellValue value={row.values[col]} />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Section>
+
+      <Section id="competitive-honesty" eyebrow="Honest positioning" headline="What to expect in enterprise evaluations">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+          {competitiveHonestyNotes.map((note) => (
+            <div key={note.title} className="flex flex-col gap-2 rounded-xl bg-mist-950/2.5 p-6 dark:bg-white/5">
+              <h3 className="text-base font-semibold text-mist-950 dark:text-white">{note.title}</h3>
+              <p className="text-sm/7 text-mist-700 dark:text-mist-400">{note.body}</p>
+            </div>
+          ))}
+        </div>
+      </Section>
+    </div>
+  )
+}

--- a/landing-page/demo/src/components/sections/pricing-hero-multi-tier.tsx
+++ b/landing-page/demo/src/components/sections/pricing-hero-multi-tier.tsx
@@ -108,7 +108,7 @@ export function PricingHeroMultiTier<T extends string>({
             {options.map((option) => (
               <div
                 key={option}
-                className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"
+                className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4"
               >
                 {plans[option]}
               </div>

--- a/landing-page/demo/src/components/sections/pricing-multi-tier.tsx
+++ b/landing-page/demo/src/components/sections/pricing-multi-tier.tsx
@@ -62,7 +62,7 @@ export function PricingMultiTier({
 } & ComponentProps<typeof Section>) {
   return (
     <Section {...props}>
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
         {plans}
       </div>
     </Section>

--- a/landing-page/demo/src/lib/competitive-pricing.ts
+++ b/landing-page/demo/src/lib/competitive-pricing.ts
@@ -1,0 +1,143 @@
+/** Competitive landscape benchmarks — July 2026 research. Illustrative; verify at procurement time. */
+
+export const competitiveHeadline =
+  'IDP, VDR, semantic search, and agent orchestration — competitors make you buy these separately.'
+
+export const competitiveSummary =
+  'Hyperscience, ABBYY Vantage, and legacy VDR vendors price per page, per user, or six-figure annual contracts. ClawQL charges flat monthly tiers with document volume caps — and bundles parsing, redaction, archive, Onyx search, Coneshare VDR, and MCP agent tooling in one stack.'
+
+export const tcoBenchmarks = [
+  {
+    label: 'vs Hyperscience (IDP)',
+    scenario: 'Business tier: 25,000 documents/mo × ~5 pages = 125,000 pages',
+    incumbent: '~$1.50/page → ~$187,500/mo',
+    clawql: 'Business tier: $299/mo flat',
+    note: 'Volume-based IDP pricing scales linearly with every page processed.',
+  },
+  {
+    label: 'vs ABBYY Vantage (IDP)',
+    scenario: 'Same 125,000 pages/mo at mid-range ~$0.05/page',
+    incumbent: '~$6,250/mo + professional services',
+    clawql: 'Business tier: $299/mo flat',
+    note: 'Enterprise IDP deals often run $40K–$100K/yr before services (30–60% of year-one cost).',
+  },
+  {
+    label: 'vs VDR incumbents',
+    scenario: 'Starter tier with Coneshare VDR included',
+    incumbent: 'Intralinks/Datasite: $10K–$200K+/yr; $0.40–$0.85/page',
+    clawql: 'Starter: $149/mo ($1,788/yr)',
+    note: 'Legacy VDR adds storage overages ($100–$300/GB), per-seat fees, and setup charges.',
+  },
+] as const
+
+export type CompetitorColumn = 'ClawQL Business' | 'Hyperscience' | 'ABBYY Vantage' | 'Intralinks / Datasite'
+
+export type CompetitorFeatureRow = {
+  feature: string
+  values: Record<CompetitorColumn, string | boolean>
+  footnote?: string
+}
+
+export const competitorColumns: CompetitorColumn[] = [
+  'ClawQL Business',
+  'Hyperscience',
+  'ABBYY Vantage',
+  'Intralinks / Datasite',
+]
+
+/** Feature comparison vs IDP and VDR incumbents — Business tier as ClawQL reference. */
+export const competitorFeatureRows: CompetitorFeatureRow[] = [
+  {
+    feature: 'Document parsing (1,000+ formats)',
+    values: { 'ClawQL Business': true, Hyperscience: true, 'ABBYY Vantage': true, 'Intralinks / Datasite': false },
+  },
+  {
+    feature: 'OCR',
+    values: { 'ClawQL Business': true, Hyperscience: true, 'ABBYY Vantage': true, 'Intralinks / Datasite': false },
+  },
+  {
+    feature: 'PII redaction',
+    values: { 'ClawQL Business': true, Hyperscience: 'Partial', 'ABBYY Vantage': true, 'Intralinks / Datasite': 'Add-on' },
+  },
+  {
+    feature: 'Merkle cryptographic audit trail',
+    values: { 'ClawQL Business': true, Hyperscience: false, 'ABBYY Vantage': false, 'Intralinks / Datasite': false },
+  },
+  {
+    feature: 'Semantic search (Onyx)',
+    values: { 'ClawQL Business': true, Hyperscience: false, 'ABBYY Vantage': false, 'Intralinks / Datasite': false },
+  },
+  {
+    feature: 'AI agent orchestration (MCP)',
+    values: { 'ClawQL Business': true, Hyperscience: false, 'ABBYY Vantage': false, 'Intralinks / Datasite': false },
+  },
+  {
+    feature: 'Virtual data room (Coneshare)',
+    values: { 'ClawQL Business': true, Hyperscience: false, 'ABBYY Vantage': false, 'Intralinks / Datasite': true },
+  },
+  {
+    feature: 'Page-level engagement analytics',
+    values: { 'ClawQL Business': true, Hyperscience: false, 'ABBYY Vantage': false, 'Intralinks / Datasite': true },
+  },
+  {
+    feature: 'Dynamic watermarking',
+    values: { 'ClawQL Business': true, Hyperscience: false, 'ABBYY Vantage': false, 'Intralinks / Datasite': true },
+  },
+  {
+    feature: 'Local / sovereign LLM inference',
+    values: { 'ClawQL Business': true, Hyperscience: false, 'ABBYY Vantage': false, 'Intralinks / Datasite': false },
+  },
+  {
+    feature: 'Self-hosted option',
+    values: { 'ClawQL Business': true, Hyperscience: 'Partial', 'ABBYY Vantage': true, 'Intralinks / Datasite': false },
+  },
+  {
+    feature: 'Data stays in tenant boundary',
+    values: { 'ClawQL Business': true, Hyperscience: false, 'ABBYY Vantage': false, 'Intralinks / Datasite': false },
+  },
+  {
+    feature: 'HITL review queue',
+    values: { 'ClawQL Business': true, Hyperscience: true, 'ABBYY Vantage': true, 'Intralinks / Datasite': false },
+    footnote: 'ClawQL uses Label Studio HITL — mature for W-2/lending samples; enterprise multi-reviewer RBAC on roadmap.',
+  },
+  {
+    feature: 'Pre-trained document skills library',
+    values: {
+      'ClawQL Business': 'Vertical adapters (building)',
+      Hyperscience: 'Extensive',
+      'ABBYY Vantage': '150+ skills',
+      'Intralinks / Datasite': false,
+    },
+    footnote:
+      'ABBYY ships broad pre-built skills day one. ClawQL composes classify/extract/HITL per vertical — honest gap until vertical packages ship.',
+  },
+  {
+    feature: 'SSO / SAML',
+    values: { 'ClawQL Business': false, Hyperscience: true, 'ABBYY Vantage': true, 'Intralinks / Datasite': true },
+    footnote: 'ClawQL Dedicated includes SSO/RBAC; Enterprise adds full SAML programs.',
+  },
+  {
+    feature: 'Pricing model',
+    values: {
+      'ClawQL Business': '$299/mo flat',
+      Hyperscience: '~$0.50–$1.50/page',
+      'ABBYY Vantage': '$40K–$100K+/yr',
+      'Intralinks / Datasite': '$10K–$200K+/yr',
+    },
+  },
+]
+
+export const competitiveHonestyNotes = [
+  {
+    title: 'Why flat pricing can look “too cheap”',
+    body: 'Procurement teams comparing $299/mo to six-figure IDP or VDR quotes may assume something is missing. The answer is bundle economics: you are not buying a single capability — and ClawQL self-host and managed options eliminate separate infrastructure engineering teams that incumbents bake into TCO arguments.',
+  },
+  {
+    title: 'The per-page TCO counter-argument',
+    body: 'Hyperscience argues per-page quotes ignore engineering hours, infra scaling, and model maintenance. ClawQL counters with managed hosting (no separate ops team), self-host for teams who want control, and a fine-tuned model pipeline that improves from Langfuse traces rather than manual retraining projects.',
+  },
+  {
+    title: 'Where incumbents still lead',
+    body: 'ABBYY Vantage ships 150+ pre-trained skills for common document types. ClawQL’s answer is vertical fine-tune adapters and the full IDP + VDR + agent stack — but those vertical packages take time to build. We do not claim parity on day-one skill libraries.',
+  },
+] as const

--- a/landing-page/demo/src/lib/competitive-pricing.ts
+++ b/landing-page/demo/src/lib/competitive-pricing.ts
@@ -1,34 +1,48 @@
 /** Competitive landscape benchmarks — July 2026 research. Illustrative; verify at procurement time. */
 
+import { businessAllInMonthly } from './pricing'
+
 export const competitiveHeadline =
   'IDP, VDR, semantic search, and agent orchestration — competitors make you buy these separately.'
 
 export const competitiveSummary =
-  'Hyperscience, ABBYY Vantage, and legacy VDR vendors price per page, per user, or six-figure annual contracts. ClawQL charges flat monthly tiers with document volume caps — and bundles parsing, redaction, archive, Onyx search, Coneshare VDR, and MCP agent tooling in one stack.'
+  'Pricing is anchored to what ClawQL replaces — IDP vendors, VDR platforms, and compliance tooling that together run $5,000–15,000+/month. Flat tiers remain dramatically below per-page incumbents while pricing credibly against the stack, not generic SaaS.'
 
 export const tcoBenchmarks = [
   {
     label: 'vs Hyperscience (IDP)',
     scenario: 'Business tier: 25,000 documents/mo × ~5 pages = 125,000 pages',
     incumbent: '~$1.50/page → ~$187,500/mo',
-    clawql: 'Business tier: $299/mo flat',
+    clawql: 'Business tier: $599/mo flat',
     note: 'Volume-based IDP pricing scales linearly with every page processed.',
   },
   {
     label: 'vs ABBYY Vantage (IDP)',
     scenario: 'Same 125,000 pages/mo at mid-range ~$0.05/page',
     incumbent: '~$6,250/mo + professional services',
-    clawql: 'Business tier: $299/mo flat',
+    clawql: 'Business tier: $599/mo flat',
     note: 'Enterprise IDP deals often run $40K–$100K/yr before services (30–60% of year-one cost).',
   },
   {
     label: 'vs VDR incumbents',
     scenario: 'Starter tier with Coneshare VDR included',
-    incumbent: 'Intralinks/Datasite: $10K–$200K+/yr; $0.40–$0.85/page',
-    clawql: 'Starter: $149/mo ($1,788/yr)',
+    incumbent: 'Intralinks/Datasite: $10K–$200K+/yr; Ansarada ~$3,069/mo for 5 GB',
+    clawql: 'Starter: $299/mo ($3,588/yr)',
     note: 'Legacy VDR adds storage overages ($100–$300/GB), per-seat fees, and setup charges.',
   },
 ] as const
+
+export const stackReplacementSummary = {
+  headline: 'Full stack replacement cost (Business-tier customer)',
+  profile: '25 users · 25,000 documents/month · VDR sharing with external parties',
+  incumbentRange: '$5,000–15,000+/month',
+  incumbentDetail:
+    'Across Hyperscience or ABBYY (IDP), Intralinks or Datasite (VDR), standalone enterprise search, and custom audit tooling — separate contracts and data exposure points.',
+  clawqlBusiness: '$599/month',
+  clawqlBusinessMax: `${businessAllInMonthly}/month with Sovereign Security Pack`,
+  savingsNote:
+    '6–20× below incumbent stack at comparable capability, with sovereign inference and zero external LLM API calls.',
+} as const
 
 export type CompetitorColumn = 'ClawQL Business' | 'Hyperscience' | 'ABBYY Vantage' | 'Intralinks / Datasite'
 
@@ -45,7 +59,7 @@ export const competitorColumns: CompetitorColumn[] = [
   'Intralinks / Datasite',
 ]
 
-/** Feature comparison vs IDP and VDR incumbents — Business tier as ClawQL reference. */
+/** Feature comparison vs IDP and VDR incumbents — Business tier ($599/mo) as ClawQL reference. */
 export const competitorFeatureRows: CompetitorFeatureRow[] = [
   {
     feature: 'Document parsing (1,000+ formats)',
@@ -96,30 +110,25 @@ export const competitorFeatureRows: CompetitorFeatureRow[] = [
     values: { 'ClawQL Business': true, Hyperscience: false, 'ABBYY Vantage': false, 'Intralinks / Datasite': false },
   },
   {
-    feature: 'HITL review queue',
-    values: { 'ClawQL Business': true, Hyperscience: true, 'ABBYY Vantage': true, 'Intralinks / Datasite': false },
-    footnote: 'ClawQL uses Label Studio HITL — mature for W-2/lending samples; enterprise multi-reviewer RBAC on roadmap.',
-  },
-  {
     feature: 'Pre-trained document skills library',
     values: {
-      'ClawQL Business': 'Vertical adapters (building)',
+      'ClawQL Business': 'Vertical adapters (Professional+)',
       Hyperscience: 'Extensive',
       'ABBYY Vantage': '150+ skills',
       'Intralinks / Datasite': false,
     },
     footnote:
-      'ABBYY ships broad pre-built skills day one. ClawQL composes classify/extract/HITL per vertical — honest gap until vertical packages ship.',
+      'ABBYY ships broad pre-built skills day one. ClawQL Professional includes one vertical fine-tune adapter; Enterprise adds custom retraining.',
   },
   {
     feature: 'SSO / SAML',
     values: { 'ClawQL Business': false, Hyperscience: true, 'ABBYY Vantage': true, 'Intralinks / Datasite': true },
-    footnote: 'ClawQL Dedicated includes SSO/RBAC; Enterprise adds full SAML programs.',
+    footnote: 'ClawQL Professional and Enterprise include SSO/SAML.',
   },
   {
     feature: 'Pricing model',
     values: {
-      'ClawQL Business': '$299/mo flat',
+      'ClawQL Business': '$599/mo flat',
       Hyperscience: '~$0.50–$1.50/page',
       'ABBYY Vantage': '$40K–$100K+/yr',
       'Intralinks / Datasite': '$10K–$200K+/yr',
@@ -129,8 +138,8 @@ export const competitorFeatureRows: CompetitorFeatureRow[] = [
 
 export const competitiveHonestyNotes = [
   {
-    title: 'Why flat pricing can look “too cheap”',
-    body: 'Procurement teams comparing $299/mo to six-figure IDP or VDR quotes may assume something is missing. The answer is bundle economics: you are not buying a single capability — and ClawQL self-host and managed options eliminate separate infrastructure engineering teams that incumbents bake into TCO arguments.',
+    title: 'Value-anchored, not volume-discounted',
+    body: 'Revised tiers price against the $5K–15K/month stack ClawQL replaces — not against generic SaaS. Starter at $299/mo credibly replaces DocSend plus basic IDP; Business at $599/mo replaces a multi-vendor compliance stack that incumbents sell separately.',
   },
   {
     title: 'The per-page TCO counter-argument',
@@ -138,6 +147,6 @@ export const competitiveHonestyNotes = [
   },
   {
     title: 'Where incumbents still lead',
-    body: 'ABBYY Vantage ships 150+ pre-trained skills for common document types. ClawQL’s answer is vertical fine-tune adapters and the full IDP + VDR + agent stack — but those vertical packages take time to build. We do not claim parity on day-one skill libraries.',
+    body: 'ABBYY Vantage ships 150+ pre-trained skills for common document types. ClawQL Professional includes one vertical fine-tune adapter; building the full library takes time. We state this openly in competitive evaluations rather than overclaiming day-one parity.',
   },
 ] as const

--- a/landing-page/demo/src/lib/pricing.ts
+++ b/landing-page/demo/src/lib/pricing.ts
@@ -38,7 +38,7 @@ export const pricing = {
     period: '/mo',
     badge: 'Managed · early access',
     subheadline:
-      'Try the real hosted pipeline — Tika, Gotenberg, Stirling, archive, and Onyx basic — with usage limits. Coneshare VDR not included.',
+      'Try the real hosted pipeline — Tika, Gotenberg, Stirling, archive, and Onyx basic — with usage limits. Coneshare VDR and sovereign inference not included on Free.',
     features: [
       '500 documents/month',
       '1 user · 5 GB storage',
@@ -59,8 +59,8 @@ export const pricing = {
     features: [
       '5,000 documents/month',
       '5 users · 50 GB storage',
-      'Coneshare VDR',
-      'Full Onyx semantic search',
+      'Coneshare VDR + Label Studio HITL',
+      'Full Onyx · sovereign inference',
       'Email support (48 hr)',
     ],
   },
@@ -106,7 +106,7 @@ export const pricing = {
       'Everything in Dedicated',
       'SSO / SAML',
       'EU data residency (roadmap)',
-      'hitl_enqueue_label_studio',
+      'Multi-reviewer HITL RBAC',
       'Dedicated CSM & custom SLA',
       'Security review assistance',
     ],

--- a/landing-page/demo/src/lib/pricing.ts
+++ b/landing-page/demo/src/lib/pricing.ts
@@ -1,9 +1,9 @@
 export type BillingPeriod = 'Monthly' | 'Yearly'
 
-export type ManagedTierId = 'starter' | 'business' | 'dedicated'
+export type ManagedTierId = 'starter' | 'business' | 'professional'
 
-/** Comparison table columns — self-hosted plus managed tiers from the GTM playbook. */
-export const pricingPlanNames = ['Self-hosted', 'Free', 'Starter', 'Business', 'Dedicated'] as const
+/** Comparison table columns — self-hosted plus managed tiers (June 2026 GTM, revised pricing). */
+export const pricingPlanNames = ['Self-hosted', 'Free', 'Starter', 'Business', 'Professional'] as const
 
 export type PricingPlanName = (typeof pricingPlanNames)[number]
 
@@ -11,9 +11,25 @@ export type PricingPlanName = (typeof pricingPlanNames)[number]
 export const annualBillingSavingsLabel = '2 months free'
 
 export const annualBillingTotals = {
-  starter: '$1,488/yr',
-  business: '$2,988/yr',
-  dedicated: '$5,988/yr',
+  starter: '$2,988/yr',
+  business: '$5,988/yr',
+  professional: '$12,000/yr',
+} as const
+
+export const sovereignSecurityPack = {
+  name: 'Sovereign Security Pack',
+  monthlyPrice: '$200',
+  period: '/mo',
+  subheadline:
+    'Optional on Starter, Business, and Professional. Included in Enterprise. Makes defense-in-depth controls visible and purchasable — Kata isolation, model weight verification, WORM Merkle audit logs, Panguard fail-closed ATR, and monthly posture reports.',
+  features: [
+    'Kata Container VM isolation for agent workloads',
+    'Model weight integrity verification (SHA-256 + Cosign)',
+    'WORM Merkle audit logs with signed Git commits',
+    'Panguard ATR fail-closed enforcement',
+    'Presidio pre-log redaction pipeline',
+    'Monthly automated security posture report',
+  ],
 } as const
 
 export const pricing = {
@@ -38,11 +54,11 @@ export const pricing = {
     period: '/mo',
     badge: 'Managed · early access',
     subheadline:
-      'Try the real hosted pipeline — Tika, Gotenberg, Stirling, archive, and Onyx basic — with usage limits. Coneshare VDR and sovereign inference not included on Free.',
+      'Real pipeline access — not a demo environment. Process documents through the full stack before committing. Coneshare VDR and sovereign inference not included.',
     features: [
-      '500 documents/month',
+      '200 documents/month',
       '1 user · 5 GB storage',
-      'Hosted MCP + IDP pipeline',
+      'Full pipeline + Merkle audit',
       'Onyx semantic search (basic)',
       'Community support',
     ],
@@ -50,65 +66,70 @@ export const pricing = {
   starter: {
     name: 'Starter',
     shortName: 'Starter' as const,
-    monthlyPrice: '$149',
-    annualPricePerMonth: '$124',
+    monthlyPrice: '$299',
+    annualPricePerMonth: '$249',
     period: '/mo',
     badge: 'Shared tenancy',
+    valueAnchor: 'Replaces DocSend + basic IDP — DocSend alone runs $150–250/user/mo with no processing.',
     subheadline:
-      'Multi-tenant managed hosting for teams processing contracts, invoices, or compliance docs — Coneshare VDR included.',
+      'Small teams replacing DocSend and point OCR tools. Coneshare VDR, sovereign inference, and Obsidian vault included.',
     features: [
       '5,000 documents/month',
       '5 users · 50 GB storage',
-      'Coneshare VDR + Label Studio HITL',
-      'Full Onyx · sovereign inference',
+      'Coneshare VDR + dynamic watermarking',
+      'Sovereign LLM · Obsidian vault',
       'Email support (48 hr)',
     ],
   },
   business: {
     name: 'Business',
     shortName: 'Business' as const,
-    monthlyPrice: '$299',
-    annualPricePerMonth: '$249',
-    period: '/mo',
-    badge: 'Shared tenancy',
-    subheadline:
-      'Higher document volume and priority processing for growing teams — still multi-tenant, with 99.5% uptime SLA.',
-    features: [
-      '25,000 documents/month',
-      '25 users · 500 GB storage',
-      'Coneshare VDR + priority queue',
-      'Full Onyx semantic search',
-      'Email support (24 hr)',
-    ],
-  },
-  dedicated: {
-    name: 'Dedicated',
-    shortName: 'Dedicated' as const,
     monthlyPrice: '$599',
     annualPricePerMonth: '$499',
     period: '/mo',
-    badge: 'Single-tenant',
+    badge: 'Shared tenancy',
+    valueAnchor: 'Equivalent incumbent stack: $3,000–6,000/mo across IDP + VDR + search.',
     subheadline:
-      'Dedicated namespace with full node resource allocation — no neighbor tenants. Sovereign inference; unlimited documents.',
+      'Growing teams with real document volume and compliance awareness. Priority queue, full VDR analytics, 99.5% SLA.',
     features: [
-      'Unlimited documents',
-      'Unlimited users · 1 TB storage',
-      'Coneshare VDR + analytics',
-      '99.9% uptime SLA',
-      'Priority email + Slack connect',
+      '25,000 documents/month',
+      '25 users · 500 GB storage',
+      'Coneshare VDR · full analytics',
+      'Onyx cross-document search',
+      'Email support (24 hr)',
+    ],
+  },
+  professional: {
+    name: 'Professional',
+    shortName: 'Professional' as const,
+    monthlyPrice: '$1,200',
+    annualPricePerMonth: '$1,000',
+    period: '/mo',
+    badge: 'Dedicated namespace',
+    valueAnchor: 'Vertical deployments — lending, legal, healthcare. One fine-tune adapter included.',
+    subheadline:
+      'Compliance-driven buyers needing a dedicated namespace, SSO/SAML, and a vertical fine-tune adapter trained on your document patterns.',
+    features: [
+      '75,000 documents/month',
+      'Unlimited users · 2 TB storage',
+      'Dedicated namespace + priority queue',
+      'One vertical fine-tune adapter',
+      'SSO/SAML · Slack Connect · 99.9% SLA',
     ],
   },
   enterprise: {
     name: 'Enterprise',
+    priceFrom: '$3,500',
+    period: '/mo',
     subheadline:
-      'Custom annual contracts for EU data residency, SSO/SAML, on-call support, and very high volume. Scoped individually — contact sales.',
+      'Large enterprises and regulated industries. Dedicated node, custom fine-tune with ongoing retraining, multi-region (EU available), DPA/BAA, dedicated CSM. Sovereign Security Pack included.',
     features: [
-      'Everything in Dedicated',
-      'SSO / SAML',
-      'EU data residency (roadmap)',
-      'Multi-reviewer HITL RBAC',
+      'Unlimited documents · custom storage',
+      'Dedicated node (not just namespace)',
+      'Custom vertical fine-tune + retraining',
+      'EU multi-region · white-label Coneshare',
+      'Sovereign Security Pack included',
       'Dedicated CSM & custom SLA',
-      'Security review assistance',
     ],
   },
 } as const
@@ -120,5 +141,8 @@ export function managedPrice(tier: ManagedTierId, billing: BillingPeriod): strin
 
 export function annualBillingNoteText(billing: BillingPeriod): string | null {
   if (billing !== 'Yearly') return null
-  return ` Billed annually (${annualBillingTotals.starter} Starter · ${annualBillingTotals.business} Business · ${annualBillingTotals.dedicated} Dedicated) — ${annualBillingSavingsLabel} vs monthly billing.`
+  return ` Billed annually (${annualBillingTotals.starter} Starter · ${annualBillingTotals.business} Business · ${annualBillingTotals.professional} Professional) — ${annualBillingSavingsLabel} vs monthly billing.`
 }
+
+/** Business tier all-in max with optional Sovereign Security Pack. */
+export const businessAllInMonthly = '$799'

--- a/landing-page/demo/src/lib/pricing.ts
+++ b/landing-page/demo/src/lib/pricing.ts
@@ -1,16 +1,28 @@
 export type BillingPeriod = 'Monthly' | 'Yearly'
 
-export const pricingPlanNames = ['Self-hosted', 'Shared', 'Dedicated'] as const
+export type ManagedTierId = 'starter' | 'business' | 'dedicated'
 
-/** Annual billing saves ~16% vs monthly ($3,588 → $3,000 shared; $7,188 → $6,000 dedicated). */
+/** Comparison table columns — self-hosted plus managed tiers from the GTM playbook. */
+export const pricingPlanNames = ['Self-hosted', 'Free', 'Starter', 'Business', 'Dedicated'] as const
+
+export type PricingPlanName = (typeof pricingPlanNames)[number]
+
+/** Annual billing: ~2 months free on paid managed tiers. */
 export const annualBillingSavingsLabel = '2 months free'
+
+export const annualBillingTotals = {
+  starter: '$1,488/yr',
+  business: '$2,988/yr',
+  dedicated: '$5,988/yr',
+} as const
 
 export const pricing = {
   selfHosted: {
     name: 'Self-hosted',
+    shortName: 'Self-hosted' as const,
     price: '$0',
     period: '',
-    subheadline: 'Run ClawQL on your own hardware — full open-source stack, no license fee.',
+    subheadline: 'Run the full open-source stack on your hardware — no license fee, no document caps enforced by us.',
     features: [
       'search, execute, audit, cache',
       'memory_ingest & memory_recall',
@@ -19,58 +31,94 @@ export const pricing = {
       'Helm charts & GHCR images',
     ],
   },
-  shared: {
-    name: 'Shared hosting',
-    shortName: 'Shared',
-    monthlyPrice: '$299',
-    annualPricePerMonth: '$250',
+  managedFree: {
+    name: 'Free',
+    shortName: 'Free' as const,
+    monthlyPrice: '$0',
     period: '/mo',
-    badge: 'Multi-tenant',
+    badge: 'Managed · early access',
     subheadline:
-      'Hosted MCP, vault, and IDP on shared infrastructure. Cost-effective — may see reduced performance during burst periods and is not fully isolated for strict compliance regimes.',
+      'Try the real hosted pipeline — Tika, Gotenberg, Stirling, archive, and Onyx basic — with usage limits. Coneshare VDR not included.',
     features: [
-      'Everything in Self-hosted',
-      'Hosted MCP endpoint',
-      'Vault-backed memory',
-      'Managed IDP (8 vendors)',
-      'knowledge_search_onyx',
-      'Email support',
+      '500 documents/month',
+      '1 user · 5 GB storage',
+      'Hosted MCP + IDP pipeline',
+      'Onyx semantic search (basic)',
+      'Community support',
+    ],
+  },
+  starter: {
+    name: 'Starter',
+    shortName: 'Starter' as const,
+    monthlyPrice: '$149',
+    annualPricePerMonth: '$124',
+    period: '/mo',
+    badge: 'Shared tenancy',
+    subheadline:
+      'Multi-tenant managed hosting for teams processing contracts, invoices, or compliance docs — Coneshare VDR included.',
+    features: [
+      '5,000 documents/month',
+      '5 users · 50 GB storage',
+      'Coneshare VDR',
+      'Full Onyx semantic search',
+      'Email support (48 hr)',
+    ],
+  },
+  business: {
+    name: 'Business',
+    shortName: 'Business' as const,
+    monthlyPrice: '$299',
+    annualPricePerMonth: '$249',
+    period: '/mo',
+    badge: 'Shared tenancy',
+    subheadline:
+      'Higher document volume and priority processing for growing teams — still multi-tenant, with 99.5% uptime SLA.',
+    features: [
+      '25,000 documents/month',
+      '25 users · 500 GB storage',
+      'Coneshare VDR + priority queue',
+      'Full Onyx semantic search',
+      'Email support (24 hr)',
     ],
   },
   dedicated: {
-    name: 'Dedicated hosting',
-    shortName: 'Dedicated',
+    name: 'Dedicated',
+    shortName: 'Dedicated' as const,
     monthlyPrice: '$599',
-    annualPricePerMonth: '$500',
+    annualPricePerMonth: '$499',
     period: '/mo',
     badge: 'Single-tenant',
     subheadline:
-      'Your own isolated hardware — no other customers on the cluster. Full data and compute isolation for regulators and compliance-sensitive workloads.',
+      'Dedicated namespace with full node resource allocation — no neighbor tenants. Sovereign inference; unlimited documents.',
     features: [
-      'Everything in Shared',
-      'Dedicated infrastructure',
-      'No multi-tenant neighbors',
-      'Predictable performance',
-      'SSO and RBAC',
-      'Priority email support',
+      'Unlimited documents',
+      'Unlimited users · 1 TB storage',
+      'Coneshare VDR + analytics',
+      '99.9% uptime SLA',
+      'Priority email + Slack connect',
     ],
   },
   enterprise: {
     name: 'Enterprise',
     subheadline:
-      'Very high volume, custom SLAs, and on-call support. Contracts are tailored — typically starting around $3,000/month. Contact us to scope your requirements.',
+      'Custom annual contracts for EU data residency, SSO/SAML, on-call support, and very high volume. Scoped individually — contact sales.',
     features: [
       'Everything in Dedicated',
-      'Custom usage limits',
-      'Dedicated SLA',
-      'On-call support',
+      'SSO / SAML',
+      'EU data residency (roadmap)',
       'hitl_enqueue_label_studio',
+      'Dedicated CSM & custom SLA',
       'Security review assistance',
     ],
   },
 } as const
 
-export function managedPrice(tier: 'shared' | 'dedicated', billing: BillingPeriod): string {
+export function managedPrice(tier: ManagedTierId, billing: BillingPeriod): string {
   const t = pricing[tier]
   return billing === 'Monthly' ? t.monthlyPrice : t.annualPricePerMonth
+}
+
+export function annualBillingNoteText(billing: BillingPeriod): string | null {
+  if (billing !== 'Yearly') return null
+  return ` Billed annually (${annualBillingTotals.starter} Starter · ${annualBillingTotals.business} Business · ${annualBillingTotals.dedicated} Dedicated) — ${annualBillingSavingsLabel} vs monthly billing.`
 }

--- a/landing-page/demo/src/lib/site.ts
+++ b/landing-page/demo/src/lib/site.ts
@@ -6,9 +6,9 @@ export const site = {
   earlyAccess: {
     badge: 'Managed hosting is in early access — accepting waitlist signups',
     summary:
-      'ClawQL is open source and self-hostable today. Managed hosting (Free, Starter, Business, Dedicated) is onboarding its first tenants — founder-led setup, limited slots, sovereign inference on hosted plans.',
+      'ClawQL is open source and self-hostable today. Managed hosting (Free, Starter, Business, Professional, Enterprise) is onboarding its first tenants — founder-led setup, limited slots, sovereign inference on paid plans.',
     pricingNote:
-      'Managed tiers follow the June 2026 GTM model. We onboard Dedicated customers first, then Starter and Business shared slots as capacity grows. All managed tiers are early access — founder-led onboarding.',
+      'Managed tiers follow the June 2026 GTM model — value-anchored pricing against the IDP + VDR + search stack incumbents sell separately. We onboard Professional and Business customers first, then Starter shared slots as capacity grows. All managed tiers are early access with founder-led onboarding.',
   },
   waitlistPromise:
     'Join the waitlist for managed hosting — we reply personally when a slot opens. Self-host free with npm or Helm while you wait.',

--- a/landing-page/demo/src/lib/site.ts
+++ b/landing-page/demo/src/lib/site.ts
@@ -6,9 +6,9 @@ export const site = {
   earlyAccess: {
     badge: 'Managed hosting is in early access — accepting waitlist signups',
     summary:
-      'ClawQL is open source and self-hostable today. Shared and dedicated managed hosting is onboarding its first tenants — founder-led setup, limited slots, full IDP pipeline included.',
+      'ClawQL is open source and self-hostable today. Managed hosting (Free, Starter, Business, Dedicated) is onboarding its first tenants — founder-led setup, limited slots, sovereign inference on hosted plans.',
     pricingNote:
-      'Listed managed prices are early-access anchors. We onboard Dedicated customers first, then expand shared tenancy as capacity grows.',
+      'Managed tiers follow the June 2026 GTM model. We onboard Dedicated customers first, then Starter and Business shared slots as capacity grows. All managed tiers are early access — founder-led onboarding.',
   },
   waitlistPromise:
     'Join the waitlist for managed hosting — we reply personally when a slot opens. Self-host free with npm or Helm while you wait.',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the landing site to match the **revised June 2026 GTM playbook** — value-anchored pricing against the IDP + VDR + search stack incumbents sell separately.

### New tier structure

| Tier | Price | Key change |
|------|-------|------------|
| Free | $0 | 200 docs/mo (was 500) |
| Starter | **$299/mo** | VDR + sovereign inference + Obsidian vault |
| Business | **$599/mo** | 25K docs, priority queue, full VDR analytics |
| Professional | **$1,200/mo** | Dedicated namespace, vertical fine-tune, SSO |
| Enterprise | **from $3,500/mo** | Dedicated node, custom fine-tune, Security Pack included |
| Sovereign Security Pack | **+$200/mo** | Add-on on Starter/Business/Professional |

The old **Dedicated $599** tier is removed — that price point is now **Business**.

### Pages updated

- `/pricing` — full tier grid, comparison table, Sovereign Security Pack section, revised FAQs
- `/` — homepage pricing teaser and FAQs
- `/signup` — waitlist copy
- Competitive landscape section — Business at $599/mo, stack replacement TCO summary

### Build

`npm run build` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

