### PR TITLE
fix(release): npm 7.0.0 publish fallback for new workspace packages

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -81,6 +81,8 @@ jobs:
           node-version: "25"
           registry-url: https://registry.npmjs.org
           cache: npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install dependencies
         run: npm ci

--- a/scripts/release/npm-publish-workspace.mjs
+++ b/scripts/release/npm-publish-workspace.mjs
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
 /**
  * Publish clawql-* workspace packages in topological order, then clawql-mcp.
- * Requires NPM_TOKEN or npm OIDC trusted publishing on the repo.
+ *
+ * First-time 7.x: workspace package names may not exist on npm yet. OIDC trusted
+ * publishing only works for packages already linked on npmjs.com. When a workspace
+ * publish returns 404, fall back to a single clawql-mcp tarball with
+ * bundledDependencies (same install story as 6.4.x).
+ *
+ * Requires NPM_TOKEN (NODE_AUTH_TOKEN) and/or npm OIDC trusted publishing.
  *
  * Dry run: node scripts/release/npm-publish-workspace.mjs --dry-run
  */
@@ -12,33 +18,54 @@ import { fileURLToPath } from "node:url";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "../..");
 const dryRun = process.argv.includes("--dry-run");
+const forceBundle = process.env.CLAWQL_NPM_BUNDLE_WORKSPACE === "1";
 const { packages } = JSON.parse(
   readFileSync(join(root, "scripts/release/npm-publish-order.json"), "utf8"),
 );
 
