### PR TITLE
fix(docker): dashboard image build for 7.0.0 release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -225,17 +225,7 @@ jobs:
       - name: Install skopeo
         run: sudo apt-get update && sudo apt-get install -y skopeo
 
-      # `dashboard/Dockerfile` copies `.env.example` into the image for `prebuild` (env catalog). Build context is `./dashboard` only, so stage the repo-root catalog source first.
-      - name: Stage repo sources for dashboard Docker context
-        run: |
-          cp "${GITHUB_WORKSPACE}/.env.example" "${GITHUB_WORKSPACE}/dashboard/.env.example"
-          mkdir -p "${GITHUB_WORKSPACE}/dashboard/scripts/kubernetes"
-          cp "${GITHUB_WORKSPACE}/scripts/kubernetes/provider-vault-key-catalog.ts" \
-            "${GITHUB_WORKSPACE}/dashboard/scripts/kubernetes/provider-vault-key-catalog.ts"
-          mkdir -p "${GITHUB_WORKSPACE}/dashboard/src/provider-vault"
-          cp "${GITHUB_WORKSPACE}/src/provider-vault/catalog.ts" \
-            "${GITHUB_WORKSPACE}/dashboard/src/provider-vault/catalog.ts"
-
+      # `dashboard/Dockerfile` build context is repo root (clawql-api file: dep + catalog generators).
       - name: Build OCI layout (single artifact — scanned and pushed)
         run: |
           set -euo pipefail
@@ -250,7 +240,7 @@ jobs:
             --cache-to type=gha,mode=max,scope=docker-publish-dashboard \
             --provenance=mode=max \
             --sbom=true \
-            ./dashboard
+            .
 
       - name: Trivy scan OCI layout (HIGH / CRITICAL — before registry push)
         run: |

--- a/RELEASE_NOTES_v7.0.0.md
+++ b/RELEASE_NOTES_v7.0.0.md
@@ -71,20 +71,20 @@ All feature toggles use **`CLAWQL_ENABLE_*`**: unset = default for that flag; **
 
 Split **`clawql-*`** workspace packages are **not** published as separate npm modules yet (OIDC trusted publishing requires each package to be linked on npmjs.com first). The release workflow falls back to **`bundledDependencies`** inside the **`clawql-mcp`** tarball — same install story as **6.4.x**, with all eleven horizontal packages vendored under `node_modules/clawql-mcp/node_modules/`.
 
-| Package             | Role                                        |
-| ------------------- | ------------------------------------------- |
-| `clawql-core`       | Audit, cache, Merkle, plugin types          |
-| `clawql-auth`       | Gateway auth + upstream credential headers  |
-| `clawql-pageindex`  | Vectorless hierarchical indexing            |
-| `clawql-api`        | Spec load, search/execute, Presidio hooks   |
-| `clawql-memory`     | Vault I/O, embeddings, ingest/recall        |
-| `clawql-documents`  | IDP pipeline, classify/extract              |
-| `clawql-automation` | Schedule, notify, Argo workflow/argocd      |
-| `clawql-sandbox`    | `sandbox_exec`                              |
-| `clawql-ouroboros`  | Evolutionary loop tools                     |
-| `clawql-operator`   | K8s operator library                        |
-| `clawql-release`    | Layer 0 manifest MVP                        |
-| `clawql-mcp`        | MCP transport (bundles workspace packages)  |
+| Package             | Role                                       |
+| ------------------- | ------------------------------------------ |
+| `clawql-core`       | Audit, cache, Merkle, plugin types         |
+| `clawql-auth`       | Gateway auth + upstream credential headers |
+| `clawql-pageindex`  | Vectorless hierarchical indexing           |
+| `clawql-api`        | Spec load, search/execute, Presidio hooks  |
+| `clawql-memory`     | Vault I/O, embeddings, ingest/recall       |
+| `clawql-documents`  | IDP pipeline, classify/extract             |
+| `clawql-automation` | Schedule, notify, Argo workflow/argocd     |
+| `clawql-sandbox`    | `sandbox_exec`                             |
+| `clawql-ouroboros`  | Evolutionary loop tools                    |
+| `clawql-operator`   | K8s operator library                       |
+| `clawql-release`    | Layer 0 manifest MVP                       |
+| `clawql-mcp`        | MCP transport (bundles workspace packages) |
 
 Publish order (when split packages go live): [`scripts/release/npm-publish-order.json`](scripts/release/npm-publish-order.json). Smoke: [`scripts/dev/test-npm-pack-install.sh`](scripts/dev/test-npm-pack-install.sh).
 

