### PR TITLE
feat(landing): plugin-bundle pricing — Developer/Teams gateway vs IDP tiers

### DIFF
--- a/docs/vision/clawql-idp-platform.md
+++ b/docs/vision/clawql-idp-platform.md
@@ -106,18 +106,23 @@ Each hosted customer receives a dedicated tenant with full isolation at the data
 - Coneshare VDR links scoped to the tenant's Nextcloud instance.
 - mTLS between all tenant services via Istio; tenant-scoped secrets in HashiCorp Vault.
 
-### Hosted Plan: Pricing Model (Proposed)
+### Hosted Plan: Pricing Model (July 2026 — plugin bundles)
 
-The hosted plan is structured around document volume and seat count, with a free tier to drive adoption:
+Managed hosting is structured around **plugin bundles**, not a single document-volume ladder. Gateway-only customers pay dramatically less than IDP customers.
 
-| Tier           | Included                                                                              | Target Customer                          |
-| -------------- | ------------------------------------------------------------------------------------- | ---------------------------------------- |
-| **Free**       | 500 documents/month, 1 user, 5 GB storage. Full pipeline, no VDR.                     | Individual evaluation, freelancers.      |
-| **Starter**    | 5,000 documents/month, 5 users, 50 GB storage. Full pipeline + Coneshare VDR.         | Small teams, startups, SMBs.             |
-| **Business**   | 25,000 documents/month, 25 users, 500 GB storage. Priority processing, SLA.           | Growing companies, legal/finance teams.  |
-| **Enterprise** | Unlimited documents, unlimited users, dedicated infrastructure, custom SLA, SSO/SAML. | Large enterprises, regulated industries. |
+| Tier | Price | Plugin bundle | Included |
+| ---- | ----- | ------------- | -------- |
+| **Free** | $0/mo | MCP Gateway | 10,000 executions/mo, 1 user, basic memory vault — no IDP, no VDR |
+| **Developer** | $29/mo | Gateway + memory | 50,000 executions/mo, 3 users, vault memory — no IDP, no GPU |
+| **Teams** | $99/mo | Gateway + memory + Onyx | 250,000 executions/mo, 10 users, full Onyx semantic search — no IDP |
+| **Starter** | $299/mo | IDP plugin bundle | 5,000 documents/mo, VDR, classify/extract, sovereign inference |
+| **Business** | $599/mo | IDP plugin bundle | 25,000 documents/mo, priority queue, full VDR analytics, 99.5% SLA |
+| **Professional** | $1,200/mo | Full stack | 75,000 documents/mo, dedicated namespace, vertical fine-tune, SSO/SAML |
+| **Enterprise** | from $3,500/mo | Full stack + security | Dedicated node, custom fine-tune, EU multi-region, Sovereign Security Pack included |
 
