### PR TITLE
feat(landing): edge hosting and vault recall copy for gateway tiers

### DIFF
--- a/landing-page/demo/src/app/pricing/page.tsx
+++ b/landing-page/demo/src/app/pricing/page.tsx
@@ -9,6 +9,7 @@ import { Plan, PricingHeroMultiTier } from '@/components/sections/pricing-hero-m
 import {
   annualBillingNoteText,
   annualBillingSavingsLabel,
+  gatewayEdgeHostingFeature,
   managedPrice,
   pluginBundles,
   pricing,
@@ -154,8 +155,8 @@ export default function Page() {
         headline="Agent gateway & memory"
         subheadline={
           <p>
-            MCP gateway + vault memory for teams connecting agents to APIs — no IDP pipeline, no GPU inference.{' '}
-            {unlimitedExecutionsTagline}
+            {gatewayEdgeHostingFeature} + vault memory for teams connecting agents to APIs — no IDP pipeline, no GPU
+            inference. {unlimitedExecutionsTagline}
           </p>
         }
         options={['Monthly', 'Yearly']}
@@ -242,6 +243,30 @@ export default function Page() {
                   Starter: 'Unlimited',
                   Business: 'Unlimited',
                   Professional: 'Unlimited',
+                },
+              },
+              {
+                name: 'Gateway hosting',
+                value: {
+                  'Self-hosted': 'Your infra',
+                  Free: 'Global edge',
+                  Developer: 'Global edge',
+                  Teams: 'Global edge',
+                  Starter: 'Dedicated tenant',
+                  Business: 'Dedicated tenant',
+                  Professional: 'Dedicated tenant',
+                },
+              },
+              {
+                name: 'Vault recall egress',
+                value: {
+                  'Self-hosted': 'Your infra',
+                  Free: 'No penalties',
+                  Developer: 'No penalties',
+                  Teams: 'No penalties',
+                  Starter: 'Included',
+                  Business: 'Included',
+                  Professional: 'Included',
                 },
               },
               {
@@ -401,12 +426,12 @@ export default function Page() {
         <Faq
           id="faq-3"
           question="How does ClawQL compare to executor.sh?"
-          answer={`executor.sh caps executions (250,000/mo on Team) and charges $0.20/1,000 overage — customers watch a meter. ClawQL offers unlimited executions on every tier, including Free. ClawQL Developer (${pricing.developer.monthlyPrice}/mo) and Teams (${pricing.teams.monthlyPrice}/mo) add seven additional token-efficiency layers, persistent Obsidian vault memory, and Onyx semantic search on top of the same search/execute pattern. IDP tiers from ${pricing.starter.monthlyPrice}/mo add document processing, Coneshare VDR, and sovereign inference — none of which executor.sh offers.`}
+          answer={`executor.sh caps executions (250,000/mo on Team) and charges $0.20/1,000 overage — customers watch a meter. ClawQL offers unlimited executions on every tier, including Free, with no egress penalties on vault memory recall. ClawQL Developer (${pricing.developer.monthlyPrice}/mo) and Teams (${pricing.teams.monthlyPrice}/mo) add a global edge gateway, seven additional token-efficiency layers, persistent Obsidian vault memory, and Onyx semantic search on Teams. IDP tiers from ${pricing.starter.monthlyPrice}/mo add document processing, Coneshare VDR, and sovereign inference — none of which executor.sh offers.`}
         />
         <Faq
           id="faq-3b"
           question="Are MCP executions really unlimited?"
-          answer="Yes. Every managed tier — Free through Enterprise — includes unlimited MCP executions. We price on hosting model, storage, and plugin bundles because those drive real infrastructure cost. Stateless gateway workers scale automatically; taxing executions only encourages customers to throttle their agents. executor.sh is the outlier with execution caps and overage billing."
+          answer="Yes. Every managed tier — Free through Enterprise — includes unlimited MCP executions. We price on hosting model, storage, and plugin bundles because those drive real infrastructure cost — not per-call metering or egress on memory recall. Gateway tiers scale at the global edge; taxing executions or recall only encourages customers to throttle their agents. executor.sh is the outlier with execution caps and overage billing."
         />
         <Faq
           id="faq-4"

--- a/landing-page/demo/src/lib/competitive-pricing.ts
+++ b/landing-page/demo/src/lib/competitive-pricing.ts
@@ -5,7 +5,7 @@ import { businessAllInMonthly, pricing, unlimitedExecutionsTagline } from './pri
 export const competitiveHeadline = 'Gateway, memory, and IDP — price each plugin bundle against the right incumbent.'
 
 export const competitiveSummary =
-  'ClawQL is not one product at one price. Developer and Teams tiers replace stateless MCP routers like executor.sh with persistent vault memory, Onyx semantic search, eight compounding token-efficiency layers, and unlimited executions on every tier — no meter, no overage. Starter through Professional compete with IDP and VDR incumbents on document volume — a $8,000–15,000/month stack sold separately elsewhere.'
+  'ClawQL is not one product at one price. Developer and Teams tiers replace stateless MCP routers like executor.sh with a global edge gateway, persistent vault memory (no egress penalties on recall), Onyx semantic search, eight compounding token-efficiency layers, and unlimited executions — no meter, no overage. Starter through Professional compete with IDP and VDR incumbents on document volume — a $8,000–15,000/month stack sold separately elsewhere.'
 
 /** MCP gateway competitor — executor.sh (direct competitor to ClawQL gateway layer). */
 export const executorBenchmark = {
@@ -48,7 +48,8 @@ export const executorComparisonRows: ExecutorComparisonRow[] = [
   {
     dimension: 'Agent memory',
     executor: 'None. No cross-session memory, no vault, no memory_recall.',
-    clawql: 'Built-in Obsidian vault — agents recall architectural decisions from prior sessions.',
+    clawql:
+      'Built-in Obsidian vault — agents recall architectural decisions from prior sessions. No egress penalties on memory recall.',
   },
   {
     dimension: 'Semantic search',
@@ -79,7 +80,7 @@ export const executorComparisonRows: ExecutorComparisonRow[] = [
   {
     dimension: 'Execution pricing',
     executor: '250,000 cap on Team + $0.20/1,000 overage. Customers watch a meter and throttle agents.',
-    clawql: 'Unlimited executions on every tier — Free through Enterprise. No caps, no overage bills.',
+    clawql: 'Unlimited executions on every tier. No caps, no overage bills, no egress tax on vault recall.',
   },
   {
     dimension: 'Pricing (gateway-only)',
@@ -93,8 +94,8 @@ export const tcoBenchmarks = [
     label: 'vs executor.sh (MCP gateway)',
     scenario: 'Team connecting Cursor to GitHub, Stripe, Jira — heavy daily agent usage',
     incumbent: 'executor.sh Team: $150/org/mo + $0.20/1,000 overage — pay more as agents work harder',
-    clawql: `Teams: ${pricing.teams.monthlyPrice}/mo — unlimited executions, vault memory, Onyx search`,
-    note: 'We do not tax usage. executor.sh meters executions and bills overage.',
+    clawql: `Teams: ${pricing.teams.monthlyPrice}/mo — unlimited executions, edge-hosted gateway, vault memory, Onyx search`,
+    note: 'No execution meter, no egress tax on vault recall. executor.sh meters executions and bills overage.',
   },
   {
     label: 'vs Hyperscience (IDP)',
@@ -234,7 +235,7 @@ export const competitorFeatureRows: CompetitorFeatureRow[] = [
 export const competitiveHonestyNotes = [
   {
     title: 'Unlimited executions — deliberate pricing',
-    body: 'MCP gateway workers are stateless and scale on spot capacity — an extra execution costs us almost nothing. Charging per execution creates a perverse incentive to throttle agents. ClawQL prices on hosting model, storage, and plugin bundles. Unlimited executions on every tier, including Free. executor.sh caps usage and bills $0.20/1,000 overage.',
+    body: 'Gateway tiers run at the global edge and scale with demand — an extra execution or memory_recall costs us almost nothing in egress. Charging per execution creates a perverse incentive to throttle agents. ClawQL prices on hosting model, storage, and plugin bundles. Unlimited executions on every tier, including Free. executor.sh caps usage and bills $0.20/1,000 overage.',
   },
   {
     title: 'Plugin bundles, not one-size-fits-all',
@@ -242,7 +243,7 @@ export const competitiveHonestyNotes = [
   },
   {
     title: 'executor.sh vs ClawQL (MCP gateway)',
-    body: 'executor.sh implements one token-efficiency layer and routes tool calls behind a usage meter. ClawQL compounds eight efficiency layers, ships persistent vault memory, Onyx semantic search, unlimited executions, and an optional full IDP platform. executor.sh has no equivalent at any price point beyond Layer 1 routing.',
+    body: 'executor.sh implements one token-efficiency layer and routes tool calls behind a usage meter. ClawQL compounds eight efficiency layers, ships a global edge gateway, persistent vault memory without egress penalties on recall, Onyx semantic search, unlimited executions, and an optional full IDP platform. executor.sh has no equivalent at any price point beyond Layer 1 routing.',
   },
   {
     title: 'Where incumbents still lead',

--- a/landing-page/demo/src/lib/pricing.ts
+++ b/landing-page/demo/src/lib/pricing.ts
@@ -24,6 +24,10 @@ export type PricingPlanName = (typeof pricingPlanNames)[number]
 /** Customer-facing promise — no execution caps or overage on any tier. */
 export const unlimitedExecutionsTagline = 'Unlimited MCP executions on every tier — no caps, no overage, no meter.'
 
+/** Gateway-tier hosting benefits (customer-facing; no provider names). */
+export const gatewayEdgeHostingFeature = 'Global edge-hosted MCP endpoint'
+export const vaultRecallStorageFeature = 'Vault storage — no egress penalties on memory recall'
+
 /** Annual billing: ~2 months free on paid managed tiers. */
 export const annualBillingSavingsLabel = '2 months free'
 
@@ -39,7 +43,7 @@ export const pluginBundles = {
   gateway: {
     name: 'MCP Gateway',
     description:
-      'search, execute, audit, cache — always-on Core. Unlimited integrations. Unlimited executions on every tier.',
+      'search, execute, audit, cache — always-on Core. Global edge hosting on gateway tiers. Unlimited integrations and executions. Vault-backed memory with no per-recall egress penalties.',
     tiers: ['Free', 'Developer', 'Teams'] as const,
   },
   memory: {
@@ -97,6 +101,8 @@ export const pricing = {
       'Try the hosted MCP gateway — connect agents to your APIs without IDP or VDR overhead. Memory vault included at evaluation scale.',
     features: [
       'Unlimited MCP executions',
+      gatewayEdgeHostingFeature,
+      vaultRecallStorageFeature,
       '1 user · 3 integrations',
       'Core MCP + basic memory vault',
       'No IDP pipeline · no Coneshare VDR',
@@ -117,6 +123,8 @@ export const pricing = {
       'MCP gateway + agent memory vault for developers connecting Claude Code, Cursor, or Codex to your APIs. No IDP, no GPU inference.',
     features: [
       'Unlimited MCP executions',
+      gatewayEdgeHostingFeature,
+      vaultRecallStorageFeature,
       '1 user · unlimited integrations',
       'memory_ingest & memory_recall vault',
       'Email support (72 hr)',
@@ -135,6 +143,8 @@ export const pricing = {
       'Full Onyx semantic search + memory vault + MCP gateway for teams building agent workflows. Still no IDP bundle — add Starter when you need document processing.',
     features: [
       'Unlimited MCP executions',
+      gatewayEdgeHostingFeature,
+      vaultRecallStorageFeature,
       '5 users · unlimited integrations',
       'Full Onyx semantic search',
       'Obsidian vault + ingest_external_knowledge',

--- a/landing-page/demo/src/lib/site.ts
+++ b/landing-page/demo/src/lib/site.ts
@@ -8,7 +8,7 @@ export const site = {
     summary:
       'ClawQL is open source and self-hostable today. Managed hosting uses plugin bundles — unlimited executions on every tier, gateway + memory from $29/mo, IDP document processing from $299/mo — with founder-led onboarding and limited slots.',
     pricingNote:
-      'Gateway tiers (Developer $29, Teams $99) ship unlimited MCP executions plus vault memory and Onyx search. IDP tiers (Starter $299+) activate document processing, VDR, and sovereign inference explicitly. All managed tiers are early access with founder-led onboarding.',
+      'Gateway tiers (Developer $29, Teams $99) deploy at the global edge with unlimited MCP executions, vault memory (no egress penalties on recall), and Onyx search on Teams. IDP tiers (Starter $299+) activate document processing, VDR, and sovereign inference explicitly. All managed tiers are early access with founder-led onboarding.',
   },
   waitlistPromise:
     'Join the waitlist for managed hosting — we reply personally when a slot opens. Self-host free with npm or Helm while you wait.',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Minimal customer-facing copy pass from the hybrid Cloudflare/AWS hosting strategy — benefits only, no infrastructure split exposed.

## Changes

- **Gateway tiers (Free/Developer/Teams):** `Global edge-hosted MCP endpoint` and `Vault storage — no egress penalties on memory recall` feature bullets
- **Pricing comparison table:** Gateway hosting + vault recall egress rows
- **Competitive section:** executor.sh meter vs unlimited executions + no recall egress tax
- **FAQs:** Refined unlimited-executions and executor.sh answers
- **`site.ts`:** Early-access pricing note mentions global edge

## Not included

- GTM doc, Cloudflare Workers/D1/KV naming, or AWS/CF routing details
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

