### PR TITLE
fix(ci): redeploy landing page after #495 Pages deploy failure

### DIFF
--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: deploy-landing-page-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -59,6 +59,21 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Deploy
+      - name: Deploy to GitHub Pages (attempt 1)
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
+        continue-on-error: true
+      - name: Deploy to GitHub Pages (attempt 2)
+        id: deployment_retry_2
+        if: steps.deployment.outcome == 'failure'
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
+        continue-on-error: true
+      - name: Deploy to GitHub Pages (attempt 3)
+        id: deployment_retry_3
+        if: steps.deployment.outcome == 'failure' && steps.deployment_retry_2.outcome == 'failure'
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
+      - name: Verify deploy succeeded
+        if: steps.deployment.outcome == 'failure' && steps.deployment_retry_2.outcome == 'failure' && steps.deployment_retry_3.outcome == 'failure'
+        run: |
+          echo "GitHub Pages deploy failed after 3 attempts"
+          exit 1

--- a/landing-page/README.md
+++ b/landing-page/README.md
@@ -39,10 +39,10 @@ Open [http://localhost:3000](http://localhost:3000).
 The site promotes three hosting models:
 
 1. **Self-hosted (free)** — Open-source `clawql-mcp` on your own hardware
-2. **Shared managed hosting ($299/mo · $250/mo annual)** — Multi-tenant hosted MCP, vault, and IDP
-3. **Dedicated managed hosting ($599/mo · $500/mo annual)** — Single-tenant hardware, full isolation
+2. **Shared managed hosting** — Free, Starter ($299/mo), Business ($599/mo) on multi-tenant infrastructure
+3. **Professional ($1,200/mo)** — Dedicated namespace, SSO/SAML, vertical fine-tune adapter
 
-**Enterprise** contracts (custom SLAs, on-call, high volume) are contact-sales only — no fixed list price.
+**Enterprise** contracts (from $3,500/mo — dedicated node, custom fine-tuning, EU multi-region) are contact-sales only.
 
 Signup forms currently point to the waitlist flow (`/signup`). Wire `EmailSignupForm` actions to your backend or email provider when ready for production.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

[PR #495](https://github.com/danielsmithdevelopment/ClawQL/pull/495) merged to `main` but **did not reach clawql.com**. The `Deploy landing page (GitHub Pages)` workflow run [28757534242](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/28757534242) **built successfully** then failed at the deploy step with:

> Deployment failed, try again later.

Pricing from #494 is live; real estate dual-audience page and signup demo pitch are still on the previous static export.

## Fix

- Re-trigger deploy by touching `landing-page/**` (README tier copy sync)
- Add 3-attempt retry on `actions/deploy-pages` for transient GitHub Pages API errors
- Set `cancel-in-progress: false` so overlapping deploys are not cancelled mid-flight

## Verify after merge

- [clawql.com/industries/real-estate](https://clawql.com/industries/real-estate) shows brokerage + FSBO dual-audience content (not "Planned vertical")
- [clawql.com/signup](https://clawql.com/signup) includes real estate demo pitch link
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

