### PR TITLE
feat(landing): remove hosted Free tier, add 14-day Developer trial

### DIFF
--- a/docs/vision/clawql-idp-platform.md
+++ b/docs/vision/clawql-idp-platform.md
@@ -112,7 +112,7 @@ Managed hosting is structured around **plugin bundles**, not a single document-v
 
 | Tier             | Price          | Plugin bundle           | Included                                                                                                  |
 | ---------------- | -------------- | ----------------------- | --------------------------------------------------------------------------------------------------------- |
-| **Developer**    | $29/mo         | Gateway + memory        | Unlimited executions, 1 user, vault memory — no IDP, no GPU. 14-day free trial available.                   |
+| **Developer**    | $29/mo         | Gateway + memory        | Unlimited executions, 1 user, vault memory — no IDP, no GPU. 14-day free trial available.                 |
 | **Teams**        | $99/mo         | Gateway + memory + Onyx | Unlimited executions, 5 users, full Onyx semantic search — no IDP                                         |
 | **Starter**      | $299/mo        | IDP plugin bundle       | Unlimited executions, 5 users, 5,000 documents/mo, VDR, classify/extract, sovereign inference             |
 | **Business**     | $599/mo        | IDP plugin bundle       | Unlimited executions, 25,000 documents/mo, priority queue, full VDR analytics, 99.5% SLA                  |

--- a/docs/vision/clawql-idp-platform.md
+++ b/docs/vision/clawql-idp-platform.md
@@ -108,12 +108,11 @@ Each hosted customer receives a dedicated tenant with full isolation at the data
 
 ### Hosted Plan: Pricing Model (July 2026 — plugin bundles)
 
-Managed hosting is structured around **plugin bundles**, not a single document-volume ladder. Gateway-only customers pay dramatically less than IDP customers.
+Managed hosting is structured around **plugin bundles**, not a single document-volume ladder. Gateway-only customers pay dramatically less than IDP customers. There is **no perpetual free hosted tier** — self-host free forever on Apache 2.0, or start a **14-day Developer trial** (no credit card).
 
 | Tier             | Price          | Plugin bundle           | Included                                                                                                  |
 | ---------------- | -------------- | ----------------------- | --------------------------------------------------------------------------------------------------------- |
-| **Free**         | $0/mo          | MCP Gateway             | Unlimited executions, 1 user, basic memory vault — no IDP, no VDR                                         |
-| **Developer**    | $29/mo         | Gateway + memory        | Unlimited executions, 1 user, vault memory — no IDP, no GPU                                               |
+| **Developer**    | $29/mo         | Gateway + memory        | Unlimited executions, 1 user, vault memory — no IDP, no GPU. 14-day free trial available.                   |
 | **Teams**        | $99/mo         | Gateway + memory + Onyx | Unlimited executions, 5 users, full Onyx semantic search — no IDP                                         |
 | **Starter**      | $299/mo        | IDP plugin bundle       | Unlimited executions, 5 users, 5,000 documents/mo, VDR, classify/extract, sovereign inference             |
 | **Business**     | $599/mo        | IDP plugin bundle       | Unlimited executions, 25,000 documents/mo, priority queue, full VDR analytics, 99.5% SLA                  |
@@ -466,7 +465,7 @@ Managed hosting uses a **hybrid model** aligned to plugin bundles — without ch
 
 | Tier class                                      | Infrastructure                         | What the customer gets                                                                         |
 | ----------------------------------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| **Free, Developer, Teams**                      | Global edge + object storage for vault | MCP gateway, memory vault, cache, audit. Unlimited executions. Low-latency endpoint worldwide. |
+| **Developer, Teams**                            | Global edge + object storage for vault | MCP gateway, memory vault, cache, audit. Unlimited executions. Low-latency endpoint worldwide. |
 | **Starter, Business, Professional, Enterprise** | Dedicated tenant (Kubernetes)          | Full IDP pipeline, Onyx at scale, Nextcloud archive, Coneshare VDR, sovereign inference.       |
 
 A single routing layer dispatches each request by tenant tier. **Vault documents live in shared object storage** accessible from both gateway and IDP backends — upgrading from Teams to Starter retains full agent memory history without migration. The customer's MCP URL and auth token do not change on upgrade.
@@ -516,7 +515,7 @@ The following outlines planned capabilities beyond the April 2026 release. Roadm
 
 ### Near-Term (Next 1–3 Months)
 
-- Hosted plan beta launch with Free and Starter tiers.
+- Hosted plan beta launch with 14-day Developer trial and Starter tiers.
 - ClawQL Metadata Store REST API for direct metadata query without MCP client.
 - Nextcloud app for in-browser document processing trigger (no agent client required).
 - Automated tenant provisioning and onboarding flow for hosted customers.

--- a/landing-page/demo/src/app/about/page.tsx
+++ b/landing-page/demo/src/app/about/page.tsx
@@ -1,10 +1,10 @@
 import { ButtonLink, PlainButtonLink } from '@/components/elements/button'
 import { Link } from '@/components/elements/link'
