### PR TITLE
fix(landing): aggressive executor.sh competitive positioning per GTM

### DIFF
--- a/docs/vision/clawql-idp-platform.md
+++ b/docs/vision/clawql-idp-platform.md
@@ -404,12 +404,12 @@ The entire sequence above runs from a single natural-language agent prompt. No c
 
 ClawQL competes across four adjacent markets — price each plugin bundle against the right incumbent:
 
-| Competitor Category                                                                | ClawQL tier                                                | ClawQL differentiation                                                                                                                                                                                                                    |
-| ---------------------------------------------------------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Competitor Category                                                                   | ClawQL tier                                                | ClawQL differentiation                                                                                                                                                                                                                                                                                                          |
+| ------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **MCP gateways** ([executor.sh](https://executor.sh/), emerging agent infrastructure) | Developer ($29/mo), Teams ($99/mo)                         | executor.sh is a stateless tool router — one token-efficiency layer, basic audit log, no memory, no semantic search, no document pipeline. ClawQL compounds eight efficiency layers, ships persistent Obsidian vault memory, Onyx semantic search, and an optional full IDP platform executor.sh does not attempt at any price. |
-| **SaaS IDP vendors** (Hyperscience, Kofax, ABBYY)                                  | Starter–Professional (IDP bundle)                          | Cloud-hosted; per-document pricing at scale. No native MCP/agent interface. ClawQL: tenant-isolated hosted or self-hosted, flat IDP tiers, MCP-native from day one.                                                                       |
-| **VDR incumbents** (Intralinks, Datasite, Ansarada)                                | Starter+ (IDP bundle includes Coneshare)                   | Hosted VDRs with no document processing pipeline. High per-user/per-GB/per-deal licensing. ClawQL: full pipeline integration, Coneshare VDR included in IDP subscription.                                                                 |
-| **Vertical CRMs** (REsimpli, franchise transaction tools)                          | Teams ($99/mo) for agent memory; Starter ($299/mo) for IDP | CRMs track pipeline; Drive folders hold files. ClawQL connects CRM APIs + storage via MCP, indexes documents in Onyx, threads deal context in vault — without replacing Command, Dotloop, or SkySlope.                                    |
+| **SaaS IDP vendors** (Hyperscience, Kofax, ABBYY)                                     | Starter–Professional (IDP bundle)                          | Cloud-hosted; per-document pricing at scale. No native MCP/agent interface. ClawQL: tenant-isolated hosted or self-hosted, flat IDP tiers, MCP-native from day one.                                                                                                                                                             |
+| **VDR incumbents** (Intralinks, Datasite, Ansarada)                                   | Starter+ (IDP bundle includes Coneshare)                   | Hosted VDRs with no document processing pipeline. High per-user/per-GB/per-deal licensing. ClawQL: full pipeline integration, Coneshare VDR included in IDP subscription.                                                                                                                                                       |
+| **Vertical CRMs** (REsimpli, franchise transaction tools)                             | Teams ($99/mo) for agent memory; Starter ($299/mo) for IDP | CRMs track pipeline; Drive folders hold files. ClawQL connects CRM APIs + storage via MCP, indexes documents in Onyx, threads deal context in vault — without replacing Command, Dotloop, or SkySlope.                                                                                                                          |
 
 ### Real estate vertical
 
@@ -427,16 +427,16 @@ ClawQL does **not** replace Dotloop (forms, e-sign, broker compliance) or MLS li
 
 executor.sh is the closest direct competitor to ClawQL's MCP gateway layer. It routes tool calls; ClawQL operates a stateful agent platform.
 
-| Dimension | executor.sh | ClawQL |
-| --------- | ----------- | ------ |
-| Token efficiency | One layer: search-and-execute only | Eight compounding layers on top of search/execute |
-| Agent memory | None — every session starts from zero | Obsidian vault with memory_ingest / memory_recall |
-| Semantic search | None | Onyx — 40+ connectors, hybrid search, citations |
-| Security | Host-side secrets, basic audit log | Kata isolation, WORM Merkle logs, Panguard fail-closed, documented defense-in-depth |
-| Document pipeline | None | Tika → Gotenberg → Stirling → archive → Onyx |
-| VDR | None | Coneshare included from IDP Starter |
-| Sovereign LLM | None | Fine-tuned Qwen inside tenant boundary (IDP tiers) |
-| Gateway pricing | Team $150/org/mo — executions only | Developer $29/mo · Teams $99/mo with memory + search |
+| Dimension         | executor.sh                           | ClawQL                                                                              |
+| ----------------- | ------------------------------------- | ----------------------------------------------------------------------------------- |
+| Token efficiency  | One layer: search-and-execute only    | Eight compounding layers on top of search/execute                                   |
+| Agent memory      | None — every session starts from zero | Obsidian vault with memory_ingest / memory_recall                                   |
+| Semantic search   | None                                  | Onyx — 40+ connectors, hybrid search, citations                                     |
+| Security          | Host-side secrets, basic audit log    | Kata isolation, WORM Merkle logs, Panguard fail-closed, documented defense-in-depth |
+| Document pipeline | None                                  | Tika → Gotenberg → Stirling → archive → Onyx                                        |
+| VDR               | None                                  | Coneshare included from IDP Starter                                                 |
+| Sovereign LLM     | None                                  | Fine-tuned Qwen inside tenant boundary (IDP tiers)                                  |
+| Gateway pricing   | Team $150/org/mo — executions only    | Developer $29/mo · Teams $99/mo with memory + search                                |
 
 executor.sh is a stateless tool router. ClawQL is a stateful agent operating system with eight compounding token-efficiency layers, persistent memory, semantic search, sovereign AI inference, a full document pipeline, a VDR, and defense-in-depth security that executor.sh cannot match at any price.
 

--- a/docs/vision/clawql-idp-platform.md
+++ b/docs/vision/clawql-idp-platform.md
@@ -120,7 +120,7 @@ Managed hosting is structured around **plugin bundles**, not a single document-v
 | **Professional** | $1,200/mo      | Full stack              | 75,000 documents/mo, dedicated namespace, vertical fine-tune, SSO/SAML              |
 | **Enterprise**   | from $3,500/mo | Full stack + security   | Dedicated node, custom fine-tune, EU multi-region, Sovereign Security Pack included |
 
-Execution overage on gateway tiers: **$0.20 per 1,000 executions** (matches [Executor](https://executor.sh/) Team pricing). Sovereign Security Pack: **+$200/mo** on any paid tier.
+Execution overage on gateway tiers: **$0.20 per 1,000 executions**. Sovereign Security Pack: **+$200/mo** on any paid tier.
 
 > **Note:** tiers are indicative for GTM positioning. Validate against infrastructure cost modeling before launch.
 
@@ -406,7 +406,7 @@ ClawQL competes across four adjacent markets — price each plugin bundle agains
 
 | Competitor Category                                                                | ClawQL tier                                                | ClawQL differentiation                                                                                                                                                                                                                    |
 | ---------------------------------------------------------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **MCP gateways** ([Executor](https://executor.sh/), emerging agent infrastructure) | Developer ($29/mo), Teams ($99/mo)                         | Same context-efficient search/execute pattern. ClawQL adds Obsidian vault memory, Onyx semantic search, and optional IDP platform Executor does not ship. Executor Team is $150/org for 250K executions; ClawQL Teams is $99 with memory. |
+| **MCP gateways** ([executor.sh](https://executor.sh/), emerging agent infrastructure) | Developer ($29/mo), Teams ($99/mo)                         | executor.sh is a stateless tool router — one token-efficiency layer, basic audit log, no memory, no semantic search, no document pipeline. ClawQL compounds eight efficiency layers, ships persistent Obsidian vault memory, Onyx semantic search, and an optional full IDP platform executor.sh does not attempt at any price. |
 | **SaaS IDP vendors** (Hyperscience, Kofax, ABBYY)                                  | Starter–Professional (IDP bundle)                          | Cloud-hosted; per-document pricing at scale. No native MCP/agent interface. ClawQL: tenant-isolated hosted or self-hosted, flat IDP tiers, MCP-native from day one.                                                                       |
 | **VDR incumbents** (Intralinks, Datasite, Ansarada)                                | Starter+ (IDP bundle includes Coneshare)                   | Hosted VDRs with no document processing pipeline. High per-user/per-GB/per-deal licensing. ClawQL: full pipeline integration, Coneshare VDR included in IDP subscription.                                                                 |
 | **Vertical CRMs** (REsimpli, franchise transaction tools)                          | Teams ($99/mo) for agent memory; Starter ($299/mo) for IDP | CRMs track pipeline; Drive folders hold files. ClawQL connects CRM APIs + storage via MCP, indexes documents in Onyx, threads deal context in vault — without replacing Command, Dotloop, or SkySlope.                                    |
@@ -422,6 +422,23 @@ Brokerages on Keller Williams Command, eXp BoldTrail, Follow Up Boss, or Compass
 | REsimpli comparison                                              | Teams vs REsimpli Basic ($149/mo) | REsimpli is CRM-only for investors; ClawQL unifies CRM integration, document search, and agent memory |
 
 ClawQL does **not** replace Dotloop (forms, e-sign, broker compliance) or MLS listing platforms. It is the intelligent document layer on top.
+
+### MCP gateway: executor.sh (Market 1)
+
+executor.sh is the closest direct competitor to ClawQL's MCP gateway layer. It routes tool calls; ClawQL operates a stateful agent platform.
+
+| Dimension | executor.sh | ClawQL |
+| --------- | ----------- | ------ |
+| Token efficiency | One layer: search-and-execute only | Eight compounding layers on top of search/execute |
+| Agent memory | None — every session starts from zero | Obsidian vault with memory_ingest / memory_recall |
+| Semantic search | None | Onyx — 40+ connectors, hybrid search, citations |
+| Security | Host-side secrets, basic audit log | Kata isolation, WORM Merkle logs, Panguard fail-closed, documented defense-in-depth |
+| Document pipeline | None | Tika → Gotenberg → Stirling → archive → Onyx |
+| VDR | None | Coneshare included from IDP Starter |
+| Sovereign LLM | None | Fine-tuned Qwen inside tenant boundary (IDP tiers) |
+| Gateway pricing | Team $150/org/mo — executions only | Developer $29/mo · Teams $99/mo with memory + search |
+
+executor.sh is a stateless tool router. ClawQL is a stateful agent operating system with eight compounding token-efficiency layers, persistent memory, semantic search, sovereign AI inference, a full document pipeline, a VDR, and defense-in-depth security that executor.sh cannot match at any price.
 
 ClawQL's MCP-native architecture means it benefits automatically from improvements in AI model capabilities. As frontier models improve, ClawQL's automation depth increases without code changes.
 

--- a/landing-page/demo/src/app/pricing/page.tsx
+++ b/landing-page/demo/src/app/pricing/page.tsx
@@ -155,7 +155,7 @@ export default function Page() {
         subheadline={
           <p>
             MCP gateway + vault memory for teams connecting agents to APIs — no IDP pipeline, no GPU inference. Execution
-            overage {executionOveragePerThousand}/1,000 (matches Executor).
+            overage {executionOveragePerThousand}/1,000 beyond included volume.
           </p>
         }
         options={['Monthly', 'Yearly']}
@@ -412,8 +412,8 @@ export default function Page() {
         />
         <Faq
           id="faq-3"
-          question="How does ClawQL compare to Executor?"
-          answer={`Executor Team is $150/org/mo for 250,000 MCP executions. ClawQL Developer is ${pricing.developer.monthlyPrice}/mo (50,000 executions) and Teams is ${pricing.teams.monthlyPrice}/mo with vault memory and Onyx search — capabilities Executor does not ship. Overage matches at ${executionOveragePerThousand}/1,000 executions.`}
+          question="How does ClawQL compare to executor.sh?"
+          answer={`executor.sh is a stateless MCP tool router — one token-efficiency layer, basic audit log, no memory, no semantic search, no document pipeline. ClawQL Developer (${pricing.developer.monthlyPrice}/mo) and Teams (${pricing.teams.monthlyPrice}/mo) implement the same search/execute pattern plus seven additional efficiency layers, persistent Obsidian vault memory, and Onyx semantic search. IDP tiers from ${pricing.starter.monthlyPrice}/mo add document processing, Coneshare VDR, and sovereign inference — none of which executor.sh offers at any price.`}
         />
         <Faq
           id="faq-4"

--- a/landing-page/demo/src/components/sections/competitive-pricing-section.tsx
+++ b/landing-page/demo/src/components/sections/competitive-pricing-section.tsx
@@ -11,6 +11,7 @@ import {
   competitiveHonestyNotes,
   competitiveSummary,
   executorBenchmark,
+  executorComparisonRows,
   realEstateVertical,
   stackReplacementSummary,
   tcoBenchmarks,
@@ -69,10 +70,9 @@ export function CompetitivePricingSection({ className, ...props }: ComponentProp
 
         <div className="mt-10 rounded-xl border border-mist-950/10 bg-mist-950/2.5 p-6 sm:p-8 dark:border-white/10 dark:bg-white/5">
           <h3 className="text-xl font-semibold text-mist-950 dark:text-white">
-            vs {executorBenchmark.name} — direct MCP gateway competitor
+            vs {executorBenchmark.name} — stateless tool router, not a platform
           </h3>
-          <p className="mt-2 text-sm/7 text-mist-700 dark:text-mist-400">{executorBenchmark.tagline}</p>
-          <p className="mt-2 text-sm/7 text-mist-600 dark:text-mist-500">{executorBenchmark.tokenEfficiency}</p>
+          <p className="mt-2 text-sm/7 text-mist-700 dark:text-mist-400">{executorBenchmark.positioning}</p>
           <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div>
               <p className="text-xs font-medium tracking-wide text-mist-500 uppercase">{executorBenchmark.name} pricing</p>
@@ -86,17 +86,39 @@ export function CompetitivePricingSection({ className, ...props }: ComponentProp
               </ul>
             </div>
             <div>
-              <p className="text-xs font-medium tracking-wide text-mist-500 uppercase">ClawQL response</p>
+              <p className="text-xs font-medium tracking-wide text-mist-500 uppercase">ClawQL gateway tiers</p>
               <p className="mt-2 text-sm font-semibold text-mist-950 dark:text-white">
-                {executorBenchmark.clawqlResponse.tier}
+                {executorBenchmark.clawqlResponse.tiers}
               </p>
               <p className="mt-2 text-sm/7 text-mist-700 dark:text-mist-400">
                 {executorBenchmark.clawqlResponse.advantage}
               </p>
-              <p className="mt-2 text-xs/6 text-mist-500 dark:text-mist-400">
-                {executorBenchmark.clawqlResponse.honestGap}
+              <p className="mt-2 text-sm/7 font-medium text-mist-800 dark:text-mist-200">
+                {executorBenchmark.clawqlResponse.closing}
               </p>
             </div>
+          </div>
+          <div className="mt-6 overflow-x-auto">
+            <table className="w-full min-w-[640px] border-collapse text-left text-sm/5">
+              <thead>
+                <tr>
+                  <th className="py-3 pr-4 font-medium text-mist-950 dark:text-white">Dimension</th>
+                  <th className="px-3 py-3 font-medium text-mist-950 dark:text-white">{executorBenchmark.name}</th>
+                  <th className="px-3 py-3 font-medium text-mist-950 dark:text-white">ClawQL</th>
+                </tr>
+              </thead>
+              <tbody>
+                {executorComparisonRows.map((row) => (
+                  <tr key={row.dimension} className="border-t border-mist-950/5 dark:border-white/10">
+                    <th scope="row" className="py-3 pr-4 font-normal text-mist-700 dark:text-mist-400">
+                      {row.dimension}
+                    </th>
+                    <td className="px-3 py-3 text-mist-600 dark:text-mist-500">{row.executor}</td>
+                    <td className="px-3 py-3 text-mist-700 dark:text-mist-400">{row.clawql}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         </div>
 
@@ -155,7 +177,7 @@ export function CompetitivePricingSection({ className, ...props }: ComponentProp
         subheadline={
           <p>
             Competitors typically sell IDP <em>or</em> VDR. ClawQL IDP tiers bundle both plus semantic search, MCP
-            gateway, and agent memory. Gateway-only tiers are compared against Executor above.
+            gateway, and agent memory. Gateway-only tiers are compared against executor.sh above.
           </p>
         }
       >
@@ -199,7 +221,7 @@ export function CompetitivePricingSection({ className, ...props }: ComponentProp
         </div>
       </Section>
 
-      <Section id="competitive-honesty" eyebrow="Honest positioning" headline="What to expect in evaluations">
+      <Section id="competitive-honesty" eyebrow="Competitive positioning" headline="What to expect in evaluations">
         <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
           {competitiveHonestyNotes.map((note) => (
             <div key={note.title} className="flex flex-col gap-2 rounded-xl bg-mist-950/2.5 p-6 dark:bg-white/5">

--- a/landing-page/demo/src/components/sections/competitive-pricing-section.tsx
+++ b/landing-page/demo/src/components/sections/competitive-pricing-section.tsx
@@ -1,21 +1,21 @@
-import { clsx } from 'clsx/lite'
-import type { ComponentProps } from 'react'
 import { Link } from '@/components/elements/link'
-import { Section } from '../elements/section'
-import { CheckmarkIcon } from '../icons/checkmark-icon'
-import { MinusIcon } from '../icons/minus-icon'
 import {
-  competitorColumns,
-  competitorFeatureRows,
   competitiveHeadline,
   competitiveHonestyNotes,
   competitiveSummary,
+  competitorColumns,
+  competitorFeatureRows,
   executorBenchmark,
   executorComparisonRows,
   realEstateVertical,
   stackReplacementSummary,
   tcoBenchmarks,
 } from '@/lib/competitive-pricing'
+import { clsx } from 'clsx/lite'
+import type { ComponentProps } from 'react'
+import { Section } from '../elements/section'
+import { CheckmarkIcon } from '../icons/checkmark-icon'
+import { MinusIcon } from '../icons/minus-icon'
 
 function CellValue({ value }: { value: string | boolean }) {
   if (value === true) {
@@ -75,7 +75,9 @@ export function CompetitivePricingSection({ className, ...props }: ComponentProp
           <p className="mt-2 text-sm/7 text-mist-700 dark:text-mist-400">{executorBenchmark.positioning}</p>
           <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div>
-              <p className="text-xs font-medium tracking-wide text-mist-500 uppercase">{executorBenchmark.name} pricing</p>
+              <p className="text-xs font-medium tracking-wide text-mist-500 uppercase">
+                {executorBenchmark.name} pricing
+              </p>
               <ul className="mt-2 space-y-1 text-sm/7 text-mist-700 dark:text-mist-400">
                 {executorBenchmark.pricing.map((row) => (
                   <li key={row.tier}>

--- a/landing-page/demo/src/lib/competitive-pricing.ts
+++ b/landing-page/demo/src/lib/competitive-pricing.ts
@@ -1,4 +1,4 @@
-/** Competitive landscape benchmarks — July 2026 research. Illustrative; verify at procurement time. */
+/** Competitive landscape benchmarks — June 2026 GTM playbook. Illustrative; verify at procurement time. */
 
 import { businessAllInMonthly, executionOveragePerThousand, pricing } from './pricing'
 
@@ -6,35 +6,87 @@ export const competitiveHeadline =
   'Gateway, memory, and IDP — price each plugin bundle against the right incumbent.'
 
 export const competitiveSummary =
-  'ClawQL is not one product at one price. Developer and Teams tiers compete with MCP gateways like Executor on executions while adding vault memory Executor does not ship. Starter through Professional compete with IDP and VDR incumbents on document volume — a $5,000–15,000/month stack sold separately elsewhere.'
+  'ClawQL is not one product at one price. Developer and Teams tiers replace stateless MCP routers like executor.sh with persistent vault memory, Onyx semantic search, and eight compounding token-efficiency layers — capabilities executor.sh does not ship at any price. Starter through Professional compete with IDP and VDR incumbents on document volume — a $8,000–15,000/month stack sold separately elsewhere.'
 
-/** MCP gateway competitor — Executor.sh (YC-backed, MIT, July 2026). */
+/** MCP gateway competitor — executor.sh (direct competitor to ClawQL gateway layer). */
 export const executorBenchmark = {
-  name: 'Executor',
+  name: 'executor.sh',
   href: 'https://executor.sh/',
-  tagline: 'MCP gateway — one endpoint, normalized OpenAPI/GraphQL/MCP tools, sandboxed execution.',
-  tokenEfficiency: '1,640 tools → ~278,800 tokens without Executor vs 1 execute tool → ~1,044 tokens with.',
+  positioning:
+    'Stateless MCP tool router. Normalizes OpenAPI/GraphQL/MCP into a search-and-execute gateway with host-side secret injection and basic audit logging. That is the complete product.',
   pricing: [
     { tier: 'Free', price: '$0', includes: '3 members · 10,000 executions/mo' },
-    { tier: 'Team', price: '$150/org/mo', includes: 'Unlimited members · 250,000 executions/mo' },
+    { tier: 'Team', price: '$150/org/mo', includes: 'Unlimited members · 250,000 executions/mo · basic audit log only' },
     { tier: 'Overage', price: executionOveragePerThousand + '/1,000', includes: 'Both Free and Team' },
   ],
   clawqlResponse: {
-    tier: `Developer ${pricing.developer.monthlyPrice}/mo`,
+    tiers: `Developer ${pricing.developer.monthlyPrice}/mo · Teams ${pricing.teams.monthlyPrice}/mo`,
     advantage:
-      'Undercuts Executor Team on price while adding Obsidian vault memory, memory_recall across sessions, and optional Onyx search on Teams — capabilities Executor lists as "coming soon" for traces only.',
-    honestGap:
-      'Executor ships desktop/CLI/cloud, polished onboarding, and YC distribution. ClawQL wins on memory + platform depth, not on gateway UX polish alone.',
+      'ClawQL implements the same Layer 1 search/execute pattern, then compounds seven additional efficiency layers on top — plus persistent Obsidian vault memory, Onyx semantic search, and an optional full IDP platform. executor.sh stops at Layer 1.',
+    closing:
+      'executor.sh is a stateless tool router. ClawQL is a stateful agent operating system. This is not a close comparison.',
   },
 } as const
 
+export type ExecutorComparisonRow = {
+  dimension: string
+  executor: string
+  clawql: string
+}
+
+/** Dimension-by-dimension comparison — Market 1 (MCP Gateway) from GTM playbook. */
+export const executorComparisonRows: ExecutorComparisonRow[] = [
+  {
+    dimension: 'Token efficiency architecture',
+    executor: 'One layer: search-and-execute pattern only.',
+    clawql:
+      'Eight compounding layers — response trimming, prose compression, prompt caching, semantic cache, history compression, final prompt trimming, and model routing on top of search/execute.',
+  },
+  {
+    dimension: 'Agent memory',
+    executor: 'None. No cross-session memory, no vault, no memory_recall.',
+    clawql: 'Built-in Obsidian vault — agents recall architectural decisions from prior sessions.',
+  },
+  {
+    dimension: 'Semantic search',
+    executor: 'None.',
+    clawql: 'Onyx enterprise search — 40+ connectors, hybrid keyword + vector, citation-backed results.',
+  },
+  {
+    dimension: 'Security architecture',
+    executor: 'Host-side secret injection and basic audit log. No public defense-in-depth documentation.',
+    clawql:
+      'Kata VM isolation, WORM Merkle audit logs, Panguard fail-closed ATR, model weight integrity verification, Presidio pre-log redaction — documented at docs.clawql.com/security/defense-in-depth.',
+  },
+  {
+    dimension: 'Document processing pipeline',
+    executor: 'None.',
+    clawql: 'Full IDP — Tika, Gotenberg, Stirling-PDF, archive layer, Merkle audit per step.',
+  },
+  {
+    dimension: 'Virtual data room',
+    executor: 'None.',
+    clawql: 'Coneshare VDR included from IDP Starter tier — trackable links, engagement analytics, watermarking.',
+  },
+  {
+    dimension: 'Sovereign LLM inference',
+    executor: 'None. All inference routes to external APIs.',
+    clawql: 'Fine-tuned Qwen3.6-27B inside tenant boundary — Istio egress block, no tokens leave the namespace.',
+  },
+  {
+    dimension: 'Pricing (gateway-only)',
+    executor: 'Team $150/org/mo — executions only, no memory or search.',
+    clawql: `Developer ${pricing.developer.monthlyPrice}/mo with vault memory; Teams ${pricing.teams.monthlyPrice}/mo adds Onyx search. IDP from ${pricing.starter.monthlyPrice}/mo.`,
+  },
+]
+
 export const tcoBenchmarks = [
   {
-    label: 'vs Executor (MCP gateway)',
+    label: 'vs executor.sh (MCP gateway)',
     scenario: 'Team connecting Cursor to GitHub, Stripe, Jira — 250,000 executions/mo',
-    incumbent: 'Executor Team: $150/org/mo',
-    clawql: `Teams: ${pricing.teams.monthlyPrice}/mo with vault + Onyx search`,
-    note: 'Developer at $29/mo undercuts for smaller teams; Teams adds semantic memory Executor does not offer.',
+    incumbent: 'executor.sh Team: $150/org/mo — tool routing only',
+    clawql: `Teams: ${pricing.teams.monthlyPrice}/mo — vault memory + Onyx search + eight efficiency layers`,
+    note: 'executor.sh routes API calls. ClawQL routes, remembers, searches, and optionally processes documents.',
   },
   {
     label: 'vs Hyperscience (IDP)',
@@ -78,13 +130,13 @@ export const realEstateVertical = {
 export const stackReplacementSummary = {
   headline: 'Full stack replacement cost (Business-tier IDP customer)',
   profile: '25 users · 25,000 documents/month · VDR sharing with external parties',
-  incumbentRange: '$5,000–15,000+/month',
+  incumbentRange: '$8,000–15,000+/month',
   incumbentDetail:
-    'Across Hyperscience or ABBYY (IDP), Intralinks or Datasite (VDR), standalone enterprise search, and custom audit tooling — separate contracts and data exposure points.',
+    'executor.sh + ABBYY + Intralinks + Glean + compliance tooling — separate contracts, separate data exposure points, no unified audit trail.',
   clawqlBusiness: `${pricing.business.monthlyPrice}/month`,
   clawqlBusinessMax: `${businessAllInMonthly}/month with Sovereign Security Pack`,
   savingsNote:
-    '6–20× below incumbent stack at comparable capability, with sovereign inference and zero external LLM API calls.',
+    '10–19× below incumbent stack at comparable capability, with sovereign inference and zero external LLM API calls.',
 } as const
 
 export type CompetitorColumn = 'ClawQL Business' | 'Hyperscience' | 'ABBYY Vantage' | 'Intralinks / Datasite'
@@ -169,11 +221,11 @@ export const competitorFeatureRows: CompetitorFeatureRow[] = [
 export const competitiveHonestyNotes = [
   {
     title: 'Plugin bundles, not one-size-fits-all',
-    body: 'Gateway-only buyers should not pay for Stirling, Gotenberg, and GPU inference. Developer ($29) and Teams ($99) compete on executions and memory. IDP tiers ($299+) are explicitly opted-in document processing — priced against Hyperscience and Intralinks, not Executor.',
+    body: 'Gateway-only buyers should not pay for Stirling, Gotenberg, and GPU inference. Developer ($29) and Teams ($99) replace executor.sh for pure API routing — with memory and search executor.sh cannot match. IDP tiers ($299+) are explicitly opted-in document processing — priced against Hyperscience and Intralinks.',
   },
   {
-    title: 'Respect Executor on gateway UX',
-    body: 'Executor is YC-backed, MIT licensed, and genuinely good at context-efficient MCP routing. ClawQL matches search/execute efficiency and adds durable vault memory, Onyx search, and an optional IDP platform Executor does not attempt.',
+    title: 'executor.sh vs ClawQL (MCP gateway)',
+    body: 'executor.sh implements one token-efficiency layer and routes tool calls. ClawQL compounds eight efficiency layers, ships persistent vault memory, Onyx semantic search, a full IDP pipeline, Coneshare VDR, sovereign LLM inference, and documented defense-in-depth security. executor.sh has no equivalent at any price point beyond Layer 1 routing.',
   },
   {
     title: 'Where incumbents still lead',

--- a/landing-page/demo/src/lib/competitive-pricing.ts
+++ b/landing-page/demo/src/lib/competitive-pricing.ts
@@ -2,8 +2,7 @@
 
 import { businessAllInMonthly, executionOveragePerThousand, pricing } from './pricing'
 
-export const competitiveHeadline =
-  'Gateway, memory, and IDP — price each plugin bundle against the right incumbent.'
+export const competitiveHeadline = 'Gateway, memory, and IDP — price each plugin bundle against the right incumbent.'
 
 export const competitiveSummary =
   'ClawQL is not one product at one price. Developer and Teams tiers replace stateless MCP routers like executor.sh with persistent vault memory, Onyx semantic search, and eight compounding token-efficiency layers — capabilities executor.sh does not ship at any price. Starter through Professional compete with IDP and VDR incumbents on document volume — a $8,000–15,000/month stack sold separately elsewhere.'
@@ -16,7 +15,11 @@ export const executorBenchmark = {
     'Stateless MCP tool router. Normalizes OpenAPI/GraphQL/MCP into a search-and-execute gateway with host-side secret injection and basic audit logging. That is the complete product.',
   pricing: [
     { tier: 'Free', price: '$0', includes: '3 members · 10,000 executions/mo' },
-    { tier: 'Team', price: '$150/org/mo', includes: 'Unlimited members · 250,000 executions/mo · basic audit log only' },
+    {
+      tier: 'Team',
+      price: '$150/org/mo',
+      includes: 'Unlimited members · 250,000 executions/mo · basic audit log only',
+    },
     { tier: 'Overage', price: executionOveragePerThousand + '/1,000', includes: 'Both Free and Team' },
   ],
   clawqlResponse: {
@@ -166,7 +169,12 @@ export const competitorFeatureRows: CompetitorFeatureRow[] = [
   },
   {
     feature: 'PII redaction',
-    values: { 'ClawQL Business': true, Hyperscience: 'Partial', 'ABBYY Vantage': true, 'Intralinks / Datasite': 'Add-on' },
+    values: {
+      'ClawQL Business': true,
+      Hyperscience: 'Partial',
+      'ABBYY Vantage': true,
+      'Intralinks / Datasite': 'Add-on',
+    },
   },
   {
     feature: 'Merkle cryptographic audit trail',

--- a/landing-page/demo/src/lib/pricing.ts
+++ b/landing-page/demo/src/lib/pricing.ts
@@ -21,7 +21,7 @@ export const pricingPlanNames = [
 
 export type PricingPlanName = (typeof pricingPlanNames)[number]
 
-/** Execution overage — matches Executor.sh (July 2026). */
+/** Execution overage on gateway tiers. */
 export const executionOveragePerThousand = '$0.20'
 
 /** Annual billing: ~2 months free on paid managed tiers. */
@@ -109,7 +109,7 @@ export const pricing = {
     period: '/mo',
     badge: 'Gateway + memory',
     pluginBundle: 'gateway' as const,
-    valueAnchor: 'Executor Team is $150/org — ClawQL adds durable vault memory they do not ship.',
+    valueAnchor: 'Replace executor.sh routing with vault memory, Onyx search, and eight efficiency layers — from $29/mo.',
     subheadline:
       'MCP gateway + agent memory vault for developers connecting Claude Code, Cursor, or Codex to your APIs. No IDP, no GPU inference.',
     features: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rewrites every customer-facing mention of executor.sh to match the June 2026 GTM playbook competitive positioning. Removes friendly/neutral framing that promoted executor's token savings, YC backing, or UX polish.

## Changes

- **`competitive-pricing.ts`**: Replaces "Respect Executor" and token-efficiency promo with Market 1 dimension comparison (8 layers vs 1, memory, Onyx, security, IDP, VDR, sovereign LLM). Stack replacement now cites executor.sh + point solutions.
- **`competitive-pricing-section.tsx`**: Adds executor.sh vs ClawQL comparison table; removes honest-gap and token-savings lines.
- **`pricing.ts` / `pricing/page.tsx`**: Developer value anchor and FAQ rewritten; removes "matches Executor" overage copy.
- **`clawql-idp-platform.md`**: Aggressive MCP gateway row + new Market 1 comparison table section.

## Test plan

- [x] `npm run build` in `landing-page/demo` passes
- [ ] Verify `/pricing` competitive section renders comparison table
- [ ] Confirm no remaining positive executor.sh copy on site
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

