### PR TITLE
feat(landing): hybrid hosting copy — tier upgrades, single endpoint

### DIFF
--- a/docs/vision/clawql-idp-platform.md
+++ b/docs/vision/clawql-idp-platform.md
@@ -460,7 +460,20 @@ ClawQL deploys via a unified Helm chart that provisions the full stack. All serv
 - Persistent volumes for Obsidian vaults, Nextcloud files, Onyx indexes, and Postgres.
 - Paperless-ngx available via feature toggle for operators who prefer it (self-hosted only).
 
-### Hosted Stack (per tenant)
+### Hosted infrastructure model
+
+Managed hosting uses a **hybrid model** aligned to plugin bundles — without changing the customer-facing MCP endpoint:
+
+| Tier class                                      | Infrastructure                         | What the customer gets                                                                         |
+| ----------------------------------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| **Free, Developer, Teams**                      | Global edge + object storage for vault | MCP gateway, memory vault, cache, audit. Unlimited executions. Low-latency endpoint worldwide. |
+| **Starter, Business, Professional, Enterprise** | Dedicated tenant (Kubernetes)          | Full IDP pipeline, Onyx at scale, Nextcloud archive, Coneshare VDR, sovereign inference.       |
+
+A single routing layer dispatches each request by tenant tier. **Vault documents live in shared object storage** accessible from both gateway and IDP backends — upgrading from Teams to Starter retains full agent memory history without migration. The customer's MCP URL and auth token do not change on upgrade.
+
+AWS (EKS + Karpenter) provisions **only when the first IDP customer signs** — not at gateway-tier launch. This keeps bootstrap burn minimal while gateway tiers validate product-market fit.
+
+### Hosted Stack (per tenant — IDP tiers)
 
 - Dedicated Nextcloud instance, Postgres schema, and Onyx index per tenant.
 - Shared ClawQL core and processing services (Tika, Gotenberg, Stirling-PDF) with tenant-scoped job queues.

--- a/landing-page/demo/src/app/pricing/page.tsx
+++ b/landing-page/demo/src/app/pricing/page.tsx
@@ -133,9 +133,9 @@ export default function Page() {
         subheadline={
           <p>
             ClawQL Core (<code className="text-sm">search</code>, <code className="text-sm">execute</code>,{' '}
-            <code className="text-sm">audit</code>, <code className="text-sm">cache</code>) is always on. Memory, IDP,
-            and vertical packages activate via <code className="text-sm">CLAWQL_ENABLE_*</code> flags — managed tiers
-            map to plugin bundles, not one-size-fits-all document quotas.
+            <code className="text-sm">audit</code>, <code className="text-sm">cache</code>) is always on. Gateway
+            bundles run at the global edge; the IDP bundle provisions dedicated document-processing infrastructure when
+            you opt in — same MCP endpoint and vault across upgrades.
           </p>
         }
       >