-import { ChevronIcon } from '@/components/icons/chevron-icon'
-import { CaseStudyCard, CaseStudyGrid, ToolTierSection } from '@/components/sections/clawql-marketing'
-import { CallToActionSimple } from '@/components/sections/call-to-action-simple'
-import { HeroSimpleCentered } from '@/components/sections/hero-simple-centered'
 import { Section } from '@/components/elements/section'
+import { ChevronIcon } from '@/components/icons/chevron-icon'
+import { CallToActionSimple } from '@/components/sections/call-to-action-simple'
+import { CaseStudyCard, CaseStudyGrid, ToolTierSection } from '@/components/sections/clawql-marketing'
+import { HeroSimpleCentered } from '@/components/sections/hero-simple-centered'
 import { caseStudies, mcpToolTiers } from '@/lib/marketing'
 import { site } from '@/lib/site'
 
@@ -34,9 +34,9 @@ export default function Page() {
         headline="Built from production agent work — not a demo."
         subheadline={
           <p>
-            ClawQL started as the MCP layer behind real deployments: multi-provider DevOps workflows, document
-            pipelines for regulated industries, and cross-session memory that survives when you switch between Cursor,
-            OpenClaw, and Kubernetes. The open-source core ships what we run in production.
+            ClawQL started as the MCP layer behind real deployments: multi-provider DevOps workflows, document pipelines
+            for regulated industries, and cross-session memory that survives when you switch between Cursor, OpenClaw,
+            and Kubernetes. The open-source core ships what we run in production.
           </p>
         }
       >
@@ -44,21 +44,21 @@ export default function Page() {
           <div className="rounded-xl bg-mist-950/2.5 p-6 dark:bg-white/5">
             <h3 className="font-semibold text-mist-950 dark:text-white">ClawQL and See The Greens</h3>
             <p className="mt-2">
-              See The Greens is a mortgage-first loan origination system powered by ClawQL — the same IDP pipeline, vault
-              memory, and HITL patterns documented on this site. ClawQL is the horizontal platform; See The Greens is one
-              vertical product built on it. Neither implies exclusivity — lenders can self-host ClawQL or build their own
-              LOS on the same stack.
+              See The Greens is a mortgage-first loan origination system powered by ClawQL — the same IDP pipeline,
+              vault memory, and HITL patterns documented on this site. ClawQL is the horizontal platform; See The Greens
+              is one vertical product built on it. Neither implies exclusivity — lenders can self-host ClawQL or build
+              their own LOS on the same stack.
             </p>
           </div>
           <div className="rounded-xl bg-mist-950/2.5 p-6 dark:bg-white/5">
             <h3 className="font-semibold text-mist-950 dark:text-white">Early access, founder-led</h3>
             <p className="mt-2">
               Managed hosting is in early access — onboarding the first Professional and shared-tenancy tenants with
-              founder-led setup, not a self-serve checkout. The open-source core is production-ready today; hosted slots are limited
-              while we validate pipeline reliability under real workloads.
+              founder-led setup, not a self-serve checkout. The open-source core is production-ready today; hosted slots
+              are limited while we validate pipeline reliability under real workloads.
             </p>
           </div>
-          <div className="rounded-xl bg-mist-950/2.5 p-6 dark:bg-white/5 sm:col-span-2 lg:col-span-1">
+          <div className="rounded-xl bg-mist-950/2.5 p-6 sm:col-span-2 lg:col-span-1 dark:bg-white/5">
             <h3 className="font-semibold text-mist-950 dark:text-white">What we publish</h3>
             <p className="mt-2">
               Case studies include tool traces, failure modes, fixes, and token measurements. The{' '}
@@ -89,8 +89,9 @@ export default function Page() {
           <div className="rounded-xl bg-mist-950/2.5 p-6 dark:bg-white/5">
             <h3 className="font-semibold text-mist-950 dark:text-white">Token efficiency</h3>
             <p className="mt-2">
-              GitHub&apos;s bundled spec alone is ~2.28M planning tokens. <code className="text-sm">search</code> returns
-              ranked operation IDs in thousands of tokens — measured in our published GitHub provider case study.
+              GitHub&apos;s bundled spec alone is ~2.28M planning tokens. <code className="text-sm">search</code>{' '}
+              returns ranked operation IDs in thousands of tokens — measured in our published GitHub provider case
+              study.
             </p>
           </div>
           <div className="rounded-xl bg-mist-950/2.5 p-6 dark:bg-white/5">
@@ -130,15 +131,11 @@ export default function Page() {
       <CallToActionSimple
         id="call-to-action"
         headline="Read the case studies. Run the tools."
-        subheadline={
-          <p>
-            Self-host today or join the managed waitlist for hosted MCP, vault, and IDP. {site.waitlistPromise}
-          </p>
-        }
+        subheadline={<p>Self-host today or start a 14-day Developer trial. {site.waitlistPromise}</p>}
         cta={
           <div className="flex items-center gap-4">
             <ButtonLink href={site.urls.signup} size="lg">
-              Join early access
+              Start free trial
             </ButtonLink>
             <PlainButtonLink href={`${site.urls.docs}/case-studies`} size="lg">
               All case studies <ChevronIcon />

--- a/landing-page/demo/src/app/page.tsx
+++ b/landing-page/demo/src/app/page.tsx
@@ -1,26 +1,23 @@
 import { AnnouncementBadge } from '@/components/elements/announcement-badge'
 import { ButtonLink, PlainButtonLink } from '@/components/elements/button'
-import { InstallCommand } from '@/components/elements/install-command'
 import { ClawQLHeroLogo } from '@/components/elements/clawql-hero-logo'
+import { InstallCommand } from '@/components/elements/install-command'
 import { Link } from '@/components/elements/link'
+import { Section } from '@/components/elements/section'
 import { ArrowNarrowRightIcon } from '@/components/icons/arrow-narrow-right-icon'
 import { CallToActionSimple } from '@/components/sections/call-to-action-simple'
-import {
-  IdpStageCard,
-  ToolTierSection,
-} from '@/components/sections/clawql-marketing'
+import { IdpStageCard, ToolTierSection } from '@/components/sections/clawql-marketing'
 import { FAQsTwoColumnAccordion, Faq } from '@/components/sections/faqs-two-column-accordion'
 import { HeroTwoColumnWithPhoto } from '@/components/sections/hero-two-column-with-photo'
 import { Plan, PricingMultiTier } from '@/components/sections/pricing-multi-tier'
 import { SecuritySection } from '@/components/sections/security-section'
 import { Stat, StatsFourColumns } from '@/components/sections/stats-four-columns'
-import { Section } from '@/components/elements/section'
 import { WorkflowFeedSection } from '@/components/sections/workflow-feed'
 import { idpPipelineStages, mcpToolTiers, multiProviderBenchmark } from '@/lib/marketing'
-import { securityEnforcementLayers, securityPillars } from '@/lib/security-marketing'
-import { workflowFeeds } from '@/lib/workflow-feeds'
 import { pricing } from '@/lib/pricing'
+import { securityEnforcementLayers, securityPillars } from '@/lib/security-marketing'
 import { site } from '@/lib/site'
+import { workflowFeeds } from '@/lib/workflow-feeds'
 
 export default function Page() {
   return (
@@ -28,9 +25,7 @@ export default function Page() {
       {/* Hero */}
       <HeroTwoColumnWithPhoto
         id="hero"
-        eyebrow={
-          <AnnouncementBadge href={site.urls.signup} text={site.earlyAccess.badge} cta="Join waitlist" />
-        }
+        eyebrow={<AnnouncementBadge href={site.urls.signup} text={site.earlyAccess.badge} cta="Start trial" />}
         headline="AI agents that work your entire stack — without blowing your context budget."
         subheadline={
           <p>
@@ -43,7 +38,7 @@ export default function Page() {
           <div className="flex w-full max-w-xl flex-col gap-6">
             <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
               <ButtonLink href={site.urls.signup} size="lg">
-                Join early access
+                Start free trial
               </ButtonLink>
               <PlainButtonLink href={`${site.urls.docs}/readme/getting-started`} size="lg">
                 Self-host free <ArrowNarrowRightIcon />
@@ -153,10 +148,11 @@ export default function Page() {
         headline="Eight vendors. One agent-composable pipeline."
         subheadline={
           <p>
-            Drop a file in Nextcloud; agents orchestrate layout parsing, PDF normalization, PII redaction, archival, hybrid
-            search, and secure sharing — via <code className="text-sm">search</code> → <code className="text-sm">execute</code>{' '}
-            or automated <code className="text-sm">run_idp_pipeline</code>. Self-host the full stack with Helm; managed
-            accounts run the ClawQL Archive Layer (Nextcloud + Onyx-indexed metadata) by default.
+            Drop a file in Nextcloud; agents orchestrate layout parsing, PDF normalization, PII redaction, archival,
+            hybrid search, and secure sharing — via <code className="text-sm">search</code> →{' '}
+            <code className="text-sm">execute</code> or automated <code className="text-sm">run_idp_pipeline</code>.
+            Self-host the full stack with Helm; managed accounts run the ClawQL Archive Layer (Nextcloud + Onyx-indexed
+            metadata) by default.
           </p>
         }
         cta={
@@ -179,9 +175,9 @@ export default function Page() {
         headline="Built to prove, not just claim."
         subheadline={
           <p>
-            ClawQL documents how container images are scanned, signed, and enforced from CI through Kubernetes
-            admission — plus a 32-module curriculum for agentic AI deployments. Same controls on self-hosted Helm and
-            dedicated managed accounts.
+            ClawQL documents how container images are scanned, signed, and enforced from CI through Kubernetes admission
+            — plus a 32-module curriculum for agentic AI deployments. Same controls on self-hosted Helm and dedicated
+            managed accounts.
           </p>
         }
         cta={
@@ -218,7 +214,7 @@ export default function Page() {
         <Faq
           id="faq-5"
           question="Is managed hosting available today?"
-          answer="Self-hosting is available now — npm, Helm, and the full open-source stack. Managed gateway tiers from $29/mo and IDP bundles from $299/mo are in early access: limited tenant slots, founder-led onboarding, and personal replies to waitlist signups."
+          answer="Self-hosting is available now — npm, Helm, and the full Apache 2.0 stack with no license fee. That is your free tier. Hosted gateway starts with a 14-day Developer trial (no credit card): full persistent vault and unlimited executions. IDP bundles from $299/mo onboard with founder-led setup."
         />
         <Faq
           id="faq-6"
@@ -230,8 +226,10 @@ export default function Page() {
       {/* Pricing teaser — full grid on /pricing */}
       <PricingMultiTier
         id="pricing"
-        headline={`Self-host free. Gateway from ${pricing.developer.monthlyPrice}/mo · IDP from ${pricing.starter.monthlyPrice}/mo.`}
-        subheadline={<p className="text-center text-sm/7 text-mist-600 dark:text-mist-400">{site.earlyAccess.pricingNote}</p>}
+        headline="Start your 14-day trial or self-host free"
+        subheadline={
+          <p className="text-center text-sm/7 text-mist-600 dark:text-mist-400">{site.earlyAccess.pricingNote}</p>
+        }
         plans={
           <>
             <Plan
@@ -255,7 +253,7 @@ export default function Page() {
               features={pricing.developer.features.slice(0, 4)}
               cta={
                 <ButtonLink href={site.urls.signup} size="lg">
-                  Join early access
+                  Start free trial
                 </ButtonLink>
               }
             />
@@ -299,7 +297,6 @@ export default function Page() {
           </ButtonLink>
         }
       />
-
     </>
   )
 }

--- a/landing-page/demo/src/app/pricing/page.tsx
+++ b/landing-page/demo/src/app/pricing/page.tsx
@@ -10,6 +10,7 @@ import {
   annualBillingNoteText,
   annualBillingSavingsLabel,
   gatewayEdgeHostingFeature,
+  hostedFreeTrial,
   managedPrice,
   pluginBundles,
   pricing,
@@ -27,22 +28,10 @@ function gatewayPlans(billing: BillingPeriod) {
 
   return (
     <>
-      <Plan
-        name={pricing.managedFree.name}
-        price={pricing.managedFree.monthlyPrice}
-        period={pricing.managedFree.period}
-        subheadline={<p>{pricing.managedFree.subheadline}</p>}
-        badge={pricing.managedFree.badge}
-        features={[...pricing.managedFree.features]}
-        cta={
-          <ButtonLink href={site.urls.signup} size="lg">
-            Join early access
-          </ButtonLink>
-        }
-      />
       {gatewayTiers.map((tier) => {
         const plan = pricing[tier]
         const annualNote = annualBillingNoteText(billing, tier)
+        const isDeveloper = tier === 'developer'
         return (
           <Plan
             key={tier}
@@ -59,7 +48,7 @@ function gatewayPlans(billing: BillingPeriod) {
             features={[...plan.features]}
             cta={
               <ButtonLink href={site.urls.signup} size="lg">
-                Join early access
+                {isDeveloper ? 'Start free trial' : 'Join early access'}
               </ButtonLink>
             }
           />
@@ -110,7 +99,7 @@ export const metadata = {
 export default function Page() {
   return (
     <>
-      <Section id="self-hosted" eyebrow="Open source" headline="Self-host free on your hardware">
+      <Section id="self-hosted" eyebrow="Open source" headline="Want free forever? Run it yourself.">
         <div className="flex flex-col gap-6 rounded-xl bg-mist-950/2.5 p-6 sm:flex-row sm:items-center sm:justify-between dark:bg-white/5">
           <div className="max-w-2xl">
             <p className="text-sm/7 text-mist-700 dark:text-mist-400">{pricing.selfHosted.subheadline}</p>
@@ -179,7 +168,23 @@ export default function Page() {
         plans={{ Monthly: idpPlans('Monthly'), Yearly: idpPlans('Yearly') }}
       />
 
-      <Section id="early-access" eyebrow="Early access" headline="Managed hosting is onboarding its first tenants">
+      <Section
+        id="free-trial"
+        eyebrow="Hosted entry"
+        headline={`${hostedFreeTrial.headline} — no credit card required`}
+      >
+        <p className="max-w-3xl text-sm/7 text-mist-700 dark:text-mist-400">{hostedFreeTrial.subheadline}</p>
+        <p className="mt-4 max-w-3xl text-sm/7 text-mist-600 dark:text-mist-500">
+          Evaluate the full Developer tier — not a crippled sandbox. When the trial ends, continue at{' '}
+          {pricing.developer.monthlyPrice}/mo or upgrade to Teams. Prefer zero cost? Self-host the full Apache 2.0 stack
+          with no feature restrictions.
+        </p>
+        <ButtonLink href={site.urls.signup} size="lg" className="mt-6">
+          Start free trial
+        </ButtonLink>
+      </Section>
+
+      <Section id="early-access" eyebrow="IDP tiers" headline="Document processing tiers are onboarding first tenants">
         <p className="max-w-3xl text-sm/7 text-mist-700 dark:text-mist-400">{site.earlyAccess.pricingNote}</p>
         <p className="mt-4 max-w-3xl text-sm/7 text-mist-600 dark:text-mist-500">{site.waitlistPromise}</p>
       </Section>
@@ -197,7 +202,6 @@ export default function Page() {
                 name: 'MCP Gateway (Core)',
                 value: {
                   'Self-hosted': true,
-                  Free: true,
                   Developer: true,
                   Teams: true,
                   Starter: true,
@@ -209,7 +213,6 @@ export default function Page() {
                 name: 'Memory vault + Onyx search',
                 value: {
                   'Self-hosted': 'Self-managed',
-                  Free: 'Basic vault',
                   Developer: true,
                   Teams: 'Full Onyx',
                   Starter: true,
@@ -221,7 +224,6 @@ export default function Page() {
                 name: 'IDP plugin bundle',
                 value: {
                   'Self-hosted': 'Opt-in',
-                  Free: false,
                   Developer: false,
                   Teams: false,
                   Starter: true,
@@ -238,7 +240,6 @@ export default function Page() {
                 name: 'MCP executions',
                 value: {
                   'Self-hosted': 'Unlimited (your infra)',
-                  Free: 'Unlimited',
                   Developer: 'Unlimited',
                   Teams: 'Unlimited',
                   Starter: 'Unlimited',
@@ -250,7 +251,6 @@ export default function Page() {
                 name: 'Gateway hosting',
                 value: {
                   'Self-hosted': 'Your infra',
-                  Free: 'Global edge',
                   Developer: 'Global edge',
                   Teams: 'Global edge',
                   Starter: 'Dedicated tenant',
@@ -262,7 +262,6 @@ export default function Page() {
                 name: 'MCP endpoint',
                 value: {
                   'Self-hosted': 'Your deployment',
-                  Free: 'Same URL all tiers',
                   Developer: 'Same URL all tiers',
                   Teams: 'Same URL all tiers',
                   Starter: 'Same URL all tiers',
@@ -274,7 +273,6 @@ export default function Page() {
                 name: 'Vault on tier upgrade',
                 value: {
                   'Self-hosted': 'Your data',
-                  Free: 'Carries over',
                   Developer: 'Carries over',
                   Teams: 'Carries over',
                   Starter: 'Carries over',
@@ -286,7 +284,6 @@ export default function Page() {
                 name: 'Vault recall egress',
                 value: {
                   'Self-hosted': 'Your infra',
-                  Free: 'No penalties',
                   Developer: 'No penalties',
                   Teams: 'No penalties',
                   Starter: 'Included',
@@ -298,7 +295,6 @@ export default function Page() {
                 name: 'Documents / month',
                 value: {
                   'Self-hosted': 'Unlimited (your infra)',
-                  Free: '—',
                   Developer: '—',
                   Teams: '—',
                   Starter: '5,000',
@@ -310,7 +306,6 @@ export default function Page() {
                 name: 'Users',
                 value: {
                   'Self-hosted': 'Unlimited',
-                  Free: '1',
                   Developer: '1',
                   Teams: '5',
                   Starter: '5',
@@ -327,7 +322,6 @@ export default function Page() {
                 name: 'Coneshare VDR',
                 value: {
                   'Self-hosted': 'Self-deploy optional',
-                  Free: false,
                   Developer: false,
                   Teams: false,
                   Starter: true,
@@ -339,7 +333,6 @@ export default function Page() {
                 name: 'Sovereign inference',
                 value: {
                   'Self-hosted': 'Your deployment',
-                  Free: false,
                   Developer: false,
                   Teams: false,
                   Starter: true,
@@ -351,7 +344,6 @@ export default function Page() {
                 name: 'classify / extract / HITL',
                 value: {
                   'Self-hosted': 'Opt-in',
-                  Free: false,
                   Developer: false,
                   Teams: false,
                   Starter: true,
@@ -368,7 +360,6 @@ export default function Page() {
                 name: 'SLA',
                 value: {
                   'Self-hosted': '—',
-                  Free: 'None',
                   Developer: 'None',
                   Teams: '99% uptime',
                   Starter: '99% uptime',
@@ -380,7 +371,6 @@ export default function Page() {
                 name: 'SSO / SAML',
                 value: {
                   'Self-hosted': false,
-                  Free: false,
                   Developer: false,
                   Teams: false,
                   Starter: false,
@@ -441,7 +431,12 @@ export default function Page() {
         <Faq
           id="faq-1"
           question="Is self-hosted really free?"
-          answer="Yes. ClawQL is open source. You pay only for compute and storage on your hardware. Enable plugins via CLAWQL_ENABLE_* flags — Core is always on; IDP vendors activate when you need document processing."
+          answer="Yes — that is your free tier. ClawQL is Apache 2.0 open source. Run the full stack on your hardware with no license fee and no feature restrictions. You pay only for compute and storage. Enable plugins via CLAWQL_ENABLE_* flags — Core is always on; IDP vendors activate when you need document processing."
+        />
+        <Faq
+          id="faq-1b"
+          question="Do I need a credit card to start the free trial?"
+          answer={`No. The ${hostedFreeTrial.durationDays}-day trial gives you the full Developer tier — persistent vault memory, unlimited executions, global edge endpoint. No credit card required. When the trial ends, continue at ${pricing.developer.monthlyPrice}/mo or upgrade to Teams.`}
         />
         <Faq
           id="faq-2"
@@ -451,12 +446,12 @@ export default function Page() {
         <Faq
           id="faq-3"
           question="How does ClawQL compare to executor.sh?"
-          answer={`executor.sh caps executions (250,000/mo on Team) and charges $0.20/1,000 overage — customers watch a meter. ClawQL offers unlimited executions on every tier, including Free, with no egress penalties on vault memory recall. ClawQL Developer (${pricing.developer.monthlyPrice}/mo) and Teams (${pricing.teams.monthlyPrice}/mo) add a global edge gateway, seven additional token-efficiency layers, persistent Obsidian vault memory, and Onyx semantic search on Teams. IDP tiers from ${pricing.starter.monthlyPrice}/mo add document processing, Coneshare VDR, and sovereign inference — none of which executor.sh offers.`}
+          answer={`executor.sh caps executions (250,000/mo on Team) and charges $0.20/1,000 overage — customers watch a meter. ClawQL offers unlimited executions on every hosted tier, with no egress penalties on vault memory recall. Self-host free forever on Apache 2.0, or start a 14-day Developer trial. ClawQL Developer (${pricing.developer.monthlyPrice}/mo) and Teams (${pricing.teams.monthlyPrice}/mo) add a global edge gateway, seven additional token-efficiency layers, persistent Obsidian vault memory, and Onyx semantic search on Teams. IDP tiers from ${pricing.starter.monthlyPrice}/mo add document processing, Coneshare VDR, and sovereign inference — none of which executor.sh offers.`}
         />
         <Faq
           id="faq-3b"
           question="Are MCP executions really unlimited?"
-          answer="Yes. Every managed tier — Free through Enterprise — includes unlimited MCP executions. We price on hosting model, storage, and plugin bundles because those drive real infrastructure cost — not per-call metering or egress on memory recall. Gateway tiers scale at the global edge; taxing executions or recall only encourages customers to throttle their agents. executor.sh is the outlier with execution caps and overage billing."
+          answer="Yes. Every hosted tier — Developer through Enterprise — includes unlimited MCP executions. We price on hosting model, storage, and plugin bundles because those drive real infrastructure cost — not per-call metering or egress on memory recall. Gateway tiers scale at the global edge; taxing executions or recall only encourages customers to throttle their agents. executor.sh is the outlier with execution caps and overage billing."
         />
         <Faq
           id="faq-4"
@@ -466,7 +461,7 @@ export default function Page() {
         <Faq
           id="faq-4b"
           question="Why are gateway and IDP tiers priced differently?"
-          answer="Gateway tiers (Free, Developer, Teams) need only MCP routing, vault memory, cache, and audit — lightweight workloads that run at the global edge with near-zero marginal cost per tenant. IDP tiers (Starter+) activate document processing, Onyx at scale, Coneshare VDR, and sovereign inference on dedicated tenant infrastructure. You only pay for the heavy stack when you opt in."
+          answer="Gateway tiers (Developer, Teams) need only MCP routing, vault memory, cache, and audit — lightweight workloads that run at the global edge. IDP tiers (Starter+) activate document processing, Onyx at scale, Coneshare VDR, and sovereign inference on dedicated tenant infrastructure. You only pay for the heavy stack when you opt in. No perpetual free hosted plan — self-host free forever or start a 14-day Developer trial."
         />
         <Faq
           id="faq-5"
@@ -492,17 +487,18 @@ export default function Page() {
 
       <CallToActionSimpleCentered
         id="call-to-action"
-        headline="Self-host free or join early access"
+        headline="Self-host free or start your 14-day trial"
         subheadline={
           <p>
-            Install clawql-mcp on your hardware, or join the waitlist — unlimited executions on every tier, gateway from{' '}
-            {pricing.developer.monthlyPrice}/mo, IDP bundle from {pricing.starter.monthlyPrice}/mo.
+            Install clawql-mcp on your hardware — Apache 2.0, no license fee — or try hosted Developer free for{' '}
+            {hostedFreeTrial.durationDays} days. Gateway from {pricing.developer.monthlyPrice}/mo, IDP bundle from{' '}
+            {pricing.starter.monthlyPrice}/mo.
           </p>
         }
         cta={
           <div className="flex items-center gap-4">
             <ButtonLink href={site.urls.signup} size="lg">
-              Join early access
+              Start free trial
             </ButtonLink>
             <PlainButtonLink href={site.urls.docs} size="lg">
               Self-host guide <ChevronIcon />

--- a/landing-page/demo/src/app/signup/page.tsx
+++ b/landing-page/demo/src/app/signup/page.tsx
@@ -1,14 +1,14 @@
 import { ButtonLink, PlainButtonLink } from '@/components/elements/button'
-import { WaitlistSignupForm } from '@/components/elements/waitlist-signup-form'
 import { InstallCommand } from '@/components/elements/install-command'
+import { Section } from '@/components/elements/section'
+import { WaitlistSignupForm } from '@/components/elements/waitlist-signup-form'
 import { ArrowNarrowRightIcon } from '@/components/icons/arrow-narrow-right-icon'
 import { CheckmarkIcon } from '@/components/icons/checkmark-icon'
 import { IdpStageCard, ToolCard } from '@/components/sections/clawql-marketing'
 import { Feature, FeaturesThreeColumn } from '@/components/sections/features-three-column'
 import { HeroSimpleCentered } from '@/components/sections/hero-simple-centered'
-import { Section } from '@/components/elements/section'
 import { idpPipelineStages, mcpToolTiers } from '@/lib/marketing'
-import { pricing } from '@/lib/pricing'
+import { hostedFreeTrial, pricing } from '@/lib/pricing'
 import { site } from '@/lib/site'
 
 export const metadata = {
@@ -20,16 +20,16 @@ export default function Page() {
     <>
       <HeroSimpleCentered
         id="signup-hero"
-        headline="Book a demo or join early access"
+        headline="Start your 14-day trial or book a demo"
         subheadline={
           <p>
             {site.earlyAccess.summary} Real estate teams: see the{' '}
             <a href="/industries/real-estate#demo-pitch" className="underline">
               one-paragraph pitch
             </a>{' '}
-            to forward before your demo. Gateway from {pricing.developer.monthlyPrice}/mo, Teams{' '}
-            {pricing.teams.monthlyPrice}/mo, IDP bundle from {pricing.starter.monthlyPrice}/mo — join the waitlist for
-            founder-led onboarding. {site.waitlistPromise}
+            to forward before your demo. Developer trial is {hostedFreeTrial.durationDays} days, no credit card. Gateway
+            from {pricing.developer.monthlyPrice}/mo, Teams {pricing.teams.monthlyPrice}/mo, IDP bundle from{' '}
+            {pricing.starter.monthlyPrice}/mo. {site.waitlistPromise}
           </p>
         }
         cta={<WaitlistSignupForm className="mx-auto" />}

--- a/landing-page/demo/src/lib/competitive-pricing.ts
+++ b/landing-page/demo/src/lib/competitive-pricing.ts
@@ -235,7 +235,7 @@ export const competitorFeatureRows: CompetitorFeatureRow[] = [
 export const competitiveHonestyNotes = [
   {
     title: 'Unlimited executions — deliberate pricing',
-    body: 'Gateway tiers run at the global edge and scale with demand — an extra execution or memory_recall costs us almost nothing in egress. Charging per execution creates a perverse incentive to throttle agents. ClawQL prices on hosting model, storage, and plugin bundles. Unlimited executions on every tier, including Free. executor.sh caps usage and bills $0.20/1,000 overage.',
+    body: 'Gateway tiers run at the global edge and scale with demand — an extra execution or memory_recall costs us almost nothing in egress. Charging per execution creates a perverse incentive to throttle agents. ClawQL prices on hosting model, storage, and plugin bundles. Unlimited executions on every hosted tier. Self-host free forever on Apache 2.0. executor.sh caps usage and bills $0.20/1,000 overage.',
   },
   {
     title: 'Plugin bundles, not one-size-fits-all',

--- a/landing-page/demo/src/lib/pricing.ts
+++ b/landing-page/demo/src/lib/pricing.ts
@@ -9,20 +9,22 @@ export type IdpTierId = 'starter' | 'business' | 'professional'
 export type ManagedTierId = GatewayTierId | IdpTierId
 
 /** Comparison table columns — self-hosted plus all managed tiers. */
-export const pricingPlanNames = [
-  'Self-hosted',
-  'Free',
-  'Developer',
-  'Teams',
-  'Starter',
-  'Business',
-  'Professional',
-] as const
+export const pricingPlanNames = ['Self-hosted', 'Developer', 'Teams', 'Starter', 'Business', 'Professional'] as const
 
 export type PricingPlanName = (typeof pricingPlanNames)[number]
 
-/** Customer-facing promise — no execution caps or overage on any tier. */
-export const unlimitedExecutionsTagline = 'Unlimited MCP executions on every tier — no caps, no overage, no meter.'
+/** Customer-facing promise — no execution caps or overage on hosted tiers. */
+export const unlimitedExecutionsTagline =
+  'Unlimited MCP executions on every hosted tier — no caps, no overage, no meter.'
+
+/** Hosted entry point — full Developer tier evaluation, no perpetual free hosted plan. */
+export const hostedFreeTrial = {
+  durationDays: 14,
+  headline: '14-day free trial',
+  subheadline:
+    'Full Developer tier — persistent vault memory, unlimited executions, global edge endpoint. No credit card required.',
+  noCreditCard: true,
+} as const
 
 /** Gateway-tier hosting benefits (customer-facing; no provider names). */
 export const gatewayEdgeHostingFeature = 'Global edge-hosted MCP endpoint'
@@ -45,7 +47,7 @@ export const pluginBundles = {
     name: 'MCP Gateway',
     description:
       'search, execute, audit, cache — always-on Core. Global edge hosting on gateway tiers. Unlimited integrations and executions. Vault-backed memory with no per-recall egress penalties.',
-    tiers: ['Free', 'Developer', 'Teams'] as const,
+    tiers: ['Developer', 'Teams'] as const,
   },
   memory: {
     name: 'Memory & Search',
@@ -83,33 +85,13 @@ export const pricing = {
     price: '$0',
     period: '',
     subheadline:
-      'Run the full open-source stack on your hardware — enable only the plugins you need via CLAWQL_ENABLE_* flags.',
+      'Want free forever? Run the full Apache 2.0 stack on your hardware — Helm chart, GHCR images, no license fee, no feature restrictions. Enable only the plugins you need via CLAWQL_ENABLE_* flags.',
     features: [
       'search, execute, audit, cache (Core — always on)',
       'memory_ingest & memory_recall (default on)',
       'Full IDP pipeline when you opt in (8 vendors)',
+      'Apache 2.0 — free forever, you pay infra only',
       'Helm charts & GHCR images',
-      'No license fee — you pay infra only',
-    ],
-  },
-  managedFree: {
-    name: 'Free',
-    shortName: 'Free' as const,
-    monthlyPrice: '$0',
-    period: '/mo',
-    badge: 'Gateway · early access',
-    pluginBundle: 'gateway' as const,
-    subheadline:
-      'Try the hosted MCP gateway — connect agents to your APIs without IDP or VDR overhead. Memory vault included at evaluation scale.',
-    features: [
-      'Unlimited MCP executions',
-      gatewayEdgeHostingFeature,
-      vaultRecallStorageFeature,
-      singleMcpEndpointFeature,
-      '1 user · 3 integrations',
-      'Core MCP + basic memory vault',
-      'No IDP pipeline · no Coneshare VDR',
-      'Community support',
     ],
   },
   developer: {
@@ -118,12 +100,12 @@ export const pricing = {
     monthlyPrice: '$29',
     annualPricePerMonth: '$24',
     period: '/mo',
-    badge: 'Gateway + memory',
+    badge: 'Gateway + memory · 14-day trial',
     pluginBundle: 'gateway' as const,
     valueAnchor:
       'Unlimited executions + vault memory + eight efficiency layers — executor.sh caps usage and charges overage.',
     subheadline:
-      'MCP gateway + agent memory vault for developers connecting Claude Code, Cursor, or Codex to your APIs. No IDP, no GPU inference.',
+      'MCP gateway + agent memory vault for developers connecting Claude Code, Cursor, or Codex to your APIs. Start with a 14-day free trial — no credit card. No IDP, no GPU inference.',
     features: [
       'Unlimited MCP executions',
       gatewayEdgeHostingFeature,

--- a/landing-page/demo/src/lib/site.ts
+++ b/landing-page/demo/src/lib/site.ts
@@ -4,14 +4,14 @@ export const site = {
   description:
     'Token-efficient search → execute workflows over OpenAPI, Google Discovery, GraphQL, and gRPC — with vault memory, documents, and enterprise tooling.',
   earlyAccess: {
-    badge: 'Managed hosting is in early access — accepting waitlist signups',
+    badge: '14-day free trial — no credit card required',
     summary:
-      'ClawQL is open source and self-hostable today. Gateway tiers (Free, Developer, Teams) launch at the global edge with unlimited executions and vault memory. IDP document processing provisions dedicated infrastructure when you opt into Starter+. Founder-led onboarding, limited slots.',
+      'ClawQL is open source and self-hostable today — that is your free tier. Hosted gateway starts with a 14-day trial of Developer: full persistent vault, unlimited executions, global edge endpoint. Upgrade to Teams or IDP tiers when you are ready.',
     pricingNote:
-      'Gateway tiers deploy at the global edge first — unlimited MCP executions, vault memory with no egress penalties on recall, Onyx search on Teams. IDP tiers (Starter $299+) activate document processing, VDR, and sovereign inference on a dedicated tenant. One MCP endpoint for every tier: upgrade from Teams to Starter without changing your URL, auth token, or vault history.',
+      'No perpetual free hosted plan — self-host free forever on Apache 2.0, or start a 14-day Developer trial. Gateway tiers deploy at the global edge with unlimited MCP executions, vault memory with no egress penalties on recall, and Onyx search on Teams. IDP tiers (Starter $299+) activate document processing, VDR, and sovereign inference on a dedicated tenant. One MCP endpoint for every tier: upgrade from Teams to Starter without changing your URL, auth token, or vault history.',
   },
   waitlistPromise:
-    'Join the waitlist for managed hosting — we reply personally when a slot opens. Self-host free with npm or Helm while you wait.',
+    'Start your 14-day trial or self-host free with npm or Helm — full Apache 2.0 stack, no license fee.',
   urls: {
     home: '/',
     docs: 'https://docs.clawql.com',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the perpetual hosted Free tier and reframes pricing around a **14-day Developer trial** (no credit card) plus **self-hosted as the free-forever path**.

## Changes

- **pricing.ts**: Remove `managedFree`; add `hostedFreeTrial`; update `pricingPlanNames`, plugin bundle tiers, self-hosted copy, and Developer trial badge
- **pricing page**: Remove Free plan column; add trial section; update FAQs and CTAs (`Start free trial` on Developer)
- **site.ts / homepage / signup / about**: Trial-first messaging; self-hosted framed as Apache 2.0 free tier
- **competitive-pricing.ts**: Remove "including Free" from honesty notes (executor.sh Free tier unchanged — competitor data)
- **clawql-idp-platform.md**: Remove Free tier row; document trial + self-hosted path

## PLG funnel

Self-host free → 14-day Developer trial → $29/mo Developer → Teams / IDP tiers

## Test plan

- [x] `npm run build` in `landing-page/demo` passes
- [ ] Visual review of `/pricing` comparison table (6 columns, no Free)
- [ ] Verify Developer CTA reads "Start free trial"
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

