### PR TITLE
feat(landing): unlimited MCP executions on every tier

### DIFF
--- a/docs/vision/clawql-idp-platform.md
+++ b/docs/vision/clawql-idp-platform.md
@@ -110,17 +110,19 @@ Each hosted customer receives a dedicated tenant with full isolation at the data
 
 Managed hosting is structured around **plugin bundles**, not a single document-volume ladder. Gateway-only customers pay dramatically less than IDP customers.
 
-| Tier             | Price          | Plugin bundle           | Included                                                                            |
-| ---------------- | -------------- | ----------------------- | ----------------------------------------------------------------------------------- |
-| **Free**         | $0/mo          | MCP Gateway             | 10,000 executions/mo, 1 user, basic memory vault — no IDP, no VDR                   |
-| **Developer**    | $29/mo         | Gateway + memory        | 50,000 executions/mo, 3 users, vault memory — no IDP, no GPU                        |
-| **Teams**        | $99/mo         | Gateway + memory + Onyx | 250,000 executions/mo, 10 users, full Onyx semantic search — no IDP                 |
-| **Starter**      | $299/mo        | IDP plugin bundle       | 5,000 documents/mo, VDR, classify/extract, sovereign inference                      |
-| **Business**     | $599/mo        | IDP plugin bundle       | 25,000 documents/mo, priority queue, full VDR analytics, 99.5% SLA                  |
-| **Professional** | $1,200/mo      | Full stack              | 75,000 documents/mo, dedicated namespace, vertical fine-tune, SSO/SAML              |
-| **Enterprise**   | from $3,500/mo | Full stack + security   | Dedicated node, custom fine-tune, EU multi-region, Sovereign Security Pack included |
+| Tier             | Price          | Plugin bundle           | Included                                                                                                  |
+| ---------------- | -------------- | ----------------------- | --------------------------------------------------------------------------------------------------------- |
+| **Free**         | $0/mo          | MCP Gateway             | Unlimited executions, 1 user, basic memory vault — no IDP, no VDR                                         |
+| **Developer**    | $29/mo         | Gateway + memory        | Unlimited executions, 3 users, vault memory — no IDP, no GPU                                              |
+| **Teams**        | $99/mo         | Gateway + memory + Onyx | Unlimited executions, 10 users, full Onyx semantic search — no IDP                                        |
+| **Starter**      | $299/mo        | IDP plugin bundle       | Unlimited executions, 5,000 documents/mo, VDR, classify/extract, sovereign inference                      |
+| **Business**     | $599/mo        | IDP plugin bundle       | Unlimited executions, 25,000 documents/mo, priority queue, full VDR analytics, 99.5% SLA                  |
+| **Professional** | $1,200/mo      | Full stack              | Unlimited executions, 75,000 documents/mo, dedicated namespace, vertical fine-tune, SSO/SAML              |
+| **Enterprise**   | from $3,500/mo | Full stack + security   | Unlimited executions, dedicated node, custom fine-tune, EU multi-region, Sovereign Security Pack included |
 
-Execution overage on gateway tiers: **$0.20 per 1,000 executions**. Sovereign Security Pack: **+$200/mo** on any paid tier.
+**Unlimited executions on every tier.** ClawQL does not meter MCP gateway usage or charge execution overage. Stateless gateway workers scale on spot capacity — usage-based execution pricing would only encourage customers to throttle their agents. Real cost drivers are reserved-pool memory (Onyx, Nextcloud per tenant), GPU inference, and document storage (R2). Those are covered by flat subscription tiers and storage overage. executor.sh caps Team at 250,000 executions/mo with $0.20/1,000 overage; ClawQL does not.
+
+Sovereign Security Pack: **+$200/mo** on any paid tier.
 
 > **Note:** tiers are indicative for GTM positioning. Validate against infrastructure cost modeling before launch.
 
@@ -404,12 +406,12 @@ The entire sequence above runs from a single natural-language agent prompt. No c
 
 ClawQL competes across four adjacent markets — price each plugin bundle against the right incumbent:
 