-> **Note:** these tiers are indicative. Final pricing should be validated against infrastructure cost modeling and customer discovery before launch.
+Execution overage on gateway tiers: **$0.20 per 1,000 executions** (matches [Executor](https://executor.sh/) Team pricing). Sovereign Security Pack: **+$200/mo** on any paid tier.
+
+> **Note:** tiers are indicative for GTM positioning. Validate against infrastructure cost modeling before launch.
 
 ---
 
@@ -397,14 +402,26 @@ The entire sequence above runs from a single natural-language agent prompt. No c
 
 ## Competitive Positioning
 
-ClawQL competes across three adjacent markets simultaneously: IDP platforms, Virtual Data Rooms, and AI agent infrastructure. Its differentiation is the combination of full-stack sovereignty, native AI orchestration, cryptographic auditability, and a hosted product that requires none of the infrastructure overhead of incumbents.
+ClawQL competes across four adjacent markets — price each plugin bundle against the right incumbent:
 
-| Competitor Category                                                | ClawQL Differentiation                                                                                                                                                                                                           |
-| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **SaaS IDP Vendors** (Hyperscience, Kofax, ABBYY)                  | Cloud-hosted; data leaves your environment. Per-document pricing becomes expensive at scale. No native MCP/agent interface. ClawQL: self-hosted or tenant-isolated hosted, flat pricing, MCP-native from day one.                |
-| **VDR Incumbents** (Intralinks, Datasite, Ansarada)                | Hosted VDRs with no document processing pipeline. Cannot redact, convert, or semantically index. High per-user/per-GB/per-deal licensing. ClawQL: full pipeline integration, usage-based hosted pricing, Coneshare VDR included. |
-| **Open-source point tools** (Tika, Stirling, Nextcloud standalone) | Individual tools without orchestration. Significant custom integration effort required. No AI agent interface. ClawQL: unified orchestration, Helm deployment, MCP-native agent access out of the box.                           |
-| **AI document platforms** (emerging LLM-native tools)              | Typically cloud-only, limited format support, no VDR, no Merkle audit trail. ClawQL: 1,000+ formats, cryptographic audit, VDR distribution, self-hosted option for regulated industries.                                         |
+| Competitor Category | ClawQL tier | ClawQL differentiation |
+| ------------------- | ----------- | ---------------------- |
+| **MCP gateways** ([Executor](https://executor.sh/), emerging agent infrastructure) | Developer ($29/mo), Teams ($99/mo) | Same context-efficient search/execute pattern. ClawQL adds Obsidian vault memory, Onyx semantic search, and optional IDP platform Executor does not ship. Executor Team is $150/org for 250K executions; ClawQL Teams is $99 with memory. |
+| **SaaS IDP vendors** (Hyperscience, Kofax, ABBYY) | Starter–Professional (IDP bundle) | Cloud-hosted; per-document pricing at scale. No native MCP/agent interface. ClawQL: tenant-isolated hosted or self-hosted, flat IDP tiers, MCP-native from day one. |
+| **VDR incumbents** (Intralinks, Datasite, Ansarada) | Starter+ (IDP bundle includes Coneshare) | Hosted VDRs with no document processing pipeline. High per-user/per-GB/per-deal licensing. ClawQL: full pipeline integration, Coneshare VDR included in IDP subscription. |
+| **Vertical CRMs** (REsimpli, franchise transaction tools) | Teams ($99/mo) for agent memory; Starter ($299/mo) for IDP | CRMs track pipeline; Drive folders hold files. ClawQL connects CRM APIs + storage via MCP, indexes documents in Onyx, threads deal context in vault — without replacing Command, Dotloop, or SkySlope. |
+
+### Real estate vertical
+
+Brokerages on Keller Williams Command, eXp BoldTrail, Follow Up Boss, or Compass share a structural gap: **CRM knows the deal, Drive holds the files** — no semantic link between contacts and transaction PDFs.
+
+| Need | Recommended tier | Why |
+| ---- | ---------------- | --- |
+| Connect Command + Drive, semantic search, deal memory | **Teams ($99/mo)** | MCP gateway + Onyx + vault — no IDP overhead for teams that do not process documents daily |
+| Title commitment classify/extract, Coneshare VDR for disclosures | **Starter ($299/mo)** | IDP plugin bundle — explicitly opted in |
+| REsimpli comparison | Teams vs REsimpli Basic ($149/mo) | REsimpli is CRM-only for investors; ClawQL unifies CRM integration, document search, and agent memory |
+
+ClawQL does **not** replace Dotloop (forms, e-sign, broker compliance) or MLS listing platforms. It is the intelligent document layer on top.
 
 ClawQL's MCP-native architecture means it benefits automatically from improvements in AI model capabilities. As frontier models improve, ClawQL's automation depth increases without code changes.
 

--- a/docs/vision/clawql-idp-platform.md
+++ b/docs/vision/clawql-idp-platform.md
@@ -110,15 +110,15 @@ Each hosted customer receives a dedicated tenant with full isolation at the data
 
 Managed hosting is structured around **plugin bundles**, not a single document-volume ladder. Gateway-only customers pay dramatically less than IDP customers.
 
-| Tier | Price | Plugin bundle | Included |
-| ---- | ----- | ------------- | -------- |
-| **Free** | $0/mo | MCP Gateway | 10,000 executions/mo, 1 user, basic memory vault — no IDP, no VDR |
-| **Developer** | $29/mo | Gateway + memory | 50,000 executions/mo, 3 users, vault memory — no IDP, no GPU |
-| **Teams** | $99/mo | Gateway + memory + Onyx | 250,000 executions/mo, 10 users, full Onyx semantic search — no IDP |
-| **Starter** | $299/mo | IDP plugin bundle | 5,000 documents/mo, VDR, classify/extract, sovereign inference |
-| **Business** | $599/mo | IDP plugin bundle | 25,000 documents/mo, priority queue, full VDR analytics, 99.5% SLA |
-| **Professional** | $1,200/mo | Full stack | 75,000 documents/mo, dedicated namespace, vertical fine-tune, SSO/SAML |
-| **Enterprise** | from $3,500/mo | Full stack + security | Dedicated node, custom fine-tune, EU multi-region, Sovereign Security Pack included |
+| Tier             | Price          | Plugin bundle           | Included                                                                            |
+| ---------------- | -------------- | ----------------------- | ----------------------------------------------------------------------------------- |
+| **Free**         | $0/mo          | MCP Gateway             | 10,000 executions/mo, 1 user, basic memory vault — no IDP, no VDR                   |
+| **Developer**    | $29/mo         | Gateway + memory        | 50,000 executions/mo, 3 users, vault memory — no IDP, no GPU                        |
+| **Teams**        | $99/mo         | Gateway + memory + Onyx | 250,000 executions/mo, 10 users, full Onyx semantic search — no IDP                 |
+| **Starter**      | $299/mo        | IDP plugin bundle       | 5,000 documents/mo, VDR, classify/extract, sovereign inference                      |
+| **Business**     | $599/mo        | IDP plugin bundle       | 25,000 documents/mo, priority queue, full VDR analytics, 99.5% SLA                  |
+| **Professional** | $1,200/mo      | Full stack              | 75,000 documents/mo, dedicated namespace, vertical fine-tune, SSO/SAML              |
+| **Enterprise**   | from $3,500/mo | Full stack + security   | Dedicated node, custom fine-tune, EU multi-region, Sovereign Security Pack included |
 
 Execution overage on gateway tiers: **$0.20 per 1,000 executions** (matches [Executor](https://executor.sh/) Team pricing). Sovereign Security Pack: **+$200/mo** on any paid tier.
 
@@ -404,22 +404,22 @@ The entire sequence above runs from a single natural-language agent prompt. No c
 
 ClawQL competes across four adjacent markets — price each plugin bundle against the right incumbent:
 
-| Competitor Category | ClawQL tier | ClawQL differentiation |
-| ------------------- | ----------- | ---------------------- |
-| **MCP gateways** ([Executor](https://executor.sh/), emerging agent infrastructure) | Developer ($29/mo), Teams ($99/mo) | Same context-efficient search/execute pattern. ClawQL adds Obsidian vault memory, Onyx semantic search, and optional IDP platform Executor does not ship. Executor Team is $150/org for 250K executions; ClawQL Teams is $99 with memory. |
-| **SaaS IDP vendors** (Hyperscience, Kofax, ABBYY) | Starter–Professional (IDP bundle) | Cloud-hosted; per-document pricing at scale. No native MCP/agent interface. ClawQL: tenant-isolated hosted or self-hosted, flat IDP tiers, MCP-native from day one. |
-| **VDR incumbents** (Intralinks, Datasite, Ansarada) | Starter+ (IDP bundle includes Coneshare) | Hosted VDRs with no document processing pipeline. High per-user/per-GB/per-deal licensing. ClawQL: full pipeline integration, Coneshare VDR included in IDP subscription. |
-| **Vertical CRMs** (REsimpli, franchise transaction tools) | Teams ($99/mo) for agent memory; Starter ($299/mo) for IDP | CRMs track pipeline; Drive folders hold files. ClawQL connects CRM APIs + storage via MCP, indexes documents in Onyx, threads deal context in vault — without replacing Command, Dotloop, or SkySlope. |
+| Competitor Category                                                                | ClawQL tier                                                | ClawQL differentiation                                                                                                                                                                                                                    |
+| ---------------------------------------------------------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **MCP gateways** ([Executor](https://executor.sh/), emerging agent infrastructure) | Developer ($29/mo), Teams ($99/mo)                         | Same context-efficient search/execute pattern. ClawQL adds Obsidian vault memory, Onyx semantic search, and optional IDP platform Executor does not ship. Executor Team is $150/org for 250K executions; ClawQL Teams is $99 with memory. |
+| **SaaS IDP vendors** (Hyperscience, Kofax, ABBYY)                                  | Starter–Professional (IDP bundle)                          | Cloud-hosted; per-document pricing at scale. No native MCP/agent interface. ClawQL: tenant-isolated hosted or self-hosted, flat IDP tiers, MCP-native from day one.                                                                       |
+| **VDR incumbents** (Intralinks, Datasite, Ansarada)                                | Starter+ (IDP bundle includes Coneshare)                   | Hosted VDRs with no document processing pipeline. High per-user/per-GB/per-deal licensing. ClawQL: full pipeline integration, Coneshare VDR included in IDP subscription.                                                                 |
+| **Vertical CRMs** (REsimpli, franchise transaction tools)                          | Teams ($99/mo) for agent memory; Starter ($299/mo) for IDP | CRMs track pipeline; Drive folders hold files. ClawQL connects CRM APIs + storage via MCP, indexes documents in Onyx, threads deal context in vault — without replacing Command, Dotloop, or SkySlope.                                    |
 
 ### Real estate vertical
 
 Brokerages on Keller Williams Command, eXp BoldTrail, Follow Up Boss, or Compass share a structural gap: **CRM knows the deal, Drive holds the files** — no semantic link between contacts and transaction PDFs.
 
-| Need | Recommended tier | Why |
-| ---- | ---------------- | --- |
-| Connect Command + Drive, semantic search, deal memory | **Teams ($99/mo)** | MCP gateway + Onyx + vault — no IDP overhead for teams that do not process documents daily |
-| Title commitment classify/extract, Coneshare VDR for disclosures | **Starter ($299/mo)** | IDP plugin bundle — explicitly opted in |
-| REsimpli comparison | Teams vs REsimpli Basic ($149/mo) | REsimpli is CRM-only for investors; ClawQL unifies CRM integration, document search, and agent memory |
+| Need                                                             | Recommended tier                  | Why                                                                                                   |
+| ---------------------------------------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Connect Command + Drive, semantic search, deal memory            | **Teams ($99/mo)**                | MCP gateway + Onyx + vault — no IDP overhead for teams that do not process documents daily            |
+| Title commitment classify/extract, Coneshare VDR for disclosures | **Starter ($299/mo)**             | IDP plugin bundle — explicitly opted in                                                               |
+| REsimpli comparison                                              | Teams vs REsimpli Basic ($149/mo) | REsimpli is CRM-only for investors; ClawQL unifies CRM integration, document search, and agent memory |
 
 ClawQL does **not** replace Dotloop (forms, e-sign, broker compliance) or MLS listing platforms. It is the intelligent document layer on top.
 

--- a/landing-page/README.md
+++ b/landing-page/README.md
@@ -36,15 +36,16 @@ Open [http://localhost:3000](http://localhost:3000).
 
 ## Content model
 
-The site promotes three hosting models:
+The site promotes plugin-bundle hosting models:
 
-1. **Self-hosted (free)** — Open-source `clawql-mcp` on your own hardware
-2. **Shared managed hosting** — Free, Starter ($299/mo), Business ($599/mo) on multi-tenant infrastructure
-3. **Professional ($1,200/mo)** — Dedicated namespace, SSO/SAML, vertical fine-tune adapter
+1. **Self-hosted (free)** — Open-source `clawql-mcp`; enable plugins via `CLAWQL_ENABLE_*`
+2. **Gateway + memory** — Developer $29/mo, Teams $99/mo (MCP executions + vault + Onyx; no IDP)
+3. **IDP plugin bundle** — Starter $299/mo, Business $599/mo, Professional $1,200/mo (document processing + VDR)
+4. **Enterprise** — from $3,500/mo (dedicated node, custom fine-tune, Sovereign Security Pack included)
 
-**Enterprise** contracts (from $3,500/mo — dedicated node, custom fine-tuning, EU multi-region) are contact-sales only.
+**Sovereign Security Pack** (+$200/mo on any paid tier) bundles Kata isolation, WORM Merkle audit, Panguard ATR.
 
-Signup forms currently point to the waitlist flow (`/signup`). Wire `EmailSignupForm` actions to your backend or email provider when ready for production.
+Signup forms point to the waitlist flow (`/signup`). Wire `WaitlistSignupForm` to your backend when ready.
 
 ## Template origin
 

--- a/landing-page/demo/src/app/page.tsx
+++ b/landing-page/demo/src/app/page.tsx
@@ -202,8 +202,8 @@ export default function Page() {
         />
         <Faq
           id="faq-2"
-          question="What's the difference between Starter, Business, and Professional?"
-          answer={`Starter (${pricing.starter.monthlyPrice}/mo) and Business (${pricing.business.monthlyPrice}/mo) are shared multi-tenant plans with 5,000 and 25,000 documents/month respectively. Professional (${pricing.professional.monthlyPrice}/mo) gives your organization a dedicated namespace, one vertical fine-tune adapter, SSO/SAML, and 99.9% uptime SLA. All managed tiers are in early access — join the waitlist for founder-led onboarding.`}
+          question="What's the difference between Developer, Teams, and Starter?"
+          answer={`Developer (${pricing.developer.monthlyPrice}/mo) is MCP gateway + memory — no IDP. Teams (${pricing.teams.monthlyPrice}/mo) adds full Onyx search. Starter (${pricing.starter.monthlyPrice}/mo) activates the IDP plugin bundle. Gateway-only buyers should not pay for document processing they do not use.`}
         />
         <Faq
           id="faq-3"
@@ -218,7 +218,7 @@ export default function Page() {
         <Faq
           id="faq-5"
           question="Is managed hosting available today?"
-          answer="Self-hosting is available now — npm, Helm, and the full open-source stack. Managed Free, Starter, Business, Professional, and Enterprise hosting is in early access: limited tenant slots, founder-led onboarding, and personal replies to waitlist signups."
+          answer="Self-hosting is available now — npm, Helm, and the full open-source stack. Managed gateway tiers from $29/mo and IDP bundles from $299/mo are in early access: limited tenant slots, founder-led onboarding, and personal replies to waitlist signups."
         />
         <Faq
           id="faq-6"
@@ -230,7 +230,7 @@ export default function Page() {
       {/* Pricing teaser — full grid on /pricing */}
       <PricingMultiTier
         id="pricing"
-        headline={`Self-host free. Managed tiers from ${pricing.starter.monthlyPrice}/mo — early access.`}
+        headline={`Self-host free. Gateway from ${pricing.developer.monthlyPrice}/mo · IDP from ${pricing.starter.monthlyPrice}/mo.`}
         subheadline={<p className="text-center text-sm/7 text-mist-600 dark:text-mist-400">{site.earlyAccess.pricingNote}</p>}
         plans={
           <>
@@ -247,38 +247,38 @@ export default function Page() {
               }
             />
             <Plan
+              name={pricing.developer.name}
+              price={pricing.developer.monthlyPrice}
+              period={pricing.developer.period}
+              subheadline={<p>{pricing.developer.subheadline}</p>}
+              badge={pricing.developer.badge}
+              features={pricing.developer.features.slice(0, 4)}
+              cta={
+                <ButtonLink href={site.urls.signup} size="lg">
+                  Join early access
+                </ButtonLink>
+              }
+            />
+            <Plan
+              name={pricing.teams.name}
+              price={pricing.teams.monthlyPrice}
+              period={pricing.teams.period}
+              subheadline={<p>{pricing.teams.subheadline}</p>}
+              badge={pricing.teams.badge}
+              features={pricing.teams.features.slice(0, 4)}
+              cta={
+                <ButtonLink href={site.urls.signup} size="lg">
+                  Join early access
+                </ButtonLink>
+              }
+            />
+            <Plan
               name={pricing.starter.name}
               price={pricing.starter.monthlyPrice}
               period={pricing.starter.period}
               subheadline={<p>{pricing.starter.subheadline}</p>}
               badge={pricing.starter.badge}
               features={pricing.starter.features.slice(0, 4)}
-              cta={
-                <ButtonLink href={site.urls.signup} size="lg">
-                  Join early access
-                </ButtonLink>
-              }
-            />
-            <Plan
-              name={pricing.business.name}
-              price={pricing.business.monthlyPrice}
-              period={pricing.business.period}
-              subheadline={<p>{pricing.business.subheadline}</p>}
-              badge={pricing.business.badge}
-              features={pricing.business.features.slice(0, 4)}
-              cta={
-                <ButtonLink href={site.urls.signup} size="lg">
-                  Join early access
-                </ButtonLink>
-              }
-            />
-            <Plan
-              name={pricing.professional.name}
-              price={pricing.professional.monthlyPrice}
-              period={pricing.professional.period}
-              subheadline={<p>{pricing.professional.subheadline}</p>}
-              badge={pricing.professional.badge}
-              features={pricing.professional.features.slice(0, 4)}
               cta={
                 <PlainButtonLink href={site.urls.pricing} size="lg">
                   All tiers & limits <ArrowNarrowRightIcon />

--- a/landing-page/demo/src/app/pricing/page.tsx
+++ b/landing-page/demo/src/app/pricing/page.tsx
@@ -9,16 +9,20 @@ import { Section } from '@/components/elements/section'
 import {
   annualBillingNoteText,
   annualBillingSavingsLabel,
+  executionOveragePerThousand,
   managedPrice,
+  pluginBundles,
   pricing,
   pricingPlanNames,
   sovereignSecurityPack,
   type BillingPeriod,
+  type GatewayTierId,
+  type IdpTierId,
 } from '@/lib/pricing'
 import { site } from '@/lib/site'
 
-function managedPlans(billing: BillingPeriod) {
-  const annualNote = annualBillingNoteText(billing)
+function gatewayPlans(billing: BillingPeriod) {
+  const gatewayTiers: GatewayTierId[] = ['developer', 'teams']
 
   return (
     <>
@@ -35,60 +39,65 @@ function managedPlans(billing: BillingPeriod) {
           </ButtonLink>
         }
       />
-      <Plan
-        name={pricing.starter.name}
-        price={managedPrice('starter', billing)}
-        period={pricing.starter.period}
-        subheadline={
-          <p>
-            {pricing.starter.subheadline}
-            {annualNote ? <span className="block text-mist-500">{annualNote}</span> : null}
-          </p>
-        }
-        badge={pricing.starter.badge}
-        features={[...pricing.starter.features]}
-        cta={
-          <ButtonLink href={site.urls.signup} size="lg">
-            Join early access
-          </ButtonLink>
-        }
-      />
-      <Plan
-        name={pricing.business.name}
-        price={managedPrice('business', billing)}
-        period={pricing.business.period}
-        subheadline={
-          <p>
-            {pricing.business.subheadline}
-            {annualNote ? <span className="block text-mist-500">{annualNote}</span> : null}
-          </p>
-        }
-        badge={pricing.business.badge}
-        features={[...pricing.business.features]}
-        cta={
-          <ButtonLink href={site.urls.signup} size="lg">
-            Join early access
-          </ButtonLink>
-        }
-      />
-      <Plan
-        name={pricing.professional.name}
-        price={managedPrice('professional', billing)}
-        period={pricing.professional.period}
-        subheadline={
-          <p>
-            {pricing.professional.subheadline}
-            {annualNote ? <span className="block text-mist-500">{annualNote}</span> : null}
-          </p>
-        }
-        badge={pricing.professional.badge}
-        features={[...pricing.professional.features]}
-        cta={
-          <ButtonLink href={site.urls.signup} size="lg">
-            Join early access
-          </ButtonLink>
-        }
-      />
+      {gatewayTiers.map((tier) => {
+        const plan = pricing[tier]
+        const annualNote = annualBillingNoteText(billing, tier)
+        return (
+          <Plan
+            key={tier}
+            name={plan.name}
+            price={managedPrice(tier, billing)}
+            period={plan.period}
+            subheadline={
+              <p>
+                {plan.subheadline}
+                {annualNote ? <span className="block text-mist-500">{annualNote}</span> : null}
+              </p>
+            }
+            badge={plan.badge}
+            features={[...plan.features]}
+            cta={
+              <ButtonLink href={site.urls.signup} size="lg">
+                Join early access
+              </ButtonLink>
+            }
+          />
+        )
+      })}
+    </>
+  )
+}
+
+function idpPlans(billing: BillingPeriod) {
+  const idpTiers: IdpTierId[] = ['starter', 'business', 'professional']
+
+  return (
+    <>
+      {idpTiers.map((tier) => {
+        const plan = pricing[tier]
+        const annualNote = annualBillingNoteText(billing, tier)
+        return (
+          <Plan
+            key={tier}
+            name={plan.name}
+            price={managedPrice(tier, billing)}
+            period={plan.period}
+            subheadline={
+              <p>
+                {plan.subheadline}
+                {annualNote ? <span className="block text-mist-500">{annualNote}</span> : null}
+              </p>
+            }
+            badge={plan.badge}
+            features={[...plan.features]}
+            cta={
+              <ButtonLink href={site.urls.signup} size="lg">
+                Join early access
+              </ButtonLink>
+            }
+          />
+        )
+      })}
     </>
   )
 }
@@ -116,18 +125,56 @@ export default function Page() {
         </div>
       </Section>
 
-      <PricingHeroMultiTier
-        id="pricing"
-        headline="Managed hosting"
+      <Section
+        id="plugin-bundles"
+        eyebrow="Plugin model"
+        headline="Pay for the plugins you activate"
         subheadline={
           <p>
-            {site.earlyAccess.summary} Document volume and storage limits apply per tier; storage overage billed at
-            $0.02/GB on Starter and Business, $0.015/GB pass-through on Professional.
+            ClawQL Core (<code className="text-sm">search</code>, <code className="text-sm">execute</code>,{' '}
+            <code className="text-sm">audit</code>, <code className="text-sm">cache</code>) is always on. Memory, IDP,
+            and vertical packages activate via <code className="text-sm">CLAWQL_ENABLE_*</code> flags — managed tiers map
+            to plugin bundles, not one-size-fits-all document quotas.
+          </p>
+        }
+      >
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+          {Object.values(pluginBundles).map((bundle) => (
+            <div key={bundle.name} className="flex flex-col gap-2 rounded-xl bg-mist-950/2.5 p-5 dark:bg-white/5">
+              <h3 className="text-base font-semibold text-mist-950 dark:text-white">{bundle.name}</h3>
+              <p className="text-sm/7 text-mist-700 dark:text-mist-400">{bundle.description}</p>
+              <p className="text-xs text-mist-500">Tiers: {bundle.tiers.join(' · ')}</p>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <PricingHeroMultiTier
+        id="pricing-gateway"
+        headline="Agent gateway & memory"
+        subheadline={
+          <p>
+            MCP gateway + vault memory for teams connecting agents to APIs — no IDP pipeline, no GPU inference. Execution
+            overage {executionOveragePerThousand}/1,000 (matches Executor).
           </p>
         }
         options={['Monthly', 'Yearly']}
         annualSavingsLabel={annualBillingSavingsLabel}
-        plans={{ Monthly: managedPlans('Monthly'), Yearly: managedPlans('Yearly') }}
+        plans={{ Monthly: gatewayPlans('Monthly'), Yearly: gatewayPlans('Yearly') }}
+      />
+
+      <PricingHeroMultiTier
+        id="pricing-idp"
+        headline="IDP plugin bundle"
+        subheadline={
+          <p>
+            Document processing, Coneshare VDR, and sovereign inference — explicitly opted in. Storage overage $0.02/GB
+            on Starter and Business, $0.015/GB on Professional.
+          </p>
+        }
+        options={['Monthly', 'Yearly']}
+        annualSavingsLabel={annualBillingSavingsLabel}
+        plans={{ Monthly: idpPlans('Monthly'), Yearly: idpPlans('Yearly') }}
       />
 
       <Section id="early-access" eyebrow="Early access" headline="Managed hosting is onboarding its first tenants">
@@ -142,13 +189,80 @@ export default function Page() {
         plans={[...pricingPlanNames]}
         features={[
           {
-            title: 'Usage & storage',
+            title: 'Plugin bundle',
             features: [
+              {
+                name: 'MCP Gateway (Core)',
+                value: {
+                  'Self-hosted': true,
+                  Free: true,
+                  Developer: true,
+                  Teams: true,
+                  Starter: true,
+                  Business: true,
+                  Professional: true,
+                },
+              },
+              {
+                name: 'Memory vault + Onyx search',
+                value: {
+                  'Self-hosted': 'Self-managed',
+                  Free: 'Basic vault',
+                  Developer: true,
+                  Teams: 'Full Onyx',
+                  Starter: true,
+                  Business: true,
+                  Professional: true,
+                },
+              },
+              {
+                name: 'IDP plugin bundle',
+                value: {
+                  'Self-hosted': 'Opt-in',
+                  Free: false,
+                  Developer: false,
+                  Teams: false,
+                  Starter: true,
+                  Business: true,
+                  Professional: true,
+                },
+              },
+            ],
+          },
+          {
+            title: 'Usage & metering',
+            features: [
+              {
+                name: 'Executions / month',
+                value: {
+                  'Self-hosted': 'Unlimited (your infra)',
+                  Free: '10,000',
+                  Developer: '50,000',
+                  Teams: '250,000',
+                  Starter: '—',
+                  Business: '—',
+                  Professional: '—',
+                },
+              },
+              {
+                name: 'Execution overage',
+                value: {
+                  'Self-hosted': 'N/A',
+                  Free: executionOveragePerThousand + '/1K',
+                  Developer: executionOveragePerThousand + '/1K',
+                  Teams: executionOveragePerThousand + '/1K',
+                  Starter: '—',
+                  Business: '—',
+                  Professional: '—',
+                },
+              },
               {
                 name: 'Documents / month',
                 value: {
                   'Self-hosted': 'Unlimited (your infra)',
-                  Free: '200',
+                  Free: '—',
+                  Developer: '—',
+                  Teams: '—',
                   Starter: '5,000',
                   Business: '25,000',
                   Professional: '75,000',
@@ -159,153 +273,52 @@ export default function Page() {
                 value: {
                   'Self-hosted': 'Unlimited',
                   Free: '1',
+                  Developer: '3',
+                  Teams: '10',
                   Starter: '5',
                   Business: '25',
                   Professional: 'Unlimited',
                 },
               },
-              {
-                name: 'Storage included',
-                value: {
-                  'Self-hosted': 'Your choice',
-                  Free: '5 GB',
-                  Starter: '50 GB',
-                  Business: '500 GB',
-                  Professional: '2 TB',
-                },
-              },
-              {
-                name: 'Storage overage',
-                value: {
-                  'Self-hosted': 'N/A',
-                  Free: 'N/A',
-                  Starter: '$0.02/GB',
-                  Business: '$0.02/GB',
-                  Professional: '$0.015/GB',
-                },
-              },
             ],
           },
           {
-            title: 'Document intelligence',
+            title: 'Document intelligence (IDP bundle)',
             features: [
               {
                 name: 'Coneshare VDR',
                 value: {
                   'Self-hosted': 'Self-deploy optional',
                   Free: false,
+                  Developer: false,
+                  Teams: false,
                   Starter: true,
                   Business: true,
                   Professional: 'Full + advanced analytics',
                 },
               },
               {
-                name: 'Onyx semantic search',
-                value: {
-                  'Self-hosted': 'Self-managed',
-                  Free: 'Basic',
-                  Starter: 'Full',
-                  Business: 'Full + cross-doc',
-                  Professional: 'Full + cross-doc',
-                },
-              },
-              {
-                name: 'Processing priority',
-                value: {
-                  'Self-hosted': '—',
-                  Free: 'Low',
-                  Starter: 'Standard',
-                  Business: 'Priority',
-                  Professional: 'Dedicated queue',
-                },
-              },
-              {
-                name: 'Obsidian memory vault',
-                value: {
-                  'Self-hosted': 'Self-managed',
-                  Free: false,
-                  Starter: true,
-                  Business: true,
-                  Professional: true,
-                },
-              },
-              {
-                name: 'Dynamic watermarking (VDR)',
-                value: {
-                  'Self-hosted': 'Self-deploy optional',
-                  Free: false,
-                  Starter: true,
-                  Business: true,
-                  Professional: true,
-                },
-              },
-              {
-                name: 'ClawQL Archive Layer (managed)',
-                value: {
-                  'Self-hosted': 'Paperless-ngx optional',
-                  Free: true,
-                  Starter: true,
-                  Business: true,
-                  Professional: true,
-                },
-              },
-            ],
-          },
-          {
-            title: 'Platform',
-            features: [
-              {
-                name: 'Hosted HTTP MCP',
-                value: {
-                  'Self-hosted': false,
-                  Free: true,
-                  Starter: true,
-                  Business: true,
-                  Professional: true,
-                },
-              },
-              {
-                name: 'Tenant isolation',
-                value: {
-                  'Self-hosted': 'Your hardware',
-                  Free: 'Shared',
-                  Starter: 'Shared',
-                  Business: 'Shared',
-                  Professional: 'Dedicated namespace',
-                },
-              },
-              {
-                name: 'Merkle cryptographic audit trail',
-                value: true,
-              },
-              {
-                name: 'Sovereign inference (no external LLM APIs)',
+                name: 'Sovereign inference',
                 value: {
                   'Self-hosted': 'Your deployment',
                   Free: false,
+                  Developer: false,
+                  Teams: false,
                   Starter: true,
                   Business: true,
                   Professional: true,
                 },
               },
               {
-                name: 'HITL review (Label Studio)',
+                name: 'classify / extract / HITL',
                 value: {
-                  'Self-hosted': 'Self-deploy',
+                  'Self-hosted': 'Opt-in',
                   Free: false,
+                  Developer: false,
+                  Teams: false,
                   Starter: true,
                   Business: true,
                   Professional: true,
-                },
-              },
-              {
-                name: 'Pre-trained document skill library',
-                value: {
-                  'Self-hosted': 'Vertical adapters',
-                  Free: 'Vertical adapters',
-                  Starter: 'Vertical adapters',
-                  Business: 'Vertical adapters',
-                  Professional: 'One vertical fine-tune included',
                 },
               },
             ],
@@ -318,19 +331,11 @@ export default function Page() {
                 value: {
                   'Self-hosted': '—',
                   Free: 'None',
+                  Developer: 'None',
+                  Teams: '99% uptime',
                   Starter: '99% uptime',
                   Business: '99.5% uptime',
                   Professional: '99.9% uptime',
-                },
-              },
-              {
-                name: 'Support',
-                value: {
-                  'Self-hosted': 'Community',
-                  Free: 'Community',
-                  Starter: 'Email (48 hr)',
-                  Business: 'Email (24 hr)',
-                  Professional: 'Slack Connect + email',
                 },
               },
               {
@@ -338,6 +343,8 @@ export default function Page() {
                 value: {
                   'Self-hosted': false,
                   Free: false,
+                  Developer: false,
+                  Teams: false,
                   Starter: false,
                   Business: false,
                   Professional: true,
@@ -396,47 +403,42 @@ export default function Page() {
         <Faq
           id="faq-1"
           question="Is self-hosted really free?"
-          answer="Yes. ClawQL is open source. You pay only for compute and storage on your hardware. All core MCP tools and the full IDP pipeline are included with no license fee."
+          answer="Yes. ClawQL is open source. You pay only for compute and storage on your hardware. Enable plugins via CLAWQL_ENABLE_* flags — Core is always on; IDP vendors activate when you need document processing."
         />
         <Faq
           id="faq-2"
-          question="What's the difference between Starter, Business, and Professional?"
-          answer={`Starter (${pricing.starter.monthlyPrice}/mo) and Business (${pricing.business.monthlyPrice}/mo) run on shared multi-tenant infrastructure with document volume limits (5,000 and 25,000 documents/month). Professional (${pricing.professional.monthlyPrice}/mo) gives your organization a dedicated namespace, one vertical fine-tune adapter, SSO/SAML, and 99.9% uptime SLA. All managed tiers are in early access with founder-led onboarding.`}
+          question="What's the difference between Developer, Teams, and Starter?"
+          answer={`Developer (${pricing.developer.monthlyPrice}/mo) is MCP gateway + memory vault — no IDP. Teams (${pricing.teams.monthlyPrice}/mo) adds full Onyx semantic search. Starter (${pricing.starter.monthlyPrice}/mo) activates the IDP plugin bundle (classify, extract, VDR, sovereign inference). You only pay for document processing when you opt into IDP tiers.`}
         />
         <Faq
           id="faq-3"
-          question="What is the managed Free tier?"
-          answer="Free ($0/mo) lets you process up to 200 documents/month on hosted infrastructure with basic Onyx search — a way to try the real pipeline before upgrading to Starter for Coneshare VDR, sovereign inference, and higher limits. It is not the same as self-hosting, which has no document cap enforced by ClawQL."
+          question="How does ClawQL compare to Executor?"
+          answer={`Executor Team is $150/org/mo for 250,000 MCP executions. ClawQL Developer is ${pricing.developer.monthlyPrice}/mo (50,000 executions) and Teams is ${pricing.teams.monthlyPrice}/mo with vault memory and Onyx search — capabilities Executor does not ship. Overage matches at ${executionOveragePerThousand}/1,000 executions.`}
         />
         <Faq
           id="faq-4"
           question="Can I switch tiers later?"
-          answer="Yes. Vault exports, provider auth, and pipeline configuration can migrate between tiers. Upgrade when you hit document quotas or need Professional isolation and vertical fine-tuning for compliance."
+          answer="Yes. Vault exports, provider auth, and plugin flags migrate between tiers. Start on Teams for agent memory; upgrade to Starter when you need IDP document processing."
         />
         <Faq
           id="faq-5"
-          question="How does ClawQL pricing compare to Hyperscience or ABBYY?"
-          answer={`Incumbent IDP vendors often charge per page ($0.02–$1.50+) or $40K–$100K+/year in enterprise contracts. A Business customer processing 25,000 documents/month at ~5 pages each would pay tens of thousands per month at per-page IDP rates. ClawQL Business is ${pricing.business.monthlyPrice}/month flat with IDP, VDR, semantic search, and agent orchestration bundled — see the competitive section above for illustrative TCO math.`}
+          question="How does ClawQL IDP pricing compare to Hyperscience or ABBYY?"
+          answer={`Incumbent IDP vendors charge per page or $40K–$100K+/year. ClawQL Business (IDP bundle) is ${pricing.business.monthlyPrice}/month flat with VDR, semantic search, and agent orchestration included — see the competitive section for TCO math.`}
         />
         <Faq
           id="faq-6"
-          question="Why is ClawQL priced below legacy VDR and IDP stacks?"
-          answer={`Intralinks, Datasite, and similar vendors price per deal, per page, or $10K–$200K+/year with storage overages and setup fees. Starter at ${pricing.starter.monthlyPrice}/month includes Coneshare VDR in the subscription. Pricing is anchored to replacement value — still 6–20× below the incumbent stack — while remaining credible to enterprise procurement teams.`}
+          question="What tier fits real estate teams on Command + Google Drive?"
+          answer={`Teams (${pricing.teams.monthlyPrice}/mo) for MCP gateway + Onyx search over Drive folders + vault memory across deals. Add Starter (${pricing.starter.monthlyPrice}/mo) when you need title commitment classify/extract or Coneshare VDR for trackable disclosure packages. See /industries/real-estate.`}
         />
         <Faq
           id="faq-7"
-          question="Do you match ABBYY's pre-trained document skills?"
-          answer="Not on day one. ABBYY Vantage ships 150+ pre-built skills for common document types. ClawQL composes classify, extract, and HITL per vertical — lending W-2 samples ship today; broader skill libraries build with vertical packages. We state this openly in competitive evaluations rather than overclaiming."
+          question="What is the Sovereign Security Pack?"
+          answer={`The Sovereign Security Pack (${sovereignSecurityPack.monthlyPrice}${sovereignSecurityPack.period}) is an optional add-on on any paid tier. Enterprise includes it by default.`}
         />
         <Faq
           id="faq-8"
-          question="What is the Sovereign Security Pack?"
-          answer={`The Sovereign Security Pack (${sovereignSecurityPack.monthlyPrice}${sovereignSecurityPack.period}) is an optional add-on on Starter, Business, and Professional. It bundles Kata VM isolation, model weight integrity verification, WORM Merkle audit logs, Panguard fail-closed ATR, and monthly posture reports. Enterprise includes it by default.`}
-        />
-        <Faq
-          id="faq-9"
           question="Do you publish enterprise pricing?"
-          answer={`Enterprise contracts start from ${pricing.enterprise.priceFrom}${pricing.enterprise.period} for dedicated nodes, custom fine-tuning with retraining, EU multi-region, DPA/BAA, and a dedicated CSM. Contact sales to discuss annual terms.`}
+          answer={`Enterprise contracts start from ${pricing.enterprise.priceFrom}${pricing.enterprise.period} for dedicated nodes, custom fine-tuning, EU multi-region, DPA/BAA, and a dedicated CSM.`}
         />
       </FAQsAccordion>
 
@@ -445,8 +447,8 @@ export default function Page() {
         headline="Self-host free or join early access"
         subheadline={
           <p>
-            Install clawql-mcp on your hardware, or join the waitlist for managed Free, Starter, Business, or Professional
-            hosting.
+            Install clawql-mcp on your hardware, or join the waitlist — gateway from {pricing.developer.monthlyPrice}/mo,
+            IDP bundle from {pricing.starter.monthlyPrice}/mo.
           </p>
         }
         cta={

--- a/landing-page/demo/src/app/signup/page.tsx
+++ b/landing-page/demo/src/app/signup/page.tsx
@@ -27,9 +27,9 @@ export default function Page() {
             <a href="/industries/real-estate#demo-pitch" className="underline">
               one-paragraph pitch
             </a>{' '}
-            to forward before your demo. Managed Free ($0), Starter ({pricing.starter.monthlyPrice}/mo), Business (
-            {pricing.business.monthlyPrice}/mo), and Professional ({pricing.professional.monthlyPrice}/mo) — join the
-            waitlist for founder-led onboarding. {site.waitlistPromise}
+            to forward before your demo. Gateway from {pricing.developer.monthlyPrice}/mo, Teams{' '}
+            {pricing.teams.monthlyPrice}/mo, IDP bundle from {pricing.starter.monthlyPrice}/mo — join the waitlist for
+            founder-led onboarding. {site.waitlistPromise}
           </p>
         }
         cta={<WaitlistSignupForm className="mx-auto" />}

--- a/landing-page/demo/src/components/sections/competitive-pricing-section.tsx
+++ b/landing-page/demo/src/components/sections/competitive-pricing-section.tsx
@@ -1,5 +1,6 @@
 import { clsx } from 'clsx/lite'
 import type { ComponentProps } from 'react'
+import { Link } from '@/components/elements/link'
 import { Section } from '../elements/section'
 import { CheckmarkIcon } from '../icons/checkmark-icon'
 import { MinusIcon } from '../icons/minus-icon'
@@ -9,6 +10,8 @@ import {
   competitiveHeadline,
   competitiveHonestyNotes,
   competitiveSummary,
+  executorBenchmark,
+  realEstateVertical,
   stackReplacementSummary,
   tcoBenchmarks,
 } from '@/lib/competitive-pricing'
@@ -40,11 +43,7 @@ export function CompetitivePricingSection({ className, ...props }: ComponentProp
         id="competitive"
         eyebrow="Competitive landscape"
         headline={competitiveHeadline}
-        subheadline={
-          <p>
-            {competitiveSummary}
-          </p>
-        }
+        subheadline={<p>{competitiveSummary}</p>}
       >
         <div className="grid grid-cols-1 gap-2 lg:grid-cols-3">
           {tcoBenchmarks.map((benchmark) => (
@@ -67,6 +66,57 @@ export function CompetitivePricingSection({ className, ...props }: ComponentProp
             </div>
           ))}
         </div>
+
+        <div className="mt-10 rounded-xl border border-mist-950/10 bg-mist-950/2.5 p-6 sm:p-8 dark:border-white/10 dark:bg-white/5">
+          <h3 className="text-xl font-semibold text-mist-950 dark:text-white">
+            vs {executorBenchmark.name} — direct MCP gateway competitor
+          </h3>
+          <p className="mt-2 text-sm/7 text-mist-700 dark:text-mist-400">{executorBenchmark.tagline}</p>
+          <p className="mt-2 text-sm/7 text-mist-600 dark:text-mist-500">{executorBenchmark.tokenEfficiency}</p>
+          <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+              <p className="text-xs font-medium tracking-wide text-mist-500 uppercase">{executorBenchmark.name} pricing</p>
+              <ul className="mt-2 space-y-1 text-sm/7 text-mist-700 dark:text-mist-400">
+                {executorBenchmark.pricing.map((row) => (
+                  <li key={row.tier}>
+                    <span className="font-medium text-mist-950 dark:text-white">{row.tier}</span> {row.price} —{' '}
+                    {row.includes}
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <p className="text-xs font-medium tracking-wide text-mist-500 uppercase">ClawQL response</p>
+              <p className="mt-2 text-sm font-semibold text-mist-950 dark:text-white">
+                {executorBenchmark.clawqlResponse.tier}
+              </p>
+              <p className="mt-2 text-sm/7 text-mist-700 dark:text-mist-400">
+                {executorBenchmark.clawqlResponse.advantage}
+              </p>
+              <p className="mt-2 text-xs/6 text-mist-500 dark:text-mist-400">
+                {executorBenchmark.clawqlResponse.honestGap}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-6 rounded-xl border border-mist-950/10 bg-mist-950/2.5 p-6 sm:p-8 dark:border-white/10 dark:bg-white/5">
+          <h3 className="text-xl font-semibold text-mist-950 dark:text-white">{realEstateVertical.headline}</h3>
+          <p className="mt-2 text-sm/7 text-mist-700 dark:text-mist-400">{realEstateVertical.problem}</p>
+          <p className="mt-4 text-sm/7 text-mist-700 dark:text-mist-400">{realEstateVertical.clawqlPitch}</p>
+          <p className="mt-4 text-sm font-medium text-mist-950 dark:text-white">{realEstateVertical.recommendedTier}</p>
+          <ul className="mt-4 space-y-2 text-sm/7 text-mist-600 dark:text-mist-500">
+            {realEstateVertical.competitors.map((c) => (
+              <li key={c.name}>
+                <span className="font-medium text-mist-800 dark:text-mist-200">{c.name}</span> ({c.pricing}) — {c.gap}
+              </li>
+            ))}
+          </ul>
+          <Link href={realEstateVertical.href} className="mt-4 inline-block text-sm font-medium">
+            Real estate vertical →
+          </Link>
+        </div>
+
         <div className="mt-10 rounded-xl border border-mist-950/10 bg-mist-950/2.5 p-6 sm:p-8 dark:border-white/10 dark:bg-white/5">
           <h3 className="text-xl font-semibold text-mist-950 dark:text-white">{stackReplacementSummary.headline}</h3>
           <p className="mt-2 text-sm/7 text-mist-600 dark:text-mist-400">{stackReplacementSummary.profile}</p>
@@ -81,7 +131,7 @@ export function CompetitivePricingSection({ className, ...props }: ComponentProp
               </p>
             </div>
             <div>
-              <p className="text-xs font-medium tracking-wide text-mist-500 uppercase">ClawQL Business</p>
+              <p className="text-xs font-medium tracking-wide text-mist-500 uppercase">ClawQL Business (IDP bundle)</p>
               <p className="mt-1 text-lg font-semibold text-mist-950 dark:text-white">
                 {stackReplacementSummary.clawqlBusiness}
               </p>
@@ -101,11 +151,11 @@ export function CompetitivePricingSection({ className, ...props }: ComponentProp
       <Section
         id="competitor-features"
         eyebrow="Feature comparison"
-        headline="ClawQL Business ($599/mo) vs IDP and VDR incumbents"
+        headline="ClawQL Business ($599/mo IDP bundle) vs IDP and VDR incumbents"
         subheadline={
           <p>
-            Competitors typically sell IDP <em>or</em> VDR. ClawQL bundles both plus semantic search and MCP agent
-            orchestration. Compare at the Business tier — our mid-market managed plan.
+            Competitors typically sell IDP <em>or</em> VDR. ClawQL IDP tiers bundle both plus semantic search, MCP
+            gateway, and agent memory. Gateway-only tiers are compared against Executor above.
           </p>
         }
       >
@@ -129,10 +179,7 @@ export function CompetitivePricingSection({ className, ...props }: ComponentProp
             <tbody>
               {competitorFeatureRows.map((row) => (
                 <tr key={row.feature} className="group border-t border-mist-950/5 dark:border-white/10">
-                  <th
-                    scope="row"
-                    className="py-4 pr-4 font-normal text-mist-700 dark:text-mist-400"
-                  >
+                  <th scope="row" className="py-4 pr-4 font-normal text-mist-700 dark:text-mist-400">
                     <div className="flex flex-col gap-1">
                       <span>{row.feature}</span>
                       {row.footnote ? (
@@ -141,10 +188,7 @@ export function CompetitivePricingSection({ className, ...props }: ComponentProp
                     </div>
                   </th>
                   {competitorColumns.map((col) => (
-                    <td
-                      key={col}
-                      className="px-3 py-4 text-center text-mist-700 dark:text-mist-400"
-                    >
+                    <td key={col} className="px-3 py-4 text-center text-mist-700 dark:text-mist-400">
                       <CellValue value={row.values[col]} />
                     </td>
                   ))}
@@ -155,7 +199,7 @@ export function CompetitivePricingSection({ className, ...props }: ComponentProp
         </div>
       </Section>
 
-      <Section id="competitive-honesty" eyebrow="Honest positioning" headline="What to expect in enterprise evaluations">
+      <Section id="competitive-honesty" eyebrow="Honest positioning" headline="What to expect in evaluations">
         <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
           {competitiveHonestyNotes.map((note) => (
             <div key={note.title} className="flex flex-col gap-2 rounded-xl bg-mist-950/2.5 p-6 dark:bg-white/5">

--- a/landing-page/demo/src/lib/competitive-pricing.ts
+++ b/landing-page/demo/src/lib/competitive-pricing.ts
@@ -1,44 +1,87 @@
 /** Competitive landscape benchmarks — July 2026 research. Illustrative; verify at procurement time. */
 
-import { businessAllInMonthly } from './pricing'
+import { businessAllInMonthly, executionOveragePerThousand, pricing } from './pricing'
 
 export const competitiveHeadline =
-  'IDP, VDR, semantic search, and agent orchestration — competitors make you buy these separately.'
+  'Gateway, memory, and IDP — price each plugin bundle against the right incumbent.'
 
 export const competitiveSummary =
-  'Pricing is anchored to what ClawQL replaces — IDP vendors, VDR platforms, and compliance tooling that together run $5,000–15,000+/month. Flat tiers remain dramatically below per-page incumbents while pricing credibly against the stack, not generic SaaS.'
+  'ClawQL is not one product at one price. Developer and Teams tiers compete with MCP gateways like Executor on executions while adding vault memory Executor does not ship. Starter through Professional compete with IDP and VDR incumbents on document volume — a $5,000–15,000/month stack sold separately elsewhere.'
+
+/** MCP gateway competitor — Executor.sh (YC-backed, MIT, July 2026). */
+export const executorBenchmark = {
+  name: 'Executor',
+  href: 'https://executor.sh/',
+  tagline: 'MCP gateway — one endpoint, normalized OpenAPI/GraphQL/MCP tools, sandboxed execution.',
+  tokenEfficiency: '1,640 tools → ~278,800 tokens without Executor vs 1 execute tool → ~1,044 tokens with.',
+  pricing: [
+    { tier: 'Free', price: '$0', includes: '3 members · 10,000 executions/mo' },
+    { tier: 'Team', price: '$150/org/mo', includes: 'Unlimited members · 250,000 executions/mo' },
+    { tier: 'Overage', price: executionOveragePerThousand + '/1,000', includes: 'Both Free and Team' },
+  ],
+  clawqlResponse: {
+    tier: `Developer ${pricing.developer.monthlyPrice}/mo`,
+    advantage:
+      'Undercuts Executor Team on price while adding Obsidian vault memory, memory_recall across sessions, and optional Onyx search on Teams — capabilities Executor lists as "coming soon" for traces only.',
+    honestGap:
+      'Executor ships desktop/CLI/cloud, polished onboarding, and YC distribution. ClawQL wins on memory + platform depth, not on gateway UX polish alone.',
+  },
+} as const
 
 export const tcoBenchmarks = [
+  {
+    label: 'vs Executor (MCP gateway)',
+    scenario: 'Team connecting Cursor to GitHub, Stripe, Jira — 250,000 executions/mo',
+    incumbent: 'Executor Team: $150/org/mo',
+    clawql: `Teams: ${pricing.teams.monthlyPrice}/mo with vault + Onyx search`,
+    note: 'Developer at $29/mo undercuts for smaller teams; Teams adds semantic memory Executor does not offer.',
+  },
   {
     label: 'vs Hyperscience (IDP)',
     scenario: 'Business tier: 25,000 documents/mo × ~5 pages = 125,000 pages',
     incumbent: '~$1.50/page → ~$187,500/mo',
-    clawql: 'Business tier: $599/mo flat',
+    clawql: `Business (IDP bundle): ${pricing.business.monthlyPrice}/mo flat`,
     note: 'Volume-based IDP pricing scales linearly with every page processed.',
   },
   {
-    label: 'vs ABBYY Vantage (IDP)',
-    scenario: 'Same 125,000 pages/mo at mid-range ~$0.05/page',
-    incumbent: '~$6,250/mo + professional services',
-    clawql: 'Business tier: $599/mo flat',
-    note: 'Enterprise IDP deals often run $40K–$100K/yr before services (30–60% of year-one cost).',
-  },
-  {
     label: 'vs VDR incumbents',
-    scenario: 'Starter tier with Coneshare VDR included',
+    scenario: 'Starter IDP bundle with Coneshare VDR included',
     incumbent: 'Intralinks/Datasite: $10K–$200K+/yr; Ansarada ~$3,069/mo for 5 GB',
-    clawql: 'Starter: $299/mo ($3,588/yr)',
+    clawql: `Starter: ${pricing.starter.monthlyPrice}/mo ($3,588/yr)`,
     note: 'Legacy VDR adds storage overages ($100–$300/GB), per-seat fees, and setup charges.',
   },
 ] as const
 
+/** Real estate vertical — brokerage CRM + Drive disconnect. */
+export const realEstateVertical = {
+  headline: 'Real estate: CRM knows the deal, Drive holds the files',
+  problem:
+    'Keller Williams Command, eXp BoldTrail, Follow Up Boss, and Compass track contacts and pipeline — but Google Drive folders do not classify title commitments, extract offer contingencies, or link documents back to the deal record. Coordinators re-read PDFs; FSBO sellers compare offers manually.',
+  clawqlPitch:
+    'Teams tier ($99/mo): MCP gateway connects Command API + Google Drive; Onyx indexes transaction folders semantically; vault memory threads deal context across sessions. Add IDP Starter ($299/mo) when you need classify/extract on title commitments and PSAs, or Coneshare VDR for trackable disclosure packages instead of ad-hoc Drive links.',
+  competitors: [
+    {
+      name: 'REsimpli',
+      pricing: 'Basic $149/mo · Pro $299/mo · Enterprise $599/mo',
+      gap: 'CRM-only for real estate investors — no MCP gateway, no semantic document layer, no VDR pipeline integration.',
+    },
+    {
+      name: 'Dotloop / SkySlope',
+      pricing: 'Per-agent transaction fees',
+      gap: 'Forms, e-sign, broker compliance — not document intelligence or cross-deal memory. Complementary, not competitive.',
+    },
+  ],
+  recommendedTier: `Teams ${pricing.teams.monthlyPrice}/mo for agent memory + unified search; IDP Starter when document processing is required.`,
+  href: '/industries/real-estate',
+} as const
+
 export const stackReplacementSummary = {
-  headline: 'Full stack replacement cost (Business-tier customer)',
+  headline: 'Full stack replacement cost (Business-tier IDP customer)',
   profile: '25 users · 25,000 documents/month · VDR sharing with external parties',
   incumbentRange: '$5,000–15,000+/month',
   incumbentDetail:
     'Across Hyperscience or ABBYY (IDP), Intralinks or Datasite (VDR), standalone enterprise search, and custom audit tooling — separate contracts and data exposure points.',
-  clawqlBusiness: '$599/month',
+  clawqlBusiness: `${pricing.business.monthlyPrice}/month`,
   clawqlBusinessMax: `${businessAllInMonthly}/month with Sovereign Security Pack`,
   savingsNote:
     '6–20× below incumbent stack at comparable capability, with sovereign inference and zero external LLM API calls.',
@@ -86,15 +129,11 @@ export const competitorFeatureRows: CompetitorFeatureRow[] = [
     values: { 'ClawQL Business': true, Hyperscience: false, 'ABBYY Vantage': false, 'Intralinks / Datasite': false },
   },
   {
+    feature: 'Agent memory vault (Obsidian)',
+    values: { 'ClawQL Business': true, Hyperscience: false, 'ABBYY Vantage': false, 'Intralinks / Datasite': false },
+  },
+  {
     feature: 'Virtual data room (Coneshare)',
-    values: { 'ClawQL Business': true, Hyperscience: false, 'ABBYY Vantage': false, 'Intralinks / Datasite': true },
-  },
-  {
-    feature: 'Page-level engagement analytics',
-    values: { 'ClawQL Business': true, Hyperscience: false, 'ABBYY Vantage': false, 'Intralinks / Datasite': true },
-  },
-  {
-    feature: 'Dynamic watermarking',
     values: { 'ClawQL Business': true, Hyperscience: false, 'ABBYY Vantage': false, 'Intralinks / Datasite': true },
   },
   {
@@ -104,10 +143,6 @@ export const competitorFeatureRows: CompetitorFeatureRow[] = [
   {
     feature: 'Self-hosted option',
     values: { 'ClawQL Business': true, Hyperscience: 'Partial', 'ABBYY Vantage': true, 'Intralinks / Datasite': false },
-  },
-  {
-    feature: 'Data stays in tenant boundary',
-    values: { 'ClawQL Business': true, Hyperscience: false, 'ABBYY Vantage': false, 'Intralinks / Datasite': false },
   },
   {
     feature: 'Pre-trained document skills library',
@@ -121,14 +156,9 @@ export const competitorFeatureRows: CompetitorFeatureRow[] = [
       'ABBYY ships broad pre-built skills day one. ClawQL Professional includes one vertical fine-tune adapter; Enterprise adds custom retraining.',
   },
   {
-    feature: 'SSO / SAML',
-    values: { 'ClawQL Business': false, Hyperscience: true, 'ABBYY Vantage': true, 'Intralinks / Datasite': true },
-    footnote: 'ClawQL Professional and Enterprise include SSO/SAML.',
-  },
-  {
     feature: 'Pricing model',
     values: {
-      'ClawQL Business': '$599/mo flat',
+      'ClawQL Business': '$599/mo flat (IDP bundle)',
       Hyperscience: '~$0.50–$1.50/page',
       'ABBYY Vantage': '$40K–$100K+/yr',
       'Intralinks / Datasite': '$10K–$200K+/yr',
@@ -138,12 +168,12 @@ export const competitorFeatureRows: CompetitorFeatureRow[] = [
 
 export const competitiveHonestyNotes = [
   {
-    title: 'Value-anchored, not volume-discounted',
-    body: 'Revised tiers price against the $5K–15K/month stack ClawQL replaces — not against generic SaaS. Starter at $299/mo credibly replaces DocSend plus basic IDP; Business at $599/mo replaces a multi-vendor compliance stack that incumbents sell separately.',
+    title: 'Plugin bundles, not one-size-fits-all',
+    body: 'Gateway-only buyers should not pay for Stirling, Gotenberg, and GPU inference. Developer ($29) and Teams ($99) compete on executions and memory. IDP tiers ($299+) are explicitly opted-in document processing — priced against Hyperscience and Intralinks, not Executor.',
   },
   {
-    title: 'The per-page TCO counter-argument',
-    body: 'Hyperscience argues per-page quotes ignore engineering hours, infra scaling, and model maintenance. ClawQL counters with managed hosting (no separate ops team), self-host for teams who want control, and a fine-tuned model pipeline that improves from Langfuse traces rather than manual retraining projects.',
+    title: 'Respect Executor on gateway UX',
+    body: 'Executor is YC-backed, MIT licensed, and genuinely good at context-efficient MCP routing. ClawQL matches search/execute efficiency and adds durable vault memory, Onyx search, and an optional IDP platform Executor does not attempt.',
   },
   {
     title: 'Where incumbents still lead',

--- a/landing-page/demo/src/lib/pricing.ts
+++ b/landing-page/demo/src/lib/pricing.ts
@@ -1,19 +1,56 @@
 export type BillingPeriod = 'Monthly' | 'Yearly'
 
-export type ManagedTierId = 'starter' | 'business' | 'professional'
+/** Gateway + memory tiers (no IDP bundle). */
+export type GatewayTierId = 'developer' | 'teams'
 
-/** Comparison table columns — self-hosted plus managed tiers (June 2026 GTM, revised pricing). */
-export const pricingPlanNames = ['Self-hosted', 'Free', 'Starter', 'Business', 'Professional'] as const
+/** IDP plugin bundle tiers — document pipeline + VDR. */
+export type IdpTierId = 'starter' | 'business' | 'professional'
+
+export type ManagedTierId = GatewayTierId | IdpTierId
+
+/** Comparison table columns — self-hosted plus all managed tiers. */
+export const pricingPlanNames = [
+  'Self-hosted',
+  'Free',
+  'Developer',
+  'Teams',
+  'Starter',
+  'Business',
+  'Professional',
+] as const
 
 export type PricingPlanName = (typeof pricingPlanNames)[number]
+
+/** Execution overage — matches Executor.sh (July 2026). */
+export const executionOveragePerThousand = '$0.20'
 
 /** Annual billing: ~2 months free on paid managed tiers. */
 export const annualBillingSavingsLabel = '2 months free'
 
 export const annualBillingTotals = {
+  developer: '$290/yr',
+  teams: '$990/yr',
   starter: '$2,988/yr',
   business: '$5,988/yr',
   professional: '$12,000/yr',
+} as const
+
+export const pluginBundles = {
+  gateway: {
+    name: 'MCP Gateway',
+    description: 'search, execute, audit, cache — always-on Core. Unlimited integrations.',
+    tiers: ['Free', 'Developer', 'Teams'] as const,
+  },
+  memory: {
+    name: 'Memory & Search',
+    description: 'Obsidian vault, memory_ingest/recall, Onyx semantic search over your indexed data.',
+    tiers: ['Developer', 'Teams'] as const,
+  },
+  idp: {
+    name: 'IDP Plugin Bundle',
+    description: 'Tika, Gotenberg, Stirling, archive layer, classify/extract, Coneshare VDR, sovereign inference.',
+    tiers: ['Starter', 'Business', 'Professional'] as const,
+  },
 } as const
 
 export const sovereignSecurityPack = {
@@ -21,7 +58,7 @@ export const sovereignSecurityPack = {
   monthlyPrice: '$200',
   period: '/mo',
   subheadline:
-    'Optional on Starter, Business, and Professional. Included in Enterprise. Makes defense-in-depth controls visible and purchasable — Kata isolation, model weight verification, WORM Merkle audit logs, Panguard fail-closed ATR, and monthly posture reports.',
+    'Optional on any paid tier. Included in Enterprise. Kata isolation, model weight verification, WORM Merkle audit logs, Panguard fail-closed ATR, and monthly posture reports.',
   features: [
     'Kata Container VM isolation for agent workloads',
     'Model weight integrity verification (SHA-256 + Cosign)',
@@ -38,13 +75,13 @@ export const pricing = {
     shortName: 'Self-hosted' as const,
     price: '$0',
     period: '',
-    subheadline: 'Run the full open-source stack on your hardware — no license fee, no document caps enforced by us.',
+    subheadline: 'Run the full open-source stack on your hardware — enable only the plugins you need via CLAWQL_ENABLE_* flags.',
     features: [
-      'search, execute, audit, cache',
-      'memory_ingest & memory_recall',
-      'Full IDP pipeline (8 vendors)',
-      'ingest_external_knowledge',
+      'search, execute, audit, cache (Core — always on)',
+      'memory_ingest & memory_recall (default on)',
+      'Full IDP pipeline when you opt in (8 vendors)',
       'Helm charts & GHCR images',
+      'No license fee — you pay infra only',
     ],
   },
   managedFree: {
@@ -52,15 +89,54 @@ export const pricing = {
     shortName: 'Free' as const,
     monthlyPrice: '$0',
     period: '/mo',
-    badge: 'Managed · early access',
+    badge: 'Gateway · early access',
+    pluginBundle: 'gateway' as const,
     subheadline:
-      'Real pipeline access — not a demo environment. Process documents through the full stack before committing. Coneshare VDR and sovereign inference not included.',
+      'Try the hosted MCP gateway — connect agents to your APIs without IDP or VDR overhead. Memory vault included at evaluation scale.',
     features: [
-      '200 documents/month',
-      '1 user · 5 GB storage',
-      'Full pipeline + Merkle audit',
-      'Onyx semantic search (basic)',
+      '10,000 executions/month',
+      '1 user · 3 integrations',
+      'Core MCP + basic memory vault',
+      'No IDP pipeline · no Coneshare VDR',
       'Community support',
+    ],
+  },
+  developer: {
+    name: 'Developer',
+    shortName: 'Developer' as const,
+    monthlyPrice: '$29',
+    annualPricePerMonth: '$24',
+    period: '/mo',
+    badge: 'Gateway + memory',
+    pluginBundle: 'gateway' as const,
+    valueAnchor: 'Executor Team is $150/org — ClawQL adds durable vault memory they do not ship.',
+    subheadline:
+      'MCP gateway + agent memory vault for developers connecting Claude Code, Cursor, or Codex to your APIs. No IDP, no GPU inference.',
+    features: [
+      '50,000 executions/month',
+      '3 users · unlimited integrations',
+      'memory_ingest & memory_recall vault',
+      `Overage ${executionOveragePerThousand}/1,000 executions`,
+      'Email support (72 hr)',
+    ],
+  },
+  teams: {
+    name: 'Teams',
+    shortName: 'Teams' as const,
+    monthlyPrice: '$99',
+    annualPricePerMonth: '$82',
+    period: '/mo',
+    badge: 'Gateway + memory + search',
+    pluginBundle: 'memory' as const,
+    valueAnchor: 'Agent infrastructure — semantic memory across connected tools without document processing.',
+    subheadline:
+      'Full Onyx semantic search + memory vault + MCP gateway for teams building agent workflows. Still no IDP bundle — add Starter when you need document processing.',
+    features: [
+      '250,000 executions/month',
+      '10 users · unlimited integrations',
+      'Full Onyx semantic search',
+      'Obsidian vault + ingest_external_knowledge',
+      `Overage ${executionOveragePerThousand}/1,000 executions`,
     ],
   },
   starter: {
@@ -69,15 +145,16 @@ export const pricing = {
     monthlyPrice: '$299',
     annualPricePerMonth: '$249',
     period: '/mo',
-    badge: 'Shared tenancy',
-    valueAnchor: 'Replaces DocSend + basic IDP — DocSend alone runs $150–250/user/mo with no processing.',
+    badge: 'IDP plugin bundle',
+    pluginBundle: 'idp' as const,
+    valueAnchor: 'Replaces DocSend + basic IDP — you opted into document processing explicitly.',
     subheadline:
-      'Small teams replacing DocSend and point OCR tools. Coneshare VDR, sovereign inference, and Obsidian vault included.',
+      'Activates the IDP plugin bundle: Tika, Gotenberg, Stirling, archive layer, classify/extract, Coneshare VDR, sovereign inference.',
     features: [
       '5,000 documents/month',
       '5 users · 50 GB storage',
       'Coneshare VDR + dynamic watermarking',
-      'Sovereign LLM · Obsidian vault',
+      'Sovereign LLM · full IDP pipeline',
       'Email support (48 hr)',
     ],
   },
@@ -87,10 +164,11 @@ export const pricing = {
     monthlyPrice: '$599',
     annualPricePerMonth: '$499',
     period: '/mo',
-    badge: 'Shared tenancy',
+    badge: 'IDP plugin bundle',
+    pluginBundle: 'idp' as const,
     valueAnchor: 'Equivalent incumbent stack: $3,000–6,000/mo across IDP + VDR + search.',
     subheadline:
-      'Growing teams with real document volume and compliance awareness. Priority queue, full VDR analytics, 99.5% SLA.',
+      'Full IDP bundle + priority processing, enhanced Onyx, 25,000 documents/month, 99.5% SLA.',
     features: [
       '25,000 documents/month',
       '25 users · 500 GB storage',
@@ -105,10 +183,11 @@ export const pricing = {
     monthlyPrice: '$1,200',
     annualPricePerMonth: '$1,000',
     period: '/mo',
-    badge: 'Dedicated namespace',
-    valueAnchor: 'Vertical deployments — lending, legal, healthcare. One fine-tune adapter included.',
+    badge: 'Full stack',
+    pluginBundle: 'idp' as const,
+    valueAnchor: 'Vertical deployments — lending, legal, real estate. One fine-tune adapter included.',
     subheadline:
-      'Compliance-driven buyers needing a dedicated namespace, SSO/SAML, and a vertical fine-tune adapter trained on your document patterns.',
+      'Full IDP bundle + dedicated namespace, SSO/SAML, one vertical fine-tune adapter, 99.9% SLA.',
     features: [
       '75,000 documents/month',
       'Unlimited users · 2 TB storage',
@@ -122,7 +201,7 @@ export const pricing = {
     priceFrom: '$3,500',
     period: '/mo',
     subheadline:
-      'Large enterprises and regulated industries. Dedicated node, custom fine-tune with ongoing retraining, multi-region (EU available), DPA/BAA, dedicated CSM. Sovereign Security Pack included.',
+      'Large enterprises and regulated industries. Dedicated node, custom fine-tune with retraining, multi-region (EU available), DPA/BAA, dedicated CSM. Sovereign Security Pack included.',
     features: [
       'Unlimited documents · custom storage',
       'Dedicated node (not just namespace)',
@@ -139,9 +218,10 @@ export function managedPrice(tier: ManagedTierId, billing: BillingPeriod): strin
   return billing === 'Monthly' ? t.monthlyPrice : t.annualPricePerMonth
 }
 
-export function annualBillingNoteText(billing: BillingPeriod): string | null {
+export function annualBillingNoteText(billing: BillingPeriod, tier: ManagedTierId): string | null {
   if (billing !== 'Yearly') return null
-  return ` Billed annually (${annualBillingTotals.starter} Starter · ${annualBillingTotals.business} Business · ${annualBillingTotals.professional} Professional) — ${annualBillingSavingsLabel} vs monthly billing.`
+  const total = annualBillingTotals[tier]
+  return ` Billed annually (${total}) — ${annualBillingSavingsLabel} vs monthly billing.`
 }
 
 /** Business tier all-in max with optional Sovereign Security Pack. */

--- a/landing-page/demo/src/lib/site.ts
+++ b/landing-page/demo/src/lib/site.ts
@@ -6,9 +6,9 @@ export const site = {
   earlyAccess: {
     badge: 'Managed hosting is in early access — accepting waitlist signups',
     summary:
-      'ClawQL is open source and self-hostable today. Managed hosting (Free, Starter, Business, Professional, Enterprise) is onboarding its first tenants — founder-led setup, limited slots, sovereign inference on paid plans.',
+      'ClawQL is open source and self-hostable today. Managed hosting uses plugin bundles — gateway + memory from $29/mo, IDP document processing from $299/mo — with founder-led onboarding and limited slots.',
     pricingNote:
-      'Managed tiers follow the June 2026 GTM model — value-anchored pricing against the IDP + VDR + search stack incumbents sell separately. We onboard Professional and Business customers first, then Starter shared slots as capacity grows. All managed tiers are early access with founder-led onboarding.',
+      'Gateway tiers (Developer $29, Teams $99) compete on MCP executions and vault memory. IDP tiers (Starter $299+) activate document processing, VDR, and sovereign inference explicitly. All managed tiers are early access with founder-led onboarding.',
   },
   waitlistPromise:
     'Join the waitlist for managed hosting — we reply personally when a slot opens. Self-host free with npm or Helm while you wait.',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restructures managed pricing around **plugin bundles** so gateway-only customers pay much less than IDP customers — matching the `CLAWQL_ENABLE_*` architecture and competitive reality vs [Executor](https://executor.sh/).

### New gateway tiers (no IDP)
| Tier | Price | Includes |
|------|-------|----------|
| Free | $0 | 10K executions/mo, basic vault |
| **Developer** | **$29/mo** | 50K executions, memory vault, 3 users |
| **Teams** | **$99/mo** | 250K executions, full Onyx, 10 users |

Overage: $0.20/1K executions (matches Executor).

### IDP plugin bundle (unchanged anchors)
Starter $299 · Business $599 · Professional $1,200 · Enterprise from $3,500

### Competitive intelligence
- Executor.sh benchmark (token efficiency, pricing, honest gap)
- Real estate vertical section (Teams for Command+Drive, Starter for title/VDR; REsimpli comparison)
- Updated honesty notes: plugin bundles, respect Executor on gateway UX

### Docs
- `docs/vision/clawql-idp-platform.md` — hosted pricing table + competitive chapter rewrite

### Pages
- `/pricing` — split into gateway + IDP hero sections, plugin bundle explainer, updated comparison table
- Homepage + signup copy aligned

## Testing
- `npm run build` in `landing-page/demo`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