@@ -169,8 +169,9 @@ export default function Page() {
         headline="IDP plugin bundle"
         subheadline={
           <p>
-            Document processing, Coneshare VDR, and sovereign inference — explicitly opted in. Storage overage $0.02/GB
-            on Starter and Business, $0.015/GB on Professional.
+            Dedicated tenant infrastructure for document processing, Coneshare VDR, and sovereign inference — explicitly
+            opted in. Your MCP endpoint and vault memory stay the same when you upgrade from Teams. Storage overage
+            $0.02/GB on Starter and Business, $0.015/GB on Professional.
           </p>
         }
         options={['Monthly', 'Yearly']}
@@ -255,6 +256,30 @@ export default function Page() {
                   Starter: 'Dedicated tenant',
                   Business: 'Dedicated tenant',
                   Professional: 'Dedicated tenant',
+                },
+              },
+              {
+                name: 'MCP endpoint',
+                value: {
+                  'Self-hosted': 'Your deployment',
+                  Free: 'Same URL all tiers',
+                  Developer: 'Same URL all tiers',
+                  Teams: 'Same URL all tiers',
+                  Starter: 'Same URL all tiers',
+                  Business: 'Same URL all tiers',
+                  Professional: 'Same URL all tiers',
+                },
+              },
+              {
+                name: 'Vault on tier upgrade',
+                value: {
+                  'Self-hosted': 'Your data',
+                  Free: 'Carries over',
+                  Developer: 'Carries over',
+                  Teams: 'Carries over',
+                  Starter: 'Carries over',
+                  Business: 'Carries over',
+                  Professional: 'Carries over',
                 },
               },
               {
@@ -436,7 +461,12 @@ export default function Page() {
         <Faq
           id="faq-4"
           question="Can I switch tiers later?"
-          answer="Yes. Vault exports, provider auth, and plugin flags migrate between tiers. Start on Teams for agent memory; upgrade to Starter when you need IDP document processing."
+          answer="Yes. Upgrade from Teams to Starter (or any IDP tier) without changing your MCP endpoint URL, auth token, or vault memory — agents pick up where they left off. Vault exports, provider auth, and plugin flags migrate between tiers. Start on Teams for agent memory; add the IDP bundle when you need document processing."
+        />
+        <Faq
+          id="faq-4b"
+          question="Why are gateway and IDP tiers priced differently?"
+          answer="Gateway tiers (Free, Developer, Teams) need only MCP routing, vault memory, cache, and audit — lightweight workloads that run at the global edge with near-zero marginal cost per tenant. IDP tiers (Starter+) activate document processing, Onyx at scale, Coneshare VDR, and sovereign inference on dedicated tenant infrastructure. You only pay for the heavy stack when you opt in."
         />
         <Faq
           id="faq-5"

--- a/landing-page/demo/src/lib/competitive-pricing.ts
+++ b/landing-page/demo/src/lib/competitive-pricing.ts
@@ -239,7 +239,11 @@ export const competitiveHonestyNotes = [
   },
   {
     title: 'Plugin bundles, not one-size-fits-all',
-    body: 'Gateway-only buyers should not pay for Stirling, Gotenberg, and GPU inference. Developer ($29) and Teams ($99) replace executor.sh for pure API routing — with memory, search, and unlimited executions executor.sh cannot match. IDP tiers ($299+) are explicitly opted-in document processing — priced against Hyperscience and Intralinks.',
+    body: 'Gateway-only buyers should not pay for Stirling, Gotenberg, and GPU inference. Developer ($29) and Teams ($99) run at the global edge with memory, search, and unlimited executions. IDP tiers ($299+) provision dedicated document-processing infrastructure only when you opt in — priced against Hyperscience and Intralinks.',
+  },
+  {
+    title: 'Seamless tier upgrades',
+    body: 'One MCP endpoint on every tier. Upgrade from Teams to Starter and your URL, auth token, and vault memory history stay the same — agents retain full context without a migration project. IDP infrastructure activates behind the same endpoint.',
   },
   {
     title: 'executor.sh vs ClawQL (MCP gateway)',

--- a/landing-page/demo/src/lib/pricing.ts
+++ b/landing-page/demo/src/lib/pricing.ts
@@ -27,6 +27,7 @@ export const unlimitedExecutionsTagline = 'Unlimited MCP executions on every tie
 /** Gateway-tier hosting benefits (customer-facing; no provider names). */
 export const gatewayEdgeHostingFeature = 'Global edge-hosted MCP endpoint'
 export const vaultRecallStorageFeature = 'Vault storage — no egress penalties on memory recall'
+export const singleMcpEndpointFeature = 'One MCP endpoint on every tier — same URL when you upgrade'
 
 /** Annual billing: ~2 months free on paid managed tiers. */
 export const annualBillingSavingsLabel = '2 months free'
@@ -53,7 +54,8 @@ export const pluginBundles = {
   },
   idp: {
     name: 'IDP Plugin Bundle',
-    description: 'Tika, Gotenberg, Stirling, archive layer, classify/extract, Coneshare VDR, sovereign inference.',
+    description:
+      'Opt-in dedicated document-processing infrastructure — Tika, Gotenberg, Stirling, archive layer, classify/extract, Coneshare VDR, sovereign inference. Provisions when you activate Starter or above.',
     tiers: ['Starter', 'Business', 'Professional'] as const,
   },
 } as const
@@ -103,6 +105,7 @@ export const pricing = {
       'Unlimited MCP executions',
       gatewayEdgeHostingFeature,
       vaultRecallStorageFeature,
+      singleMcpEndpointFeature,
       '1 user · 3 integrations',
       'Core MCP + basic memory vault',
       'No IDP pipeline · no Coneshare VDR',
@@ -125,6 +128,7 @@ export const pricing = {
       'Unlimited MCP executions',
       gatewayEdgeHostingFeature,
       vaultRecallStorageFeature,
+      singleMcpEndpointFeature,
       '1 user · unlimited integrations',
       'memory_ingest & memory_recall vault',
       'Email support (72 hr)',
@@ -145,6 +149,7 @@ export const pricing = {
       'Unlimited MCP executions',
       gatewayEdgeHostingFeature,
       vaultRecallStorageFeature,
+      singleMcpEndpointFeature,
       '5 users · unlimited integrations',
       'Full Onyx semantic search',
       'Obsidian vault + ingest_external_knowledge',
@@ -160,9 +165,10 @@ export const pricing = {
     pluginBundle: 'idp' as const,
     valueAnchor: 'Replaces DocSend + basic IDP — you opted into document processing explicitly.',
     subheadline:
-      'Activates the IDP plugin bundle: Tika, Gotenberg, Stirling, archive layer, classify/extract, Coneshare VDR, sovereign inference.',
+      'Activates the IDP plugin bundle on dedicated tenant infrastructure: Tika, Gotenberg, Stirling, archive layer, classify/extract, Coneshare VDR, sovereign inference. Your MCP endpoint and vault memory stay the same.',
     features: [
       'Unlimited MCP executions',
+      'Dedicated tenant · full IDP pipeline',
       '5,000 documents/month',
       '5 users · 50 GB storage',
       'Coneshare VDR + dynamic watermarking',

--- a/landing-page/demo/src/lib/site.ts
+++ b/landing-page/demo/src/lib/site.ts
@@ -6,9 +6,9 @@ export const site = {
   earlyAccess: {
     badge: 'Managed hosting is in early access — accepting waitlist signups',
     summary:
-      'ClawQL is open source and self-hostable today. Managed hosting uses plugin bundles — unlimited executions on every tier, gateway + memory from $29/mo, IDP document processing from $299/mo — with founder-led onboarding and limited slots.',
+      'ClawQL is open source and self-hostable today. Gateway tiers (Free, Developer, Teams) launch at the global edge with unlimited executions and vault memory. IDP document processing provisions dedicated infrastructure when you opt into Starter+. Founder-led onboarding, limited slots.',
     pricingNote:
-      'Gateway tiers (Developer $29, Teams $99) deploy at the global edge with unlimited MCP executions, vault memory (no egress penalties on recall), and Onyx search on Teams. IDP tiers (Starter $299+) activate document processing, VDR, and sovereign inference explicitly. All managed tiers are early access with founder-led onboarding.',
+      'Gateway tiers deploy at the global edge first — unlimited MCP executions, vault memory with no egress penalties on recall, Onyx search on Teams. IDP tiers (Starter $299+) activate document processing, VDR, and sovereign inference on a dedicated tenant. One MCP endpoint for every tier: upgrade from Teams to Starter without changing your URL, auth token, or vault history.',
   },
   waitlistPromise:
     'Join the waitlist for managed hosting — we reply personally when a slot opens. Self-host free with npm or Helm while you wait.',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Customer-facing copy aligned with the revised hybrid GTM (Cloudflare gateway tiers, AWS IDP tiers) — benefits only, no Workers/D1/Karpenter naming on the marketing site.

## Changes

- **Single MCP endpoint** on all tiers; vault memory carries over on upgrade (Teams → Starter)
- **Plugin bundles**: gateway at global edge; IDP provisions dedicated tenant infrastructure on opt-in
- **Comparison table**: MCP endpoint URL + vault on tier upgrade rows (vault recall egress retained)
- **FAQs**: tier switch continuity; why gateway vs IDP pricing differs
- **Competitive section**: seamless tier upgrades note
- **`clawql-idp-platform.md`**: Hosted infrastructure model (architect-facing, no CF product names)

## Not included

- GTM playbook document in repo
- Internal cost models or bootstrap burn figures
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