--- a/RELEASE_NOTES_v7.0.0.md
+++ b/RELEASE_NOTES_v7.0.0.md
@@ -1,6 +1,6 @@
 ## clawql-mcp 7.0.0
 
-**npm:** packages aligned at **7.0.0** — publish pending (see [§11 npm distribution](docs/design/modularization-implementation-status.md#11-npm-distribution-70--separate-packages))  
+**npm:** [`clawql-mcp@7.0.0`](https://www.npmjs.com/package/clawql-mcp/v/7.0.0) on npmjs.com (workspace packages ship inside the tarball via **`bundledDependencies`** until separate **`clawql-*`** modules are linked for OIDC publish)  
 **Full changelog:** [CHANGELOG.md#700---2026-07-10](https://github.com/danielsmithdevelopment/ClawQL/blob/main/CHANGELOG.md#700---2026-07-10)  
 **Release date:** 2026-07-10
 
@@ -67,7 +67,9 @@ All feature toggles use **`CLAWQL_ENABLE_*`**: unset = default for that flag; **
 
 ## npm distribution (7.0.0)
 
-Horizontal workspace packages publish as separate **`clawql-*`** npm modules at **7.0.0** (replacing **`bundledDependencies`** in **`clawql-mcp@6.4.x`**).
+**`clawql-mcp@7.0.0`** is on npm. Install with `npm install clawql-mcp@7.0.0` or `npx -p clawql-mcp@7.0.0 clawql-mcp`.
+
+Split **`clawql-*`** workspace packages are **not** published as separate npm modules yet (OIDC trusted publishing requires each package to be linked on npmjs.com first). The release workflow falls back to **`bundledDependencies`** inside the **`clawql-mcp`** tarball — same install story as **6.4.x**, with all eleven horizontal packages vendored under `node_modules/clawql-mcp/node_modules/`.
 
 | Package             | Role                                        |
 | ------------------- | ------------------------------------------- |
@@ -82,9 +84,9 @@ Horizontal workspace packages publish as separate **`clawql-*`** npm modules at 
 | `clawql-ouroboros`  | Evolutionary loop tools                     |
 | `clawql-operator`   | K8s operator library                        |
 | `clawql-release`    | Layer 0 manifest MVP                        |
-| `clawql-mcp`        | MCP transport (depends on above via semver) |
+| `clawql-mcp`        | MCP transport (bundles workspace packages)  |
 
-Publish order: [`scripts/release/npm-publish-order.json`](scripts/release/npm-publish-order.json). Smoke: [`scripts/dev/test-npm-pack-install.sh`](scripts/dev/test-npm-pack-install.sh). **Not published to npm yet** — install from repo checkout or wait for **`clawql-mcp@7.0.0`** on registry.
+Publish order (when split packages go live): [`scripts/release/npm-publish-order.json`](scripts/release/npm-publish-order.json). Smoke: [`scripts/dev/test-npm-pack-install.sh`](scripts/dev/test-npm-pack-install.sh).
 
 ---
 
@@ -217,7 +219,7 @@ Docling, LangExtract, IDP pipeline runner, NATS/KEDA worker, Langfuse→Ouroboro
 4. `clawql onboard --interactive` or import provider KV
 5. `helm upgrade` — choose **`default`** or **`all-providers`**
 6. Operator: confirm **`ProviderSecretsReady=True`**
-7. npm: expect separate **`clawql-*`** packages once **7.0.0** publishes (no **`bundledDependencies`** tarball)
+7. npm: **`clawql-mcp@7.0.0`** on npm (bundled workspace packages); separate **`clawql-*`** modules when registry linking is complete
 
 ---
 
@@ -225,7 +227,7 @@ Docling, LangExtract, IDP pipeline runner, NATS/KEDA worker, Langfuse→Ouroboro
 
 ```bash
 curl -fsSL https://clawql.com/install | bash
-# or (after npm publish):
+# or:
 npm install clawql-mcp@7.0.0
 npx clawql onboard --interactive
 npx clawql-mcp-http

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,15 +1,36 @@
-FROM node:22-alpine AS deps
+# syntax=docker/dockerfile:1
+# ClawQL dashboard — Next.js UI (Provider secrets, Agent Chat, custom sources).
+#
+# Build from repo root (needs clawql-api workspace package):
+#   docker build -f dashboard/Dockerfile -t clawql-dashboard .
+
+FROM node:22-alpine AS clawql-builder
 WORKDIR /app
 RUN apk upgrade --no-cache
-COPY package*.json ./
+COPY package.json package-lock.json ./
+COPY packages/clawql-core/package.json packages/clawql-core/
+COPY packages/clawql-auth/package.json packages/clawql-auth/
+COPY packages/clawql-api/package.json packages/clawql-api/
+RUN npm ci --ignore-scripts -w clawql-core -w clawql-auth -w clawql-api
+COPY tsconfig.json ./
+COPY packages/clawql-core packages/clawql-core
+COPY packages/clawql-auth packages/clawql-auth
+COPY packages/clawql-api packages/clawql-api
+RUN npm run build -w clawql-core -w clawql-auth -w clawql-api
+
+FROM node:22-alpine AS deps
+WORKDIR /app/dashboard
+RUN apk upgrade --no-cache
+COPY dashboard/package.json dashboard/package-lock.json ./
+COPY --from=clawql-builder /app/packages /app/packages
 RUN npm ci
 
 FROM node:22-alpine AS builder
-WORKDIR /app
+WORKDIR /app/dashboard
 ENV NEXT_TELEMETRY_DISABLED=1
-COPY --from=deps /app/node_modules ./node_modules
-COPY . .
-# Monorepo catalog generators resolve repoRoot as `/` when build context is `./dashboard` only.
+COPY --from=deps /app/dashboard/node_modules ./node_modules
+COPY --from=clawql-builder /app/packages /app/packages
+COPY dashboard/ .
 COPY .env.example /.env.example
 COPY scripts/kubernetes/provider-vault-key-catalog.ts /scripts/kubernetes/provider-vault-key-catalog.ts
 COPY src/provider-vault/catalog.ts /src/provider-vault/catalog.ts
@@ -22,9 +43,9 @@ ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV HOSTNAME=0.0.0.0
 ENV PORT=3040
-COPY --from=builder /app/package*.json ./
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/.next ./.next
-COPY --from=builder /app/next.config.mjs ./next.config.mjs
+COPY --from=builder /app/dashboard/package*.json ./
+COPY --from=builder /app/dashboard/node_modules ./node_modules
+COPY --from=builder /app/dashboard/.next ./.next
+COPY --from=builder /app/dashboard/next.config.mjs ./next.config.mjs
 EXPOSE 3040
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fixes **clawql-dashboard** Docker publish failure (`Module not found: Can't resolve 'clawql-api'`) by building `clawql-core`, `clawql-auth`, and `clawql-api` from the monorepo root and using repo-root build context.
- Updates **RELEASE_NOTES_v7.0.0.md** to reflect that **`clawql-mcp@7.0.0`** is live on npm with `bundledDependencies` fallback.

## Context

Scheduled `docker-publish` has been failing on the dashboard job since the dashboard gained a `file:../packages/clawql-api` dependency. The previous workflow staged catalog files into `./dashboard` but not workspace packages, leaving a broken symlink at `node_modules/clawql-api`.

## Test plan

- [x] Verified `npm ci -w clawql-core -w clawql-auth -w clawql-api` + dashboard `npm ci` chain locally
- [ ] CI `docker-publish` dashboard job (after merge, manual `workflow_dispatch`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1711-824f-7aa5-afbd-2d81edc7c0fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1711-824f-7aa5-afbd-2d81edc7c0fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

