### PR TITLE
docs: finalize 7.0.0 release notes and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,47 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Breaking
+## [7.0.0] - 2026-07-10
 
-- **`CLAWQL_DISABLE_HTTP_METRICS` removed:** use **`CLAWQL_ENABLE_HTTP_METRICS=0`** to opt out of **`GET /metrics`** (default on when unset).
-
-### Added
-
-- **npm distribution — separate `clawql-*` packages (7.0.0):** All horizontal workspace packages aligned to **`7.0.0`** with `publishConfig`; **`clawql-mcp`** uses registry semver dependencies instead of **`bundledDependencies`**. Publish order: [`scripts/release/npm-publish-order.json`](scripts/release/npm-publish-order.json); smoke: [`scripts/dev/test-npm-pack-install.sh`](scripts/dev/test-npm-pack-install.sh). **Not published to npm yet.**
-- **Observability ADR 0005** — Langfuse default work-trace store, bundled/external/minimal profiles ([#252](https://github.com/danielsmithdevelopment/ClawQL/issues/252)).
-- **Docs site:** **`/vision/ecosystem`**, **`/getting-started/clawql-release-mvp`**; shared doc link rewriter for generated MDX.
-- **`CLAWQL_ENABLE_LOKI_PUSH=0`** — opt out of audit Loki push when **`CLAWQL_LOKI_PUSH_URL`** is set.
-- **Layer 0 MVP — `clawql-release`**: `clawql release init|collect|manifest|publish|verify` builds manifest **v0.1** with git commit, npm tarball + CycloneDX SBOM SHA-256, GHCR image digests, and **Merkle root** (`clawql-core`); output under `releases/vX.Y.Z/`. **`clawql doctor --smoke`** verifies the bundle when present; **`CLAWQL_RELEASE_MANIFEST`** enables verify-at-startup for MCP. Package: `packages/clawql-release`. Docs: [`docs/getting-started/clawql-release-mvp.md`](docs/getting-started/clawql-release-mvp.md). Arweave permanent anchor deferred.
-- **Add any source from URL** — `clawql sources add <url>` with auto-detect for OpenAPI, Google Discovery, GraphQL SDL/introspection, gRPC `.proto`, and MCP HTTP endpoints; persisted in **`~/.ClawQL/sources.json`** and merged into MCP `search`/`execute` on startup.
-- **MCP and CLI as source types** — proxy remote MCP tools and wrap local CLI commands as searchable operations (`protocolKind` **`mcp`** / **`cli`**).
-- **Harness wrappers** — `clawql claude`, `clawql codex`, `clawql cursor`, `clawql opencode` write harness-specific MCP config and launch the agent binary on PATH.
-- **One-line install** — `curl -fsSL https://clawql.com/install | bash` (`scripts/install.sh`, served from the docs site).
-- **ClawQL Desktop Windows/Linux** — `make desktop-dist-win`, `make desktop-dist-linux` (NSIS + AppImage/deb).
-- **Dashboard custom sources UI** — Custom sources nav panel in ClawQL Desktop; add/list/remove via `/api/local/sources` (URL auto-detect + CLI).
-- **Phase 1 exit (7.0.0 finalized):**
-  - **`clawql-auth`** — gateway `noAuth`/`apiKey`, ATR claims, provider credential headers; HTTP MCP middleware when `CLAWQL_AUTH_MODE=apiKey`.
-  - **`clawql-pageindex`** — MIT vectorless hierarchical indexing; `pageindex_build_tree`, `pageindex_traverse`, `pageindex_synthesize`, `pageindex_get_content` (default on; `CLAWQL_ENABLE_PAGEINDEX=0` to hide).
-  - **Presidio gateway hooks** — `CLAWQL_ENABLE_PRESIDIO=1` redacts `execute` responses, `memory_ingest`, and `ingest_external_knowledge` markdown.
-  - **Tier 1 Docker Compose** — `examples/clawql-local-docker-compose` (bootstrap, MCP + Tika + Gotenberg + Paperless + memory); `make compose-tier1-config-test`.
-
-### Changed
-
-- **HITL docs:** **`docs/mcp/hitl-label-studio.md`** is the operator guide; **`docs/plugins/hitl-label-studio.md`** is a short plugin index stub.
-- **Helm / vault docs:** default stack references updated from **6.4.x** to **7.0.x**.
-
-## [7.0.0] - 2026-07-09
-
-Major release: **opinionated default stack everywhere** (npm + Helm), **vault-first defense in depth**, **ClawQL Operator** with provider-secret reconciliation, and consolidated IDP wave. Release notes: **[`RELEASE_NOTES_v7.0.0.md`](RELEASE_NOTES_v7.0.0.md)**.
+Major release: **opinionated default stack everywhere** (npm + Helm), **vault-first defense in depth**, **ClawQL Operator** with provider-secret reconciliation, **npm package separation at 7.0.0**, observability ADR 0005, and consolidated IDP wave. Release notes: **[`RELEASE_NOTES_v7.0.0.md`](RELEASE_NOTES_v7.0.0.md)**.
 
 ### Breaking
 
 - **Helm default provider = npm default stack:** **`charts/clawql-mcp`** and **`values-docker-desktop.yaml`** now set **`provider: default`** (Cloudflare, GitHub, Slack, Linear, Notion, Onyx). Use **`provider: all-providers`** or **`helm --set provider=all-providers`** for the full IDP + every bundled vendor merge.
 - **Legacy env aliases removed:** **`API_BASE_URL`**, **`OPENAPI_SPEC_URL`**, **`GOOGLE_DISCOVERY_URL`**, and merged preset **`google-top50`** are no longer accepted — use **`CLAWQL_API_BASE_URL`**, **`CLAWQL_SPEC_URL`**, **`CLAWQL_DISCOVERY_URL`**, and **`CLAWQL_PROVIDER=google`**.
 - **Vault-backed secrets required by default:** **`secretSourcing.requireVaultBackedSecrets: true`** (default) fails render without **`envFromSecret`** / **`envFromSecrets`**. Set **`false`** only in lab overlays that accept non-Vault env sourcing.
+- **`CLAWQL_DISABLE_HTTP_METRICS` removed:** use **`CLAWQL_ENABLE_HTTP_METRICS=0`** to opt out of **`GET /metrics`** (default on when unset).
 
 ### Added
 
-- **ClawQL Desktop (macOS):** Electron app (`desktop/`) bundling the dashboard — local **Provider secrets** (`~/.ClawQL/vault/providers.json`) and **Agent Chat** via OpenClaw bridge; `npm run dist:mac` produces a `.dmg`. Design: [`docs/design/clawql-desktop-macos.md`](docs/design/clawql-desktop-macos.md).
+- **npm distribution — separate `clawql-*` packages (7.0.0):** All horizontal workspace packages aligned to **`7.0.0`** with `publishConfig`; **`clawql-mcp`** uses registry semver dependencies instead of **`bundledDependencies`**. Publish order: [`scripts/release/npm-publish-order.json`](scripts/release/npm-publish-order.json); smoke: [`scripts/dev/test-npm-pack-install.sh`](scripts/dev/test-npm-pack-install.sh). **Not published to npm yet.**
+- **Observability ADR 0005** — Langfuse default work-trace store, bundled/external/minimal profiles ([#252](https://github.com/danielsmithdevelopment/ClawQL/issues/252)); implementation plan [`docs/observability/7.0-observability-profiles-plan.md`](docs/observability/7.0-observability-profiles-plan.md).
+- **Docs site:** **`/vision/ecosystem`**, **`/getting-started/clawql-release-mvp`**; shared doc link rewriter for generated MDX; consolidated nav.
+- **`CLAWQL_ENABLE_LOKI_PUSH=0`** — opt out of audit Loki push when **`CLAWQL_LOKI_PUSH_URL`** is set.
+- **Layer 0 MVP — `clawql-release`**: `clawql release init|collect|manifest|publish|verify` builds manifest **v0.1** with git commit, npm tarball + CycloneDX SBOM SHA-256, GHCR image digests, and **Merkle root** (`clawql-core`); output under `releases/vX.Y.Z/`. **`clawql doctor --smoke`** verifies the bundle when present; **`CLAWQL_RELEASE_MANIFEST`** enables verify-at-startup for MCP. Package: `packages/clawql-release`. Docs: [`docs/getting-started/clawql-release-mvp.md`](docs/getting-started/clawql-release-mvp.md). Arweave permanent anchor deferred.
+- **Add any source from URL** — `clawql sources add <url>` with auto-detect for OpenAPI, Google Discovery, GraphQL SDL/introspection, gRPC `.proto`, and MCP HTTP endpoints; persisted in **`~/.ClawQL/sources.json`** and merged into MCP `search`/`execute` on startup.
+- **MCP and CLI as source types** — proxy remote MCP tools and wrap local CLI commands as searchable operations (`protocolKind` **`mcp`** / **`cli`**).
+- **Harness wrappers** — `clawql claude`, `clawql codex`, `clawql cursor`, `clawql opencode` write harness-specific MCP config and launch the agent binary on PATH.
+- **One-line install** — `curl -fsSL https://clawql.com/install | bash` (`scripts/install.sh`, served from the docs site).
+- **ClawQL Desktop (macOS, Windows, Linux):** Electron app (`desktop/`) bundling the dashboard — local **Provider secrets** (`~/.ClawQL/vault/providers.json`), **Agent Chat** via OpenClaw bridge, and **Custom sources** UI; `npm run dist:mac|dist:win|dist:linux`. Design: [`docs/design/clawql-desktop-macos.md`](docs/design/clawql-desktop-macos.md).
 - **Opinionated default bundled stack** ([#528](https://github.com/danielsmithdevelopment/ClawQL/pull/528)): bare `npx clawql-mcp` loads **Cloudflare, GitHub, Slack, Linear, Notion, Onyx**; **`CLAWQL_PROVIDER=all-providers`** remains explicit opt-in for every vendor + Google top-50 + AWS top-50.
 - **AWS top-50 bundled preset** ([#528](https://github.com/danielsmithdevelopment/ClawQL/pull/528)): SigV4 **`execute`**, manifest under `providers/aws/`, onboarding [`docs/providers/aws-onboarding.md`](docs/providers/aws-onboarding.md).
 - **Notion bundled provider**: official OpenAPI; **`NOTION_API_TOKEN`** auth; onboarding [`docs/providers/notion-onboarding.md`](docs/providers/notion-onboarding.md).
@@ -66,13 +48,19 @@ Major release: **opinionated default stack everywhere** (npm + Helm), **vault-fi
 - **NATS JetStream workflow events** ([#254](https://github.com/danielsmithdevelopment/ClawQL/issues/254), [#127](https://github.com/danielsmithdevelopment/ClawQL/issues/127)): opt-in publish/consumer for HITL/workflow lifecycle.
 - **Langfuse eval → Ouroboros** ([#250](https://github.com/danielsmithdevelopment/ClawQL/issues/250)): **`CLAWQL_ENABLE_LANGFUSE_EVAL=1`** + **`CLAWQL_ENABLE_OUROBOROS=1`** — webhook + **`ouroboros_propose_seed_revision_from_eval`**.
 - **7.0 setup guide:** [`docs/getting-started/clawql-7-setup-guide.md`](docs/getting-started/clawql-7-setup-guide.md).
-- **ClawQL Desktop (macOS):** downloadable Electron app — provider secrets + Agent Chat without localhost browser tabs.
+- **Phase 1 exit (7.0.0 finalized):**
+  - **`clawql-auth`** — gateway `noAuth`/`apiKey`, ATR claims, provider credential headers; HTTP MCP middleware when `CLAWQL_AUTH_MODE=apiKey`.
+  - **`clawql-pageindex`** — MIT vectorless hierarchical indexing; `pageindex_build_tree`, `pageindex_traverse`, `pageindex_synthesize`, `pageindex_get_content` (default on; `CLAWQL_ENABLE_PAGEINDEX=0` to hide).
+  - **Presidio gateway hooks** — `CLAWQL_ENABLE_PRESIDIO=1` redacts `execute` responses, `memory_ingest`, and `ingest_external_knowledge` markdown.
+  - **Tier 1 Docker Compose** — `examples/clawql-local-docker-compose` (bootstrap, MCP + Tika + Gotenberg + Paperless + memory); `make compose-tier1-config-test`.
 
 ### Changed
 
 - **Multi-spec HTTP**: `/graphql` is not mounted in merged multi-spec mode (MCP `search`/`execute` unchanged).
 - **First-run docs**: README, getting-started, quickstart, install, migration guide, and Helm defaults aligned to default stack vs `all-providers`.
 - **Plugin model/registry docs**: Phase 2 `onRegister` status updated (July 2026).
+- **HITL docs:** **`docs/mcp/hitl-label-studio.md`** is the operator guide; **`docs/plugins/hitl-label-studio.md`** is a short plugin index stub.
+- **Helm / vault docs:** default stack references updated from **6.4.x** to **7.0.x**.
 
 ### Fixed
 

--- a/RELEASE_NOTES_v7.0.0.md
+++ b/RELEASE_NOTES_v7.0.0.md
@@ -56,10 +56,10 @@ helm upgrade --install clawql ./charts/clawql-mcp --set provider=all-providers
 
 All feature toggles use **`CLAWQL_ENABLE_*`**: unset = default for that flag; **`=0`** opt-out; **`=1`** opt-in when default-off.
 
-| Removed / old                         | Replacement                                      |
-| ------------------------------------- | ------------------------------------------------ |
-| **`CLAWQL_DISABLE_HTTP_METRICS`**     | **`CLAWQL_ENABLE_HTTP_METRICS=0`**               |
-| (implicit Loki push when URL set)     | **`CLAWQL_ENABLE_LOKI_PUSH=0`** to opt out       |
+| Removed / old                     | Replacement                                |
+| --------------------------------- | ------------------------------------------ |
+| **`CLAWQL_DISABLE_HTTP_METRICS`** | **`CLAWQL_ENABLE_HTTP_METRICS=0`**         |
+| (implicit Loki push when URL set) | **`CLAWQL_ENABLE_LOKI_PUSH=0`** to opt out |
 
 → [`.env.example`](.env.example) · [configuration.md](docs/readme/configuration.md)
 
@@ -69,20 +69,20 @@ All feature toggles use **`CLAWQL_ENABLE_*`**: unset = default for that flag; **
 
 Horizontal workspace packages publish as separate **`clawql-*`** npm modules at **7.0.0** (replacing **`bundledDependencies`** in **`clawql-mcp@6.4.x`**).
 
-| Package            | Role                                      |
-| ------------------ | ----------------------------------------- |
-| `clawql-core`      | Audit, cache, Merkle, plugin types        |
-| `clawql-auth`      | Gateway auth + upstream credential headers |
-| `clawql-pageindex` | Vectorless hierarchical indexing          |
-| `clawql-api`       | Spec load, search/execute, Presidio hooks |
-| `clawql-memory`    | Vault I/O, embeddings, ingest/recall      |
-| `clawql-documents` | IDP pipeline, classify/extract            |
-| `clawql-automation`| Schedule, notify, Argo workflow/argocd    |
-| `clawql-sandbox`   | `sandbox_exec`                            |
-| `clawql-ouroboros` | Evolutionary loop tools                   |
-| `clawql-operator`  | K8s operator library                      |
-| `clawql-release`   | Layer 0 manifest MVP                      |
-| `clawql-mcp`       | MCP transport (depends on above via semver) |
+| Package             | Role                                        |
+| ------------------- | ------------------------------------------- |
+| `clawql-core`       | Audit, cache, Merkle, plugin types          |
+| `clawql-auth`       | Gateway auth + upstream credential headers  |
+| `clawql-pageindex`  | Vectorless hierarchical indexing            |
+| `clawql-api`        | Spec load, search/execute, Presidio hooks   |
+| `clawql-memory`     | Vault I/O, embeddings, ingest/recall        |
+| `clawql-documents`  | IDP pipeline, classify/extract              |
+| `clawql-automation` | Schedule, notify, Argo workflow/argocd      |
+| `clawql-sandbox`    | `sandbox_exec`                              |
+| `clawql-ouroboros`  | Evolutionary loop tools                     |
+| `clawql-operator`   | K8s operator library                        |
+| `clawql-release`    | Layer 0 manifest MVP                        |
+| `clawql-mcp`        | MCP transport (depends on above via semver) |
 
 Publish order: [`scripts/release/npm-publish-order.json`](scripts/release/npm-publish-order.json). Smoke: [`scripts/dev/test-npm-pack-install.sh`](scripts/dev/test-npm-pack-install.sh). **Not published to npm yet** — install from repo checkout or wait for **`clawql-mcp@7.0.0`** on registry.
 
@@ -92,11 +92,11 @@ Publish order: [`scripts/release/npm-publish-order.json`](scripts/release/npm-pu
 
 Accepted architecture for **Langfuse as default work-trace store** with profile-based deployment ([#252](https://github.com/danielsmithdevelopment/ClawQL/issues/252)):
 
-| Profile      | Use case                         | Langfuse emission                          |
-| ------------ | -------------------------------- | ------------------------------------------ |
-| **`bundled`**  | Tier 1 Compose, local k8s lab    | On by default (`CLAWQL_ENABLE_LANGFUSE=0` to opt out) |
-| **`external`** | Production / existing stack      | On when `LANGFUSE_*` set; same opt-out      |
-| **`minimal`**  | Metrics-only / strict policy     | Off                                        |
+| Profile        | Use case                      | Langfuse emission                                     |
+| -------------- | ----------------------------- | ----------------------------------------------------- |
+| **`bundled`**  | Tier 1 Compose, local k8s lab | On by default (`CLAWQL_ENABLE_LANGFUSE=0` to opt out) |
+| **`external`** | Production / existing stack   | On when `LANGFUSE_*` set; same opt-out                |
+| **`minimal`**  | Metrics-only / strict policy  | Off                                                   |
 
 **7.0.0 ships ADR + docs + env catalog** — runtime profile wiring is Phase 1 of [`7.0-observability-profiles-plan.md`](docs/observability/7.0-observability-profiles-plan.md). Existing signals unchanged: **`GET /metrics`** on by default; OTLP and Loki push remain opt-in via their env vars.
 

--- a/RELEASE_NOTES_v7.0.0.md
+++ b/RELEASE_NOTES_v7.0.0.md
@@ -1,8 +1,8 @@
 ## clawql-mcp 7.0.0
 
-**npm:** packages aligned at 7.0.0 — publish pending (see [§11 npm distribution](docs/design/modularization-implementation-status.md#11-npm-distribution-70--separate-packages))  
-**Full changelog:** [CHANGELOG.md#700---2026-07-09](https://github.com/danielsmithdevelopment/ClawQL/blob/main/CHANGELOG.md#700---2026-07-09)  
-**Target release:** 2026-07-09
+**npm:** packages aligned at **7.0.0** — publish pending (see [§11 npm distribution](docs/design/modularization-implementation-status.md#11-npm-distribution-70--separate-packages))  
+**Full changelog:** [CHANGELOG.md#700---2026-07-10](https://github.com/danielsmithdevelopment/ClawQL/blob/main/CHANGELOG.md#700---2026-07-10)  
+**Release date:** 2026-07-10
 
 ---
 
@@ -52,9 +52,61 @@ helm upgrade --install clawql ./charts/clawql-mcp --set provider=all-providers
 
 ---
 
+## Env flag conventions (breaking)
+
+All feature toggles use **`CLAWQL_ENABLE_*`**: unset = default for that flag; **`=0`** opt-out; **`=1`** opt-in when default-off.
+
+| Removed / old                         | Replacement                                      |
+| ------------------------------------- | ------------------------------------------------ |
+| **`CLAWQL_DISABLE_HTTP_METRICS`**     | **`CLAWQL_ENABLE_HTTP_METRICS=0`**               |
+| (implicit Loki push when URL set)     | **`CLAWQL_ENABLE_LOKI_PUSH=0`** to opt out       |
+
+→ [`.env.example`](.env.example) · [configuration.md](docs/readme/configuration.md)
+
+---
+
+## npm distribution (7.0.0)
+
+Horizontal workspace packages publish as separate **`clawql-*`** npm modules at **7.0.0** (replacing **`bundledDependencies`** in **`clawql-mcp@6.4.x`**).
+
+| Package            | Role                                      |
+| ------------------ | ----------------------------------------- |
+| `clawql-core`      | Audit, cache, Merkle, plugin types        |
+| `clawql-auth`      | Gateway auth + upstream credential headers |
+| `clawql-pageindex` | Vectorless hierarchical indexing          |
+| `clawql-api`       | Spec load, search/execute, Presidio hooks |
+| `clawql-memory`    | Vault I/O, embeddings, ingest/recall      |
+| `clawql-documents` | IDP pipeline, classify/extract            |
+| `clawql-automation`| Schedule, notify, Argo workflow/argocd    |
+| `clawql-sandbox`   | `sandbox_exec`                            |
+| `clawql-ouroboros` | Evolutionary loop tools                   |
+| `clawql-operator`  | K8s operator library                      |
+| `clawql-release`   | Layer 0 manifest MVP                      |
+| `clawql-mcp`       | MCP transport (depends on above via semver) |
+
+Publish order: [`scripts/release/npm-publish-order.json`](scripts/release/npm-publish-order.json). Smoke: [`scripts/dev/test-npm-pack-install.sh`](scripts/dev/test-npm-pack-install.sh). **Not published to npm yet** — install from repo checkout or wait for **`clawql-mcp@7.0.0`** on registry.
+
+---
+
+## Observability ADR 0005
+
+Accepted architecture for **Langfuse as default work-trace store** with profile-based deployment ([#252](https://github.com/danielsmithdevelopment/ClawQL/issues/252)):
+
+| Profile      | Use case                         | Langfuse emission                          |
+| ------------ | -------------------------------- | ------------------------------------------ |
+| **`bundled`**  | Tier 1 Compose, local k8s lab    | On by default (`CLAWQL_ENABLE_LANGFUSE=0` to opt out) |
+| **`external`** | Production / existing stack      | On when `LANGFUSE_*` set; same opt-out      |
+| **`minimal`**  | Metrics-only / strict policy     | Off                                        |
+
+**7.0.0 ships ADR + docs + env catalog** — runtime profile wiring is Phase 1 of [`7.0-observability-profiles-plan.md`](docs/observability/7.0-observability-profiles-plan.md). Existing signals unchanged: **`GET /metrics`** on by default; OTLP and Loki push remain opt-in via their env vars.
+
+→ [ADR 0005](docs/adr/0005-langfuse-default-work-trace-store.md) · [bundled observability](docs/observability/bundled-observability.md) · [BYO observability](docs/observability/bring-your-own-observability.md)
+
+---
+
 ## ClawQL Desktop (macOS, Windows, Linux)
 
-Downloadable app wrapping the dashboard — **Provider secrets** + **Agent Chat** locally (no Kubernetes required for solo dev).
+Downloadable app wrapping the dashboard — **Provider secrets** + **Agent Chat** + **Custom sources** locally (no Kubernetes required for solo dev).
 
 ```bash
 cd desktop && npm install && npm run dist:mac    # macOS .dmg
@@ -113,7 +165,8 @@ Custom sources persist in **`~/.ClawQL/sources.json`** and merge into **`search`
 
 ## Layer 0 — release manifest at runtime
 
-- **`clawql doctor --smoke`** verifies `releases/v{version}/manifest.json` when the bundle exists (repo checkout after `clawql release publish`)
+- **`clawql release init|collect|manifest|publish|verify`** — manifest **v0.1** with git commit, npm tarball + CycloneDX SBOM SHA-256, GHCR image digests, Merkle root
+- **`clawql doctor --smoke`** verifies `releases/v{version}/manifest.json` when the bundle exists
 - **`CLAWQL_RELEASE_MANIFEST`** — optional MCP startup verify (strict when `NODE_ENV=production` or `CLAWQL_RELEASE_MANIFEST_STRICT=1`)
 
 → [clawql-release-mvp.md](docs/getting-started/clawql-release-mvp.md)
@@ -137,23 +190,34 @@ Docling, LangExtract, IDP pipeline runner, NATS/KEDA worker, Langfuse→Ouroboro
 
 ---
 
+## Docs site
+
+- **`/vision/ecosystem`** — ecosystem overview synced from docs
+- **`/getting-started/clawql-release-mvp`** — Layer 0 release manifest guide
+- Shared doc link rewriter for generated MDX; consolidated nav via [`docs-nav-data.ts`](website/src/lib/docs-nav-data.ts)
+- HITL: [`docs/mcp/hitl-label-studio.md`](docs/mcp/hitl-label-studio.md) is canonical; plugin index is a stub
+
+---
+
 ## Helm charts
 
 | Chart                    | Chart.version | appVersion |
 | ------------------------ | ------------- | ---------- |
 | `charts/clawql-mcp`      | `0.7.0`       | `7.0.0`    |
 | `charts/clawql-operator` | `0.2.0`       | `7.0.0`    |
+| `charts/clawql-idp`      | `0.1.0`       | `7.0.0`    |
 
 ---
 
-## Upgrade checklist
+## Upgrade checklist (6.4.x → 7.0.0)
 
 1. [Migration](https://docs.clawql.com/resources/migration) + [7.0 setup guide](docs/getting-started/clawql-7-setup-guide.md)
-2. Replace legacy env aliases
+2. Replace legacy env aliases and **`CLAWQL_DISABLE_HTTP_METRICS`** → **`CLAWQL_ENABLE_HTTP_METRICS=0`**
 3. Wire Vault → **`clawql-provider-env`**
 4. `clawql onboard --interactive` or import provider KV
 5. `helm upgrade` — choose **`default`** or **`all-providers`**
 6. Operator: confirm **`ProviderSecretsReady=True`**
+7. npm: expect separate **`clawql-*`** packages once **7.0.0** publishes (no **`bundledDependencies`** tarball)
 
 ---
 
@@ -161,10 +225,12 @@ Docling, LangExtract, IDP pipeline runner, NATS/KEDA worker, Langfuse→Ouroboro
 
 ```bash
 curl -fsSL https://clawql.com/install | bash
-# or:
+# or (after npm publish):
 npm install clawql-mcp@7.0.0
 npx clawql onboard --interactive
 npx clawql-mcp-http
 
 docker pull ghcr.io/danielsmithdevelopment/clawql-mcp:latest
 ```
+
+**Node:** `>=22` (see root `package.json` `engines`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Finalizes release documentation for **clawql-mcp 7.0.0** after the #540–#543 consolidation merge.

## RELEASE_NOTES_v7.0.0.md

- Release date **2026-07-10**
- New sections: **env flag conventions** (`ENABLE_HTTP_METRICS`, `ENABLE_LOKI_PUSH`), **npm distribution** (separate `clawql-*` packages), **observability ADR 0005** (profiles + Langfuse opt-out; runtime wiring deferred), **docs site** routes, **`clawql-idp`** chart
- Expanded Layer 0, upgrade checklist (6.4.x → 7.0.0), and install notes

## CHANGELOG.md

- Merged all `[Unreleased]` entries into `[7.0.0] - 2026-07-10`
- Updated major-release summary; removed duplicate Desktop entry; added Phase 1 exit + doc dedupe under Changed

No code or behavior changes — documentation only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1711-824f-7aa5-afbd-2d81edc7c0fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1711-824f-7aa5-afbd-2d81edc7c0fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

