### PR TITLE
feat(landing): sharpen positioning — tool vs OS, honesty notes, ICP

### DIFF
--- a/docs/vision/clawql-idp-platform.md
+++ b/docs/vision/clawql-idp-platform.md
@@ -403,14 +403,20 @@ The entire sequence above runs from a single natural-language agent prompt. No c
 
 ## Competitive Positioning
 
+ClawQL is an **operating system for agents**, not a single SKU. Sales focus follows **plugin bundles** — gateway and memory first (Developer/Teams), IDP and VDR when explicitly opted in (Starter+). The surface area is large; buyers activate layers they need rather than purchasing four products at once.
+
+**First buyers:** document-heavy teams of 20–200 people in legal, M&A diligence, healthcare operations, and lending — organizations already spending $500–2k/mo on SaaS who need agent memory and document intelligence. Gateway-only developers evaluating MCP infrastructure start on Developer or Teams.
+
+**Current state:** the open-source MCP core is production-ready and self-hostable today (npm, Helm, published case studies, Kubernetes operator). Managed gateway hosting is in early access with a 14-day Developer trial. IDP hosted tenants onboard with founder-led setup. Architecture earns trust over time — we do not claim compliance certifications or long vendor histories we do not have yet.
+
 ClawQL competes across four adjacent markets — price each plugin bundle against the right incumbent:
 
