### PR TITLE
release(7.0.0): finalize operator + onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,29 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **Opinionated default bundled stack** ([#528](https://github.com/danielsmithdevelopment/ClawQL/pull/528)): bare `npx clawql-mcp` loads **Cloudflare, GitHub, Slack, Linear, Notion, Onyx**; **`CLAWQL_PROVIDER=all-providers`** remains explicit opt-in for every vendor + Google top-50 + AWS top-50.
-- **AWS top-50 bundled preset** ([#528](https://github.com/danielsmithdevelopment/ClawQL/pull/528)): SigV4 **`execute`**, manifest under `providers/aws/`, onboarding [`docs/providers/aws-onboarding.md`](docs/providers/aws-onboarding.md).
-- **Notion bundled provider**: official OpenAPI; **`NOTION_API_TOKEN`** auth; onboarding [`docs/providers/notion-onboarding.md`](docs/providers/notion-onboarding.md).
-- **Plugins docs site**: `docs/plugins/*.md` → `/plugins` hub + per-slug pages.
-- **Init walkthrough (Phase 2)**: `clawql` CLI — **`init`**, **`doctor`**, **`mcp-config`**; local **`~/.ClawQL/vault/providers.json`** (HashiCorp KV shape); MCP loads vault at startup; [local-provider-vault.md](docs/getting-started/local-provider-vault.md).
-- **Onboarding Tier 1**: `clawql secrets list|set` (hidden token input), `clawql doctor --smoke`, `clawql mcp-config --write cursor|claude-desktop`, HashiCorp Vault auto-detect on init, MCP startup stderr summary.
-- **Onboarding Tier 2**: `clawql onboard` end-to-end walkthrough; docs/migration/agent-setup aligned to **7.0.0** and Tier 1 CLI commands.
-- **ClawQL Operator (phase 2, opt-in)**: `ClawQLInstance` tier presets, continuous reconcile Deployment, MCP rollout on tier-spec change, `clawql operator status`, `make local-k8s-up` operator install ([#255](https://github.com/danielsmithdevelopment/ClawQL/issues/255)).
-
-### Changed
-
-- **Multi-spec HTTP**: `/graphql` is not mounted in merged multi-spec mode (MCP `search`/`execute` unchanged).
-- **First-run docs**: README, getting-started, quickstart, install, and migration guide aligned to default stack vs `all-providers`.
-- **Plugin model/registry docs**: Phase 2 `onRegister` status updated (July 2026).
-
-### Fixed
-
-- **`loadSpec()` cache race** after `resetSpecCache()` — generation counter in spec loader ([#528](https://github.com/danielsmithdevelopment/ClawQL/pull/528)).
-- **HTTP test stability** on CI — fast app opts, sql.js warmup, describe-level timeouts ([#528](https://github.com/danielsmithdevelopment/ClawQL/pull/528)).
-
-> **Note:** Items below are on **`main`** (post-**6.4.1** npm tag) and documented in release notes / IDP wave guides; they will appear in the next semver release entry when tagged.
+> **Note:** IDP wave items below are on **`main`** and documented in release notes / IDP guides; they will appear in the next semver release entry when tagged.
 
 ### Added
 
@@ -51,6 +29,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`docs/deployment/nats-keda-worker.md`**, Helm `nats.worker` / `nats.keda` values, IDP matrix #257 → Shipped.
 - **`docs/mcp/idp-pipeline-runner.md`**, IDP matrix #307 → Shipped, plugin registry + **`mcp-tools.md`** **`run_idp_pipeline`** row.
 - HITL + workflow tool guides: NATS dual-path (sync webhook vs async consumer); `.env.example` NATS block.
+
+## [7.0.0] - 2026-07-09
+
+Major release: **opinionated default stack**, **vault-first onboarding CLI**, and **opt-in ClawQL Operator scaffold**. Release notes: **[`RELEASE_NOTES_v7.0.0.md`](RELEASE_NOTES_v7.0.0.md)**.
+
+### Added
+
+- **Opinionated default bundled stack** ([#528](https://github.com/danielsmithdevelopment/ClawQL/pull/528)): bare `npx clawql-mcp` loads **Cloudflare, GitHub, Slack, Linear, Notion, Onyx**; **`CLAWQL_PROVIDER=all-providers`** remains explicit opt-in for every vendor + Google top-50 + AWS top-50.
+- **AWS top-50 bundled preset** ([#528](https://github.com/danielsmithdevelopment/ClawQL/pull/528)): SigV4 **`execute`**, manifest under `providers/aws/`, onboarding [`docs/providers/aws-onboarding.md`](docs/providers/aws-onboarding.md).
+- **Notion bundled provider**: official OpenAPI; **`NOTION_API_TOKEN`** auth; onboarding [`docs/providers/notion-onboarding.md`](docs/providers/notion-onboarding.md).
+- **Plugins docs site**: `docs/plugins/*.md` → `/plugins` hub + per-slug pages.
+- **Init walkthrough (Phase 2)**: `clawql` CLI — **`init`**, **`doctor`**, **`mcp-config`**; local **`~/.ClawQL/vault/providers.json`** (HashiCorp KV shape); MCP loads vault at startup; [local-provider-vault.md](docs/getting-started/local-provider-vault.md).
+- **Onboarding Tier 1**: `clawql secrets list|set` (hidden token input), `clawql doctor --smoke`, `clawql mcp-config --write cursor|claude-desktop`, HashiCorp Vault auto-detect on init, MCP startup stderr summary.
+- **Onboarding Tier 2**: `clawql onboard` end-to-end walkthrough; docs/migration/agent-setup aligned to **7.0.0** and Tier 1 CLI commands.
+- **ClawQL Operator scaffold (opt-in)**: `ClawQLInstance` tier presets, continuous reconcile Deployment, MCP rollout on tier-spec change, `clawql operator status`, `make local-k8s-up` operator install ([#255](https://github.com/danielsmithdevelopment/ClawQL/issues/255), [#479](https://github.com/danielsmithdevelopment/ClawQL/pull/479)).
+
+### Changed
+
+- **Multi-spec HTTP**: `/graphql` is not mounted in merged multi-spec mode (MCP `search`/`execute` unchanged).
+- **First-run docs**: README, getting-started, quickstart, install, and migration guide aligned to default stack vs `all-providers`.
+- **Plugin model/registry docs**: Phase 2 `onRegister` status updated (July 2026).
+
+### Fixed
+
+- **`loadSpec()` cache race** after `resetSpecCache()` — generation counter in spec loader ([#528](https://github.com/danielsmithdevelopment/ClawQL/pull/528)).
+- **HTTP test stability** on CI — fast app opts, sql.js warmup, describe-level timeouts ([#528](https://github.com/danielsmithdevelopment/ClawQL/pull/528)).
 
 ## [6.4.1] - 2026-07-03
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deploy-cloud-run deploy-k8s deploy-docs local-k8s-up bootstrap-vault-eso local-k8s-mcp-delete local-docker-up helm-lint helm-ui-template-tests helm-workflow-template-tests helm-argocd-template-tests helm-nats-keda-template-tests helm-vault-secrets-template-tests helm-docling-template-tests helm-idp-template-tests helm-operator-template-tests compose-lending-config-test distribution-npm-pack-test mcp-docker-workspace-test kustomize-local-lint lint-k8s-manifests smoke-grpcurl-istio-gateway-mcp smoke-mcp-http-istio-gateway smoke-localhost-uis verify-vault-policy verify-mcp-core-tools-local
+.PHONY: deploy-cloud-run deploy-k8s deploy-docs local-k8s-up operator-install operator-status bootstrap-vault-eso local-k8s-mcp-delete local-docker-up helm-lint helm-ui-template-tests helm-workflow-template-tests helm-argocd-template-tests helm-nats-keda-template-tests helm-vault-secrets-template-tests helm-docling-template-tests helm-idp-template-tests helm-operator-template-tests compose-lending-config-test distribution-npm-pack-test mcp-docker-workspace-test kustomize-local-lint lint-k8s-manifests smoke-grpcurl-istio-gateway-mcp smoke-mcp-http-istio-gateway smoke-localhost-uis verify-vault-policy verify-mcp-core-tools-local
 
 # Validate charts/clawql-mcp (requires helm on PATH)
 helm-lint:
@@ -93,6 +93,14 @@ lint-k8s-manifests: helm-lint helm-ui-template-tests helm-workflow-template-test
 # Local desktop k8s: default Helm + Istio ambient + Gateway/VS + heavy observability; CLAWQL_LOCAL_K8S_ISTIO=0 skips mesh
 local-k8s-up:
 	@bash scripts/kubernetes/local-k8s-docker-desktop.sh
+
+# Install operator CRD + Deployment only (no full stack)
+operator-install:
+	@bash scripts/kubernetes/install-clawql-operator-local.sh
+
+# List ClawQLInstance CRs and tier-spec ConfigMaps (requires kubeconfig)
+operator-status:
+	@npx -p clawql-mcp clawql operator status
 
 # Verify ClawQL GHCR container packages are **public** via **GET** (read:packages; GitHub exposes no visibility PATCH API)
 ghcr-packages-public:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Feature tiers (aligned with the [architecture diagram](docs/readme/images/clawql
 - Stdio and HTTP MCP server modes
 - Bundled provider specs for offline lookup and multi-provider workflows
 
-Primary package: `clawql-mcp` (current release: **6.4.1** npm tag; **7.0.0** default-stack + onboarding on `main` — [`RELEASE_NOTES_v7.0.0.md`](RELEASE_NOTES_v7.0.0.md))  
+Primary package: `clawql-mcp` (**7.0.0** — default stack, vault-first onboarding, opt-in operator scaffold — [`RELEASE_NOTES_v7.0.0.md`](RELEASE_NOTES_v7.0.0.md))  
 Repo: https://github.com/danielsmithdevelopment/ClawQL
 
 ### Container images on GHCR (Docker / Helm)

--- a/RELEASE_NOTES_v7.0.0.md
+++ b/RELEASE_NOTES_v7.0.0.md
@@ -1,8 +1,8 @@
-# ClawQL 7.0.0 — Release notes (draft)
+## clawql-mcp 7.0.0
 
-**Target:** Next major release after **6.4.1**  
-**Status:** On `main` — npm tag pending  
-**PRs:** [#528](https://github.com/danielsmithdevelopment/ClawQL/pull/528) (default stack) + onboarding Tier 1 CLI
+**npm:** [clawql-mcp@7.0.0](https://www.npmjs.com/package/clawql-mcp)  
+**Full changelog:** [CHANGELOG.md#700---2026-07-09](https://github.com/danielsmithdevelopment/ClawQL/blob/main/CHANGELOG.md#700---2026-07-09)  
+**Released:** 2026-07-09
 
 ---
 
@@ -42,16 +42,18 @@ Helm **`clawql-mcp`** chart may still default to **`all-providers`** for full ID
 | `clawql mcp-config --write cursor`    | Merge MCP JSON into Cursor / Claude Desktop (with `.bak` backup)    |
 | `clawql operator status`              | Kubernetes: ClawQLInstance + tier-spec ConfigMap health             |
 
-## ClawQL Operator (opt-in, phase 2)
+Docs: [Agent setup](docs/getting-started/agent-setup-prompt.md), [local provider vault](docs/getting-started/local-provider-vault.md), [/agent-setup](https://docs.clawql.com/agent-setup)
+
+---
+
+## ClawQL Operator (opt-in scaffold)
 
 - **`ClawQLInstance`** CRD with tier presets (`local` / `standard` / `enterprise`)
 - Continuous reconcile via operator **Deployment** (CronJob optional via `operator.mode`)
 - Tier-spec ConfigMap with owner references; optional MCP Deployment rollout on spec change
 - **`make local-k8s-up`** installs operator on full stack — [`clawql-operator-helm.md`](docs/deployment/clawql-operator-helm.md)
 
-MCP startup logs a one-line stderr summary: spec mode, vendor count, memory vault path, configured secret count.
-
-Docs: [Agent setup](docs/getting-started/agent-setup-prompt.md), [local provider vault](docs/getting-started/local-provider-vault.md), [/agent-setup](https://docs.clawql.com/agent-setup)
+Full NL ops, vertical toggles, and auth reconciliation remain roadmap — see [operator-target-architecture.md](docs/design/operator-target-architecture.md).
 
 ---
 
@@ -60,6 +62,15 @@ Docs: [Agent setup](docs/getting-started/agent-setup-prompt.md), [local provider
 - **AWS:** curated top-50 OpenAPI presets, SigV4 on `execute`
 - **Notion:** bundled `notion` provider
 - **Plugins:** docs hub at [/plugins](https://docs.clawql.com/plugins) (MCP plugins are opt-in; bundled providers are spec merge only)
+
+---
+
+## Helm charts
+
+| Chart                    | Chart.version | appVersion |
+| ------------------------ | ------------- | ---------- |
+| `charts/clawql-mcp`      | `0.7.0`       | `7.0.0`    |
+| `charts/clawql-operator` | `0.2.0`       | `7.0.0`    |
 
 ---
 
@@ -72,6 +83,18 @@ Docs: [Agent setup](docs/getting-started/agent-setup-prompt.md), [local provider
 
 ---
 
+## Install
+
+```bash
+npm install clawql-mcp@7.0.0
+npx clawql onboard --interactive
+npx clawql-mcp-http
+
+docker pull ghcr.io/danielsmithdevelopment/clawql-mcp:latest
+```
+
+---
+
 ## Contributors
 
-See [CHANGELOG.md](CHANGELOG.md) **Unreleased** for full commit-level detail.
+See [CHANGELOG.md](CHANGELOG.md) **[7.0.0]** for full commit-level detail.

--- a/charts/clawql-idp/Chart.yaml
+++ b/charts/clawql-idp/Chart.yaml
@@ -3,8 +3,8 @@ name: clawql-idp
 description: Umbrella Helm chart for a k3s-friendly ClawQL IDP stack (MCP + document pipeline + OpenClaw + Argo hooks)
 type: application
 version: 0.1.0
-appVersion: "6.4.1"
+appVersion: "7.0.0"
 dependencies:
   - name: clawql-mcp
-    version: 0.6.8
+    version: 0.7.0
     repository: file://../clawql-mcp

--- a/charts/clawql-mcp/Chart.yaml
+++ b/charts/clawql-mcp/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: clawql-mcp
 description: ClawQL MCP server (Streamable HTTP, optional gRPC) for Kubernetes
 type: application
-version: 0.6.8
+version: 0.7.0
 # Align with npm package when cutting chart releases; image tag is separate (values.image.tag).
-appVersion: "6.4.1"
+appVersion: "7.0.0"
 dependencies:
   - name: vault
     # Lowercase RFC 1123-safe alias (Kubernetes resource names derive from Helm release prefix + alias).

--- a/charts/clawql-operator/Chart.yaml
+++ b/charts/clawql-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: clawql-operator
 description: Opt-in ClawQL Kubernetes Operator scaffold (ClawQLInstance CRD + tier-spec ConfigMaps)
 type: application
-version: 0.1.0
-appVersion: "0.0.1"
+version: 0.2.0
+appVersion: "7.0.0"

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ This directory is organized by purpose so operational guides, product docs, and 
 - **Token efficiency — layered approach** (Code Mode, response trimming, caching, semantic cache, model routing): [`architecture/clawql-token-efficiency.md`](architecture/clawql-token-efficiency.md) — [`/architecture/token-efficiency`](https://docs.clawql.com/architecture/token-efficiency)
 - **Modularization implementation status** (ground truth — packages, shims, MCP flow, Effect/plugin status, July 2026): [`design/modularization-implementation-status.md`](design/modularization-implementation-status.md)
 - **ClawQL plugin model** (memory/documents/automation as plugins, MCP tools, third-party extensions): [`design/clawql-plugin-model.md`](design/clawql-plugin-model.md) — [`/reference/plugins`](https://docs.clawql.com/reference/plugins)
-- **Operator target architecture** (planned tiers, CRD, NL ops — not shipped): [`design/operator-target-architecture.md`](design/operator-target-architecture.md)
+- **Operator target architecture** (full operator roadmap — NL ops, verticals): [`design/operator-target-architecture.md`](design/operator-target-architecture.md)
 - **Plugin registry** (shipped vs planned plugins, MCP tool ownership, enable flags): [`reference/clawql-plugin-registry.md`](reference/clawql-plugin-registry.md) — [`/reference/plugins`](https://docs.clawql.com/reference/plugins)
 - **Plugins hub** (one page per plugin — core, memory, documents, bundled providers, …): [`plugins/README.md`](plugins/README.md) — [`/plugins`](https://docs.clawql.com/plugins)
 - **Effect-TS + plugin rearchitecture plan** (Layer composition, plugin checklist): [`design/effect-ts-modularization-rearchitecture-plan.md`](design/effect-ts-modularization-rearchitecture-plan.md)
@@ -38,7 +38,7 @@ This directory is organized by purpose so operational guides, product docs, and 
 - `readme/getting-started.md`
 - `getting-started/agent-setup-prompt.md` — copy-paste Cursor/Claude onboarding prompt
 - `getting-started/local-provider-vault.md` — ~/.ClawQL secrets vault + memory home
-- `getting-started/clawql-init-walkthrough-spec.md` — Executor comparison and phased init tool design
+- `getting-started/clawql-init-walkthrough-spec.md` — Executor comparison; Phases 1–2b shipped in 7.0.0
 - `readme/configuration.md`
 - `readme/deployment.md`
 - `readme/benchmarks.md`

--- a/docs/deployment/clawql-deployment-operations-guide.md
+++ b/docs/deployment/clawql-deployment-operations-guide.md
@@ -135,15 +135,15 @@ Default provider merge with **no** spec env: **opinionated default stack** (Clou
 
 ---
 
-## Operator scaffold (opt-in)
+## Operator scaffold (opt-in, shipped 7.0.0)
 
-Phase 1 does **not** manage MCP Deployments. Existing Helm and `CLAWQL_ENABLE_*` workflows are unchanged unless you explicitly enable the operator chart and MCP `instanceSpec` mount.
+The operator scaffold reconciles `ClawQLInstance` CRs to tier-spec ConfigMaps and optionally rolls MCP when `spec.mcp.rolloutOnTierSpecChange` is set. Helm `CLAWQL_ENABLE_*` workflows remain the default when the operator is not installed.
 
 1. Install CRD + reconcile: [clawql-operator-helm.md](clawql-operator-helm.md)
 2. Apply a `ClawQLInstance` (`examples/operator/clawqlinstance-minimal.yaml`)
-3. Optionally mount the published tier-spec ConfigMap on MCP (`instanceSpec.enabled: true`)
+3. Mount the published tier-spec ConfigMap on MCP (`instanceSpec.enabled: true`)
 
-Full tier/vertical/auth reconciliation remains in **[Operator target architecture](../design/operator-target-architecture.md)**.
+Full tier/vertical/auth reconciliation and NL ops remain in **[Operator target architecture](../design/operator-target-architecture.md)** (roadmap).
 
 ---
 

--- a/docs/deployment/clawql-operator-helm.md
+++ b/docs/deployment/clawql-operator-helm.md
@@ -4,7 +4,7 @@
 
 The operator is an **additive** deployment path. Helm `charts/clawql-mcp`, `make local-k8s-up`, and env-based `CLAWQL_ENABLE_*` flags remain the default when the operator is not installed.
 
-## Architecture (phase 2)
+## Architecture (7.0 scaffold)
 
 ```mermaid
 flowchart LR

--- a/docs/design/operator-target-architecture.md
+++ b/docs/design/operator-target-architecture.md
@@ -1,17 +1,19 @@
-# ClawQL Operator — target architecture (not shipped)
+# ClawQL Operator — target architecture (full roadmap)
 
-**Status:** Design reference · **June 2026**  
+**Status:** Design reference for **full** operator (NL ops, verticals, auth) · **July 2026**  
 **Tracking:** [#255](https://github.com/danielsmithdevelopment/ClawQL/issues/255) (Operator / umbrella chart), [#251](https://github.com/danielsmithdevelopment/ClawQL/issues/251) (four Compose stacks)
 
-This document captures the **planned** three-tier deployment model: **`ClawQLInstance` CRD**, Operator reconciliation, vertical toggles, natural-language operations, and enterprise hardening. **Nothing in sections 1–13 below is runnable today** unless explicitly marked as a shipped Helm equivalent.
+> **Shipped in 7.0.0 (opt-in scaffold):** `ClawQLInstance` CRD, tier presets, tier-spec ConfigMaps, continuous reconcile, optional MCP rollout, `clawql operator status`, `make local-k8s-up` install. Deploy guide: **[clawql-operator-helm.md](../deployment/clawql-operator-helm.md)**. Sections 1–13 below describe the **full** operator vision; only items marked as shipped Helm equivalents are runnable today.
 
-**Deploy today:** [Deployment & Operations Guide](../deployment/clawql-deployment-operations-guide.md) · [Helm (`charts/clawql-mcp`)](../deployment/helm.md) · [IDP pipeline](../providers/idp-pipeline.md) · `make local-k8s-up`
+This document captures the **planned** three-tier deployment model: **`ClawQLInstance` CRD**, Operator reconciliation, vertical toggles, natural-language operations, and enterprise hardening.
+
+**Deploy today:** [Deployment & Operations Guide](../deployment/clawql-deployment-operations-guide.md) · [Operator scaffold](../deployment/clawql-operator-helm.md) · [Helm (`charts/clawql-mcp`)](../deployment/helm.md) · [IDP pipeline](../providers/idp-pipeline.md) · `make local-k8s-up`
 
 ---
 
 ## Overview
 
-Three tiers were designed around a **ClawQL Operator** (not shipped). **Tier 1** Compose/bootstrap is also planned ([#251](https://github.com/danielsmithdevelopment/ClawQL/issues/251)). **Shipped alternative:** Helm **`charts/clawql-mcp`** co-deploys MCP, document pipeline, optional Onyx/Nextcloud/Coneshare, dashboard, and vault memory without an Operator.
+Three tiers were designed around a **ClawQL Operator**. An **opt-in scaffold** shipped in **7.0.0** (CRD + reconcile + tier-spec ConfigMaps) — see [clawql-operator-helm.md](../deployment/clawql-operator-helm.md). **Tier 1** Compose/bootstrap is also planned ([#251](https://github.com/danielsmithdevelopment/ClawQL/issues/251)). **Default path:** Helm **`charts/clawql-mcp`** co-deploys MCP, document pipeline, optional Onyx/Nextcloud/Coneshare, dashboard, and vault memory without enabling the operator.
 
 ### Prerequisites by Tier
 

--- a/docs/getting-started/clawql-init-walkthrough-spec.md
+++ b/docs/getting-started/clawql-init-walkthrough-spec.md
@@ -1,6 +1,6 @@
 # ClawQL init walkthrough — design spec
 
-**Status:** Draft (July 2026)  
+**Status:** Shipped (7.0.0) — Phases 1–2b complete; Phase 3 UI optional  
 **Audience:** Product, docs, and contributors planning the next major release onboarding UX  
 **Companion:** [Agent setup prompt](./agent-setup-prompt.md) · [Getting started](../readme/getting-started.md)
 
@@ -35,21 +35,21 @@ Executor is a useful reference: one-line install, `doctor`, agent-bootstrap shor
 
 ## 3. ClawQL today (gaps)
 
-| Capability         | ClawQL today                                | Gap                                                                |
-| ------------------ | ------------------------------------------- | ------------------------------------------------------------------ |
-| Install            | `npm install clawql-mcp` / `npx clawql-mcp` | No curl installer; acceptable for npm ecosystem                    |
-| Health             | `GET /healthz` on HTTP mode only            | No `clawql doctor` CLI; stdio users lack one command               |
-| Dashboard          | Helm `clawql-dashboard` (K8s)               | No local-first “add provider” UI for solo dev                      |
-| Agent bootstrap    | Manual MCP JSON in Cursor/Claude            | No copy-paste **agent setup prompt** on docs home                  |
-| First integration  | Per-provider onboarding docs                | ~~No end-to-end walkthrough tool~~ → **`clawql onboard`** (Tier 2) |
-| Default stack docs | Partially updated post-#528                 | README/quickstart still taught `all-providers` as default          |
+| Capability         | ClawQL 7.0.0                                | Remaining gap                                           |
+| ------------------ | ------------------------------------------- | ------------------------------------------------------- |
+| Install            | `npm install clawql-mcp` / `npx clawql-mcp` | No curl installer; acceptable for npm ecosystem         |
+| Health             | `clawql doctor` / `clawql doctor --smoke`   | HTTP-only checks need `CLAWQL_MCP_URL`                  |
+| Dashboard          | Helm `clawql-dashboard` (K8s)               | No local-first “add provider” UI for solo dev (Phase 3) |
+| Agent bootstrap    | `clawql onboard` + agent-setup prompt       | —                                                       |
+| First integration  | `clawql onboard --interactive`              | —                                                       |
+| Default stack docs | README, quickstart, migration aligned       | —                                                       |
 
-**Existing assets to reuse:**
+**Existing assets:**
 
 - [Getting started](../readme/getting-started.md), [Quickstart](https://docs.clawql.com/quickstart), [MCP clients](https://docs.clawql.com/mcp-clients)
 - Per-vendor guides: `docs/providers/*-onboarding.md`
-- [Plugins hub](https://docs.clawql.com/plugins) — core, bundled providers, memory, documents
-- `scripts/dev/clawql-doctor.sh` — lightweight health/MCP wiring checks (Phase 1)
+- [Plugins hub](https://docs.clawql.com/plugins)
+- `scripts/dev/clawql-doctor.sh` — thin wrapper; prefer **`clawql doctor`**
 
 ---
 
@@ -107,7 +107,7 @@ flowchart TD
 - Restart MCP client after config change
 - Default stack list (6 vendors) vs `CLAWQL_PROVIDER=all-providers`
 - Never print or commit secrets; use env / `CLAWQL_PROVIDER_AUTH_JSON`
-- Point to `clawql-doctor.sh` after HTTP start
+- Point to `clawql doctor` after HTTP start (or `clawql doctor --smoke` for stdio MCP)
 
 ---
 

--- a/docs/vision/clawql-master-enablement-guide.md
+++ b/docs/vision/clawql-master-enablement-guide.md
@@ -197,7 +197,8 @@ Read the full documentation suite, deploy the Tier 1 stack, and begin building p
 | [Immutable releases (Layer 0)](./clawql-hybrid-decentralized-github-alternative.md)                  | Arweave bundles, Radicle, Rift, `clawql-release`, manifest schema                            |
 | [Contributor Technical Specification](../contributing/clawql-contributor-technical-specification.md) | Implementation contracts, Effect-TS patterns, CI rules                                       |
 | [Deployment & Operations Guide](../deployment/clawql-deployment-operations-guide.md)                 | Shipped Helm ops — quick start, day-2, health                                                |
-| [Operator target architecture](../design/operator-target-architecture.md)                            | Planned tiers, CRD, verticals, NL ops (not shipped)                                          |
+| [Operator scaffold (7.0)](../deployment/clawql-operator-helm.md)                                   | Shipped opt-in CRD + reconcile + tier presets                                                |
+| [Operator target architecture](../design/operator-target-architecture.md)                            | Full operator roadmap — NL ops, verticals, auth (not shipped)                                |
 | [Dashboard Agent Chat](../dashboard/agent-chat.md)                                                   | Browser UI, SSE, vault threads, IDP attachment JSON contract                                 |
 | [Defense-in-Depth Security Guide](../security/clawql-defense-in-depth-security-guide.md)             | What to deploy — condensed operator reference                                                |
 | [Security curriculum](../security/security-best-practices-series/README.md)                          | 32 modules — why and how to prove controls                                                   |

--- a/docs/vision/clawql-master-enablement-guide.md
+++ b/docs/vision/clawql-master-enablement-guide.md
@@ -197,7 +197,7 @@ Read the full documentation suite, deploy the Tier 1 stack, and begin building p
 | [Immutable releases (Layer 0)](./clawql-hybrid-decentralized-github-alternative.md)                  | Arweave bundles, Radicle, Rift, `clawql-release`, manifest schema                            |
 | [Contributor Technical Specification](../contributing/clawql-contributor-technical-specification.md) | Implementation contracts, Effect-TS patterns, CI rules                                       |
 | [Deployment & Operations Guide](../deployment/clawql-deployment-operations-guide.md)                 | Shipped Helm ops — quick start, day-2, health                                                |
-| [Operator scaffold (7.0)](../deployment/clawql-operator-helm.md)                                   | Shipped opt-in CRD + reconcile + tier presets                                                |
+| [Operator scaffold (7.0)](../deployment/clawql-operator-helm.md)                                     | Shipped opt-in CRD + reconcile + tier presets                                                |
 | [Operator target architecture](../design/operator-target-architecture.md)                            | Full operator roadmap — NL ops, verticals, auth (not shipped)                                |
 | [Dashboard Agent Chat](../dashboard/agent-chat.md)                                                   | Browser UI, SSE, vault threads, IDP attachment JSON contract                                 |
 | [Defense-in-Depth Security Guide](../security/clawql-defense-in-depth-security-guide.md)             | What to deploy — condensed operator reference                                                |

--- a/docs/vision/clawql-vision-roadmap.md
+++ b/docs/vision/clawql-vision-roadmap.md
@@ -130,7 +130,7 @@ For technical readers, the full rationale and patterns are in the [Contributor T
 
 ### Planned
 
-All vertical packages, the Kubernetes Operator, the natural language dashboard, and the remaining horizontal packages (`clawql-data`, `clawql-sandbox`, `clawql-printingpress`, `clawql-goose`, `clawql-telemetry`) are planned and not yet in development. **`clawql-automation`** is a **scaffold** on `main` (schedule + notify extracted; NATS/HITL planned). Specifications for not-yet-started packages are written and stable; work begins when upstream dependencies stabilize.
+Vertical packages, the **full** Kubernetes Operator (NL dashboard, vertical toggles, auth reconciliation), and the remaining horizontal packages (`clawql-data`, `clawql-sandbox`, `clawql-printingpress`, `clawql-goose`, `clawql-telemetry`) are planned. An **opt-in operator scaffold** shipped in **7.0.0** — see [clawql-operator-helm.md](../deployment/clawql-operator-helm.md). **`clawql-automation`** is a **scaffold** on `main` (schedule + notify extracted; NATS/HITL planned). Specifications for not-yet-started packages are written and stable; work begins when upstream dependencies stabilize.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "clawql-mcp",
-    "version": "6.4.1",
+    "version": "7.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "clawql-mcp",
-            "version": "6.4.1",
+            "version": "7.0.0",
             "bundleDependencies": [
                 "clawql-api",
                 "clawql-automation",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "clawql-mcp",
-    "version": "6.4.1",
+    "version": "7.0.0",
     "description": "MCP server: search + execute OpenAPI/Discovery APIs (internal GraphQL projection), optional native GraphQL HTTP and gRPC unary sources",
     "license": "Apache-2.0",
     "type": "module",

--- a/packages/clawql-operator/README.md
+++ b/packages/clawql-operator/README.md
@@ -2,6 +2,6 @@
 
 Opt-in Kubernetes operator scaffold for ClawQL ([#255](https://github.com/danielsmithdevelopment/ClawQL/issues/255)).
 
-Phase 1 validates `ClawQLInstance` specs and publishes tier-spec ConfigMaps. It does **not** replace `charts/clawql-mcp` or env-based `CLAWQL_ENABLE_*` flags.
+Phase 1 scaffold validates `ClawQLInstance` specs, publishes tier-spec ConfigMaps, and optionally rolls MCP Deployments. It does **not** replace `charts/clawql-mcp` or env-based `CLAWQL_ENABLE_*` flags.
 
 See [clawql-operator-helm.md](../../docs/deployment/clawql-operator-helm.md).

--- a/website/src/app/deployment/kubernetes/page.mdx
+++ b/website/src/app/deployment/kubernetes/page.mdx
@@ -145,3 +145,15 @@ Use this when enabling in-cluster Flink for real-time Onyx index freshness ([#11
 5. Keep Flink UI private by default; use temporary `kubectl port-forward` for debugging.
 
 Full architecture, values reference, and runbook: [Flink Onyx sync](/flink-onyx-sync). Helm context: [Helm](/helm).
+
+## ClawQL Operator (opt-in, 7.0.0)
+
+The operator scaffold reconciles **`ClawQLInstance`** CRs to tier-spec ConfigMaps and optionally rolls MCP when tier spec changes. It installs automatically with **`make local-k8s-up`** (full stack); skip with **`CLAWQL_INSTALL_OPERATOR=0`**.
+
+```bash
+make operator-install    # CRD + operator Deployment only
+make operator-status     # clawql operator status
+kubectl apply -f examples/operator/clawqlinstance-minimal.yaml -n clawql
+```
+
+Guide: [Operations guide](/deployment/operations-guide) · [Operator target architecture](/design/operator-target-architecture)

--- a/website/src/app/getting-started/page.mdx
+++ b/website/src/app/getting-started/page.mdx
@@ -38,9 +38,10 @@ Run ClawQL in minutes, deploy the full IDP stack with Helm, then dive into guide
 | **Operations**      | Upgrades, secrets, health | [Operations guide](/deployment/operations-guide)     |
 
 <Note>
-  A future **ClawQL Operator** and three-tier CRD model are **design-only** —
-  see [Operator target architecture](/design/operator-target-architecture).
-  Shipped installs use **Helm `clawql-mcp`** directly.
+  An **opt-in ClawQL Operator scaffold** shipped in **7.0.0** (CRD, tier
+  presets, reconcile) — see the [Operations guide](/deployment/operations-guide)
+  and [Operator target architecture](/design/operator-target-architecture) for
+  the full roadmap. Default installs still use **Helm `clawql-mcp`** directly.
 </Note>
 
 ## Next steps

--- a/website/src/generated/clawql-deployment-operations-guide-body.mdx
+++ b/website/src/generated/clawql-deployment-operations-guide-body.mdx
@@ -3,7 +3,7 @@
 **For platform engineers and operators · June 2026**  
 Apache 2.0 / MIT · [github.com/danielsmithdevelopment/ClawQL](https://github.com/danielsmithdevelopment/ClawQL)
 
-Operator-focused tier docs, **`ClawQLInstance` CRD** reference, and natural-language ops tables moved to **[Operator target architecture (design)](/design/operator-target-architecture)** — not shipped ([#255](https://github.com/danielsmithdevelopment/ClawQL/issues/255)).
+Operator-focused tier docs and natural-language ops tables remain in **[Operator target architecture (design)](/design/operator-target-architecture)**. An **opt-in operator scaffold** (CRD + reconcile + tier-spec ConfigMaps) is available separately — see **[clawql-operator-helm.md](clawql-operator-helm.md)** ([#255](https://github.com/danielsmithdevelopment/ClawQL/issues/255)).
 
 ---
 
@@ -11,19 +11,19 @@ Operator-focused tier docs, **`ClawQLInstance` CRD** reference, and natural-lang
 
 ### What you can deploy today
 
-| Component                                                    | Status     | Canonical doc                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------ | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Helm chart `clawql-mcp`**                                  | ✅ Shipped | [helm.md](/helm)                                                                                                                                                                                                                                           |
-| **Document pipeline** (Tika, Gotenberg, Stirling, Paperless) | ✅ Shipped | [idp-pipeline.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/providers/idp-pipeline.md), `documentPipeline.enabled`                                                                                                                   |
-| **Onyx** (optional + `knowledge_search_onyx`)                | ✅ Shipped | [onyx-knowledge-tool.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/mcp/onyx-knowledge-tool.md)                                                                                                                                       |
-| **Nextcloud + Coneshare** (`idpCollaboration`)               | ✅ Shipped | [nextcloud-onboarding.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/providers/nextcloud-onboarding.md), [coneshare-onboarding.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/providers/coneshare-onboarding.md) |
-| **Dashboard + docs UI**                                      | ✅ Shipped | [agent-chat.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/dashboard/agent-chat.md), chart `dashboard` / `docs`                                                                                                                       |
-| **`clawql-mcp` MCP server**                                  | ✅ Shipped | npm `clawql-mcp`, Streamable HTTP `/mcp`                                                                                                                                                                                                                   |
-| **`ingest_external_knowledge` + `DEFAULT_IDP_PIPELINE`**     | ✅ Shipped | [idp-pipeline.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/providers/idp-pipeline.md) — agent-composed `search`/`execute`; automated runner [#307](https://github.com/danielsmithdevelopment/ClawQL/issues/307)                     |
-| **Presidio / sparse-MoE agent I/O redaction**                | 📋 Partial | [#245](https://github.com/danielsmithdevelopment/ClawQL/issues/245)                                                                                                                                                                                        |
-| **Tier 1 four-stack Docker Compose**                         | 📋 Planned | [#251](https://github.com/danielsmithdevelopment/ClawQL/issues/251) — use Helm today                                                                                                                                                                       |
-| **Kubernetes Operator + `ClawQLInstance` CRD**               | 📋 Planned | [operator-target-architecture.md](/design/operator-target-architecture)                                                                                                                                                                                    |
-| **Goose / Printing Press / vertical packages**               | 📋 Planned | —                                                                                                                                                                                                                                                          |
+| Component                                                    | Status             | Canonical doc                                                                                                                                                                                                                                              |
+| ------------------------------------------------------------ | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Helm chart `clawql-mcp`**                                  | ✅ Shipped         | [helm.md](/helm)                                                                                                                                                                                                                                           |
+| **Document pipeline** (Tika, Gotenberg, Stirling, Paperless) | ✅ Shipped         | [idp-pipeline.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/providers/idp-pipeline.md), `documentPipeline.enabled`                                                                                                                   |
+| **Onyx** (optional + `knowledge_search_onyx`)                | ✅ Shipped         | [onyx-knowledge-tool.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/mcp/onyx-knowledge-tool.md)                                                                                                                                       |
+| **Nextcloud + Coneshare** (`idpCollaboration`)               | ✅ Shipped         | [nextcloud-onboarding.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/providers/nextcloud-onboarding.md), [coneshare-onboarding.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/providers/coneshare-onboarding.md) |
+| **Dashboard + docs UI**                                      | ✅ Shipped         | [agent-chat.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/dashboard/agent-chat.md), chart `dashboard` / `docs`                                                                                                                       |
+| **`clawql-mcp` MCP server**                                  | ✅ Shipped         | npm `clawql-mcp`, Streamable HTTP `/mcp`                                                                                                                                                                                                                   |
+| **`ingest_external_knowledge` + `DEFAULT_IDP_PIPELINE`**     | ✅ Shipped         | [idp-pipeline.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/providers/idp-pipeline.md) — agent-composed `search`/`execute`; automated runner [#307](https://github.com/danielsmithdevelopment/ClawQL/issues/307)                     |
+| **Presidio / sparse-MoE agent I/O redaction**                | 📋 Partial         | [#245](https://github.com/danielsmithdevelopment/ClawQL/issues/245)                                                                                                                                                                                        |
+| **Tier 1 four-stack Docker Compose**                         | 📋 Planned         | [#251](https://github.com/danielsmithdevelopment/ClawQL/issues/251) — use Helm today                                                                                                                                                                       |
+| **Kubernetes Operator + `ClawQLInstance` CRD**               | 🚧 Opt-in scaffold | [clawql-operator-helm.md](clawql-operator-helm.md), [operator-target-architecture.md](/design/operator-target-architecture)                                                                                                                                |
+| **Goose / Printing Press / vertical packages**               | 📋 Planned         | —                                                                                                                                                                                                                                                          |
 
 ### Choose a deployment path
 
@@ -32,7 +32,7 @@ Operator-focused tier docs, **`ClawQLInstance` CRD** reference, and natural-lang
 | **Local full IDP stack** (Docker Desktop) | `make local-k8s-up` → [helm.md](/helm)                                                |
 | **Minimal MCP only**                      | `npx clawql-mcp` or `npm run start:http` + `.env`                                     |
 | **Remote Kubernetes**                     | [deploy-k8s.md](/deployment/kubernetes) or Helm with your values                      |
-| **Operator / multi-tenant CRD model**     | Design only — [operator-target-architecture.md](/design/operator-target-architecture) |
+| **Operator / multi-tenant CRD model**     | Opt-in — [clawql-operator-helm.md](clawql-operator-helm.md) (Helm/env remain default) |
 
 ---
 
@@ -135,28 +135,28 @@ Default provider merge with **no** spec env: **opinionated default stack** (Clou
 
 ---
 
-## Planned architecture (not in this guide)
+## Operator scaffold (opt-in, shipped 7.0.0)
 
-The following were drafted for a future **ClawQL Operator** and are **not implemented**:
+The operator scaffold reconciles `ClawQLInstance` CRs to tier-spec ConfigMaps and optionally rolls MCP when `spec.mcp.rolloutOnTierSpecChange` is set. Helm `CLAWQL_ENABLE_*` workflows remain the default when the operator is not installed.
 
-- Three-tier model (Compose / standard K8s / enterprise Kata+Istio+Vault)
-- **`ClawQLInstance` CRD** and vertical enablement via spec patches
-- Natural-language `@hermes` operations → CRD patches
-- Goose, Printing Press, vertical packages
+1. Install CRD + reconcile: [clawql-operator-helm.md](clawql-operator-helm.md)
+2. Apply a `ClawQLInstance` (`examples/operator/clawqlinstance-minimal.yaml`)
+3. Mount the published tier-spec ConfigMap on MCP (`instanceSpec.enabled: true`)
 
-Full specification: **[Operator target architecture](/design/operator-target-architecture)**.
+Full tier/vertical/auth reconciliation and NL ops remain in **[Operator target architecture](/design/operator-target-architecture)** (roadmap).
 
 ---
 
 ## Related documentation
 
-| Topic                     | Link                                                                                                                                                                                                            |
-| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Helm chart                | [helm.md](/helm)                                                                                                                                                                                                |
-| Kustomize / K8s           | [deploy-k8s.md](/deployment/kubernetes)                                                                                                                                                                         |
-| IDP eight-vendor stack    | [idp-pipeline.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/providers/idp-pipeline.md) · [clawql-idp-helm.md](clawql-idp-helm.md) · [observability/README.md](../observability/README.md) |
-| Operator design (planned) | [operator-target-architecture.md](/design/operator-target-architecture)                                                                                                                                         |
-| Vision & roadmap          | [clawql-vision-roadmap.md](/vision/roadmap)                                                                                                                                                                     |
+| Topic                          | Link                                                                                                                                                                                                            |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Helm chart                     | [helm.md](/helm)                                                                                                                                                                                                |
+| Kustomize / K8s                | [deploy-k8s.md](/deployment/kubernetes)                                                                                                                                                                         |
+| IDP eight-vendor stack         | [idp-pipeline.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/providers/idp-pipeline.md) · [clawql-idp-helm.md](clawql-idp-helm.md) · [observability/README.md](../observability/README.md) |
+| Operator scaffold (opt-in)     | [clawql-operator-helm.md](clawql-operator-helm.md)                                                                                                                                                              |
+| Operator design (full roadmap) | [operator-target-architecture.md](/design/operator-target-architecture)                                                                                                                                         |
+| Vision & roadmap               | [clawql-vision-roadmap.md](/vision/roadmap)                                                                                                                                                                     |
 
 ---
 

--- a/website/src/generated/clawql-operator-target-architecture-body.mdx
+++ b/website/src/generated/clawql-operator-target-architecture-body.mdx
@@ -1,17 +1,19 @@
-# ClawQL Operator — target architecture (not shipped)
+# ClawQL Operator — target architecture (full roadmap)
 
-**Status:** Design reference · **June 2026**  
+**Status:** Design reference for **full** operator (NL ops, verticals, auth) · **July 2026**  
 **Tracking:** [#255](https://github.com/danielsmithdevelopment/ClawQL/issues/255) (Operator / umbrella chart), [#251](https://github.com/danielsmithdevelopment/ClawQL/issues/251) (four Compose stacks)
 
-This document captures the **planned** three-tier deployment model: **`ClawQLInstance` CRD**, Operator reconciliation, vertical toggles, natural-language operations, and enterprise hardening. **Nothing in sections 1–13 below is runnable today** unless explicitly marked as a shipped Helm equivalent.
+> **Shipped in 7.0.0 (opt-in scaffold):** `ClawQLInstance` CRD, tier presets, tier-spec ConfigMaps, continuous reconcile, optional MCP rollout, `clawql operator status`, `make local-k8s-up` install. Deploy guide: **[clawql-operator-helm.md](../deployment/clawql-operator-helm.md)**. Sections 1–13 below describe the **full** operator vision; only items marked as shipped Helm equivalents are runnable today.
 
-**Deploy today:** [Deployment & Operations Guide](/deployment/operations-guide) · [Helm (`charts/clawql-mcp`)](/helm) · [IDP pipeline](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/providers/idp-pipeline.md) · `make local-k8s-up`
+This document captures the **planned** three-tier deployment model: **`ClawQLInstance` CRD**, Operator reconciliation, vertical toggles, natural-language operations, and enterprise hardening.
+
+**Deploy today:** [Deployment & Operations Guide](/deployment/operations-guide) · [Operator scaffold](../deployment/clawql-operator-helm.md) · [Helm (`charts/clawql-mcp`)](/helm) · [IDP pipeline](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/providers/idp-pipeline.md) · `make local-k8s-up`
 
 ---
 
 ## Overview
 
-Three tiers were designed around a **ClawQL Operator** (not shipped). **Tier 1** Compose/bootstrap is also planned ([#251](https://github.com/danielsmithdevelopment/ClawQL/issues/251)). **Shipped alternative:** Helm **`charts/clawql-mcp`** co-deploys MCP, document pipeline, optional Onyx/Nextcloud/Coneshare, dashboard, and vault memory without an Operator.
+Three tiers were designed around a **ClawQL Operator**. An **opt-in scaffold** shipped in **7.0.0** (CRD + reconcile + tier-spec ConfigMaps) — see [clawql-operator-helm.md](../deployment/clawql-operator-helm.md). **Tier 1** Compose/bootstrap is also planned ([#251](https://github.com/danielsmithdevelopment/ClawQL/issues/251)). **Default path:** Helm **`charts/clawql-mcp`** co-deploys MCP, document pipeline, optional Onyx/Nextcloud/Coneshare, dashboard, and vault memory without enabling the operator.
 
 ### Prerequisites by Tier
 

--- a/website/src/generated/clawql-vision-roadmap-body.mdx
+++ b/website/src/generated/clawql-vision-roadmap-body.mdx
@@ -130,7 +130,7 @@ For technical readers, the full rationale and patterns are in the [Contributor T
 
 ### Planned
 
-All vertical packages, the Kubernetes Operator, the natural language dashboard, and the remaining horizontal packages (`clawql-data`, `clawql-sandbox`, `clawql-printingpress`, `clawql-goose`, `clawql-telemetry`) are planned and not yet in development. **`clawql-automation`** is a **scaffold** on `main` (schedule + notify extracted; NATS/HITL planned). Specifications for not-yet-started packages are written and stable; work begins when upstream dependencies stabilize.
+Vertical packages, the **full** Kubernetes Operator (NL dashboard, vertical toggles, auth reconciliation), and the remaining horizontal packages (`clawql-data`, `clawql-sandbox`, `clawql-printingpress`, `clawql-goose`, `clawql-telemetry`) are planned. An **opt-in operator scaffold** shipped in **7.0.0** — see [clawql-operator-helm.md](../deployment/clawql-operator-helm.md). **`clawql-automation`** is a **scaffold** on `main` (schedule + notify extracted; NATS/HITL planned). Specifications for not-yet-started packages are written and stable; work begins when upstream dependencies stabilize.
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Finishes operator and onboarding work for **7.0.0**.

## Release
- Version bump `clawql-mcp` → **7.0.0**
- Helm: `clawql-mcp` chart **0.7.0**, `clawql-operator` chart **0.2.0**
- CHANGELOG `[7.0.0]` section; finalize `RELEASE_NOTES_v7.0.0.md`

## Onboarding (shipped)
- Walkthrough spec marked **Shipped (7.0.0)** — Phases 1–2b complete
- Gap table refreshed (`clawql onboard`, `clawql doctor`, default-stack docs)

## Operator (shipped scaffold)
- Docs distinguish **7.0 scaffold** (CRD, tier presets, reconcile, MCP rollout) vs **full roadmap** (NL ops, verticals, auth)
- Deployment ops guide + operator-target-architecture callouts updated
- Website: getting-started Note, kubernetes operator section, synced generated MDX
- `make operator-install` / `make operator-status`

## Deferred (documented, not in this PR)
- Operator Phase 3+: auth, vertical toggles, admission webhooks, NL → CRD
- Init walkthrough Phase 3 guided UI
- npm tag / GHCR publish (separate release step)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1711-824f-7aa5-afbd-2d81edc7c0fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1711-824f-7aa5-afbd-2d81edc7c0fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