-const publish = (workspace) => {
-  const cmd = `npm publish -w ${workspace} --provenance --access public`;
-  if (dryRun) {
-    console.log(`[dry-run] ${cmd}`);
-    return;
-  }
-  execSync(cmd, { cwd: root, stdio: "inherit", env: process.env });
-};
-
-for (const name of packages) {
-  if (name === "clawql-mcp") continue;
-  console.log(`Publishing ${name}…`);
-  publish(name);
+function publishCmd(workspace) {
+  return `npm publish -w ${workspace} --provenance --access public`;
 }
 
-console.log("Publishing clawql-mcp (root)…");
-if (dryRun) {
-  console.log("[dry-run] npm pack + npm publish clawql-mcp-*.tgz");
-} else {
+function tryPublish(workspace) {
+  const cmd = publishCmd(workspace);
+  if (dryRun) {
+    console.log(`[dry-run] ${cmd}`);
+    return { ok: true };
+  }
+  try {
+    execSync(cmd, { cwd: root, stdio: "pipe", env: process.env, encoding: "utf8" });
+    return { ok: true };
+  } catch (error) {
+    const output = `${error.stdout ?? ""}${error.stderr ?? ""}${error.message ?? ""}`;
+    if (output.includes("E404") || output.includes("404 Not Found")) {
+      return { ok: false, reason: "404", output };
+    }
+    if (output) process.stderr.write(output);
+    throw error;
+  }
+}
+
+function publishClawqlMcp(bundleWorkspace) {
+  if (bundleWorkspace) {
+    process.env.CLAWQL_NPM_BUNDLE_WORKSPACE = "1";
+    console.log(
+      "Publishing clawql-mcp with bundledDependencies (workspace packages not on registry yet).",
+    );
+  } else {
+    console.log("Publishing clawql-mcp (root)…");
+  }
+
+  if (dryRun) {
+    console.log("[dry-run] npm pack + npm publish clawql-mcp-*.tgz");
+    return;
+  }
+
   const packDir = join(root, ".npm-publish-pack");
   execSync(`mkdir -p "${packDir}" && npm pack --pack-destination "${packDir}"`, {
     cwd: root,
     stdio: "inherit",
+    env: process.env,
   });
   const tarball = execSync(`find "${packDir}" -maxdepth 1 -name 'clawql-mcp-*.tgz' -print -quit`, {
     encoding: "utf8",
@@ -51,4 +78,23 @@ if (dryRun) {
   });
 }
 
-console.log(dryRun ? "Dry run complete." : "All packages published.");
+let bundleWorkspace = forceBundle;
+
+if (!bundleWorkspace) {
+  for (const name of packages) {
+    if (name === "clawql-mcp") continue;
+    console.log(`Publishing ${name}…`);
+    const result = tryPublish(name);
+    if (!result.ok) {
+      console.warn(
+        `WARN: ${name} publish failed (${result.reason}). ` +
+          "Falling back to bundled clawql-mcp — add NPM_TOKEN or link trusted publishers on npmjs.com, then re-run to publish workspace packages separately.",
+      );
+      bundleWorkspace = true;
+      break;
+    }
+  }
+}
+
+publishClawqlMcp(bundleWorkspace);
+console.log(dryRun ? "Dry run complete." : "Publish complete.");

--- a/scripts/release/prepack-clawql-mcp.mjs
+++ b/scripts/release/prepack-clawql-mcp.mjs
@@ -2,6 +2,7 @@
 /**
  * Prepare clawql-mcp for `npm pack` / `npm publish`:
  * - Pin workspace `clawql-*` deps to concrete semver (registry clients cannot resolve workspace:*).
+ * - When CLAWQL_NPM_BUNDLE_WORKSPACE=1, add bundledDependencies (first npm release of split packages).
  * - Backup package.json for postpack restore (dev tree keeps workspace:*).
  */
 import { readFileSync, writeFileSync } from "node:fs";
@@ -11,6 +12,10 @@ import { fileURLToPath } from "node:url";
 const root = join(dirname(fileURLToPath(import.meta.url)), "../..");
 const pkgPath = join(root, "package.json");
 const backupPath = join(root, ".package.json.prepack-backup");
+const bundleWorkspace = process.env.CLAWQL_NPM_BUNDLE_WORKSPACE === "1";
+
+const orderPath = join(root, "scripts/release/npm-publish-order.json");
+const { packages: publishOrder } = JSON.parse(readFileSync(orderPath, "utf8"));
 
 const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
 writeFileSync(backupPath, JSON.stringify(pkg, null, 4) + "\n");
@@ -30,10 +35,24 @@ for (const [name, spec] of Object.entries(deps)) {
   pinned += 1;
 }
 
-if (pinned === 0) {
-  console.log("prepack: clawql-* dependencies already pinned");
-} else {
+if (pinned > 0) {
   pkg.dependencies = deps;
-  writeFileSync(pkgPath, JSON.stringify(pkg, null, 4) + "\n");
+}
+
+if (bundleWorkspace) {
+  const bundled = publishOrder.filter((name) => name !== "clawql-mcp");
+  pkg.bundledDependencies = bundled;
+  console.log(
+    `prepack: bundle mode — ${bundled.length} clawql-* packages will ship inside clawql-mcp`,
+  );
+} else if (pkg.bundledDependencies) {
+  delete pkg.bundledDependencies;
+}
+
+writeFileSync(pkgPath, JSON.stringify(pkg, null, 4) + "\n");
+
+if (pinned === 0 && !bundleWorkspace) {
+  console.log("prepack: clawql-* dependencies already pinned");
+} else if (pinned > 0) {
   console.log(`prepack: pinned ${pinned} clawql-* workspace dependencies for publish`);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `v7.0.0` tag publish failed because `clawql-core` and other new workspace package names are not on npm yet — GitHub OIDC trusted publishing only works for packages already linked on npmjs.com (`clawql-mcp`).

This PR adds a **fallback**: on workspace publish `404`, ship **`clawql-mcp@7.0.0`** with **`bundledDependencies`** (same install story as 6.4.x) so the release can go live immediately.

Also wires **`NODE_AUTH_TOKEN`** from **`NPM_TOKEN`** in `setup-node` for first-time publishes when a token is configured.

## After merge

1. Move tag `v7.0.0` to the merge commit (or run **npm publish** workflow on `main` via Actions)
2. Manually trigger **Docker publish** workflow on `main`
3. Optional later: add trusted publishers / `NPM_TOKEN` and re-run to publish split `clawql-*` packages individually
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1711-824f-7aa5-afbd-2d81edc7c0fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1711-824f-7aa5-afbd-2d81edc7c0fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