-| Competitor Category                                                                   | ClawQL tier                                                | ClawQL differentiation                                                                                                                                                                                                                                  |
-| ------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **MCP gateways** ([executor.sh](https://executor.sh/), emerging agent infrastructure) | Developer ($29/mo), Teams ($99/mo)                         | executor.sh meters executions (250K cap + $0.20/1K overage on Team). ClawQL: unlimited executions on every tier. Plus eight efficiency layers, persistent vault memory, Onyx semantic search, and optional full IDP platform executor.sh does not ship. |
-| **SaaS IDP vendors** (Hyperscience, Kofax, ABBYY)                                     | Starter–Professional (IDP bundle)                          | Cloud-hosted; per-document pricing at scale. No native MCP/agent interface. ClawQL: tenant-isolated hosted or self-hosted, flat IDP tiers, MCP-native from day one.                                                                                     |
-| **VDR incumbents** (Intralinks, Datasite, Ansarada)                                   | Starter+ (IDP bundle includes Coneshare)                   | Hosted VDRs with no document processing pipeline. High per-user/per-GB/per-deal licensing. ClawQL: full pipeline integration, Coneshare VDR included in IDP subscription.                                                                               |
-| **Vertical CRMs** (REsimpli, franchise transaction tools)                             | Teams ($99/mo) for agent memory; Starter ($299/mo) for IDP | CRMs track pipeline; Drive folders hold files. ClawQL connects CRM APIs + storage via MCP, indexes documents in Onyx, threads deal context in vault — without replacing Command, Dotloop, or SkySlope.                                                  |
+| Competitor Category                                                                   | ClawQL tier                                                | ClawQL differentiation                                                                                                                                                                                                           |
+| ------------------------------------------------------------------------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **MCP gateways** ([executor.sh](https://executor.sh/), emerging agent infrastructure) | Developer ($29/mo), Teams ($99/mo)                         | executor.sh is a **tool** with a head start on developer marketing. ClawQL is a **platform**: unlimited executions, eight efficiency layers, vault memory, Onyx search, optional IDP — more capability at lower gateway pricing. |
+| **SaaS IDP vendors** (Hyperscience, Kofax, ABBYY)                                     | Starter–Professional (IDP bundle)                          | Cloud-hosted; per-document pricing at scale. No native MCP/agent interface. ClawQL: tenant-isolated hosted or self-hosted, flat IDP tiers, MCP-native from day one.                                                              |
+| **VDR incumbents** (Intralinks, Datasite, Ansarada)                                   | Starter+ (IDP bundle includes Coneshare)                   | Hosted VDRs with no document processing pipeline. High per-user/per-GB/per-deal licensing. ClawQL: full pipeline integration, Coneshare VDR included in IDP subscription.                                                        |
+| **Vertical CRMs** (REsimpli, franchise transaction tools)                             | Teams ($99/mo) for agent memory; Starter ($299/mo) for IDP | CRMs track pipeline; Drive folders hold files. ClawQL connects CRM APIs + storage via MCP, indexes documents in Onyx, threads deal context in vault — without replacing Command, Dotloop, or SkySlope.                           |
 
 ### Real estate vertical
 
@@ -426,23 +432,39 @@ ClawQL does **not** replace Dotloop (forms, e-sign, broker compliance) or MLS li
 
 ### MCP gateway: executor.sh (Market 1)
 
-executor.sh is the closest direct competitor to ClawQL's MCP gateway layer. It routes tool calls; ClawQL operates a stateful agent platform.
+executor.sh is the closest direct competitor to ClawQL's MCP gateway layer. **It is a tool; ClawQL is an operating system.** executor.sh routes tool calls well — that is its job. ClawQL adds memory, search, security depth, document pipeline, and optional sovereign inference behind one MCP endpoint.
 
-| Dimension         | executor.sh                           | ClawQL                                                                              |
-| ----------------- | ------------------------------------- | ----------------------------------------------------------------------------------- |
-| Token efficiency  | One layer: search-and-execute only    | Eight compounding layers on top of search/execute                                   |
-| Agent memory      | None — every session starts from zero | Obsidian vault with memory_ingest / memory_recall                                   |
-| Semantic search   | None                                  | Onyx — 40+ connectors, hybrid search, citations                                     |
-| Security          | Host-side secrets, basic audit log    | Kata isolation, WORM Merkle logs, Panguard fail-closed, documented defense-in-depth |
-| Document pipeline | None                                  | Tika → Gotenberg → Stirling → archive → Onyx                                        |
-| VDR               | None                                  | Coneshare included from IDP Starter                                                 |
-| Sovereign LLM     | None                                  | Fine-tuned Qwen inside tenant boundary (IDP tiers)                                  |
-| Execution pricing | 250K cap + $0.20/1K overage on Team   | Unlimited on every tier — no caps, no overage bills                                 |
-| Gateway pricing   | Team $150/org/mo — metered routing    | Developer $29/mo · Teams $99/mo with memory + search · unlimited executions         |
+**Where executor.sh leads:** developer mindshare, YC-backed go-to-market, and community velocity in the MCP gateway category. That is real and we state it plainly.
 
-executor.sh is a stateless tool router. ClawQL is a stateful agent operating system with eight compounding token-efficiency layers, persistent memory, semantic search, sovereign AI inference, a full document pipeline, a VDR, and defense-in-depth security that executor.sh cannot match at any price.
+**Collaboration:** before publishing head-to-head comparisons, we approached executor.sh about collaboration and shared MCP ecosystem work. Those overtures were not engaged. We document positioning directly for buyers making infrastructure decisions.
 
-ClawQL's MCP-native architecture means it benefits automatically from improvements in AI model capabilities. As frontier models improve, ClawQL's automation depth increases without code changes.
+| Dimension          | executor.sh                                            | ClawQL                                                                                                   |
+| ------------------ | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| Category           | Tool — routes MCP calls, injects secrets, meters usage | Operating system — gateway, memory, search, security, IDP, sovereign inference                           |
+| Developer adoption | Head start on marketing and community mindshare        | Later entrant; deeper stack, open-source core, published case studies                                    |
+| Token efficiency   | One layer: search-and-execute only                     | Eight compounding layers on top of search/execute                                                        |
+| Agent memory       | None — every session starts from zero                  | Obsidian vault with memory_ingest / memory_recall                                                        |
+| Semantic search    | None                                                   | Onyx — 40+ connectors, hybrid search, citations                                                          |
+| Security           | Host-side secrets, basic audit log                     | Kata isolation, WORM Merkle logs, Panguard fail-closed, documented defense-in-depth                      |
+| Document pipeline  | None                                                   | Tika → Gotenberg → Stirling → archive → Onyx                                                             |
+| VDR                | None                                                   | Coneshare included from IDP Starter                                                                      |
+| Sovereign LLM      | None                                                   | Fine-tuned Qwen inside tenant boundary (IDP tiers) — vertical adapters early; maturity risk named openly |
+| Execution pricing  | 250K cap + $0.20/1K overage on Team                    | Unlimited on every tier — no caps, no overage bills                                                      |
+| Gateway pricing    | Team $150/org/mo — metered routing                     | Developer $29/mo · Teams $99/mo with memory + search · unlimited executions                              |
+
+On infrastructure dimensions that matter — memory, security, token efficiency depth, document pipeline, sovereign inference — ClawQL delivers more at lower gateway pricing. executor.sh's advantage is awareness and adoption velocity, not platform depth.
+
+### Shipped vs roadmap (honest scope)
+
+| Capability                                                | Status                                                                                                        |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| ClawQL Core (search, execute, audit, cache)               | **Shipped** — open source, case studies                                                                       |
+| Vault memory, Onyx search, IDP pipeline                   | **Shipped** — self-host and early hosted tenants                                                              |
+| Ouroboros evolutionary loop library                       | **Shipped** — `clawql-ouroboros` package                                                                      |
+| DAOS swarm coordination (NSV, SGDOP, Diversity Dividends) | **Roadmap** — specified in [DAOS build plan](../ouroboros/daos-build-plan-v2.7.1.md); not production-hardened |
+| Tenant-bound fine-tuned models (Qwen3.6 family)           | **Early** — deliberate bet; newer than incumbent cloud APIs; name maturity risk in regulated evaluations      |
+
+ClawQL's MCP-native architecture benefits from improvements in frontier model capabilities. Tenant-bound fine-tunes are a differentiation bet with explicit maturity risk — regulated buyers should weigh architecture against reference history.
 
 ---
 

--- a/landing-page/demo/src/app/about/page.tsx
+++ b/landing-page/demo/src/app/about/page.tsx
@@ -20,7 +20,7 @@ export default function Page() {
         headline="The infrastructure layer agents call into."
         subheadline={
           <p>
-            ClawQL is not an agent framework — it does not reason or plan. It is the MCP gateway where agents{' '}
+            ClawQL is not an agent framework — it does not reason or plan. It is the MCP operating system where agents{' '}
             <strong>search</strong> APIs, <strong>execute</strong> operations, <strong>recall</strong> vault knowledge,
             <strong> ingest</strong> documents, and <strong>audit</strong> what happened. Memory and action form a
             closed loop.
@@ -51,11 +51,29 @@ export default function Page() {
             </p>
           </div>
           <div className="rounded-xl bg-mist-950/2.5 p-6 dark:bg-white/5">
+            <h3 className="font-semibold text-mist-950 dark:text-white">Current state</h3>
+            <p className="mt-2">
+              The open-source MCP server is production-ready and self-hostable today — npm, Helm, published case
+              studies, and a v7 operator for Kubernetes. Managed gateway hosting is in early access (14-day Developer
+              trial, then paid tiers). IDP hosted tenants are onboarding with founder-led setup. We are pre-revenue on
+              managed hosting; the core product is not vaporware.
+            </p>
+          </div>
+          <div className="rounded-xl bg-mist-950/2.5 p-6 dark:bg-white/5">
+            <h3 className="font-semibold text-mist-950 dark:text-white">First buyers</h3>
+            <p className="mt-2">
+              Document-heavy teams of 20–200 people in legal, M&A diligence, healthcare operations, and lending — teams
+              that already spend $500–2k/mo on SaaS and need agent memory plus document intelligence, not another CRM.
+              Gateway-only developers evaluating MCP infrastructure start on Developer or Teams; IDP activates when they
+              need classify/extract and VDR.
+            </p>
+          </div>
+          <div className="rounded-xl bg-mist-950/2.5 p-6 dark:bg-white/5">
             <h3 className="font-semibold text-mist-950 dark:text-white">Early access, founder-led</h3>
             <p className="mt-2">
-              Managed hosting is in early access — onboarding the first Professional and shared-tenancy tenants with
-              founder-led setup, not a self-serve checkout. The open-source core is production-ready today; hosted slots
-              are limited while we validate pipeline reliability under real workloads.
+              Managed hosting onboarding is founder-led — not self-serve checkout. Hosted slots are limited while we
+              validate pipeline reliability under real workloads. Architecture earns trust over time; we do not claim
+              compliance certifications or decade-long references we do not have yet.
             </p>
           </div>
           <div className="rounded-xl bg-mist-950/2.5 p-6 sm:col-span-2 lg:col-span-1 dark:bg-white/5">
@@ -72,9 +90,13 @@ export default function Page() {
       <Section
         id="philosophy"
         eyebrow="What we build"
-        headline="Three problems, one platform."
+        headline="Three problems — one platform, activated in layers."
         subheadline={
-          <p>Current agent systems lose context, burn tokens on API specs, and treat documents as afterthoughts.</p>
+          <p>
+            Current agent systems lose context, burn tokens on API specs, and treat documents as afterthoughts. Plugin
+            bundles let you solve gateway and memory first; add IDP and sovereign inference only when your workload
+            needs them.
+          </p>
         }
       >
         <div className="grid grid-cols-1 gap-6 text-sm/7 text-mist-700 sm:grid-cols-3 dark:text-mist-400">

--- a/landing-page/demo/src/app/page.tsx
+++ b/landing-page/demo/src/app/page.tsx
@@ -214,7 +214,7 @@ export default function Page() {
         <Faq
           id="faq-5"
           question="Is managed hosting available today?"
-          answer="Self-hosting is available now — npm, Helm, and the full Apache 2.0 stack with no license fee. That is your free tier. Hosted gateway starts with a 14-day Developer trial (no credit card): full persistent vault and unlimited executions. IDP bundles from $299/mo onboard with founder-led setup."
+          answer="The open-source MCP core is production-ready today — npm, Helm, case studies, and a Kubernetes operator. Self-host free on Apache 2.0, or start a 14-day Developer trial. Managed IDP hosting is early access with founder-led onboarding. We are pre-revenue on managed hosting; the architecture is shipped, references and compliance history are still building."
         />
         <Faq
           id="faq-6"

--- a/landing-page/demo/src/app/pricing/page.tsx
+++ b/landing-page/demo/src/app/pricing/page.tsx
@@ -446,7 +446,7 @@ export default function Page() {
         <Faq
           id="faq-3"
           question="How does ClawQL compare to executor.sh?"
-          answer={`executor.sh caps executions (250,000/mo on Team) and charges $0.20/1,000 overage — customers watch a meter. ClawQL offers unlimited executions on every hosted tier, with no egress penalties on vault memory recall. Self-host free forever on Apache 2.0, or start a 14-day Developer trial. ClawQL Developer (${pricing.developer.monthlyPrice}/mo) and Teams (${pricing.teams.monthlyPrice}/mo) add a global edge gateway, seven additional token-efficiency layers, persistent Obsidian vault memory, and Onyx semantic search on Teams. IDP tiers from ${pricing.starter.monthlyPrice}/mo add document processing, Coneshare VDR, and sovereign inference — none of which executor.sh offers.`}
+          answer={`executor.sh is a tool — it routes MCP calls well and has a head start on developer marketing. ClawQL is an operating system for agents: the same Layer 1 search/execute pattern, plus seven additional efficiency layers, persistent vault memory, Onyx search, unlimited executions (no meter), and optional IDP from ${pricing.starter.monthlyPrice}/mo. At gateway tiers, ClawQL Developer (${pricing.developer.monthlyPrice}/mo) and Teams (${pricing.teams.monthlyPrice}/mo) deliver more for less than executor.sh Team ($150/mo + overage). We approached executor.sh about collaboration before publishing comparisons; buyers deserve an honest infrastructure evaluation, not a marketing feud.`}
         />
         <Faq
           id="faq-3b"

--- a/landing-page/demo/src/components/sections/competitive-pricing-section.tsx
+++ b/landing-page/demo/src/components/sections/competitive-pricing-section.tsx
@@ -70,7 +70,7 @@ export function CompetitivePricingSection({ className, ...props }: ComponentProp
 
         <div className="mt-10 rounded-xl border border-mist-950/10 bg-mist-950/2.5 p-6 sm:p-8 dark:border-white/10 dark:bg-white/5">
           <h3 className="text-xl font-semibold text-mist-950 dark:text-white">
-            vs {executorBenchmark.name} — stateless tool router, not a platform
+            vs {executorBenchmark.name} — a tool, not a platform
           </h3>
           <p className="mt-2 text-sm/7 text-mist-700 dark:text-mist-400">{executorBenchmark.positioning}</p>
           <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">

--- a/landing-page/demo/src/lib/competitive-pricing.ts
+++ b/landing-page/demo/src/lib/competitive-pricing.ts
@@ -2,17 +2,17 @@
 
 import { businessAllInMonthly, pricing, unlimitedExecutionsTagline } from './pricing'
 
-export const competitiveHeadline = 'Gateway, memory, and IDP — price each plugin bundle against the right incumbent.'
+export const competitiveHeadline = 'Plugin bundles — price each layer against the right incumbent.'
 
 export const competitiveSummary =
-  'ClawQL is not one product at one price. Developer and Teams tiers replace stateless MCP routers like executor.sh with a global edge gateway, persistent vault memory (no egress penalties on recall), Onyx semantic search, eight compounding token-efficiency layers, and unlimited executions — no meter, no overage. Starter through Professional compete with IDP and VDR incumbents on document volume — a $8,000–15,000/month stack sold separately elsewhere.'
+  'ClawQL is an operating system for agents, not a single SKU. Developer and Teams tiers replace stateless MCP routers like executor.sh with a global edge gateway, persistent vault memory, Onyx semantic search, eight compounding token-efficiency layers, and unlimited executions. Starter through Professional compete with IDP and VDR incumbents — only when you opt into document processing. Gateway buyers should not subsidize GPU inference they never use.'
 
 /** MCP gateway competitor — executor.sh (direct competitor to ClawQL gateway layer). */
 export const executorBenchmark = {
   name: 'executor.sh',
   href: 'https://executor.sh/',
   positioning:
-    'Stateless MCP tool router. Normalizes OpenAPI/GraphQL/MCP into a search-and-execute gateway with host-side secret injection and basic audit logging. That is the complete product.',
+    'A tool — not a platform. executor.sh normalizes OpenAPI/GraphQL/MCP into a search-and-execute gateway with host-side secret injection and basic audit logging. That is the complete product, and it does that job well.',
   pricing: [
     { tier: 'Free', price: '$0', includes: '3 members · 10,000 executions/mo cap' },
     {
@@ -25,9 +25,9 @@ export const executorBenchmark = {
   clawqlResponse: {
     tiers: `Developer ${pricing.developer.monthlyPrice}/mo · Teams ${pricing.teams.monthlyPrice}/mo`,
     advantage:
-      'ClawQL implements the same Layer 1 search/execute pattern, then compounds seven additional efficiency layers on top — plus persistent Obsidian vault memory, Onyx semantic search, and an optional full IDP platform. executor.sh stops at Layer 1.',
+      'executor.sh is a hammer — excellent for routing tool calls. ClawQL is the workshop: the same Layer 1 search/execute pattern, then seven additional efficiency layers, persistent vault memory, Onyx semantic search, defense-in-depth security, and an optional full IDP platform behind one MCP endpoint.',
     closing:
-      'executor.sh is a stateless tool router. ClawQL is a stateful agent operating system. This is not a close comparison.',
+      'Their head start is developer marketing and community mindshare — real advantages. On every dimension that matters for infrastructure decisions — memory, security depth, token efficiency, document pipeline, sovereign inference — ClawQL is categorically different, delivers more, and costs less at comparable gateway tiers.',
   },
 } as const
 
@@ -39,6 +39,19 @@ export type ExecutorComparisonRow = {
 
 /** Dimension-by-dimension comparison — Market 1 (MCP Gateway) from GTM playbook. */
 export const executorComparisonRows: ExecutorComparisonRow[] = [
+  {
+    dimension: 'Category',
+    executor: 'Tool — routes MCP calls, injects secrets, meters executions.',
+    clawql:
+      'Operating system for agents — gateway, memory, search, security, IDP, and optional sovereign inference in one platform.',
+  },
+  {
+    dimension: 'Developer adoption',
+    executor:
+      'Head start: strong developer marketing, YC backing, and growing community mindshare. That is their real advantage.',
+    clawql:
+      'Later entrant with deeper stack — published case studies, open-source core, self-host evaluation path, and production deployments.',
+  },
   {
     dimension: 'Token efficiency architecture',
     executor: 'One layer: search-and-execute pattern only.',
@@ -75,7 +88,8 @@ export const executorComparisonRows: ExecutorComparisonRow[] = [
   {
     dimension: 'Sovereign LLM inference',
     executor: 'None. All inference routes to external APIs.',
-    clawql: 'Fine-tuned Qwen3.6-27B inside tenant boundary — Istio egress block, no tokens leave the namespace.',
+    clawql:
+      'Fine-tuned Qwen3.6-27B inside tenant boundary — Istio egress block, no tokens leave the namespace. Vertical adapters are early; we name maturity risk openly.',
   },
   {
     dimension: 'Execution pricing',
@@ -234,20 +248,36 @@ export const competitorFeatureRows: CompetitorFeatureRow[] = [
 
 export const competitiveHonestyNotes = [
   {
+    title: 'Tool vs operating system',
+    body: 'executor.sh routes tool calls — a focused, well-marketed hammer. ClawQL is the workshop: memory, search, security, document pipeline, and sovereign inference behind one MCP endpoint. Buyers who need routing only should evaluate executor.sh. Buyers who need agent infrastructure should not mistake a tool for a platform.',
+  },
+  {
+    title: 'Where executor.sh leads',
+    body: 'Developer mindshare and go-to-market velocity — YC backing, community growth, and brand recognition in the MCP gateway category. We acknowledge that plainly. Technical depth, security architecture, persistent memory, and platform breadth are where ClawQL competes — not on who shipped Layer 1 routing first.',
+  },
+  {
+    title: 'Collaboration before competition',
+    body: 'Before publishing head-to-head comparisons, we approached executor.sh about collaboration and shared MCP ecosystem work. Those overtures were not engaged. We document our positioning directly for buyers making infrastructure decisions — not to start a marketing feud.',
+  },
+  {
+    title: 'Focus: plugin bundles, not four companies at once',
+    body: 'The surface area is large — gateway, IDP, VDR, sovereign inference, and DAOS coordination on the roadmap. Sales focus follows plugin bundles: Developer/Teams for agent builders connecting tools; Starter+ for document-heavy teams in legal, M&A, healthcare, and lending who opt into IDP explicitly. You only pay for the heavy stack when you activate it.',
+  },
+  {
+    title: 'Shipped today vs roadmap',
+    body: 'ClawQL Core (search, execute, audit, cache), vault memory, Onyx search, the IDP pipeline, and the Ouroboros evolutionary loop library are shipped and documented with case studies. DAOS swarm coordination (NSV, SGDOP, Diversity Dividends) is specified and on the P0–P3 build plan — not production-hardened yet. We separate spec from shipped code in evaluations.',
+  },
+  {
+    title: 'Sovereign inference maturity',
+    body: 'Tenant-bound fine-tuned models (Qwen3.6 family and vertical adapters) are a deliberate differentiation bet. Base weights and adapter tooling are newer than incumbent cloud APIs — we name that risk for regulated buyers who need references and compliance history, not just architecture slides.',
+  },
+  {
     title: 'Unlimited executions — deliberate pricing',
     body: 'Gateway tiers run at the global edge and scale with demand — an extra execution or memory_recall costs us almost nothing in egress. Charging per execution creates a perverse incentive to throttle agents. ClawQL prices on hosting model, storage, and plugin bundles. Unlimited executions on every hosted tier. Self-host free forever on Apache 2.0. executor.sh caps usage and bills $0.20/1,000 overage.',
   },
   {
-    title: 'Plugin bundles, not one-size-fits-all',
-    body: 'Gateway-only buyers should not pay for Stirling, Gotenberg, and GPU inference. Developer ($29) and Teams ($99) run at the global edge with memory, search, and unlimited executions. IDP tiers ($299+) provision dedicated document-processing infrastructure only when you opt in — priced against Hyperscience and Intralinks.',
-  },
-  {
     title: 'Seamless tier upgrades',
     body: 'One MCP endpoint on every tier. Upgrade from Teams to Starter and your URL, auth token, and vault memory history stay the same — agents retain full context without a migration project. IDP infrastructure activates behind the same endpoint.',
-  },
-  {
-    title: 'executor.sh vs ClawQL (MCP gateway)',
-    body: 'executor.sh implements one token-efficiency layer and routes tool calls behind a usage meter. ClawQL compounds eight efficiency layers, ships a global edge gateway, persistent vault memory without egress penalties on recall, Onyx semantic search, unlimited executions, and an optional full IDP platform. executor.sh has no equivalent at any price point beyond Layer 1 routing.',
   },
   {
     title: 'Where incumbents still lead',

--- a/landing-page/demo/src/lib/site.ts
+++ b/landing-page/demo/src/lib/site.ts
@@ -6,7 +6,7 @@ export const site = {
   earlyAccess: {
     badge: '14-day free trial — no credit card required',
     summary:
-      'ClawQL is open source and self-hostable today — that is your free tier. Hosted gateway starts with a 14-day trial of Developer: full persistent vault, unlimited executions, global edge endpoint. Upgrade to Teams or IDP tiers when you are ready.',
+      'ClawQL is an operating system for agents — not an agent framework. The open-source MCP core is production-ready today: search, execute, vault memory, and optional IDP. Self-host free on Apache 2.0, or start a 14-day Developer trial with full persistent memory and unlimited executions.',
     pricingNote:
       'No perpetual free hosted plan — self-host free forever on Apache 2.0, or start a 14-day Developer trial. Gateway tiers deploy at the global edge with unlimited MCP executions, vault memory with no egress penalties on recall, and Onyx search on Teams. IDP tiers (Starter $299+) activate document processing, VDR, and sovereign inference on a dedicated tenant. One MCP endpoint for every tier: upgrade from Teams to Starter without changing your URL, auth token, or vault history.',
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Incorporates external positioning feedback: stay aggressive on executor.sh differentiation, but sharpen framing and add honesty where reviewers flagged gaps.

## Key changes

### executor.sh — tool vs operating system
- Acknowledge executor.sh's real advantage: developer mindshare and GTM velocity
- Reframe comparison as **tool (hammer) vs platform (workshop)** — not a deficiency checklist
- Note collaboration attempts before competitive publishing

### Honesty notes (pricing page)
- Plugin-bundle focus and first-buyer ICP (legal/M&A/healthcare/lending, 20–200 seats)
- Shipped vs roadmap (Ouroboros loop shipped; DAOS NSV/SGDOP on build plan)
- Sovereign inference maturity risk for regulated buyers

### About page
- **Current state**: open-source core production-ready; managed hosting early access; pre-revenue on hosted
- **First buyers**: document-heavy teams with existing SaaS spend
- Trust candor: architecture earns references over time

### Docs
- `clawql-idp-platform.md` competitive chapter aligned with site framing

## Test plan

- [x] `npm run build` in `landing-page/demo`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f16b6-93d8-7255-be56-41a58adf701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

