### PR TITLE
fix(landing): Developer 1 user, Teams 5 users — align with Starter

### DIFF
--- a/docs/vision/clawql-idp-platform.md
+++ b/docs/vision/clawql-idp-platform.md
@@ -113,9 +113,9 @@ Managed hosting is structured around **plugin bundles**, not a single document-v
 | Tier             | Price          | Plugin bundle           | Included                                                                                                  |
 | ---------------- | -------------- | ----------------------- | --------------------------------------------------------------------------------------------------------- |
 | **Free**         | $0/mo          | MCP Gateway             | Unlimited executions, 1 user, basic memory vault — no IDP, no VDR                                         |
-| **Developer**    | $29/mo         | Gateway + memory        | Unlimited executions, 3 users, vault memory — no IDP, no GPU                                              |
-| **Teams**        | $99/mo         | Gateway + memory + Onyx | Unlimited executions, 10 users, full Onyx semantic search — no IDP                                        |
-| **Starter**      | $299/mo        | IDP plugin bundle       | Unlimited executions, 5,000 documents/mo, VDR, classify/extract, sovereign inference                      |
+| **Developer**    | $29/mo         | Gateway + memory        | Unlimited executions, 1 user, vault memory — no IDP, no GPU                                               |
+| **Teams**        | $99/mo         | Gateway + memory + Onyx | Unlimited executions, 5 users, full Onyx semantic search — no IDP                                         |
+| **Starter**      | $299/mo        | IDP plugin bundle       | Unlimited executions, 5 users, 5,000 documents/mo, VDR, classify/extract, sovereign inference             |
 | **Business**     | $599/mo        | IDP plugin bundle       | Unlimited executions, 25,000 documents/mo, priority queue, full VDR analytics, 99.5% SLA                  |
 | **Professional** | $1,200/mo      | Full stack              | Unlimited executions, 75,000 documents/mo, dedicated namespace, vertical fine-tune, SSO/SAML              |
 | **Enterprise**   | from $3,500/mo | Full stack + security   | Unlimited executions, dedicated node, custom fine-tune, EU multi-region, Sovereign Security Pack included |

--- a/landing-page/demo/src/app/pricing/page.tsx
+++ b/landing-page/demo/src/app/pricing/page.tsx
@@ -1,11 +1,11 @@
 import { ButtonLink, PlainButtonLink } from '@/components/elements/button'
+import { Section } from '@/components/elements/section'
 import { ChevronIcon } from '@/components/icons/chevron-icon'
-import { CompetitivePricingSection } from '@/components/sections/competitive-pricing-section'
 import { CallToActionSimpleCentered } from '@/components/sections/call-to-action-simple-centered'
+import { CompetitivePricingSection } from '@/components/sections/competitive-pricing-section'
 import { FAQsAccordion, Faq } from '@/components/sections/faqs-accordion'
 import { PlanComparisonTable } from '@/components/sections/plan-comparison-table'
 import { Plan, PricingHeroMultiTier } from '@/components/sections/pricing-hero-multi-tier'
-import { Section } from '@/components/elements/section'
 import {
   annualBillingNoteText,
   annualBillingSavingsLabel,
@@ -133,8 +133,8 @@ export default function Page() {
           <p>
             ClawQL Core (<code className="text-sm">search</code>, <code className="text-sm">execute</code>,{' '}
             <code className="text-sm">audit</code>, <code className="text-sm">cache</code>) is always on. Memory, IDP,
-            and vertical packages activate via <code className="text-sm">CLAWQL_ENABLE_*</code> flags — managed tiers map
-            to plugin bundles, not one-size-fits-all document quotas.
+            and vertical packages activate via <code className="text-sm">CLAWQL_ENABLE_*</code> flags — managed tiers
+            map to plugin bundles, not one-size-fits-all document quotas.
           </p>
         }
       >
@@ -261,8 +261,8 @@ export default function Page() {
                 value: {
                   'Self-hosted': 'Unlimited',
                   Free: '1',
-                  Developer: '3',
-                  Teams: '10',
+                  Developer: '1',
+                  Teams: '5',
                   Starter: '5',
                   Business: '25',
                   Professional: 'Unlimited',

--- a/landing-page/demo/src/lib/pricing.ts
+++ b/landing-page/demo/src/lib/pricing.ts
@@ -76,7 +76,8 @@ export const pricing = {
     shortName: 'Self-hosted' as const,
     price: '$0',
     period: '',
-    subheadline: 'Run the full open-source stack on your hardware — enable only the plugins you need via CLAWQL_ENABLE_* flags.',
+    subheadline:
+      'Run the full open-source stack on your hardware — enable only the plugins you need via CLAWQL_ENABLE_* flags.',
     features: [
       'search, execute, audit, cache (Core — always on)',
       'memory_ingest & memory_recall (default on)',
@@ -116,7 +117,7 @@ export const pricing = {
       'MCP gateway + agent memory vault for developers connecting Claude Code, Cursor, or Codex to your APIs. No IDP, no GPU inference.',
     features: [
       'Unlimited MCP executions',
-      '3 users · unlimited integrations',
+      '1 user · unlimited integrations',
       'memory_ingest & memory_recall vault',
       'Email support (72 hr)',
     ],
@@ -134,7 +135,7 @@ export const pricing = {
       'Full Onyx semantic search + memory vault + MCP gateway for teams building agent workflows. Still no IDP bundle — add Starter when you need document processing.',
     features: [
       'Unlimited MCP executions',
-      '10 users · unlimited integrations',
+      '5 users · unlimited integrations',
       'Full Onyx semantic search',
       'Obsidian vault + ingest_external_knowledge',
     ],
@@ -168,8 +169,7 @@ export const pricing = {
     badge: 'IDP plugin bundle',
     pluginBundle: 'idp' as const,
     valueAnchor: 'Equivalent incumbent stack: $3,000–6,000/mo across IDP + VDR + search.',
-    subheadline:
-      'Full IDP bundle + priority processing, enhanced Onyx, 25,000 documents/month, 99.5% SLA.',
+    subheadline: 'Full IDP bundle + priority processing, enhanced Onyx, 25,000 documents/month, 99.5% SLA.',
     features: [
       'Unlimited MCP executions',
       '25,000 documents/month',
@@ -188,8 +188,7 @@ export const pricing = {
     badge: 'Full stack',
     pluginBundle: 'idp' as const,
     valueAnchor: 'Vertical deployments — lending, legal, real estate. One fine-tune adapter included.',
-    subheadline:
-      'Full IDP bundle + dedicated namespace, SSO/SAML, one vertical fine-tune adapter, 99.9% SLA.',
+    subheadline: 'Full IDP bundle + dedicated namespace, SSO/SAML, one vertical fine-tune adapter, 99.9% SLA.',
     features: [
       'Unlimited MCP executions',
       '75,000 documents/month',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adjusts gateway tier seat limits so Teams → Starter IDP upgrade does not drop users:

| Tier | Users (before) | Users (after) |
|------|----------------|---------------|
| Developer | 3 | **1** |
| Teams | 10 | **5** |
| Starter | 5 | 5 (unchanged) |

## Files

- `landing-page/demo/src/lib/pricing.ts` — tier feature bullets
- `landing-page/demo/src/app/pricing/page.tsx` — comparison table
- `docs/vision/clawql-idp-platform.md` — hosted tier table (+ explicit 5 users on Starter row)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