-| Competitor Category                                                                   | ClawQL tier                                                | ClawQL differentiation                                                                                                                                                                                                                                                                                                          |
-| ------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **MCP gateways** ([executor.sh](https://executor.sh/), emerging agent infrastructure) | Developer ($29/mo), Teams ($99/mo)                         | executor.sh is a stateless tool router — one token-efficiency layer, basic audit log, no memory, no semantic search, no document pipeline. ClawQL compounds eight efficiency layers, ships persistent Obsidian vault memory, Onyx semantic search, and an optional full IDP platform executor.sh does not attempt at any price. |
-| **SaaS IDP vendors** (Hyperscience, Kofax, ABBYY)                                     | Starter–Professional (IDP bundle)                          | Cloud-hosted; per-document pricing at scale. No native MCP/agent interface. ClawQL: tenant-isolated hosted or self-hosted, flat IDP tiers, MCP-native from day one.                                                                                                                                                             |
-| **VDR incumbents** (Intralinks, Datasite, Ansarada)                                   | Starter+ (IDP bundle includes Coneshare)                   | Hosted VDRs with no document processing pipeline. High per-user/per-GB/per-deal licensing. ClawQL: full pipeline integration, Coneshare VDR included in IDP subscription.                                                                                                                                                       |
-| **Vertical CRMs** (REsimpli, franchise transaction tools)                             | Teams ($99/mo) for agent memory; Starter ($299/mo) for IDP | CRMs track pipeline; Drive folders hold files. ClawQL connects CRM APIs + storage via MCP, indexes documents in Onyx, threads deal context in vault — without replacing Command, Dotloop, or SkySlope.                                                                                                                          |
+| Competitor Category                                                                   | ClawQL tier                                                | ClawQL differentiation                                                                                                                                                                                                                                  |
+| ------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **MCP gateways** ([executor.sh](https://executor.sh/), emerging agent infrastructure) | Developer ($29/mo), Teams ($99/mo)                         | executor.sh meters executions (250K cap + $0.20/1K overage on Team). ClawQL: unlimited executions on every tier. Plus eight efficiency layers, persistent vault memory, Onyx semantic search, and optional full IDP platform executor.sh does not ship. |
+| **SaaS IDP vendors** (Hyperscience, Kofax, ABBYY)                                     | Starter–Professional (IDP bundle)                          | Cloud-hosted; per-document pricing at scale. No native MCP/agent interface. ClawQL: tenant-isolated hosted or self-hosted, flat IDP tiers, MCP-native from day one.                                                                                     |
+| **VDR incumbents** (Intralinks, Datasite, Ansarada)                                   | Starter+ (IDP bundle includes Coneshare)                   | Hosted VDRs with no document processing pipeline. High per-user/per-GB/per-deal licensing. ClawQL: full pipeline integration, Coneshare VDR included in IDP subscription.                                                                               |
+| **Vertical CRMs** (REsimpli, franchise transaction tools)                             | Teams ($99/mo) for agent memory; Starter ($299/mo) for IDP | CRMs track pipeline; Drive folders hold files. ClawQL connects CRM APIs + storage via MCP, indexes documents in Onyx, threads deal context in vault — without replacing Command, Dotloop, or SkySlope.                                                  |
 
 ### Real estate vertical
 
@@ -436,7 +438,8 @@ executor.sh is the closest direct competitor to ClawQL's MCP gateway layer. It r
 | Document pipeline | None                                  | Tika → Gotenberg → Stirling → archive → Onyx                                        |
 | VDR               | None                                  | Coneshare included from IDP Starter                                                 |
 | Sovereign LLM     | None                                  | Fine-tuned Qwen inside tenant boundary (IDP tiers)                                  |
-| Gateway pricing   | Team $150/org/mo — executions only    | Developer $29/mo · Teams $99/mo with memory + search                                |
+| Execution pricing | 250K cap + $0.20/1K overage on Team   | Unlimited on every tier — no caps, no overage bills                                 |
+| Gateway pricing   | Team $150/org/mo — metered routing    | Developer $29/mo · Teams $99/mo with memory + search · unlimited executions         |
 
 executor.sh is a stateless tool router. ClawQL is a stateful agent operating system with eight compounding token-efficiency layers, persistent memory, semantic search, sovereign AI inference, a full document pipeline, a VDR, and defense-in-depth security that executor.sh cannot match at any price.
 

--- a/landing-page/README.md
+++ b/landing-page/README.md
@@ -39,7 +39,7 @@ Open [http://localhost:3000](http://localhost:3000).
 The site promotes plugin-bundle hosting models:
 
 1. **Self-hosted (free)** — Open-source `clawql-mcp`; enable plugins via `CLAWQL_ENABLE_*`
-2. **Gateway + memory** — Developer $29/mo, Teams $99/mo (MCP executions + vault + Onyx; no IDP)
+2. **Gateway + memory** — Developer $29/mo, Teams $99/mo (unlimited MCP executions + vault + Onyx; no IDP)
 3. **IDP plugin bundle** — Starter $299/mo, Business $599/mo, Professional $1,200/mo (document processing + VDR)
 4. **Enterprise** — from $3,500/mo (dedicated node, custom fine-tune, Sovereign Security Pack included)
 

--- a/landing-page/demo/src/app/pricing/page.tsx
+++ b/landing-page/demo/src/app/pricing/page.tsx
@@ -9,12 +9,12 @@ import { Section } from '@/components/elements/section'
 import {
   annualBillingNoteText,
   annualBillingSavingsLabel,
-  executionOveragePerThousand,
   managedPrice,
   pluginBundles,
   pricing,
   pricingPlanNames,
   sovereignSecurityPack,
+  unlimitedExecutionsTagline,
   type BillingPeriod,
   type GatewayTierId,
   type IdpTierId,
@@ -154,8 +154,8 @@ export default function Page() {
         headline="Agent gateway & memory"
         subheadline={
           <p>
-            MCP gateway + vault memory for teams connecting agents to APIs — no IDP pipeline, no GPU inference. Execution
-            overage {executionOveragePerThousand}/1,000 beyond included volume.
+            MCP gateway + vault memory for teams connecting agents to APIs — no IDP pipeline, no GPU inference.{' '}
+            {unlimitedExecutionsTagline}
           </p>
         }
         options={['Monthly', 'Yearly']}
@@ -230,30 +230,18 @@ export default function Page() {
             ],
           },
           {
-            title: 'Usage & metering',
+            title: 'Usage',
             features: [
               {
-                name: 'Executions / month',
+                name: 'MCP executions',
                 value: {
                   'Self-hosted': 'Unlimited (your infra)',
-                  Free: '10,000',
-                  Developer: '50,000',
-                  Teams: '250,000',
-                  Starter: '—',
-                  Business: '—',
-                  Professional: '—',
-                },
-              },
-              {
-                name: 'Execution overage',
-                value: {
-                  'Self-hosted': 'N/A',
-                  Free: executionOveragePerThousand + '/1K',
-                  Developer: executionOveragePerThousand + '/1K',
-                  Teams: executionOveragePerThousand + '/1K',
-                  Starter: '—',
-                  Business: '—',
-                  Professional: '—',
+                  Free: 'Unlimited',
+                  Developer: 'Unlimited',
+                  Teams: 'Unlimited',
+                  Starter: 'Unlimited',
+                  Business: 'Unlimited',
+                  Professional: 'Unlimited',
                 },
               },
               {
@@ -413,7 +401,12 @@ export default function Page() {
         <Faq
           id="faq-3"
           question="How does ClawQL compare to executor.sh?"
-          answer={`executor.sh is a stateless MCP tool router — one token-efficiency layer, basic audit log, no memory, no semantic search, no document pipeline. ClawQL Developer (${pricing.developer.monthlyPrice}/mo) and Teams (${pricing.teams.monthlyPrice}/mo) implement the same search/execute pattern plus seven additional efficiency layers, persistent Obsidian vault memory, and Onyx semantic search. IDP tiers from ${pricing.starter.monthlyPrice}/mo add document processing, Coneshare VDR, and sovereign inference — none of which executor.sh offers at any price.`}
+          answer={`executor.sh caps executions (250,000/mo on Team) and charges $0.20/1,000 overage — customers watch a meter. ClawQL offers unlimited executions on every tier, including Free. ClawQL Developer (${pricing.developer.monthlyPrice}/mo) and Teams (${pricing.teams.monthlyPrice}/mo) add seven additional token-efficiency layers, persistent Obsidian vault memory, and Onyx semantic search on top of the same search/execute pattern. IDP tiers from ${pricing.starter.monthlyPrice}/mo add document processing, Coneshare VDR, and sovereign inference — none of which executor.sh offers.`}
+        />
+        <Faq
+          id="faq-3b"
+          question="Are MCP executions really unlimited?"
+          answer="Yes. Every managed tier — Free through Enterprise — includes unlimited MCP executions. We price on hosting model, storage, and plugin bundles because those drive real infrastructure cost. Stateless gateway workers scale automatically; taxing executions only encourages customers to throttle their agents. executor.sh is the outlier with execution caps and overage billing."
         />
         <Faq
           id="faq-4"
@@ -447,8 +440,8 @@ export default function Page() {
         headline="Self-host free or join early access"
         subheadline={
           <p>
-            Install clawql-mcp on your hardware, or join the waitlist — gateway from {pricing.developer.monthlyPrice}/mo,
-            IDP bundle from {pricing.starter.monthlyPrice}/mo.
+            Install clawql-mcp on your hardware, or join the waitlist — unlimited executions on every tier, gateway from{' '}
+            {pricing.developer.monthlyPrice}/mo, IDP bundle from {pricing.starter.monthlyPrice}/mo.
           </p>
         }
         cta={

--- a/landing-page/demo/src/components/sections/competitive-pricing-section.tsx
+++ b/landing-page/demo/src/components/sections/competitive-pricing-section.tsx
@@ -224,7 +224,7 @@ export function CompetitivePricingSection({ className, ...props }: ComponentProp
       </Section>
 
       <Section id="competitive-honesty" eyebrow="Competitive positioning" headline="What to expect in evaluations">
-        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
           {competitiveHonestyNotes.map((note) => (
             <div key={note.title} className="flex flex-col gap-2 rounded-xl bg-mist-950/2.5 p-6 dark:bg-white/5">
               <h3 className="text-base font-semibold text-mist-950 dark:text-white">{note.title}</h3>

--- a/landing-page/demo/src/lib/competitive-pricing.ts
+++ b/landing-page/demo/src/lib/competitive-pricing.ts
@@ -1,11 +1,11 @@
 /** Competitive landscape benchmarks — June 2026 GTM playbook. Illustrative; verify at procurement time. */
 
-import { businessAllInMonthly, executionOveragePerThousand, pricing } from './pricing'
+import { businessAllInMonthly, pricing, unlimitedExecutionsTagline } from './pricing'
 
 export const competitiveHeadline = 'Gateway, memory, and IDP — price each plugin bundle against the right incumbent.'
 
 export const competitiveSummary =
-  'ClawQL is not one product at one price. Developer and Teams tiers replace stateless MCP routers like executor.sh with persistent vault memory, Onyx semantic search, and eight compounding token-efficiency layers — capabilities executor.sh does not ship at any price. Starter through Professional compete with IDP and VDR incumbents on document volume — a $8,000–15,000/month stack sold separately elsewhere.'
+  'ClawQL is not one product at one price. Developer and Teams tiers replace stateless MCP routers like executor.sh with persistent vault memory, Onyx semantic search, eight compounding token-efficiency layers, and unlimited executions on every tier — no meter, no overage. Starter through Professional compete with IDP and VDR incumbents on document volume — a $8,000–15,000/month stack sold separately elsewhere.'
 
 /** MCP gateway competitor — executor.sh (direct competitor to ClawQL gateway layer). */
 export const executorBenchmark = {
@@ -14,13 +14,13 @@ export const executorBenchmark = {
   positioning:
     'Stateless MCP tool router. Normalizes OpenAPI/GraphQL/MCP into a search-and-execute gateway with host-side secret injection and basic audit logging. That is the complete product.',
   pricing: [
-    { tier: 'Free', price: '$0', includes: '3 members · 10,000 executions/mo' },
+    { tier: 'Free', price: '$0', includes: '3 members · 10,000 executions/mo cap' },
     {
       tier: 'Team',
       price: '$150/org/mo',
-      includes: 'Unlimited members · 250,000 executions/mo · basic audit log only',
+      includes: '250,000 executions/mo cap · $0.20/1,000 overage · basic audit log only',
     },
-    { tier: 'Overage', price: executionOveragePerThousand + '/1,000', includes: 'Both Free and Team' },
+    { tier: 'ClawQL', price: 'All tiers', includes: unlimitedExecutionsTagline },
   ],
   clawqlResponse: {
     tiers: `Developer ${pricing.developer.monthlyPrice}/mo · Teams ${pricing.teams.monthlyPrice}/mo`,
@@ -77,19 +77,24 @@ export const executorComparisonRows: ExecutorComparisonRow[] = [
     clawql: 'Fine-tuned Qwen3.6-27B inside tenant boundary — Istio egress block, no tokens leave the namespace.',
   },
   {
+    dimension: 'Execution pricing',
+    executor: '250,000 cap on Team + $0.20/1,000 overage. Customers watch a meter and throttle agents.',
+    clawql: 'Unlimited executions on every tier — Free through Enterprise. No caps, no overage bills.',
+  },
+  {
     dimension: 'Pricing (gateway-only)',
-    executor: 'Team $150/org/mo — executions only, no memory or search.',
-    clawql: `Developer ${pricing.developer.monthlyPrice}/mo with vault memory; Teams ${pricing.teams.monthlyPrice}/mo adds Onyx search. IDP from ${pricing.starter.monthlyPrice}/mo.`,
+    executor: 'Team $150/org/mo — metered executions, no memory or search.',
+    clawql: `Developer ${pricing.developer.monthlyPrice}/mo with vault memory; Teams ${pricing.teams.monthlyPrice}/mo adds Onyx search. IDP from ${pricing.starter.monthlyPrice}/mo. All unlimited executions.`,
   },
 ]
 
 export const tcoBenchmarks = [
   {
     label: 'vs executor.sh (MCP gateway)',
-    scenario: 'Team connecting Cursor to GitHub, Stripe, Jira — 250,000 executions/mo',
-    incumbent: 'executor.sh Team: $150/org/mo — tool routing only',
-    clawql: `Teams: ${pricing.teams.monthlyPrice}/mo — vault memory + Onyx search + eight efficiency layers`,
-    note: 'executor.sh routes API calls. ClawQL routes, remembers, searches, and optionally processes documents.',
+    scenario: 'Team connecting Cursor to GitHub, Stripe, Jira — heavy daily agent usage',
+    incumbent: 'executor.sh Team: $150/org/mo + $0.20/1,000 overage — pay more as agents work harder',
+    clawql: `Teams: ${pricing.teams.monthlyPrice}/mo — unlimited executions, vault memory, Onyx search`,
+    note: 'We do not tax usage. executor.sh meters executions and bills overage.',
   },
   {
     label: 'vs Hyperscience (IDP)',
@@ -228,12 +233,16 @@ export const competitorFeatureRows: CompetitorFeatureRow[] = [
 
 export const competitiveHonestyNotes = [
   {
+    title: 'Unlimited executions — deliberate pricing',
+    body: 'MCP gateway workers are stateless and scale on spot capacity — an extra execution costs us almost nothing. Charging per execution creates a perverse incentive to throttle agents. ClawQL prices on hosting model, storage, and plugin bundles. Unlimited executions on every tier, including Free. executor.sh caps usage and bills $0.20/1,000 overage.',
+  },
+  {
     title: 'Plugin bundles, not one-size-fits-all',
-    body: 'Gateway-only buyers should not pay for Stirling, Gotenberg, and GPU inference. Developer ($29) and Teams ($99) replace executor.sh for pure API routing — with memory and search executor.sh cannot match. IDP tiers ($299+) are explicitly opted-in document processing — priced against Hyperscience and Intralinks.',
+    body: 'Gateway-only buyers should not pay for Stirling, Gotenberg, and GPU inference. Developer ($29) and Teams ($99) replace executor.sh for pure API routing — with memory, search, and unlimited executions executor.sh cannot match. IDP tiers ($299+) are explicitly opted-in document processing — priced against Hyperscience and Intralinks.',
   },
   {
     title: 'executor.sh vs ClawQL (MCP gateway)',
-    body: 'executor.sh implements one token-efficiency layer and routes tool calls. ClawQL compounds eight efficiency layers, ships persistent vault memory, Onyx semantic search, a full IDP pipeline, Coneshare VDR, sovereign LLM inference, and documented defense-in-depth security. executor.sh has no equivalent at any price point beyond Layer 1 routing.',
+    body: 'executor.sh implements one token-efficiency layer and routes tool calls behind a usage meter. ClawQL compounds eight efficiency layers, ships persistent vault memory, Onyx semantic search, unlimited executions, and an optional full IDP platform. executor.sh has no equivalent at any price point beyond Layer 1 routing.',
   },
   {
     title: 'Where incumbents still lead',

--- a/landing-page/demo/src/lib/pricing.ts
+++ b/landing-page/demo/src/lib/pricing.ts
@@ -21,8 +21,8 @@ export const pricingPlanNames = [
 
 export type PricingPlanName = (typeof pricingPlanNames)[number]
 
-/** Execution overage on gateway tiers. */
-export const executionOveragePerThousand = '$0.20'
+/** Customer-facing promise — no execution caps or overage on any tier. */
+export const unlimitedExecutionsTagline = 'Unlimited MCP executions on every tier — no caps, no overage, no meter.'
 
 /** Annual billing: ~2 months free on paid managed tiers. */
 export const annualBillingSavingsLabel = '2 months free'
@@ -38,7 +38,8 @@ export const annualBillingTotals = {
 export const pluginBundles = {
   gateway: {
     name: 'MCP Gateway',
-    description: 'search, execute, audit, cache — always-on Core. Unlimited integrations.',
+    description:
+      'search, execute, audit, cache — always-on Core. Unlimited integrations. Unlimited executions on every tier.',
     tiers: ['Free', 'Developer', 'Teams'] as const,
   },
   memory: {
@@ -94,7 +95,7 @@ export const pricing = {
     subheadline:
       'Try the hosted MCP gateway — connect agents to your APIs without IDP or VDR overhead. Memory vault included at evaluation scale.',
     features: [
-      '10,000 executions/month',
+      'Unlimited MCP executions',
       '1 user · 3 integrations',
       'Core MCP + basic memory vault',
       'No IDP pipeline · no Coneshare VDR',
@@ -109,14 +110,14 @@ export const pricing = {
     period: '/mo',
     badge: 'Gateway + memory',
     pluginBundle: 'gateway' as const,
-    valueAnchor: 'Replace executor.sh routing with vault memory, Onyx search, and eight efficiency layers — from $29/mo.',
+    valueAnchor:
+      'Unlimited executions + vault memory + eight efficiency layers — executor.sh caps usage and charges overage.',
     subheadline:
       'MCP gateway + agent memory vault for developers connecting Claude Code, Cursor, or Codex to your APIs. No IDP, no GPU inference.',
     features: [
-      '50,000 executions/month',
+      'Unlimited MCP executions',
       '3 users · unlimited integrations',
       'memory_ingest & memory_recall vault',
-      `Overage ${executionOveragePerThousand}/1,000 executions`,
       'Email support (72 hr)',
     ],
   },
@@ -132,11 +133,10 @@ export const pricing = {
     subheadline:
       'Full Onyx semantic search + memory vault + MCP gateway for teams building agent workflows. Still no IDP bundle — add Starter when you need document processing.',
     features: [
-      '250,000 executions/month',
+      'Unlimited MCP executions',
       '10 users · unlimited integrations',
       'Full Onyx semantic search',
       'Obsidian vault + ingest_external_knowledge',
-      `Overage ${executionOveragePerThousand}/1,000 executions`,
     ],
   },
   starter: {
@@ -151,6 +151,7 @@ export const pricing = {
     subheadline:
       'Activates the IDP plugin bundle: Tika, Gotenberg, Stirling, archive layer, classify/extract, Coneshare VDR, sovereign inference.',
     features: [
+      'Unlimited MCP executions',
       '5,000 documents/month',
       '5 users · 50 GB storage',
       'Coneshare VDR + dynamic watermarking',
@@ -170,6 +171,7 @@ export const pricing = {
     subheadline:
       'Full IDP bundle + priority processing, enhanced Onyx, 25,000 documents/month, 99.5% SLA.',
     features: [
+      'Unlimited MCP executions',
       '25,000 documents/month',
       '25 users · 500 GB storage',
       'Coneshare VDR · full analytics',
@@ -189,6 +191,7 @@ export const pricing = {
     subheadline:
       'Full IDP bundle + dedicated namespace, SSO/SAML, one vertical fine-tune adapter, 99.9% SLA.',
     features: [
+      'Unlimited MCP executions',
       '75,000 documents/month',
       'Unlimited users · 2 TB storage',
       'Dedicated namespace + priority queue',

--- a/landing-page/demo/src/lib/site.ts
+++ b/landing-page/demo/src/lib/site.ts
@@ -6,9 +6,9 @@ export const site = {
   earlyAccess: {
     badge: 'Managed hosting is in early access — accepting waitlist signups',
     summary:
-      'ClawQL is open source and self-hostable today. Managed hosting uses plugin bundles — gateway + memory from $29/mo, IDP document processing from $299/mo — with founder-led onboarding and limited slots.',
+      'ClawQL is open source and self-hostable today. Managed hosting uses plugin bundles — unlimited executions on every tier, gateway + memory from $29/mo, IDP document processing from $299/mo — with founder-led onboarding and limited slots.',
     pricingNote:
-      'Gateway tiers (Developer $29, Teams $99) compete on MCP executions and vault memory. IDP tiers (Starter $299+) activate document processing, VDR, and sovereign inference explicitly. All managed tiers are early access with founder-led onboarding.',
+      'Gateway tiers (Developer $29, Teams $99) ship unlimited MCP executions plus vault memory and Onyx search. IDP tiers (Starter $299+) activate document processing, VDR, and sovereign inference explicitly. All managed tiers are early access with founder-led onboarding.',
   },
   waitlistPromise:
     'Join the waitlist for managed hosting — we reply personally when a slot opens. Self-host free with npm or Helm while you wait.',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes execution-based pricing entirely. Every managed tier — including Free — now includes **unlimited MCP executions**. No caps, no overage, no meter.

## Rationale

Stateless gateway workers scale on spot capacity; execution volume is not a meaningful cost driver. Charging per execution (executor.sh's model) creates a perverse incentive to throttle agents. ClawQL prices on hosting model, storage, and plugin bundles instead.

## Changes

- **`pricing.ts`**: Remove `executionOveragePerThousand`; add `unlimitedExecutionsTagline`; all tier feature lists show unlimited executions
- **`pricing/page.tsx`**: Gateway subheadline, comparison table, executor FAQ, and new unlimited-executions FAQ
- **`competitive-pricing.ts`**: executor.sh metered pricing vs ClawQL unlimited; new comparison dimension and competitive positioning note
- **`clawql-idp-platform.md`**: Tier table + pricing philosophy paragraph
- **`site.ts`**, **`landing-page/README.md`**: Copy updates

## Test plan

- [x] `npm run build` in `landing-page/demo` passes
- [ ] Verify `/pricing` shows unlimited executions on all tiers
- [ ] Confirm no execution overage copy remains on site
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

