### PR TITLE
fix(landing): close mobile nav menu when a link is clicked

### DIFF
--- a/landing-page/demo/src/components/elements/close-mobile-menu.ts
+++ b/landing-page/demo/src/components/elements/close-mobile-menu.ts
@@ -1,0 +1,7 @@
+/** Close the Tailwind Plus mobile nav dialog after navigation. */
+export function closeMobileMenu(): void {
+  const dialog = document.getElementById('mobile-menu')
+  if (dialog instanceof HTMLDialogElement && dialog.open) {
+    dialog.close()
+  }
+}

--- a/landing-page/demo/src/components/elements/navbar-industries-menu.tsx
+++ b/landing-page/demo/src/components/elements/navbar-industries-menu.tsx
@@ -6,18 +6,23 @@ import { clsx } from 'clsx/lite'
 import { type ReactNode, useState } from 'react'
 import { industries } from '@/lib/industries'
 
+import { closeMobileMenu } from './close-mobile-menu'
+
 function IndustryMenuLink({
   href,
   children,
   className,
+  onNavigate,
 }: {
   href: string
   children: ReactNode
   className?: string
+  onNavigate?: () => void
 }) {
   return (
     <Link
       href={href}
+      onClick={() => onNavigate?.()}
       className={clsx(
         'block rounded-lg px-3 py-2 text-sm font-medium text-mist-700 hover:bg-mist-950/5 hover:text-mist-950 dark:text-mist-300 dark:hover:bg-white/10 dark:hover:text-white',
         className,
@@ -30,31 +35,56 @@ function IndustryMenuLink({
 
 export function NavbarIndustriesMenu() {
   const [mobileOpen, setMobileOpen] = useState(false)
+  const [desktopOpen, setDesktopOpen] = useState(false)
+
+  function handleNavigate() {
+    closeMobileMenu()
+    setMobileOpen(false)
+    setDesktopOpen(false)
+  }
 
   return (
     <>
       {/* Desktop dropdown */}
-      <div className="group relative hidden lg:block">
+      <div className="relative hidden lg:block">
         <button
           type="button"
           className="inline-flex items-center gap-1.5 text-sm/7 font-medium text-mist-950 dark:text-white"
           aria-haspopup="true"
+          aria-expanded={desktopOpen}
+          onClick={() => setDesktopOpen((open) => !open)}
+          onBlur={(event) => {
+            if (!event.currentTarget.parentElement?.contains(event.relatedTarget as Node | null)) {
+              setDesktopOpen(false)
+            }
+          }}
         >
           Industries
-          <svg viewBox="0 0 8 5" fill="currentColor" className="size-2 opacity-60" aria-hidden>
+          <svg
+            viewBox="0 0 8 5"
+            fill="currentColor"
+            className={clsx('size-2 opacity-60 transition-transform', desktopOpen && 'rotate-180')}
+            aria-hidden
+          >
             <path d="M.22.22a.75.75 0 0 1 1.06 0L4 2.94 7.72.22a.75.75 0 1 1 1.06 1.06L4.53 4.53a.75.75 0 0 1-1.06 0L.22 1.28a.75.75 0 0 1 0-1.06Z" />
           </svg>
         </button>
-        <div className="pointer-events-none absolute top-full left-1/2 z-20 mt-2 w-52 -translate-x-1/2 rounded-xl border border-mist-950/10 bg-mist-100 p-2 opacity-0 shadow-lg transition group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 dark:border-white/10 dark:bg-mist-900">
-          {industries.map((industry) => (
-            <IndustryMenuLink key={industry.slug} href={`/industries/${industry.slug}`}>
-              {industry.name}
+        {desktopOpen ? (
+          <div className="absolute top-full left-1/2 z-20 mt-2 w-52 -translate-x-1/2 rounded-xl border border-mist-950/10 bg-mist-100 p-2 shadow-lg dark:border-white/10 dark:bg-mist-900">
+            {industries.map((industry) => (
+              <IndustryMenuLink
+                key={industry.slug}
+                href={`/industries/${industry.slug}`}
+                onNavigate={handleNavigate}
+              >
+                {industry.name}
+              </IndustryMenuLink>
+            ))}
+            <IndustryMenuLink href="/industries" className="text-mist-500 dark:text-mist-400" onNavigate={handleNavigate}>
+              All industries
             </IndustryMenuLink>
-          ))}
-          <IndustryMenuLink href="/industries" className="text-mist-500 dark:text-mist-400">
-            All industries
-          </IndustryMenuLink>
-        </div>
+          </div>
+        ) : null}
       </div>
 
       {/* Mobile — click to expand submenu */}
@@ -82,12 +112,17 @@ export function NavbarIndustriesMenu() {
               <Link
                 key={industry.slug}
                 href={`/industries/${industry.slug}`}
+                onClick={handleNavigate}
                 className="text-2xl/10 font-medium text-mist-600 dark:text-mist-300"
               >
                 {industry.name}
               </Link>
             ))}
-            <Link href="/industries" className="text-2xl/10 font-medium text-mist-500 dark:text-mist-400">
+            <Link
+              href="/industries"
+              onClick={handleNavigate}
+              className="text-2xl/10 font-medium text-mist-500 dark:text-mist-400"
+            >
               All industries
             </Link>
           </div>

--- a/landing-page/demo/src/components/elements/navbar-link.tsx
+++ b/landing-page/demo/src/components/elements/navbar-link.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import Link from 'next/link'
+
+import { clsx } from 'clsx/lite'
+import type { ComponentProps } from 'react'
+
+import { closeMobileMenu } from './close-mobile-menu'
+
+export function NavbarLink({
+  children,
+  href,
+  className,
+  onClick,
+  ...props
+}: { href: string } & Omit<ComponentProps<'a'>, 'href'>) {
+  return (
+    <Link
+      href={href}
+      className={clsx(
+        'group inline-flex items-center justify-between gap-2 text-3xl/10 font-medium text-mist-950 lg:text-sm/7 dark:text-white',
+        className,
+      )}
+      onClick={(event) => {
+        closeMobileMenu()
+        onClick?.(event)
+      }}
+      {...props}
+    >
+      {children}
+      <span className="inline-flex p-1.5 opacity-0 group-hover:opacity-100 lg:hidden" aria-hidden="true">
+        <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+          <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+        </svg>
+      </span>
+    </Link>
+  )
+}

--- a/landing-page/demo/src/components/sections/navbar-with-links-actions-and-centered-logo.tsx
+++ b/landing-page/demo/src/components/sections/navbar-with-links-actions-and-centered-logo.tsx
@@ -4,30 +4,7 @@ import { ElDialog, ElDialogPanel } from '@tailwindplus/elements/react'
 import { clsx } from 'clsx/lite'
 import type { ComponentProps, ReactNode } from 'react'
 
-export function NavbarLink({
-  children,
-  href,
-  className,
-  ...props
-}: { href: string } & Omit<ComponentProps<'a'>, 'href'>) {
-  return (
-    <Link
-      href={href}
-      className={clsx(
-        'group inline-flex items-center justify-between gap-2 text-3xl/10 font-medium text-mist-950 lg:text-sm/7 dark:text-white',
-        className,
-      )}
-      {...props}
-    >
-      {children}
-      <span className="inline-flex p-1.5 opacity-0 group-hover:opacity-100 lg:hidden" aria-hidden="true">
-        <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
-          <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
-        </svg>
-      </span>
-    </Link>
-  )
-}
+export { NavbarLink } from '@/components/elements/navbar-link'
 
 export function NavbarLogo({ className, href, ...props }: { href: string } & Omit<ComponentProps<'a'>, 'href'>) {
   return <Link href={href} {...props} className={clsx('inline-flex items-stretch', className)} />

--- a/landing-page/demo/src/components/sections/navbar-with-logo-actions-and-centered-links.tsx
+++ b/landing-page/demo/src/components/sections/navbar-with-logo-actions-and-centered-links.tsx
@@ -4,30 +4,7 @@ import { ElDialog, ElDialogPanel } from '@tailwindplus/elements/react'
 import { clsx } from 'clsx/lite'
 import type { ComponentProps, ReactNode } from 'react'
 
-export function NavbarLink({
-  children,
-  href,
-  className,
-  ...props
-}: { href: string } & Omit<ComponentProps<'a'>, 'href'>) {
-  return (
-    <Link
-      href={href}
-      className={clsx(
-        'group inline-flex items-center justify-between gap-2 text-3xl/10 font-medium text-mist-950 lg:text-sm/7 dark:text-white',
-        className,
-      )}
-      {...props}
-    >
-      {children}
-      <span className="inline-flex p-1.5 opacity-0 group-hover:opacity-100 lg:hidden" aria-hidden="true">
-        <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
-          <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
-        </svg>
-      </span>
-    </Link>
-  )
-}
+export { NavbarLink } from '@/components/elements/navbar-link'
 
 export function NavbarLogo({ className, href, ...props }: { href: string } & Omit<ComponentProps<'a'>, 'href'>) {
   return <Link href={href} {...props} className={clsx('inline-flex items-stretch', className)} />

--- a/landing-page/demo/src/components/sections/navbar-with-logo-actions-and-left-aligned-links.tsx
+++ b/landing-page/demo/src/components/sections/navbar-with-logo-actions-and-left-aligned-links.tsx
@@ -4,30 +4,7 @@ import { ElDialog, ElDialogPanel } from '@tailwindplus/elements/react'
 import { clsx } from 'clsx/lite'
 import type { ComponentProps, ReactNode } from 'react'
 
-export function NavbarLink({
-  children,
-  href,
-  className,
-  ...props
-}: { href: string } & Omit<ComponentProps<'a'>, 'href'>) {
-  return (
-    <Link
-      href={href}
-      className={clsx(
-        'group inline-flex items-center justify-between gap-2 text-3xl/10 font-medium text-mist-950 lg:text-sm/7 dark:text-white',
-        className,
-      )}
-      {...props}
-    >
-      {children}
-      <span className="inline-flex p-1.5 opacity-0 group-hover:opacity-100 lg:hidden" aria-hidden="true">
-        <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
-          <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
-        </svg>
-      </span>
-    </Link>
-  )
-}
+export { NavbarLink } from '@/components/elements/navbar-link'
 
 export function NavbarLogo({ className, href, ...props }: { href: string } & Omit<ComponentProps<'a'>, 'href'>) {
   return <Link href={href} {...props} className={clsx('inline-flex items-stretch', className)} />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On mobile, tapping a nav link (Tools, Pricing, Industries → Lending, etc.) left the full-screen menu dialog open — users had to tap the X manually.

Desktop Industries dropdown also stayed open after selecting an item (CSS hover/focus-within).

## Fix

- `NavbarLink` calls `closeMobileMenu()` on click, which closes `#mobile-menu` dialog
- Industries submenu links close both the submenu and parent mobile dialog
- Desktop Industries menu switched from hover-only to click-to-toggle; closes on link select

## Testing

- `npm run build` in `landing-page/demo`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

