### PR TITLE
feat(packer): golden host images with verified team vault bootstrap

### DIFF
--- a/.github/workflows/packer-publish.yml
+++ b/.github/workflows/packer-publish.yml
@@ -1,0 +1,140 @@
+# Golden host image pipeline — validate on PR, cloud builds on release dispatch.
+# VM images complement the GHCR container golden pipeline (Cosign on containers; AMI/GCP IDs recorded in workflow summary).
+
+name: Packer golden host
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packer/**"
+      - "scripts/packer/**"
+      - "src/home-sync/**"
+      - ".github/workflows/packer-publish.yml"
+  pull_request:
+    paths:
+      - "packer/**"
+      - "scripts/packer/**"
+      - "src/home-sync/**"
+      - ".github/workflows/packer-publish.yml"
+  workflow_dispatch:
+    inputs:
+      clawql_version:
+        description: "clawql-mcp npm version or dist-tag"
+        required: false
+        default: "latest"
+      build_aws:
+        description: "Build AWS AMI (requires secrets)"
+        type: boolean
+        default: false
+      build_gcp:
+        description: "Build GCP image (requires secrets)"
+        type: boolean
+        default: false
+      aws_region:
+        description: "AWS region for AMI"
+        required: false
+        default: "us-east-1"
+      gcp_project_id:
+        description: "GCP project id"
+        required: false
+        default: ""
+
+concurrency:
+  group: packer-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate templates & scripts
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Install ShellCheck
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y shellcheck unzip
+
+      - name: Golden host script + packer validate
+        run: bash scripts/packer/test-golden-host-scripts.sh
+
+  test-sync-verify:
+    name: Sync pull verification tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "25"
+          cache: npm
+
+      - run: npm ci
+      - run: npm test -- --run src/home-sync/home-sync.test.ts
+
+  build-aws:
+    name: Build AWS AMI
+    needs: [validate, test-sync-verify]
+    if: github.event_name == 'workflow_dispatch' && inputs.build_aws == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Install Packer
+        run: |
+          PACKER_VERSION=1.11.2
+          curl -fsSL "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip" -o /tmp/packer.zip
+          unzip -qo /tmp/packer.zip -d /usr/local/bin
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a16d10021e7ce35612f3f6a7
+        with:
+          aws-access-key-id: ${{ secrets.PACKER_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PACKER_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ inputs.aws_region }}
+
+      - name: Packer build AWS
+        working-directory: packer
+        run: |
+          packer init .
+          packer build -only=amazon-ebs.clawql \
+            -var "clawql_version=${{ inputs.clawql_version }}" \
+            -var "aws_region=${{ inputs.aws_region }}" .
+
+  build-gcp:
+    name: Build GCP image
+    needs: [validate, test-sync-verify]
+    if: github.event_name == 'workflow_dispatch' && inputs.build_gcp == true && inputs.gcp_project_id != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Install Packer
+        run: |
+          PACKER_VERSION=1.11.2
+          curl -fsSL "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip" -o /tmp/packer.zip
+          unzip -qo /tmp/packer.zip -d /usr/local/bin
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.PACKER_GCP_CREDENTIALS_JSON }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Packer build GCP
+        working-directory: packer
+        run: |
+          packer init .
+          packer build -only=googlecompute.clawql \
+            -var "clawql_version=${{ inputs.clawql_version }}" \
+            -var "gcp_project_id=${{ inputs.gcp_project_id }}" .

--- a/Makefile
+++ b/Makefile
@@ -94,10 +94,13 @@ distribution-npm-pack-test:
 mcp-docker-workspace-test:
 	@bash scripts/dev/test-docker-mcp-workspace-deps.sh
 
-lint-k8s-manifests: helm-lint helm-ui-template-tests helm-workflow-template-tests helm-argocd-template-tests helm-nats-keda-template-tests helm-vault-secrets-template-tests helm-team-sync-template-tests helm-docling-template-tests helm-idp-template-tests helm-operator-template-tests compose-lending-config-test compose-tier1-config-test kustomize-local-lint packer-golden-host-tests
+lint-k8s-manifests: helm-lint helm-ui-template-tests helm-workflow-template-tests helm-argocd-template-tests helm-nats-keda-template-tests helm-vault-secrets-template-tests helm-team-sync-template-tests helm-docling-template-tests helm-idp-template-tests helm-operator-template-tests compose-lending-config-test compose-tier1-config-test kustomize-local-lint packer-golden-host-tests pulumi-provision-tests
 
 packer-golden-host-tests:
 	@bash scripts/packer/test-golden-host-scripts.sh
+
+pulumi-provision-tests:
+	@bash scripts/pulumi/test-provision-unit.sh
 
 # Local desktop k8s: default Helm + Istio ambient + Gateway/VS + heavy observability; CLAWQL_LOCAL_K8S_ISTIO=0 skips mesh
 local-k8s-up:

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,10 @@ distribution-npm-pack-test:
 mcp-docker-workspace-test:
 	@bash scripts/dev/test-docker-mcp-workspace-deps.sh
 
-lint-k8s-manifests: helm-lint helm-ui-template-tests helm-workflow-template-tests helm-argocd-template-tests helm-nats-keda-template-tests helm-vault-secrets-template-tests helm-team-sync-template-tests helm-docling-template-tests helm-idp-template-tests helm-operator-template-tests compose-lending-config-test compose-tier1-config-test kustomize-local-lint
+lint-k8s-manifests: helm-lint helm-ui-template-tests helm-workflow-template-tests helm-argocd-template-tests helm-nats-keda-template-tests helm-vault-secrets-template-tests helm-team-sync-template-tests helm-docling-template-tests helm-idp-template-tests helm-operator-template-tests compose-lending-config-test compose-tier1-config-test kustomize-local-lint packer-golden-host-tests
+
+packer-golden-host-tests:
+	@bash scripts/packer/test-golden-host-scripts.sh
 
 # Local desktop k8s: default Helm + Istio ambient + Gateway/VS + heavy observability; CLAWQL_LOCAL_K8S_ISTIO=0 skips mesh
 local-k8s-up:

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ This directory is organized by purpose so operational guides, product docs, and 
 - `getting-started/local-provider-vault.md` — ~/.ClawQL secrets vault + memory home
 - `getting-started/getting-started-for-teams.md` — **teams:** shared object storage + observability for shared Memory
 - `getting-started/team-vault-sync.md` — `clawql sync` push/pull (R2 / S3 / GCS), Helm `teamSync.*`
+- `getting-started/golden-host-images.md` — Packer golden hosts for managed AWS/GCP/Cloudflare tiers
 - `getting-started/clawql-7-setup-guide.md` — 7.0 upgrade: default stack, Vault, operator auth
 - `getting-started/phase-1-platform-guide.md` — **teach Phase 1:** clawql-auth, pageindex, Presidio, Tier 1 Compose
 - `getting-started/custom-sources.md` — URL/CLI custom sources (7.0)
@@ -114,7 +115,7 @@ This directory is organized by purpose so operational guides, product docs, and 
 
 ## Architecture / ADR / Design
 
-- ADRs: `adr/` — includes [**0002 Multi-protocol supergraph**](adr/0002-multi-protocol-supergraph.md) (native GraphQL + gRPC merged via **`CLAWQL_GRAPHQL_SOURCES`** / **`CLAWQL_GRPC_SOURCES`**; epic [#178](https://github.com/danielsmithdevelopment/ClawQL/issues/178)); [**0003 Tempo + Dragonfly for local ops**](adr/0003-tempo-dragonfly-local-operations.md) (Istio Docker Desktop lab: **Tempo-only** traces; **`clawql-mcp`**: **Dragonfly-only** Redis-protocol brokers); [**0004 Argo Workflows + Argo CD providers**](adr/0004-argo-cd-workflows-clawql-pipelines.md) (shipped **`workflow`** + **`argocd`** tools; roadmap [`roadmap/argo-workflows-cd-provider.md`](roadmap/argo-workflows-cd-provider.md), [#239](https://github.com/danielsmithdevelopment/ClawQL/issues/239))
+- ADRs: `adr/` — includes [**0006 Golden host images (Packer)**](adr/0006-golden-host-images-packer.md) (managed tier VM bootstrap + team vault seeding); [**0002 Multi-protocol supergraph**](adr/0002-multi-protocol-supergraph.md) (native GraphQL + gRPC merged via **`CLAWQL_GRAPHQL_SOURCES`** / **`CLAWQL_GRPC_SOURCES`**; epic [#178](https://github.com/danielsmithdevelopment/ClawQL/issues/178)); [**0003 Tempo + Dragonfly for local ops**](adr/0003-tempo-dragonfly-local-operations.md) (Istio Docker Desktop lab: **Tempo-only** traces; **`clawql-mcp`**: **Dragonfly-only** Redis-protocol brokers); [**0004 Argo Workflows + Argo CD providers**](adr/0004-argo-cd-workflows-clawql-pipelines.md) (shipped **`workflow`** + **`argocd`** tools; roadmap [`roadmap/argo-workflows-cd-provider.md`](roadmap/argo-workflows-cd-provider.md), [#239](https://github.com/danielsmithdevelopment/ClawQL/issues/239))
 - Design docs: [`design/effect-ts-modularization-rearchitecture-plan.md`](design/effect-ts-modularization-rearchitecture-plan.md) (Effect-TS + modularization + plugins), [`design/OPENAPI_TO_GRAPHQL_UPSTREAM.md`](design/OPENAPI_TO_GRAPHQL_UPSTREAM.md), [`design/graphql-mesh-node-compatibility.md`](design/graphql-mesh-node-compatibility.md); archived drafts: [`design/archive/`](design/archive/); vector / recall design notes live under **`memory/`** (e.g. [`memory/vector-search-design.md`](memory/vector-search-design.md))
 
 ## Content Collections

--- a/docs/adr/0006-golden-host-images-packer.md
+++ b/docs/adr/0006-golden-host-images-packer.md
@@ -1,0 +1,71 @@
+# ADR 0006: Golden host images (Packer) for managed ClawQL tiers
+
+- Status: Accepted
+- Date: 2026-07-11
+- Related: team vault sync ([`docs/getting-started/team-vault-sync.md`](../getting-started/team-vault-sync.md)), golden image pipeline ([`docs/security/golden-image-pipeline.md`](../security/golden-image-pipeline.md)), Helm `teamSync` ([`charts/clawql-mcp`](../../charts/clawql-mcp/README.md))
+- Implementation: [`packer/`](../../packer/), [`scripts/packer/`](../../scripts/packer/), [`.github/workflows/packer-publish.yml`](../../.github/workflows/packer-publish.yml)
+
+## Context
+
+Managed ClawQL offerings on **AWS**, **GCP**, and **Cloudflare** need hosts that boot with:
+
+1. ClawQL installed and onboarded
+2. Team agent context (`~/.ClawQL/Memory/`, sources, PageIndex) available via **`clawql sync pull`**
+3. Verification before serving traffic (**manifest SHA-256** + **`clawql doctor --smoke`**)
+
+Helm **`teamSync`** already implements boot-time pull for Kubernetes pods. **Packer** is the VM analogue for EC2/GCE managed tiers. **Cloudflare** uses the same bootstrap script against verified R2 state (no AMI).
+
+Users choose **providers** (`CLAWQL_PROVIDER`, team bucket prefix). Protocol routing (gRPC → GraphQL → OpenAPI) stays internal.
+
+## Decision
+
+### 1) Two-phase provisioning (secrets never in the image)
+
+| Phase | When | What |
+|-------|------|------|
+| **Bake** | Packer build | Ubuntu 24.04, Node 22, `clawql` install, `~/.ClawQL` skeleton, `sync.json` template (`CONFIGURE_AT_BOOT` bucket placeholder) |
+| **Boot** | Instance / Worker start | Inject sync credentials (metadata, Vault agent, ESO), `clawql sync pull`, `clawql doctor --smoke` |
+
+`vault/providers.json` and sync credentials **never** ship in the image (same rule as team sync docs).
+
+### 2) Pull verification (fail closed)
+
+`clawql sync pull` verifies each downloaded object against the remote manifest **SHA-256** before writing to disk. Tampered or truncated objects abort pull — required for golden-host and enterprise claims.
+
+### 3) One Packer template, multiple cloud outputs
+
+- **`validate.docker.clawql`** — CI smoke (no cloud credentials)
+- **`aws-ami.amazon-ebs.clawql`** — AWS AMI
+- **`gcp-image.googlecompute.clawql`** — GCP custom image
+- **Cloudflare** — `scripts/packer/cloudflare-bootstrap.sh` (R2 pull at first invocation)
+
+Release CI signs container artifacts today (Cosign on GHCR). VM image signing (e.g. AMI snapshot attestations) is a follow-up; Layer 0 manifest can record AMI/image IDs as **`hostImages`** in a future schema bump.
+
+### 4) Tier seeding via bucket prefix (not image variant)
+
+| Tier | Seeding |
+|------|---------|
+| **Shared** | `CLAWQL_SYNC_PREFIX=shared/`; tenant isolation via operator |
+| **Dedicated** | `CLAWQL_SYNC_PREFIX=tenant/{id}/` from instance metadata |
+| **Enterprise** | Customer bucket + Vault; ClawQL ships the signed image only |
+
+## Consequences
+
+### Positive
+
+- **Boot and work** — no post-install shell recipe for managed customers
+- **Reproducible** — same bake script across AWS/GCP validate path
+- **Aligned with vault-first** — team sync manifest verification at pull time
+- **Sales story** — signed ClawQL host + customer-controlled team bucket
+
+### Trade-offs
+
+- **Packer cloud builds** need cloud credentials (release workflow / manual dispatch only)
+- **Cloudflare** is bootstrap-script parity, not a Packer target
+- **Doctor smoke** at boot requires reachable bucket credentials and non-empty team prefix (empty bucket is a valid fresh team)
+
+## Alternatives considered
+
+- **Bake-time `sync pull` with secrets in Packer vars** — rejected (secrets in AMI layers)
+- **cloud-init only without golden AMI** — slower boot, drift between instances
+- **Merge into container image only** — does not cover EC2/GCE dedicated tiers

--- a/docs/adr/0006-golden-host-images-packer.md
+++ b/docs/adr/0006-golden-host-images-packer.md
@@ -2,7 +2,7 @@
 
 - Status: Accepted
 - Date: 2026-07-11
-- Related: team vault sync ([`docs/getting-started/team-vault-sync.md`](../getting-started/team-vault-sync.md)), golden image pipeline ([`docs/security/golden-image-pipeline.md`](../security/golden-image-pipeline.md)), Helm `teamSync` ([`charts/clawql-mcp`](../../charts/clawql-mcp/README.md))
+- Related: team vault sync ([`docs/getting-started/team-vault-sync.md`](../getting-started/team-vault-sync.md)), golden image pipeline ([`docs/security/golden-image-pipeline.md`](../security/golden-image-pipeline.md)), Pulumi provisioning ([ADR 0007](./0007-pulumi-provisioning-managed-tiers.md)), Helm `teamSync` ([`charts/clawql-mcp`](../../charts/clawql-mcp/README.md))
 - Implementation: [`packer/`](../../packer/), [`scripts/packer/`](../../scripts/packer/), [`.github/workflows/packer-publish.yml`](../../.github/workflows/packer-publish.yml)
 
 ## Context

--- a/docs/adr/0006-golden-host-images-packer.md
+++ b/docs/adr/0006-golden-host-images-packer.md
@@ -21,10 +21,10 @@ Users choose **providers** (`CLAWQL_PROVIDER`, team bucket prefix). Protocol rou
 
 ### 1) Two-phase provisioning (secrets never in the image)
 
-| Phase | When | What |
-|-------|------|------|
-| **Bake** | Packer build | Ubuntu 24.04, Node 22, `clawql` install, `~/.ClawQL` skeleton, `sync.json` template (`CONFIGURE_AT_BOOT` bucket placeholder) |
-| **Boot** | Instance / Worker start | Inject sync credentials (metadata, Vault agent, ESO), `clawql sync pull`, `clawql doctor --smoke` |
+| Phase    | When                    | What                                                                                                                         |
+| -------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| **Bake** | Packer build            | Ubuntu 24.04, Node 22, `clawql` install, `~/.ClawQL` skeleton, `sync.json` template (`CONFIGURE_AT_BOOT` bucket placeholder) |
+| **Boot** | Instance / Worker start | Inject sync credentials (metadata, Vault agent, ESO), `clawql sync pull`, `clawql doctor --smoke`                            |
 
 `vault/providers.json` and sync credentials **never** ship in the image (same rule as team sync docs).
 
@@ -43,10 +43,10 @@ Release CI signs container artifacts today (Cosign on GHCR). VM image signing (e
 
 ### 4) Tier seeding via bucket prefix (not image variant)
 
-| Tier | Seeding |
-|------|---------|
-| **Shared** | `CLAWQL_SYNC_PREFIX=shared/`; tenant isolation via operator |
-| **Dedicated** | `CLAWQL_SYNC_PREFIX=tenant/{id}/` from instance metadata |
+| Tier           | Seeding                                                     |
+| -------------- | ----------------------------------------------------------- |
+| **Shared**     | `CLAWQL_SYNC_PREFIX=shared/`; tenant isolation via operator |
+| **Dedicated**  | `CLAWQL_SYNC_PREFIX=tenant/{id}/` from instance metadata    |
 | **Enterprise** | Customer bucket + Vault; ClawQL ships the signed image only |
 
 ## Consequences

--- a/docs/adr/0007-pulumi-provisioning-managed-tiers.md
+++ b/docs/adr/0007-pulumi-provisioning-managed-tiers.md
@@ -15,12 +15,12 @@ ClawQL is **TypeScript-native** (core, CLI, operator). Multi-tenant managed tier
 
 ### 1) Pulumi over Terraform for ClawQL provisioning
 
-| Factor                        | Pulumi                                       | Terraform                          |
-| ----------------------------- | -------------------------------------------- | ---------------------------------- |
-| Language                      | TypeScript (same repo/toolchain)             | HCL (context switch)               |
-| Dynamic multi-tenant logic    | Native loops/conditionals                    | Awkward in HCL                     |
-| Programmatic `up` from ClawQL | **Automation API**                           | Terraform Cloud API / exec wrapper |
-| State backends                | Self-hosted S3 / R2 only (no Pulumi Cloud)   | S3, Terraform Cloud, etc.          |
+| Factor                        | Pulumi                                     | Terraform                          |
+| ----------------------------- | ------------------------------------------ | ---------------------------------- |
+| Language                      | TypeScript (same repo/toolchain)           | HCL (context switch)               |
+| Dynamic multi-tenant logic    | Native loops/conditionals                  | Awkward in HCL                     |
+| Programmatic `up` from ClawQL | **Automation API**                         | Terraform Cloud API / exec wrapper |
+| State backends                | Self-hosted S3 / R2 only (no Pulumi Cloud) | S3, Terraform Cloud, etc.          |
 
 **Packer builds the artifact; Pulumi provisions the infrastructure that runs it.** Clean separation of concerns.
 
@@ -40,16 +40,18 @@ Stack config namespace: `clawql:*` (see [`Pulumi.example.yaml`](../../infra/pulu
 ClawQL does **not** use Pulumi Cloud. Stack state and encrypted secrets live in object storage you control — aligned with the team-vault sovereignty story.
 
 <<<<<<< HEAD
+
 | Backend                                         | When to use                                                                            |
 | ----------------------------------------------- | -------------------------------------------------------------------------------------- |
 | **Pulumi Cloud** (default for solo/small teams) | Fastest onboarding, built-in secrets encryption, team RBAC, no state bucket to operate |
 | **Self-hosted on R2 or S3**                     | Sovereignty / air-gap; object store you already run for team vault                     |
-=======
-| Backend | When to use |
-|---------|-------------|
-| **Cloudflare R2** (preferred) | Default for managed tiers; same provider as team vault sync |
-| **AWS S3** (or S3-compatible) | When AWS is already the control plane |
->>>>>>> 3f1171f (docs(infra): require self-hosted Pulumi state, no Pulumi Cloud)
+| =======                                         |
+| Backend                                         | When to use                                                                            |
+| ---------                                       | -------------                                                                          |
+| **Cloudflare R2** (preferred)                   | Default for managed tiers; same provider as team vault sync                            |
+| **AWS S3** (or S3-compatible)                   | When AWS is already the control plane                                                  |
+
+> > > > > > > 3f1171f (docs(infra): require self-hosted Pulumi state, no Pulumi Cloud)
 
 Configure once per operator machine or CI runner:
 

--- a/docs/adr/0007-pulumi-provisioning-managed-tiers.md
+++ b/docs/adr/0007-pulumi-provisioning-managed-tiers.md
@@ -1,0 +1,82 @@
+# ADR 0007: Pulumi provisioning for managed ClawQL tiers
+
+- Status: Accepted
+- Date: 2026-07-11
+- Related: [ADR 0006: Golden host images (Packer)](./0006-golden-host-images-packer.md), [`infra/pulumi/`](../../infra/pulumi/), [`packer/`](../../packer/)
+- Supersedes: N/A (complements Packer — artifact vs infrastructure)
+
+## Context
+
+[ADR 0006](./0006-golden-host-images-packer.md) defines **Packer** as the golden **artifact** pipeline (AMI/GCP image with ClawQL baked in, secrets at boot). Operators still need **infrastructure** to launch those images: EC2/GCE instances, security groups, IAM, R2 team-vault buckets, and boot-time user-data that wires tier-specific sync prefixes.
+
+ClawQL is **TypeScript-native** (core, CLI, operator). Multi-tenant managed tiers need **conditional logic** (dedicated namespaces, per-tenant bucket prefixes, SSM paths). Future **`clawql operator provision`** should trigger provisioning programmatically.
+
+## Decision
+
+### 1) Pulumi over Terraform for ClawQL provisioning
+
+| Factor | Pulumi | Terraform |
+|--------|--------|-----------|
+| Language | TypeScript (same repo/toolchain) | HCL (context switch) |
+| Dynamic multi-tenant logic | Native loops/conditionals | Awkward in HCL |
+| Programmatic `up` from ClawQL | **Automation API** | Terraform Cloud API / exec wrapper |
+| State backends | Pulumi Cloud, S3, R2, self-hosted | S3, Terraform Cloud, etc. |
+
+**Packer builds the artifact; Pulumi provisions the infrastructure that runs it.** Clean separation of concerns.
+
+Terraform’s ecosystem breadth is acknowledged but does not outweigh TypeScript alignment and the agentic provisioning path for this codebase.
+
+### 2) Single TypeScript package: `infra/pulumi`
+
+- **Project:** `clawql-provision` ([`Pulumi.yaml`](../../infra/pulumi/Pulumi.yaml))
+- **Cloud targets:** `aws` (EC2 golden host), `gcp` (GCE), `cloudflare` (R2 team vault — no VM)
+- **Tier helpers:** `syncPrefixForTier()` — `shared/`, `tenant/{id}/`, enterprise custom prefix
+- **Boot wiring:** `buildBootstrapUserData()` delegates to `bootstrap-team-vault.sh` on golden images (same as ADR 0006)
+
+Stack config namespace: `clawql:*` (see [`Pulumi.example.yaml`](../../infra/pulumi/Pulumi.example.yaml)).
+
+### 3) State backend — both supported
+
+| Backend | When to use |
+|---------|-------------|
+| **Pulumi Cloud** (default for solo/small teams) | Fastest onboarding, built-in secrets encryption, team RBAC, no state bucket to operate |
+| **Self-hosted on R2 or S3** | Sovereignty / air-gap; object store you already run for team vault |
+
+**Recommendation:** start with **Pulumi Cloud** for development and early managed tiers; move production dedicated-tenant stacks to **R2-backed state** when sovereignty or customer contract requires it. Configure via `pulumi login` (cloud) or `pulumi login s3://…` / compatible self-hosted endpoint — not hard-coded in the program.
+
+Secrets (sync keys) belong in **Pulumi stack secrets** or **AWS SSM** (dedicated tier boot fetch), never in golden images.
+
+### 4) Automation API path
+
+[`infra/pulumi/src/automation.ts`](../../infra/pulumi/src/automation.ts) wraps `LocalWorkspace.createOrSelectStack` + `stack.up()` using `workDir` (program from `Pulumi.yaml`). Intended integration:
+
+```text
+clawql operator provision --tier dedicated --tenant acme --cloud aws
+  → automation.upProvisionStack({ stackName: dedicated-acme, config: … })
+```
+
+This is the hook for agents provisioning infrastructure through ClawQL without shelling out to a separate IaC toolchain.
+
+### 5) CI
+
+Unit tests for tier prefixes, user-data bash, and stack naming — no cloud credentials in PR CI (`npm test` in `infra/pulumi`). Cloud `pulumi preview` remains manual or release-dispatch (like Packer cloud builds).
+
+## Consequences
+
+### Positive
+
+- Same language as ClawQL for operators and future agent-generated infra
+- Tier and boot logic testable without AWS/GCP accounts
+- Clear pairing: Packer AMI id → `clawql:goldenImageId` → Pulumi EC2/GCE
+
+### Trade-offs
+
+- Pulumi provider deps add weight to `infra/pulumi` install (isolated workspace package)
+- Cloud `pulumi up` still needs credentials (not in default CI)
+- Operator CLI integration is documented but not yet wired (Automation API is ready)
+
+## Alternatives considered
+
+- **Terraform** — rejected for reasons above (HCL, weaker in-repo agent story)
+- **Pulumi only, no Packer** — rejected; slower boot, drift, secrets-in-user-data-only story weaker
+- **Helm-only** — does not cover EC2/GCE dedicated tiers (K8s path unchanged via `teamSync`)

--- a/docs/adr/0007-pulumi-provisioning-managed-tiers.md
+++ b/docs/adr/0007-pulumi-provisioning-managed-tiers.md
@@ -15,12 +15,12 @@ ClawQL is **TypeScript-native** (core, CLI, operator). Multi-tenant managed tier
 
 ### 1) Pulumi over Terraform for ClawQL provisioning
 
-| Factor | Pulumi | Terraform |
-|--------|--------|-----------|
-| Language | TypeScript (same repo/toolchain) | HCL (context switch) |
-| Dynamic multi-tenant logic | Native loops/conditionals | Awkward in HCL |
-| Programmatic `up` from ClawQL | **Automation API** | Terraform Cloud API / exec wrapper |
-| State backends | Pulumi Cloud, S3, R2, self-hosted | S3, Terraform Cloud, etc. |
+| Factor                        | Pulumi                            | Terraform                          |
+| ----------------------------- | --------------------------------- | ---------------------------------- |
+| Language                      | TypeScript (same repo/toolchain)  | HCL (context switch)               |
+| Dynamic multi-tenant logic    | Native loops/conditionals         | Awkward in HCL                     |
+| Programmatic `up` from ClawQL | **Automation API**                | Terraform Cloud API / exec wrapper |
+| State backends                | Pulumi Cloud, S3, R2, self-hosted | S3, Terraform Cloud, etc.          |
 
 **Packer builds the artifact; Pulumi provisions the infrastructure that runs it.** Clean separation of concerns.
 
@@ -37,10 +37,10 @@ Stack config namespace: `clawql:*` (see [`Pulumi.example.yaml`](../../infra/pulu
 
 ### 3) State backend — both supported
 
-| Backend | When to use |
-|---------|-------------|
+| Backend                                         | When to use                                                                            |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------- |
 | **Pulumi Cloud** (default for solo/small teams) | Fastest onboarding, built-in secrets encryption, team RBAC, no state bucket to operate |
-| **Self-hosted on R2 or S3** | Sovereignty / air-gap; object store you already run for team vault |
+| **Self-hosted on R2 or S3**                     | Sovereignty / air-gap; object store you already run for team vault                     |
 
 **Recommendation:** start with **Pulumi Cloud** for development and early managed tiers; move production dedicated-tenant stacks to **R2-backed state** when sovereignty or customer contract requires it. Configure via `pulumi login` (cloud) or `pulumi login s3://…` / compatible self-hosted endpoint — not hard-coded in the program.
 

--- a/docs/adr/0007-pulumi-provisioning-managed-tiers.md
+++ b/docs/adr/0007-pulumi-provisioning-managed-tiers.md
@@ -15,12 +15,12 @@ ClawQL is **TypeScript-native** (core, CLI, operator). Multi-tenant managed tier
 
 ### 1) Pulumi over Terraform for ClawQL provisioning
 
-| Factor                        | Pulumi                            | Terraform                          |
-| ----------------------------- | --------------------------------- | ---------------------------------- |
-| Language                      | TypeScript (same repo/toolchain)  | HCL (context switch)               |
-| Dynamic multi-tenant logic    | Native loops/conditionals         | Awkward in HCL                     |
-| Programmatic `up` from ClawQL | **Automation API**                | Terraform Cloud API / exec wrapper |
-| State backends                | Pulumi Cloud, S3, R2, self-hosted | S3, Terraform Cloud, etc.          |
+| Factor                        | Pulumi                                       | Terraform                          |
+| ----------------------------- | -------------------------------------------- | ---------------------------------- |
+| Language                      | TypeScript (same repo/toolchain)             | HCL (context switch)               |
+| Dynamic multi-tenant logic    | Native loops/conditionals                    | Awkward in HCL                     |
+| Programmatic `up` from ClawQL | **Automation API**                           | Terraform Cloud API / exec wrapper |
+| State backends                | Self-hosted S3 / R2 only (no Pulumi Cloud)   | S3, Terraform Cloud, etc.          |
 
 **Packer builds the artifact; Pulumi provisions the infrastructure that runs it.** Clean separation of concerns.
 
@@ -35,16 +35,37 @@ Terraform’s ecosystem breadth is acknowledged but does not outweigh TypeScript
 
 Stack config namespace: `clawql:*` (see [`Pulumi.example.yaml`](../../infra/pulumi/Pulumi.example.yaml)).
 
-### 3) State backend — both supported
+### 3) State backend — self-hosted only (no Pulumi Cloud)
 
+ClawQL does **not** use Pulumi Cloud. Stack state and encrypted secrets live in object storage you control — aligned with the team-vault sovereignty story.
+
+<<<<<<< HEAD
 | Backend                                         | When to use                                                                            |
 | ----------------------------------------------- | -------------------------------------------------------------------------------------- |
 | **Pulumi Cloud** (default for solo/small teams) | Fastest onboarding, built-in secrets encryption, team RBAC, no state bucket to operate |
 | **Self-hosted on R2 or S3**                     | Sovereignty / air-gap; object store you already run for team vault                     |
+=======
+| Backend | When to use |
+|---------|-------------|
+| **Cloudflare R2** (preferred) | Default for managed tiers; same provider as team vault sync |
+| **AWS S3** (or S3-compatible) | When AWS is already the control plane |
+>>>>>>> 3f1171f (docs(infra): require self-hosted Pulumi state, no Pulumi Cloud)
 
-**Recommendation:** start with **Pulumi Cloud** for development and early managed tiers; move production dedicated-tenant stacks to **R2-backed state** when sovereignty or customer contract requires it. Configure via `pulumi login` (cloud) or `pulumi login s3://…` / compatible self-hosted endpoint — not hard-coded in the program.
+Configure once per operator machine or CI runner:
 
-Secrets (sync keys) belong in **Pulumi stack secrets** or **AWS SSM** (dedicated tier boot fetch), never in golden images.
+```bash
+# R2 (S3-compatible API) — replace bucket and account id
+export AWS_ACCESS_KEY_ID=...          # R2 API token access key
+export AWS_SECRET_ACCESS_KEY=...      # R2 API token secret
+pulumi login 's3://clawql-pulumi-state?region=auto&endpoint=https://<accountid>.r2.cloudflarestorage.com&awssdk=v2'
+
+# Or AWS S3
+pulumi login s3://clawql-pulumi-state
+```
+
+State bucket layout is standard Pulumi (`s3://<bucket>/.pulumi/`). Not hard-coded in programs — only `pulumi login` / backend URL.
+
+Secrets (sync keys) belong in **Pulumi stack secrets** (encrypted by the self-hosted backend passphrase) or **AWS SSM** (dedicated tier boot fetch), never in golden images.
 
 ### 4) Automation API path
 

--- a/docs/getting-started/golden-host-images.md
+++ b/docs/getting-started/golden-host-images.md
@@ -44,7 +44,7 @@ pulumi config set clawql:goldenImageId ami-xxxxxxxx   # Packer output
 pulumi preview   # or pulumi up — requires cloud credentials
 ```
 
-See [`infra/pulumi/README.md`](../../infra/pulumi/README.md) and [ADR 0007](../adr/0007-pulumi-provisioning-managed-tiers.md).
+See [`infra/pulumi/README.md`](../../infra/pulumi/README.md) and [ADR 0007](../adr/0007-pulumi-provisioning-managed-tiers.md). State lives on **self-hosted R2 or S3** — not Pulumi Cloud.
 
 ### 3. Launch with boot-time seeding
 

--- a/docs/getting-started/golden-host-images.md
+++ b/docs/getting-started/golden-host-images.md
@@ -1,0 +1,78 @@
+# Golden host images (managed tiers)
+
+Provision **ClawQL-ready servers** with team agent context loaded at boot — for AWS, GCP, and Cloudflare managed offerings.
+
+**User model:** pick providers and team bucket. ClawQL handles connection routing internally. You only need **`search`** and **`execute`** after boot.
+
+## What you get
+
+| Component | Bake time (image) | Boot time (runtime) |
+|-----------|-------------------|---------------------|
+| ClawQL + Node 22 | Yes | — |
+| `~/.ClawQL` skeleton | Yes | — |
+| `sync.json` (bucket/prefix) | Template only | Overridden from metadata/env |
+| Sync credentials | **Never** | Injected (Vault, instance role, secrets manager) |
+| Team `Memory/` notes | — | `clawql sync pull` |
+| SHA-256 verification | — | Every pulled file vs manifest |
+| Health gate | `clawql doctor` (bake) | `clawql doctor --smoke` (boot) |
+
+## Quick start (operators)
+
+### 1. Build or promote a golden image
+
+```bash
+cd packer
+packer init .
+packer build -only=aws-ami.amazon-ebs.clawql -var 'clawql_version=7.0.0' .
+```
+
+See [`packer/README.md`](../../packer/README.md) for GCP and CI validate targets.
+
+### 2. Launch with boot-time seeding
+
+Set instance user-data / startup script to run:
+
+```bash
+export CLAWQL_SYNC_BUCKET=acme-clawql-team
+export CLAWQL_SYNC_PREFIX=teams/production/
+export CLAWQL_R2_ACCOUNT_ID=...
+export CLAWQL_SYNC_ACCESS_KEY_ID=...
+export CLAWQL_SYNC_SECRET_ACCESS_KEY=...
+/usr/local/bin/bootstrap-team-vault.sh   # installed on golden images at bake time
+```
+
+Or use the repo script path: `scripts/packer/bootstrap-team-vault.sh`.
+
+### 3. Verify
+
+```bash
+clawql doctor --smoke
+clawql sync status
+```
+
+## Tier seeding
+
+| Tier | Configuration |
+|------|----------------|
+| **Shared** | `CLAWQL_SYNC_PREFIX=shared/` |
+| **Dedicated** | `CLAWQL_SYNC_PREFIX=tenant/<tenant-id>/` |
+| **Enterprise** | Customer-owned bucket; same image, their credentials |
+
+## Cloudflare managed tier
+
+Workers and containers do not use AMIs. Run `scripts/packer/cloudflare-bootstrap.sh` on first invocation — same pull + verify + doctor gate against **verified R2 state**.
+
+## Kubernetes parity
+
+In-cluster MCP uses Helm **`teamSync`** (`autoPullOnStart`, `autoPull`) — same semantics as golden-host boot. See [team-vault-sync.md](./team-vault-sync.md).
+
+## CI and releases
+
+- **PR / main:** `scripts/packer/test-golden-host-scripts.sh` (ShellCheck + `packer validate`)
+- **Release:** [`.github/workflows/packer-publish.yml`](../../.github/workflows/packer-publish.yml) — matrix AWS/GCP on dispatch; docker validate on every run
+
+## Related
+
+- [Team vault sync](./team-vault-sync.md)
+- [ADR 0006: Golden host images](../adr/0006-golden-host-images-packer.md)
+- [Golden image pipeline (containers)](../security/golden-image-pipeline.md)

--- a/docs/getting-started/golden-host-images.md
+++ b/docs/getting-started/golden-host-images.md
@@ -6,15 +6,15 @@ Provision **ClawQL-ready servers** with team agent context loaded at boot — fo
 
 ## What you get
 
-| Component | Bake time (image) | Boot time (runtime) |
-|-----------|-------------------|---------------------|
-| ClawQL + Node 22 | Yes | — |
-| `~/.ClawQL` skeleton | Yes | — |
-| `sync.json` (bucket/prefix) | Template only | Overridden from metadata/env |
-| Sync credentials | **Never** | Injected (Vault, instance role, secrets manager) |
-| Team `Memory/` notes | — | `clawql sync pull` |
-| SHA-256 verification | — | Every pulled file vs manifest |
-| Health gate | `clawql doctor` (bake) | `clawql doctor --smoke` (boot) |
+| Component                   | Bake time (image)      | Boot time (runtime)                              |
+| --------------------------- | ---------------------- | ------------------------------------------------ |
+| ClawQL + Node 22            | Yes                    | —                                                |
+| `~/.ClawQL` skeleton        | Yes                    | —                                                |
+| `sync.json` (bucket/prefix) | Template only          | Overridden from metadata/env                     |
+| Sync credentials            | **Never**              | Injected (Vault, instance role, secrets manager) |
+| Team `Memory/` notes        | —                      | `clawql sync pull`                               |
+| SHA-256 verification        | —                      | Every pulled file vs manifest                    |
+| Health gate                 | `clawql doctor` (bake) | `clawql doctor --smoke` (boot)                   |
 
 ## Quick start (operators)
 
@@ -52,10 +52,10 @@ clawql sync status
 
 ## Tier seeding
 
-| Tier | Configuration |
-|------|----------------|
-| **Shared** | `CLAWQL_SYNC_PREFIX=shared/` |
-| **Dedicated** | `CLAWQL_SYNC_PREFIX=tenant/<tenant-id>/` |
+| Tier           | Configuration                                        |
+| -------------- | ---------------------------------------------------- |
+| **Shared**     | `CLAWQL_SYNC_PREFIX=shared/`                         |
+| **Dedicated**  | `CLAWQL_SYNC_PREFIX=tenant/<tenant-id>/`             |
 | **Enterprise** | Customer-owned bucket; same image, their credentials |
 
 ## Cloudflare managed tier

--- a/docs/getting-started/golden-host-images.md
+++ b/docs/getting-started/golden-host-images.md
@@ -28,7 +28,25 @@ packer build -only=aws-ami.amazon-ebs.clawql -var 'clawql_version=7.0.0' .
 
 See [`packer/README.md`](../../packer/README.md) for GCP and CI validate targets.
 
-### 2. Launch with boot-time seeding
+### 2. Provision infrastructure (Pulumi)
+
+Packer produces the **artifact** (AMI/GCP image). **Pulumi** provisions the VM, IAM, and boot user-data that references your tier sync prefix.
+
+```bash
+cd infra/pulumi
+npm ci
+pulumi stack init dev
+pulumi config set clawql:cloud aws
+pulumi config set clawql:tier dedicated
+pulumi config set clawql:tenantId acme
+pulumi config set clawql:syncBucket acme-clawql-team
+pulumi config set clawql:goldenImageId ami-xxxxxxxx   # Packer output
+pulumi preview   # or pulumi up — requires cloud credentials
+```
+
+See [`infra/pulumi/README.md`](../../infra/pulumi/README.md) and [ADR 0007](../adr/0007-pulumi-provisioning-managed-tiers.md).
+
+### 3. Launch with boot-time seeding
 
 Set instance user-data / startup script to run:
 
@@ -43,7 +61,7 @@ export CLAWQL_SYNC_SECRET_ACCESS_KEY=...
 
 Or use the repo script path: `scripts/packer/bootstrap-team-vault.sh`.
 
-### 3. Verify
+### 4. Verify
 
 ```bash
 clawql doctor --smoke
@@ -69,10 +87,12 @@ In-cluster MCP uses Helm **`teamSync`** (`autoPullOnStart`, `autoPull`) — same
 ## CI and releases
 
 - **PR / main:** `scripts/packer/test-golden-host-scripts.sh` (ShellCheck + `packer validate`)
+- **PR / main:** `scripts/pulumi/test-provision-unit.sh` (tier/user-data unit tests + TS build)
 - **Release:** [`.github/workflows/packer-publish.yml`](../../.github/workflows/packer-publish.yml) — matrix AWS/GCP on dispatch; docker validate on every run
 
 ## Related
 
 - [Team vault sync](./team-vault-sync.md)
-- [ADR 0006: Golden host images](../adr/0006-golden-host-images-packer.md)
+- [ADR 0006: Golden host images (Packer)](../adr/0006-golden-host-images-packer.md)
+- [ADR 0007: Pulumi provisioning](../adr/0007-pulumi-provisioning-managed-tiers.md)
 - [Golden image pipeline (containers)](../security/golden-image-pipeline.md)

--- a/docs/getting-started/team-vault-sync.md
+++ b/docs/getting-started/team-vault-sync.md
@@ -229,6 +229,7 @@ Template smoke: `make helm-team-sync-template-tests`.
 
 - Run **`clawql doctor`** or trigger **`memory_recall`** with `CLAWQL_MEMORY_DB_SYNC_ON_RECALL=1` to refresh `memory.db` from new Markdown.
 - Conflicts: if two teammates edit the same note, **`sync status`** lists conflicts; use **`sync push --force`** or **`sync pull --force`** deliberately.
+- **Golden host images:** managed AWS/GCP/Cloudflare tiers bake ClawQL and seed team vault at boot — [golden-host-images.md](./golden-host-images.md).
 
 ## Related
 

--- a/docs/readme/configuration.md
+++ b/docs/readme/configuration.md
@@ -101,13 +101,13 @@ When Stage 1 is active:
 
 #### Provider connection pitfalls
 
-| Situation | What happens |
-|----------|----------------|
-| Want **Linear** | Set **`CLAWQL_PROVIDER=linear`** + **`LINEAR_API_KEY`** — no **`CLAWQL_GRAPHQL_*`** needed |
-| **`CLAWQL_GRAPHQL_SOURCES`** with a bad **`schemaPath`** for Linear | Auto-routes to bundled **linear**; bad path ignored |
-| **`CLAWQL_GRAPHQL_SOURCES`** with a bad **`schemaPath`** for an unknown API | Path ignored; HTTP introspection attempted |
-| Custom provider env set but provider unreachable | Clear startup error — does not silently load unrelated providers |
-| No provider env set | Default stack loads (Cloudflare, GitHub, Slack, Linear, Notion, Onyx) |
+| Situation                                                                   | What happens                                                                               |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Want **Linear**                                                             | Set **`CLAWQL_PROVIDER=linear`** + **`LINEAR_API_KEY`** — no **`CLAWQL_GRAPHQL_*`** needed |
+| **`CLAWQL_GRAPHQL_SOURCES`** with a bad **`schemaPath`** for Linear         | Auto-routes to bundled **linear**; bad path ignored                                        |
+| **`CLAWQL_GRAPHQL_SOURCES`** with a bad **`schemaPath`** for an unknown API | Path ignored; HTTP introspection attempted                                                 |
+| Custom provider env set but provider unreachable                            | Clear startup error — does not silently load unrelated providers                           |
+| No provider env set                                                         | Default stack loads (Cloudflare, GitHub, Slack, Linear, Notion, Onyx)                      |
 
 ClawQL picks the best internal connection per provider (**gRPC → GraphQL → OpenAPI**). Users only need **`search`** and **`execute`**.
 

--- a/infra/pulumi/Pulumi.example.yaml
+++ b/infra/pulumi/Pulumi.example.yaml
@@ -1,0 +1,23 @@
+config:
+  clawql:cloud:
+    description: Target cloud (aws | gcp | cloudflare)
+  clawql:tier:
+    description: Managed tier (shared | dedicated | enterprise)
+  clawql:tenantId:
+    description: Tenant id (required for dedicated tier)
+  clawql:syncBucket:
+    description: Team vault object storage bucket name
+  clawql:syncProvider:
+    description: Object storage provider for team sync (r2 | s3 | gcs)
+  clawql:syncPrefix:
+    description: Optional override for enterprise tier sync prefix
+  clawql:goldenImageId:
+    description: Packer golden image id (AWS AMI id or GCP image self link)
+  clawql:instanceType:
+    description: VM instance type / machine type
+  clawql:region:
+    description: Cloud region (AWS/GCP)
+  cloudflare:accountId:
+    description: Cloudflare account id (cloudflare stacks)
+  gcp:project:
+    description: GCP project id (gcp stacks)

--- a/infra/pulumi/Pulumi.yaml
+++ b/infra/pulumi/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: clawql-provision
+description: Provision ClawQL golden hosts and team vault infrastructure (AWS / GCP / Cloudflare)
+runtime:
+  name: nodejs
+  options:
+    typescript: true
+main: src/index.ts

--- a/infra/pulumi/README.md
+++ b/infra/pulumi/README.md
@@ -1,0 +1,79 @@
+# ClawQL provision (Pulumi)
+
+TypeScript Pulumi programs to provision managed-tier infrastructure. **Packer** builds the golden host artifact; **Pulumi** creates the cloud resources that run it.
+
+## Layout
+
+| Path | Role |
+|------|------|
+| `src/index.ts` | Stack entry — routes by `clawql:cloud` |
+| `src/aws.ts` | EC2 instance, IAM, security group, user-data |
+| `src/gcp.ts` | GCE instance + startup-script metadata |
+| `src/cloudflare.ts` | R2 team-vault bucket |
+| `src/tiers.ts` | Tier → sync prefix mapping |
+| `src/user-data.ts` | Boot bash for golden images |
+| `src/automation.ts` | Automation API (`stack.up` from Node) |
+
+## Quick start
+
+```bash
+cd infra/pulumi
+npm ci
+npm test
+npm run build
+
+# Configure stack (copy and edit)
+cp Pulumi.example.yaml Pulumi.dev.yaml
+pulumi stack init dev
+pulumi config set clawql:cloud aws
+pulumi config set clawql:tier shared
+pulumi config set clawql:syncBucket acme-clawql-team
+pulumi config set clawql:goldenImageId ami-xxxxxxxx   # from Packer output
+
+pulumi preview   # needs cloud credentials
+```
+
+## Tier config
+
+| Tier | Required config | Sync prefix |
+|------|-----------------|-------------|
+| `shared` | `syncBucket`, `goldenImageId` | `shared/` |
+| `dedicated` | + `tenantId` | `tenant/{tenantId}/` |
+| `enterprise` | + `syncPrefix` | custom |
+
+Dedicated AWS stacks default `useSsmSecrets=true`; user-data reads sync credentials from SSM at boot.
+
+## State backend
+
+See [ADR 0007](../../docs/adr/0007-pulumi-provisioning-managed-tiers.md).
+
+- **Pulumi Cloud:** `pulumi login` (recommended for dev)
+- **Self-hosted (R2/S3):** `pulumi login s3://your-state-bucket` or compatible backend
+
+Stack secrets (if any) are encrypted by the backend you choose.
+
+## Automation API (operator / CLI)
+
+```typescript
+import { dedicatedStackName, upProvisionStack } from "clawql-provision/automation";
+
+await upProvisionStack({
+  workDir: "infra/pulumi",
+  stackName: dedicatedStackName("acme"),
+  config: {
+    cloud: "aws",
+    tier: "dedicated",
+    tenantId: "acme",
+    syncBucket: "acme-clawql-team",
+    goldenImageId: "ami-xxxxxxxx",
+  },
+});
+```
+
+Future: `clawql operator provision --tier dedicated --tenant acme`.
+
+## Related
+
+- [Golden host images (Packer)](../../docs/getting-started/golden-host-images.md)
+- [ADR 0006: Packer](../../docs/adr/0006-golden-host-images-packer.md)
+- [ADR 0007: Pulumi](../../docs/adr/0007-pulumi-provisioning-managed-tiers.md)

--- a/infra/pulumi/README.md
+++ b/infra/pulumi/README.md
@@ -22,6 +22,11 @@ npm ci
 npm test
 npm run build
 
+# Self-hosted state (R2 preferred — see State backend below)
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+pulumi login 's3://clawql-pulumi-state?region=auto&endpoint=https://<accountid>.r2.cloudflarestorage.com&awssdk=v2'
+
 # Configure stack (copy and edit)
 cp Pulumi.example.yaml Pulumi.dev.yaml
 pulumi stack init dev
@@ -43,14 +48,21 @@ pulumi preview   # needs cloud credentials
 
 Dedicated AWS stacks default `useSsmSecrets=true`; user-data reads sync credentials from SSM at boot.
 
-## State backend
+## State backend (self-hosted only)
 
-See [ADR 0007](../../docs/adr/0007-pulumi-provisioning-managed-tiers.md).
+See [ADR 0007](../../docs/adr/0007-pulumi-provisioning-managed-tiers.md). **No Pulumi Cloud.**
 
-- **Pulumi Cloud:** `pulumi login` (recommended for dev)
-- **Self-hosted (R2/S3):** `pulumi login s3://your-state-bucket` or compatible backend
+**Preferred:** Cloudflare R2 (S3-compatible, same stack as team vault).
 
-Stack secrets (if any) are encrypted by the backend you choose.
+```bash
+export AWS_ACCESS_KEY_ID=...          # R2 API token
+export AWS_SECRET_ACCESS_KEY=...
+pulumi login 's3://clawql-pulumi-state?region=auto&endpoint=https://<accountid>.r2.cloudflarestorage.com&awssdk=v2'
+```
+
+**Alternative:** AWS S3 — `pulumi login s3://clawql-pulumi-state`
+
+Stack secrets are encrypted with your Pulumi secrets passphrase and stored in the same object-store backend.
 
 ## Automation API (operator / CLI)
 

--- a/infra/pulumi/package.json
+++ b/infra/pulumi/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "clawql-provision",
+  "version": "7.0.0",
+  "private": true,
+  "description": "Pulumi programs to provision ClawQL golden hosts (AWS/GCP/Cloudflare) — pairs with Packer artifacts",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./tiers": {
+      "types": "./dist/tiers.d.ts",
+      "import": "./dist/tiers.js"
+    },
+    "./user-data": {
+      "types": "./dist/user-data.d.ts",
+      "import": "./dist/user-data.js"
+    },
+    "./automation": {
+      "types": "./dist/automation.d.ts",
+      "import": "./dist/automation.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "preview": "pulumi preview",
+    "up": "pulumi up",
+    "destroy": "pulumi destroy"
+  },
+  "dependencies": {
+    "@pulumi/aws": "^6.83.0",
+    "@pulumi/cloudflare": "^6.4.0",
+    "@pulumi/gcp": "^8.36.0",
+    "@pulumi/pulumi": "^3.210.0",
+    "zod": "4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.1"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/infra/pulumi/src/automation.test.ts
+++ b/infra/pulumi/src/automation.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { dedicatedStackName } from "./automation.js";
+
+describe("dedicatedStackName", () => {
+  it("lowercases and sanitizes tenant id", () => {
+    expect(dedicatedStackName("Acme Corp")).toBe("dedicated-acme-corp");
+    expect(dedicatedStackName("tenant_01")).toBe("dedicated-tenant-01");
+  });
+});

--- a/infra/pulumi/src/automation.ts
+++ b/infra/pulumi/src/automation.ts
@@ -1,0 +1,84 @@
+/**
+ * Pulumi Automation API helpers — programmatic `pulumi up` for operator / CLI flows.
+ *
+ * Example (future `clawql operator provision`):
+ *   await upDedicatedTenant({ workDir: 'infra/pulumi', tenantId: 'acme', ... })
+ */
+import { automation } from "@pulumi/pulumi";
+import type { CloudTarget, ManagedTier, SyncProvider } from "./types.js";
+
+const { LocalWorkspace } = automation;
+
+export type AutomationStackConfig = {
+  cloud: CloudTarget;
+  tier: ManagedTier;
+  tenantId?: string;
+  syncBucket: string;
+  syncProvider?: SyncProvider;
+  syncPrefix?: string;
+  goldenImageId: string;
+  region?: string;
+  instanceType?: string;
+  useSsmSecrets?: boolean;
+};
+
+export type UpStackOptions = {
+  /** Directory containing Pulumi.yaml (e.g. repo `infra/pulumi`). */
+  workDir: string;
+  stackName: string;
+  config: AutomationStackConfig;
+  /** Pulumi secrets (e.g. sync keys) — stored encrypted in stack state. */
+  secrets?: Record<string, string>;
+  onOutput?: (msg: string) => void;
+};
+
+function toPulumiConfig(cfg: AutomationStackConfig): Record<string, string> {
+  const out: Record<string, string> = {
+    "clawql:cloud": cfg.cloud,
+    "clawql:tier": cfg.tier,
+    "clawql:syncBucket": cfg.syncBucket,
+    "clawql:syncProvider": cfg.syncProvider ?? "r2",
+    "clawql:goldenImageId": cfg.goldenImageId,
+  };
+  if (cfg.tenantId) out["clawql:tenantId"] = cfg.tenantId;
+  if (cfg.syncPrefix) out["clawql:syncPrefix"] = cfg.syncPrefix;
+  if (cfg.region) out["clawql:region"] = cfg.region;
+  if (cfg.instanceType) out["clawql:instanceType"] = cfg.instanceType;
+  if (cfg.useSsmSecrets !== undefined) {
+    out["clawql:useSsmSecrets"] = cfg.useSsmSecrets ? "true" : "false";
+  }
+  return out;
+}
+
+export async function createOrSelectStack(opts: UpStackOptions) {
+  const stack = await LocalWorkspace.createOrSelectStack({
+    stackName: opts.stackName,
+    workDir: opts.workDir,
+  });
+
+  for (const [key, value] of Object.entries(toPulumiConfig(opts.config))) {
+    await stack.setConfig(key, { value });
+  }
+  if (opts.secrets) {
+    for (const [key, value] of Object.entries(opts.secrets)) {
+      await stack.setConfig(key, { value, secret: true });
+    }
+  }
+  return stack;
+}
+
+export async function upProvisionStack(opts: UpStackOptions) {
+  const stack = await createOrSelectStack(opts);
+  return stack.up({ onOutput: opts.onOutput ?? ((m) => process.stderr.write(`${m}\n`)) });
+}
+
+export async function previewProvisionStack(opts: UpStackOptions) {
+  const stack = await createOrSelectStack(opts);
+  return stack.preview({ onOutput: opts.onOutput });
+}
+
+/** Convenience: dedicated tier stack name convention. */
+export function dedicatedStackName(tenantId: string): string {
+  const safe = tenantId.replace(/[^a-zA-Z0-9-]/g, "-").toLowerCase();
+  return `dedicated-${safe}`;
+}

--- a/infra/pulumi/src/aws.ts
+++ b/infra/pulumi/src/aws.ts
@@ -1,0 +1,92 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+import type { ProvisionInputs } from "./types.js";
+import { buildBootstrapUserData } from "./user-data.js";
+
+export type AwsGoldenHostOutputs = {
+  instanceId: pulumi.Output<string>;
+  publicIp: pulumi.Output<string>;
+  syncPrefix: string;
+};
+
+export function createAwsGoldenHost(inputs: ProvisionInputs): AwsGoldenHostOutputs {
+  if (!inputs.syncPrefix) {
+    throw new Error("syncPrefix is required");
+  }
+
+  const userData = buildBootstrapUserData({
+    bucket: inputs.syncBucket,
+    prefix: inputs.syncPrefix,
+    syncProvider: inputs.syncProvider,
+    ssmParameterPrefix: inputs.useSsmSecrets ? inputs.ssmParameterPrefix : undefined,
+  });
+
+  const role = new aws.iam.Role("clawql-instance-role", {
+    assumeRolePolicy: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Action: "sts:AssumeRole",
+          Effect: "Allow",
+          Principal: { Service: "ec2.amazonaws.com" },
+        },
+      ],
+    }),
+    tags: clawqlTags(inputs),
+  });
+
+  if (inputs.useSsmSecrets && inputs.ssmParameterPrefix) {
+    new aws.iam.RolePolicy("clawql-ssm-read", {
+      role: role.id,
+      policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: ["ssm:GetParameter", "ssm:GetParameters"],
+            Resource: `arn:aws:ssm:*:*:parameter${inputs.ssmParameterPrefix}/*`,
+          },
+        ],
+      }),
+    });
+  }
+
+  const profile = new aws.iam.InstanceProfile("clawql-instance-profile", {
+    role: role.name,
+  });
+
+  const sg = new aws.ec2.SecurityGroup("clawql-mcp-sg", {
+    description: "ClawQL MCP HTTP",
+    ingress: [
+      { protocol: "tcp", fromPort: 8080, toPort: 8080, cidrBlocks: ["0.0.0.0/0"] },
+    ],
+    egress: [{ protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0"] }],
+    tags: clawqlTags(inputs),
+  });
+
+  const instance = new aws.ec2.Instance("clawql-golden-host", {
+    ami: inputs.goldenImageId,
+    instanceType: inputs.instanceType,
+    iamInstanceProfile: profile.name,
+    vpcSecurityGroupIds: [sg.id],
+    userData: userData,
+    tags: {
+      ...clawqlTags(inputs),
+      Name: `clawql-${inputs.tier}-${inputs.tenantId ?? "shared"}`,
+    },
+  });
+
+  return {
+    instanceId: instance.id,
+    publicIp: instance.publicIp,
+    syncPrefix: inputs.syncPrefix,
+  };
+}
+
+function clawqlTags(inputs: ProvisionInputs): Record<string, string> {
+  return {
+    ManagedBy: "pulumi",
+    ClawQLTier: inputs.tier,
+    ...(inputs.tenantId ? { ClawQLTenant: inputs.tenantId } : {}),
+  };
+}

--- a/infra/pulumi/src/cloudflare.ts
+++ b/infra/pulumi/src/cloudflare.ts
@@ -1,0 +1,37 @@
+import * as cloudflare from "@pulumi/cloudflare";
+import * as pulumi from "@pulumi/pulumi";
+import type { ProvisionInputs } from "./types.js";
+
+export type CloudflareTeamVaultOutputs = {
+  bucketName: pulumi.Output<string>;
+  syncPrefix: string;
+};
+
+/**
+ * Cloudflare managed tier: provision team vault bucket (R2).
+ * Workers/containers use `cloudflare-bootstrap.sh` at first invocation — no VM AMI.
+ */
+export function createCloudflareTeamVault(inputs: ProvisionInputs): CloudflareTeamVaultOutputs {
+  if (!inputs.cloudflareAccountId) {
+    throw new Error("cloudflare:accountId config is required");
+  }
+  if (!inputs.syncPrefix) {
+    throw new Error("syncPrefix is required");
+  }
+
+  const bucketName =
+    inputs.tier === "dedicated" && inputs.tenantId
+      ? `${inputs.syncBucket}-${inputs.tenantId}`.toLowerCase().replace(/[^a-z0-9-]/g, "-")
+      : inputs.syncBucket;
+
+  const bucket = new cloudflare.R2Bucket("clawql-team-vault", {
+    accountId: inputs.cloudflareAccountId,
+    name: bucketName,
+    location: "WEUR",
+  });
+
+  return {
+    bucketName: bucket.name,
+    syncPrefix: inputs.syncPrefix,
+  };
+}

--- a/infra/pulumi/src/gcp.ts
+++ b/infra/pulumi/src/gcp.ts
@@ -1,0 +1,52 @@
+import * as gcp from "@pulumi/gcp";
+import * as pulumi from "@pulumi/pulumi";
+import type { ProvisionInputs } from "./types.js";
+import { buildGcpStartupScript } from "./user-data.js";
+
+export type GcpGoldenHostOutputs = {
+  instanceName: pulumi.Output<string>;
+  externalIp: pulumi.Output<string | undefined>;
+  syncPrefix: string;
+};
+
+export function createGcpGoldenHost(inputs: ProvisionInputs): GcpGoldenHostOutputs {
+  if (!inputs.gcpProject) {
+    throw new Error("gcp:project config is required for GCP stacks");
+  }
+  if (!inputs.syncPrefix) {
+    throw new Error("syncPrefix is required");
+  }
+
+  const startupScript = buildGcpStartupScript({
+    bucket: inputs.syncBucket,
+    prefix: inputs.syncPrefix,
+    syncProvider: inputs.syncProvider,
+  });
+
+  const instance = new gcp.compute.Instance("clawql-golden-host", {
+    machineType: inputs.instanceType,
+    zone: inputs.gcpZone ?? "us-central1-a",
+    bootDisk: {
+      initializeParams: {
+        image: inputs.goldenImageId,
+      },
+    },
+    networkInterfaces: [
+      {
+        accessConfigs: [{}],
+      },
+    ],
+    metadata: {
+      "startup-script": startupScript,
+      "clawql-tier": inputs.tier,
+      ...(inputs.tenantId ? { "clawql-tenant": inputs.tenantId } : {}),
+    },
+    tags: ["clawql-mcp", `clawql-${inputs.tier}`],
+  });
+
+  return {
+    instanceName: instance.name,
+    externalIp: instance.networkInterfaces.apply((ifs) => ifs[0]?.accessConfigs?.[0]?.natIp),
+    syncPrefix: inputs.syncPrefix,
+  };
+}

--- a/infra/pulumi/src/index.ts
+++ b/infra/pulumi/src/index.ts
@@ -1,0 +1,42 @@
+import * as pulumi from "@pulumi/pulumi";
+import { createAwsGoldenHost } from "./aws.js";
+import { createCloudflareTeamVault } from "./cloudflare.js";
+import { createGcpGoldenHost } from "./gcp.js";
+import { loadProvisionInputs } from "./pulumi-config.js";
+
+const inputs = loadProvisionInputs();
+
+export const cloud = inputs.cloud;
+export const tier = inputs.tier;
+export const syncPrefix = inputs.syncPrefix ?? "";
+export const syncBucket = inputs.syncBucket;
+
+export let instanceId: pulumi.Output<string> | undefined;
+export let publicIp: pulumi.Output<string> | undefined;
+export let instanceName: pulumi.Output<string> | undefined;
+export let externalIp: pulumi.Output<string | undefined> | undefined;
+export let bucketName: pulumi.Output<string> | undefined;
+
+switch (inputs.cloud) {
+  case "aws": {
+    const awsOut = createAwsGoldenHost(inputs);
+    instanceId = awsOut.instanceId;
+    publicIp = awsOut.publicIp;
+    break;
+  }
+  case "gcp": {
+    const gcpOut = createGcpGoldenHost(inputs);
+    instanceName = gcpOut.instanceName;
+    externalIp = gcpOut.externalIp;
+    break;
+  }
+  case "cloudflare": {
+    const cfOut = createCloudflareTeamVault(inputs);
+    bucketName = cfOut.bucketName;
+    break;
+  }
+  default: {
+    const _exhaustive: never = inputs.cloud;
+    throw new Error(`Unsupported cloud: ${_exhaustive}`);
+  }
+}

--- a/infra/pulumi/src/pulumi-config.ts
+++ b/infra/pulumi/src/pulumi-config.ts
@@ -1,0 +1,53 @@
+import * as pulumi from "@pulumi/pulumi";
+import {
+  DEFAULT_INSTANCE_TYPES,
+  parseCloudTarget,
+  parseManagedTier,
+  parseSyncProvider,
+  type ProvisionInputs,
+} from "./types.js";
+import { syncPrefixForTier, ssmParameterPrefixForTenant } from "./tiers.js";
+
+/** Load stack config from Pulumi config namespace `clawql`. */
+export function loadProvisionInputs(): ProvisionInputs {
+  const cfg = new pulumi.Config("clawql");
+  const tier = parseManagedTier(cfg.get("tier"));
+  const tenantId = cfg.get("tenantId") ?? undefined;
+  const cloud = parseCloudTarget(cfg.require("cloud"));
+
+  const syncBucket = cfg.require("syncBucket");
+  const syncProvider = parseSyncProvider(cfg.get("syncProvider"));
+  const syncPrefix = syncPrefixForTier(tier, {
+    tenantId,
+    customPrefix: cfg.get("syncPrefix") ?? undefined,
+  });
+
+  const goldenImageId = cfg.require("goldenImageId");
+  const region = cfg.get("region") ?? (cloud === "aws" ? "us-east-1" : "us-central1");
+  const instanceType = cfg.get("instanceType") ?? DEFAULT_INSTANCE_TYPES[cloud];
+
+  const useSsmSecrets = cfg.getBoolean("useSsmSecrets") ?? tier === "dedicated";
+  const ssmParameterPrefix =
+    cfg.get("ssmParameterPrefix") ??
+    (tenantId && useSsmSecrets ? ssmParameterPrefixForTenant(tenantId) : undefined);
+
+  const cloudflareAccountId = new pulumi.Config("cloudflare").get("accountId");
+  const gcpProject = new pulumi.Config("gcp").get("project");
+
+  return {
+    cloud,
+    tier,
+    tenantId,
+    syncBucket,
+    syncProvider,
+    syncPrefix,
+    goldenImageId,
+    instanceType,
+    region,
+    useSsmSecrets,
+    ssmParameterPrefix,
+    cloudflareAccountId,
+    gcpProject,
+    gcpZone: cfg.get("gcpZone") ?? `${region}-a`,
+  };
+}

--- a/infra/pulumi/src/tiers.test.ts
+++ b/infra/pulumi/src/tiers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { ssmParameterPrefixForTenant, syncPrefixForTier } from "./tiers.js";
+
+describe("syncPrefixForTier", () => {
+  it("returns shared/ for shared tier", () => {
+    expect(syncPrefixForTier("shared")).toBe("shared/");
+  });
+
+  it("returns tenant/{id}/ for dedicated tier", () => {
+    expect(syncPrefixForTier("dedicated", { tenantId: "acme" })).toBe("tenant/acme/");
+  });
+
+  it("throws when dedicated tier lacks tenantId", () => {
+    expect(() => syncPrefixForTier("dedicated")).toThrow(/tenantId/);
+  });
+
+  it("normalizes enterprise custom prefix with trailing slash", () => {
+    expect(syncPrefixForTier("enterprise", { customPrefix: "teams/prod" })).toBe("teams/prod/");
+    expect(syncPrefixForTier("enterprise", { customPrefix: "teams/prod/" })).toBe("teams/prod/");
+  });
+
+  it("throws when enterprise tier lacks syncPrefix", () => {
+    expect(() => syncPrefixForTier("enterprise")).toThrow(/syncPrefix/);
+  });
+});
+
+describe("ssmParameterPrefixForTenant", () => {
+  it("sanitizes tenant id for SSM path", () => {
+    expect(ssmParameterPrefixForTenant("Acme Corp!")).toBe("/clawql/tenants/Acme-Corp-/sync");
+  });
+});

--- a/infra/pulumi/src/tiers.ts
+++ b/infra/pulumi/src/tiers.ts
@@ -1,0 +1,32 @@
+import type { ManagedTier } from "./types.js";
+
+/** Team bucket prefix for managed tiers (no secrets). */
+export function syncPrefixForTier(
+  tier: ManagedTier,
+  opts: { tenantId?: string; customPrefix?: string } = {}
+): string {
+  switch (tier) {
+    case "shared":
+      return "shared/";
+    case "dedicated": {
+      const id = opts.tenantId?.trim();
+      if (!id) {
+        throw new Error("dedicated tier requires tenantId");
+      }
+      return `tenant/${id}/`;
+    }
+    case "enterprise": {
+      const prefix = opts.customPrefix?.trim();
+      if (!prefix) {
+        throw new Error("enterprise tier requires syncPrefix");
+      }
+      return prefix.endsWith("/") ? prefix : `${prefix}/`;
+    }
+  }
+}
+
+/** SSM path prefix for per-tenant sync credentials (AWS boot fetch). */
+export function ssmParameterPrefixForTenant(tenantId: string): string {
+  const safe = tenantId.replace(/[^a-zA-Z0-9_-]/g, "-");
+  return `/clawql/tenants/${safe}/sync`;
+}

--- a/infra/pulumi/src/types.ts
+++ b/infra/pulumi/src/types.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+
+export const ManagedTierSchema = z.enum(["shared", "dedicated", "enterprise"]);
+export type ManagedTier = z.infer<typeof ManagedTierSchema>;
+
+export const CloudTargetSchema = z.enum(["aws", "gcp", "cloudflare"]);
+export type CloudTarget = z.infer<typeof CloudTargetSchema>;
+
+export const SyncProviderSchema = z.enum(["r2", "s3", "gcs"]);
+export type SyncProvider = z.infer<typeof SyncProviderSchema>;
+
+/** Stack inputs (cloud-agnostic). */
+export type ProvisionInputs = {
+  cloud: CloudTarget;
+  tier: ManagedTier;
+  tenantId?: string;
+  syncBucket: string;
+  syncProvider: SyncProvider;
+  syncPrefix?: string;
+  goldenImageId: string;
+  instanceType: string;
+  region: string;
+  /** When true, user-data fetches sync credentials from SSM at boot (AWS). */
+  useSsmSecrets?: boolean;
+  ssmParameterPrefix?: string;
+  cloudflareAccountId?: string;
+  gcpProject?: string;
+  gcpZone?: string;
+};
+
+export const DEFAULT_INSTANCE_TYPES: Record<CloudTarget, string> = {
+  aws: "t3.medium",
+  gcp: "e2-medium",
+  cloudflare: "n/a",
+};
+
+export function parseManagedTier(raw: string | undefined): ManagedTier {
+  const parsed = ManagedTierSchema.safeParse(raw ?? "shared");
+  if (!parsed.success) {
+    throw new Error(`Invalid tier "${raw}" — expected shared | dedicated | enterprise`);
+  }
+  return parsed.data;
+}
+
+export function parseCloudTarget(raw: string | undefined): CloudTarget {
+  const parsed = CloudTargetSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(`Invalid cloud "${raw}" — expected aws | gcp | cloudflare`);
+  }
+  return parsed.data;
+}
+
+export function parseSyncProvider(raw: string | undefined): SyncProvider {
+  const parsed = SyncProviderSchema.safeParse(raw ?? "r2");
+  if (!parsed.success) {
+    throw new Error(`Invalid syncProvider "${raw}" — expected r2 | s3 | gcs`);
+  }
+  return parsed.data;
+}

--- a/infra/pulumi/src/user-data.test.ts
+++ b/infra/pulumi/src/user-data.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { buildBootstrapUserData, buildGcpStartupScript } from "./user-data.js";
+
+describe("buildBootstrapUserData", () => {
+  it("emits bucket, prefix, provider, and bootstrap script", () => {
+    const script = buildBootstrapUserData({
+      bucket: "acme-team",
+      prefix: "shared/",
+      syncProvider: "r2",
+    });
+
+    expect(script).toMatch(/^#!\/bin\/bash/);
+    expect(script).toContain('export CLAWQL_SYNC_BUCKET="acme-team"');
+    expect(script).toContain('export CLAWQL_SYNC_PREFIX="shared/"');
+    expect(script).toContain('export CLAWQL_SYNC_PROVIDER="r2"');
+    expect(script).toContain("exec /usr/local/bin/bootstrap-team-vault.sh");
+    expect(script).not.toContain("SSM_PREFIX");
+  });
+
+  it("includes SSM credential fetch when ssmParameterPrefix is set", () => {
+    const script = buildBootstrapUserData({
+      bucket: "acme-team",
+      prefix: "tenant/acme/",
+      syncProvider: "s3",
+      ssmParameterPrefix: "/clawql/tenants/acme/sync",
+    });
+
+    expect(script).toContain('SSM_PREFIX="/clawql/tenants/acme/sync"');
+    expect(script).toContain("aws ssm get-parameter");
+    expect(script).toContain("CLAWQL_SYNC_ACCESS_KEY_ID");
+  });
+
+  it("escapes shell metacharacters in values", () => {
+    const script = buildBootstrapUserData({
+      bucket: 'bucket"with$quotes',
+      prefix: "shared/",
+      syncProvider: "r2",
+    });
+
+    expect(script).toContain('export CLAWQL_SYNC_BUCKET="bucket\\"with\\$quotes"');
+  });
+});
+
+describe("buildGcpStartupScript", () => {
+  it("matches AWS user-data bash", () => {
+    const opts = { bucket: "gcs-bucket", prefix: "shared/", syncProvider: "gcs" as const };
+    expect(buildGcpStartupScript(opts)).toBe(buildBootstrapUserData(opts));
+  });
+});

--- a/infra/pulumi/src/user-data.ts
+++ b/infra/pulumi/src/user-data.ts
@@ -1,0 +1,54 @@
+import type { SyncProvider } from "./types.js";
+
+export type BootstrapUserDataOptions = {
+  bucket: string;
+  prefix: string;
+  syncProvider: SyncProvider;
+  /** When set, bootstrap loads credentials from AWS SSM Parameter Store at boot. */
+  ssmParameterPrefix?: string;
+};
+
+/**
+ * Cloud-init bash for golden Packer images: set non-secret sync config, then run
+ * `/usr/local/bin/bootstrap-team-vault.sh` (credentials via env or SSM).
+ */
+export function buildBootstrapUserData(opts: BootstrapUserDataOptions): string {
+  const lines: string[] = [
+    "#!/bin/bash",
+    "set -euo pipefail",
+    'export CLAWQL_SYNC_BUCKET="' + escapeShellDoubleQuoted(opts.bucket) + '"',
+    'export CLAWQL_SYNC_PREFIX="' + escapeShellDoubleQuoted(opts.prefix) + '"',
+    'export CLAWQL_SYNC_PROVIDER="' + escapeShellDoubleQuoted(opts.syncProvider) + '"',
+  ];
+
+  if (opts.ssmParameterPrefix) {
+    const p = escapeShellDoubleQuoted(opts.ssmParameterPrefix);
+    lines.push(
+      `SSM_PREFIX="${p}"`,
+      'if command -v aws >/dev/null 2>&1; then',
+      '  export CLAWQL_SYNC_ACCESS_KEY_ID="$(aws ssm get-parameter --name "${SSM_PREFIX}/access-key-id" --with-decryption --query Parameter.Value --output text 2>/dev/null || true)"',
+      '  export CLAWQL_SYNC_SECRET_ACCESS_KEY="$(aws ssm get-parameter --name "${SSM_PREFIX}/secret-access-key" --with-decryption --query Parameter.Value --output text 2>/dev/null || true)"',
+      '  export CLAWQL_R2_ACCOUNT_ID="$(aws ssm get-parameter --name "${SSM_PREFIX}/r2-account-id" --with-decryption --query Parameter.Value --output text 2>/dev/null || true)"',
+      "fi"
+    );
+  }
+
+  lines.push(
+    'if [ -x /usr/local/bin/bootstrap-team-vault.sh ]; then',
+    "  exec /usr/local/bin/bootstrap-team-vault.sh",
+    "fi",
+    'echo "[user-data] bootstrap-team-vault.sh not found" >&2',
+    "exit 1"
+  );
+
+  return lines.join("\n") + "\n";
+}
+
+/** GCP metadata startup-script (same bash as AWS user-data). */
+export function buildGcpStartupScript(opts: BootstrapUserDataOptions): string {
+  return buildBootstrapUserData(opts);
+}
+
+function escapeShellDoubleQuoted(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\$/g, "\\$");
+}

--- a/infra/pulumi/tsconfig.json
+++ b/infra/pulumi/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/infra/pulumi/vitest.config.ts
+++ b/infra/pulumi/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
             "version": "7.0.0",
             "license": "Apache-2.0",
             "workspaces": [
-                "packages/*"
+                "packages/*",
+                "infra/pulumi"
             ],
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.1084.0",
@@ -69,6 +70,26 @@
                 "typescript": "^6.0.3",
                 "typescript-eslint": "^8.62.1",
                 "vitest": "^4.1.7"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "infra/pulumi": {
+            "name": "clawql-provision",
+            "version": "7.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@pulumi/aws": "^6.83.0",
+                "@pulumi/cloudflare": "^6.4.0",
+                "@pulumi/gcp": "^8.36.0",
+                "@pulumi/pulumi": "^3.210.0",
+                "zod": "4.3.6"
+            },
+            "devDependencies": {
+                "@types/node": "^26.1.1",
+                "typescript": "^6.0.2",
+                "vitest": "^4.1.1"
             },
             "engines": {
                 "node": ">=22"
@@ -1124,6 +1145,15 @@
             "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
             "license": "MIT"
         },
+        "node_modules/@gar/promise-retry": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
+            "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
+            "license": "MIT",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/@graphql-hive/logger": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@graphql-hive/logger/-/logger-1.1.1.tgz",
@@ -1676,6 +1706,120 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "license": "MIT"
+        },
+        "node_modules/@isaacs/cliui/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/fs-minipass": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+            "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.4"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@isaacs/string-locale-compare": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
+            "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
+            "license": "ISC"
+        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1814,6 +1958,15 @@
             "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
             "license": "MIT"
         },
+        "node_modules/@logdna/tail-file": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@logdna/tail-file/-/tail-file-2.2.0.tgz",
+            "integrity": "sha512-XGSsWDweP80Fks16lwkAUIr54ICyBs6PsI4mpfTLQaWgEJRtY9xEV+PeyDpJ+sJEGZxqINlpmAwe/6tS1pP8Ng==",
+            "license": "SEE LICENSE IN LICENSE",
+            "engines": {
+                "node": ">=10.3.0"
+            }
+        },
         "node_modules/@modelcontextprotocol/sdk": {
             "version": "1.29.0",
             "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -1871,6 +2024,845 @@
             "peerDependencies": {
                 "@emnapi/core": "^1.7.1",
                 "@emnapi/runtime": "^1.7.1"
+            }
+        },
+        "node_modules/@npmcli/agent": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.2.tgz",
+            "integrity": "sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==",
+            "license": "ISC",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.1",
+                "lru-cache": "^11.2.1",
+                "socks-proxy-agent": "^8.0.3"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/agent/node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@npmcli/arborist": {
+            "version": "9.9.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-9.9.0.tgz",
+            "integrity": "sha512-tzsb1R8mx0k0drlLDT/9ckEYaQHIaWnUti/ci2IaFoQqdqwfmYrc+90p1+QEZC/ocvqcxBep9P1xKw4FbAGofw==",
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@isaacs/string-locale-compare": "^1.1.0",
+                "@npmcli/fs": "^5.0.0",
+                "@npmcli/installed-package-contents": "^4.0.0",
+                "@npmcli/map-workspaces": "^5.0.0",
+                "@npmcli/metavuln-calculator": "^9.0.2",
+                "@npmcli/name-from-folder": "^4.0.0",
+                "@npmcli/node-gyp": "^5.0.0",
+                "@npmcli/package-json": "^7.0.0",
+                "@npmcli/query": "^5.0.0",
+                "@npmcli/redact": "^4.0.0",
+                "@npmcli/run-script": "^10.0.0",
+                "bin-links": "^6.0.0",
+                "cacache": "^20.0.1",
+                "common-ancestor-path": "^2.0.0",
+                "hosted-git-info": "^9.0.0",
+                "json-stringify-nice": "^1.1.4",
+                "lru-cache": "^11.2.1",
+                "minimatch": "^10.0.3",
+                "nopt": "^9.0.0",
+                "npm-install-checks": "^8.0.0",
+                "npm-package-arg": "^13.0.0",
+                "npm-pick-manifest": "^11.0.1",
+                "npm-registry-fetch": "^19.0.0",
+                "pacote": "^21.0.2",
+                "parse-conflict-json": "^5.0.1",
+                "proc-log": "^6.0.0",
+                "proggy": "^4.0.0",
+                "promise-all-reject-late": "^1.0.0",
+                "promise-call-limit": "^3.0.1",
+                "semver": "^7.3.7",
+                "ssri": "^13.0.0",
+                "treeverse": "^3.0.0",
+                "walk-up-path": "^4.0.0"
+            },
+            "bin": {
+                "arborist": "bin/index.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/arborist/node_modules/@npmcli/git": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.2.tgz",
+            "integrity": "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==",
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@npmcli/promise-spawn": "^9.0.0",
+                "ini": "^6.0.0",
+                "lru-cache": "^11.2.1",
+                "npm-pick-manifest": "^11.0.1",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5",
+                "which": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/arborist/node_modules/@npmcli/package-json": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.5.tgz",
+            "integrity": "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==",
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/git": "^7.0.0",
+                "glob": "^13.0.0",
+                "hosted-git-info": "^9.0.0",
+                "json-parse-even-better-errors": "^5.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.5.3",
+                "spdx-expression-parse": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/arborist/node_modules/@npmcli/promise-spawn": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
+            "integrity": "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==",
+            "license": "ISC",
+            "dependencies": {
+                "which": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/arborist/node_modules/glob": {
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@npmcli/arborist/node_modules/hosted-git-info": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^11.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/arborist/node_modules/ini": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+            "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/arborist/node_modules/isexe": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+            "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@npmcli/arborist/node_modules/json-parse-even-better-errors": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
+            "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/arborist/node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@npmcli/arborist/node_modules/npm-pick-manifest": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
+            "integrity": "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==",
+            "license": "ISC",
+            "dependencies": {
+                "npm-install-checks": "^8.0.0",
+                "npm-normalize-package-bin": "^5.0.0",
+                "npm-package-arg": "^13.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/arborist/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@npmcli/arborist/node_modules/proc-log": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/arborist/node_modules/spdx-expression-parse": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+            "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/@npmcli/arborist/node_modules/which": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+            "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^4.0.0"
+            },
+            "bin": {
+                "node-which": "bin/which.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/fs": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+            "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+            "license": "ISC",
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/git": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-6.0.3.tgz",
+            "integrity": "sha512-GUYESQlxZRAdhs3UhbB6pVRNUELQOHXwK9ruDkwmCv2aZ5y0SApQzUJCg02p3A7Ue2J5hxvlk1YI53c00NmRyQ==",
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/promise-spawn": "^8.0.0",
+                "ini": "^5.0.0",
+                "lru-cache": "^10.0.1",
+                "npm-pick-manifest": "^10.0.0",
+                "proc-log": "^5.0.0",
+                "promise-retry": "^2.0.1",
+                "semver": "^7.3.5",
+                "which": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/@npmcli/git/node_modules/isexe": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+            "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@npmcli/git/node_modules/which": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+            "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^3.1.1"
+            },
+            "bin": {
+                "node-which": "bin/which.js"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/@npmcli/installed-package-contents": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
+            "integrity": "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==",
+            "license": "ISC",
+            "dependencies": {
+                "npm-bundled": "^5.0.0",
+                "npm-normalize-package-bin": "^5.0.0"
+            },
+            "bin": {
+                "installed-package-contents": "bin/index.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/map-workspaces": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-5.0.3.tgz",
+            "integrity": "sha512-o2grssXo1e774E5OtEwwrgoszYRh0lqkJH+Pb9r78UcqdGJRDRfhpM8DvZPjzNLLNYeD/rNbjOKM3Ss5UABROw==",
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/name-from-folder": "^4.0.0",
+                "@npmcli/package-json": "^7.0.0",
+                "glob": "^13.0.0",
+                "minimatch": "^10.0.3"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/map-workspaces/node_modules/@npmcli/git": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.2.tgz",
+            "integrity": "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==",
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@npmcli/promise-spawn": "^9.0.0",
+                "ini": "^6.0.0",
+                "lru-cache": "^11.2.1",
+                "npm-pick-manifest": "^11.0.1",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5",
+                "which": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/map-workspaces/node_modules/@npmcli/package-json": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.5.tgz",
+            "integrity": "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==",
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/git": "^7.0.0",
+                "glob": "^13.0.0",
+                "hosted-git-info": "^9.0.0",
+                "json-parse-even-better-errors": "^5.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.5.3",
+                "spdx-expression-parse": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/map-workspaces/node_modules/@npmcli/promise-spawn": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
+            "integrity": "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==",
+            "license": "ISC",
+            "dependencies": {
+                "which": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/map-workspaces/node_modules/glob": {
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@npmcli/map-workspaces/node_modules/hosted-git-info": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^11.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/map-workspaces/node_modules/ini": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+            "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/map-workspaces/node_modules/isexe": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+            "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@npmcli/map-workspaces/node_modules/json-parse-even-better-errors": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
+            "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/map-workspaces/node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@npmcli/map-workspaces/node_modules/npm-pick-manifest": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
+            "integrity": "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==",
+            "license": "ISC",
+            "dependencies": {
+                "npm-install-checks": "^8.0.0",
+                "npm-normalize-package-bin": "^5.0.0",
+                "npm-package-arg": "^13.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/map-workspaces/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@npmcli/map-workspaces/node_modules/proc-log": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/map-workspaces/node_modules/spdx-expression-parse": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+            "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/@npmcli/map-workspaces/node_modules/which": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+            "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^4.0.0"
+            },
+            "bin": {
+                "node-which": "bin/which.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/metavuln-calculator": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/@npmcli/metavuln-calculator/-/metavuln-calculator-9.0.3.tgz",
+            "integrity": "sha512-94GLSYhLXF2t2LAC7pDwLaM4uCARzxShyAQKsirmlNcpidH89VA4/+K1LbJmRMgz5gy65E/QBBWQdUvGLe2Frg==",
+            "license": "ISC",
+            "dependencies": {
+                "cacache": "^20.0.0",
+                "json-parse-even-better-errors": "^5.0.0",
+                "pacote": "^21.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/metavuln-calculator/node_modules/json-parse-even-better-errors": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
+            "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/metavuln-calculator/node_modules/proc-log": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/name-from-folder": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-4.0.0.tgz",
+            "integrity": "sha512-qfrhVlOSqmKM8i6rkNdZzABj8MKEITGFAY+4teqBziksCQAOLutiAxM1wY2BKEd8KjUSpWmWCYxvXr0y4VTlPg==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/node-gyp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-5.0.0.tgz",
+            "integrity": "sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/package-json": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-6.2.0.tgz",
+            "integrity": "sha512-rCNLSB/JzNvot0SEyXqWZ7tX2B5dD2a1br2Dp0vSYVo5jh8Z0EZ7lS9TsZ1UtziddB1UfNUaMCc538/HztnJGA==",
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/git": "^6.0.0",
+                "glob": "^10.2.2",
+                "hosted-git-info": "^8.0.0",
+                "json-parse-even-better-errors": "^4.0.0",
+                "proc-log": "^5.0.0",
+                "semver": "^7.5.3",
+                "validate-npm-package-license": "^3.0.4"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/@npmcli/promise-spawn": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-8.0.3.tgz",
+            "integrity": "sha512-Yb00SWaL4F8w+K8YGhQ55+xE4RUNdMHV43WZGsiTM92gS+lC0mGsn7I4hLug7pbao035S6bj3Y3w0cUNGLfmkg==",
+            "license": "ISC",
+            "dependencies": {
+                "which": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/@npmcli/promise-spawn/node_modules/isexe": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+            "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@npmcli/promise-spawn/node_modules/which": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+            "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^3.1.1"
+            },
+            "bin": {
+                "node-which": "bin/which.js"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/@npmcli/query": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/query/-/query-5.0.0.tgz",
+            "integrity": "sha512-8TZWfTQOsODpLqo9SVhVjHovmKXNpevHU0gO9e+y4V4fRIOneiXy0u0sMP9LmS71XivrEWfZWg50ReH4WRT4aQ==",
+            "license": "ISC",
+            "dependencies": {
+                "postcss-selector-parser": "^7.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/redact": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+            "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/run-script": {
+            "version": "10.0.4",
+            "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-10.0.4.tgz",
+            "integrity": "sha512-mGUWr1uMnf0le2TwfOZY4SFxZGXGfm4Jtay/nwAa2FLNAKXUoUwaGwBMNH36UHPtinWfTSJ3nqFQr0091CxVGg==",
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/node-gyp": "^5.0.0",
+                "@npmcli/package-json": "^7.0.0",
+                "@npmcli/promise-spawn": "^9.0.0",
+                "node-gyp": "^12.1.0",
+                "proc-log": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/run-script/node_modules/@npmcli/git": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.2.tgz",
+            "integrity": "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==",
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@npmcli/promise-spawn": "^9.0.0",
+                "ini": "^6.0.0",
+                "lru-cache": "^11.2.1",
+                "npm-pick-manifest": "^11.0.1",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5",
+                "which": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/run-script/node_modules/@npmcli/package-json": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.5.tgz",
+            "integrity": "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==",
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/git": "^7.0.0",
+                "glob": "^13.0.0",
+                "hosted-git-info": "^9.0.0",
+                "json-parse-even-better-errors": "^5.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.5.3",
+                "spdx-expression-parse": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/run-script/node_modules/@npmcli/promise-spawn": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
+            "integrity": "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==",
+            "license": "ISC",
+            "dependencies": {
+                "which": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/run-script/node_modules/glob": {
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@npmcli/run-script/node_modules/hosted-git-info": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^11.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/run-script/node_modules/ini": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+            "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/run-script/node_modules/isexe": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+            "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@npmcli/run-script/node_modules/json-parse-even-better-errors": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
+            "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/run-script/node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@npmcli/run-script/node_modules/npm-pick-manifest": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
+            "integrity": "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==",
+            "license": "ISC",
+            "dependencies": {
+                "npm-install-checks": "^8.0.0",
+                "npm-normalize-package-bin": "^5.0.0",
+                "npm-package-arg": "^13.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/run-script/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@npmcli/run-script/node_modules/proc-log": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/run-script/node_modules/spdx-expression-parse": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+            "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/@npmcli/run-script/node_modules/which": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+            "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^4.0.0"
+            },
+            "bin": {
+                "node-which": "bin/which.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/@omnigraph/json-schema": {
@@ -1982,6 +2974,151 @@
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.57.2.tgz",
+            "integrity": "sha512-gHU1vA3JnHbNxEXg5iysqCWxN9j83d7/epTYBZflqQnTyCC4N7yZXn/dMM+bEmyhQPGjhCkNZLx4vZuChH1PYw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.7.1",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/otlp-exporter-base": "0.57.2",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.57.2",
+                "@opentelemetry/otlp-transformer": "0.57.2",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/sdk-trace-base": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.57.2.tgz",
+            "integrity": "sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/otlp-transformer": "0.57.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.2.tgz",
+            "integrity": "sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/sdk-logs": "0.57.2",
+                "@opentelemetry/sdk-metrics": "1.30.1",
+                "@opentelemetry/sdk-trace-base": "1.30.1",
+                "protobufjs": "^7.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/resources": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+            "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.2.tgz",
+            "integrity": "sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/sdk-metrics": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
+            "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+            "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.28.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@opentelemetry/exporter-trace-otlp-http": {
             "version": "0.220.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.220.0.tgz",
@@ -2001,6 +3138,123 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
+        "node_modules/@opentelemetry/exporter-zipkin": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.30.1.tgz",
+            "integrity": "sha512-6S2QIMJahIquvFaaxmcwpvQQRD/YFaMTNoIxrfPIPOeITN+a8lfEcPDxNxn8JDAaxkg+4EnXhz8upVDYenoQjA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/sdk-trace-base": "1.30.1",
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/resources": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+            "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+            "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.28.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-grpc": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.57.2.tgz",
+            "integrity": "sha512-TR6YQA67cLSZzdxbf2SrbADJy2Y8eBW1+9mF15P0VK2MYcpdoUSmQTF1oMkBwa3B9NwqDFA2fq7wYTTutFQqaQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "0.57.2",
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-grpc/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.28.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@opentelemetry/otlp-exporter-base": {
             "version": "0.220.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.220.0.tgz",
@@ -2015,6 +3269,148 @@
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.57.2.tgz",
+            "integrity": "sha512-USn173KTWy0saqqRB5yU9xUZ2xdgb1Rdu5IosJnm9aV4hMTuFFRTUsQxbgc24QxpCHeoKzzCSnS/JzdV0oM2iQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.7.1",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/otlp-exporter-base": "0.57.2",
+                "@opentelemetry/otlp-transformer": "0.57.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.57.2.tgz",
+            "integrity": "sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/otlp-transformer": "0.57.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.2.tgz",
+            "integrity": "sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/sdk-logs": "0.57.2",
+                "@opentelemetry/sdk-metrics": "1.30.1",
+                "@opentelemetry/sdk-trace-base": "1.30.1",
+                "protobufjs": "^7.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/resources": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+            "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.2.tgz",
+            "integrity": "sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/sdk-metrics": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
+            "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+            "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.28.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@opentelemetry/otlp-transformer": {
@@ -2035,6 +3431,36 @@
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/propagator-b3": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.30.1.tgz",
+            "integrity": "sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/propagator-jaeger": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.30.1.tgz",
+            "integrity": "sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/resources": {
@@ -2156,6 +3582,220 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@pulumi/aws": {
+            "version": "6.83.4",
+            "resolved": "https://registry.npmjs.org/@pulumi/aws/-/aws-6.83.4.tgz",
+            "integrity": "sha512-mk3LhRJF6BdOq7VAWtrZpv+loLdaPxvbOVTESommiYXlSX87xXA8mytQCaeIXaivtpdj+xcBOJ8vz0A0Ktmw9g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@pulumi/pulumi": "^3.142.0",
+                "mime": "^2.0.0"
+            }
+        },
+        "node_modules/@pulumi/cloudflare": {
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/cloudflare/-/cloudflare-6.17.0.tgz",
+            "integrity": "sha512-sIL1rfjNavy+yZQ/OjyFHD4owe2E/TpHLFCVsogQJOC+Y6Bj7JxrhoTfsJdxVEXEFBGlNCu68T+g9im8iEZM9A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@pulumi/pulumi": "^3.142.0"
+            }
+        },
+        "node_modules/@pulumi/gcp": {
+            "version": "8.41.1",
+            "resolved": "https://registry.npmjs.org/@pulumi/gcp/-/gcp-8.41.1.tgz",
+            "integrity": "sha512-cEuhyrys+h2HMMdAKIXT6QDjjMzQRDUDV9CytIw146lpXp2bACUr4NwMefX7LgzUW+ebs7t7YClU/sNbI3OaDw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@npmcli/package-json": "^6.2.0",
+                "@pulumi/pulumi": "^3.142.0",
+                "@types/express": "^4.16.0"
+            }
+        },
+        "node_modules/@pulumi/gcp/node_modules/@types/express": {
+            "version": "4.17.25",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+            "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/body-parser": "*",
+                "@types/express-serve-static-core": "^4.17.33",
+                "@types/qs": "*",
+                "@types/serve-static": "^1"
+            }
+        },
+        "node_modules/@pulumi/gcp/node_modules/@types/express-serve-static-core": {
+            "version": "4.19.9",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
+            "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*",
+                "@types/send": "*"
+            }
+        },
+        "node_modules/@pulumi/gcp/node_modules/@types/send": {
+            "version": "0.17.6",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+            "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mime": "^1",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@pulumi/gcp/node_modules/@types/serve-static": {
+            "version": "1.15.10",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+            "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/http-errors": "*",
+                "@types/node": "*",
+                "@types/send": "<1"
+            }
+        },
+        "node_modules/@pulumi/pulumi": {
+            "version": "3.251.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-3.251.0.tgz",
+            "integrity": "sha512-gtpkmQRPsEv8ll0fPHDqIDqSa8mapFqeV06QWYOMLDHj28/wNE13pNZ6jYcteYDdNCgsf4qesw8toOlWqEDQig==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.10.1",
+                "@logdna/tail-file": "^2.0.6",
+                "@npmcli/arborist": "^9.0.0",
+                "@opentelemetry/api": "^1.9",
+                "@opentelemetry/exporter-trace-otlp-grpc": "^0.57",
+                "@opentelemetry/exporter-zipkin": "^1.30",
+                "@opentelemetry/instrumentation": "^0.57",
+                "@opentelemetry/instrumentation-grpc": "^0.57",
+                "@opentelemetry/resources": "^1.30",
+                "@opentelemetry/sdk-trace-base": "^1.30",
+                "@opentelemetry/sdk-trace-node": "^1.30",
+                "@types/google-protobuf": "^3.15.5",
+                "@types/semver": "^7.5.6",
+                "execa": "^5.1.0",
+                "google-protobuf": "^3.21.4",
+                "ini": "^2.0.0",
+                "js-yaml": "^4.0.0",
+                "minimist": "^1.2.6",
+                "normalize-package-data": "^6.0.0",
+                "require-from-string": "^2.0.1",
+                "semver": "^7.5.2",
+                "source-map-support": "^0.5.6",
+                "upath": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=22"
+            },
+            "peerDependencies": {
+                "ts-node": ">= 7.0.1 < 12",
+                "typescript": ">= 3.8.3 < 7"
+            },
+            "peerDependenciesMeta": {
+                "ts-node": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@pulumi/pulumi/node_modules/@opentelemetry/context-async-hooks": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
+            "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@pulumi/pulumi/node_modules/@opentelemetry/resources": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+            "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@pulumi/pulumi/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+            "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@pulumi/pulumi/node_modules/@opentelemetry/sdk-trace-node": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.30.1.tgz",
+            "integrity": "sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/context-async-hooks": "1.30.1",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/propagator-b3": "1.30.1",
+                "@opentelemetry/propagator-jaeger": "1.30.1",
+                "@opentelemetry/sdk-trace-base": "1.30.1",
+                "semver": "^7.5.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@pulumi/pulumi/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.28.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@pulumi/pulumi/node_modules/ini": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+            "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/@repeaterjs/repeater": {
@@ -2778,6 +4418,89 @@
                 "win32"
             ]
         },
+        "node_modules/@sigstore/bundle": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
+            "integrity": "sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/protobuf-specs": "^0.5.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@sigstore/core": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-3.2.1.tgz",
+            "integrity": "sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@sigstore/protobuf-specs": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.5.1.tgz",
+            "integrity": "sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/@sigstore/sign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.1.1.tgz",
+            "integrity": "sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.2",
+                "@sigstore/bundle": "^4.0.0",
+                "@sigstore/core": "^3.2.0",
+                "@sigstore/protobuf-specs": "^0.5.0",
+                "make-fetch-happen": "^15.0.4",
+                "proc-log": "^6.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@sigstore/sign/node_modules/proc-log": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@sigstore/tuf": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.2.tgz",
+            "integrity": "sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/protobuf-specs": "^0.5.0",
+                "tuf-js": "^4.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@sigstore/verify": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-3.1.1.tgz",
+            "integrity": "sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/bundle": "^4.0.0",
+                "@sigstore/core": "^3.2.1",
+                "@sigstore/protobuf-specs": "^0.5.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/@smithy/core": {
             "version": "3.29.2",
             "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.2.tgz",
@@ -2934,6 +4657,28 @@
                 "graphql": "^16.0.0"
             }
         },
+        "node_modules/@tufjs/canonical-json": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
+            "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==",
+            "license": "MIT",
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@tufjs/models": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-4.1.0.tgz",
+            "integrity": "sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==",
+            "license": "MIT",
+            "dependencies": {
+                "@tufjs/canonical-json": "2.0.0",
+                "minimatch": "^10.1.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/@turbo/darwin-64": {
             "version": "2.10.4",
             "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.10.4.tgz",
@@ -3033,7 +4778,6 @@
             "version": "1.19.6",
             "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
             "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/connect": "*",
@@ -3055,7 +4799,6 @@
             "version": "3.4.38",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
             "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
@@ -3114,11 +4857,16 @@
                 "@types/send": "*"
             }
         },
+        "node_modules/@types/google-protobuf": {
+            "version": "3.15.12",
+            "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.12.tgz",
+            "integrity": "sha512-40um9QqwHjRS92qnOaDpL7RmDK15NuZYo9HihiJRbYkMQZlWnuH8AdvbMy8/o6lgLmKbDUKa+OALCltHdbOTpQ==",
+            "license": "MIT"
+        },
         "node_modules/@types/http-errors": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
             "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/js-yaml": {
@@ -3132,6 +4880,12 @@
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/mime": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+            "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
             "license": "MIT"
         },
         "node_modules/@types/node": {
@@ -3169,14 +4923,18 @@
             "version": "6.15.1",
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
             "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/range-parser": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
             "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
             "license": "MIT"
         },
         "node_modules/@types/send": {
@@ -3199,6 +4957,12 @@
                 "@types/http-errors": "*",
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/shimmer": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+            "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+            "license": "MIT"
         },
         "node_modules/@types/sql.js": {
             "version": "1.4.11",
@@ -3647,6 +5411,15 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/abbrev": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+            "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/accepts": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -3664,13 +5437,21 @@
             "version": "8.17.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
             "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
             },
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-import-attributes": {
+            "version": "1.9.5",
+            "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+            "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "acorn": "^8"
             }
         },
         "node_modules/acorn-jsx": {
@@ -3893,6 +5674,31 @@
                 "bare-path": "^3.0.0"
             }
         },
+        "node_modules/bin-links": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.2.tgz",
+            "integrity": "sha512-frE1t78WOwJ45PKV2cF2tNPjTcs9L1J9s6VkrV59wanRP4GlaomuxYPVma7BwthMg8WnfSory4w5PTE6FZZ81w==",
+            "license": "ISC",
+            "dependencies": {
+                "cmd-shim": "^8.0.0",
+                "npm-normalize-package-bin": "^5.0.0",
+                "proc-log": "^6.0.0",
+                "read-cmd-shim": "^6.0.0",
+                "write-file-atomic": "^7.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/bin-links/node_modules/proc-log": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/bintrees": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
@@ -3960,6 +5766,12 @@
                 "node": "18 || 20 || >=22"
             }
         },
+        "node_modules/buffer-from": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "license": "MIT"
+        },
         "node_modules/bundle-require": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
@@ -3993,6 +5805,69 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/cacache": {
+            "version": "20.0.4",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+            "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/fs": "^5.0.0",
+                "fs-minipass": "^3.0.0",
+                "glob": "^13.0.0",
+                "lru-cache": "^11.1.0",
+                "minipass": "^7.0.3",
+                "minipass-collect": "^2.0.1",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "p-map": "^7.0.2",
+                "ssri": "^13.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/cacache/node_modules/glob": {
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/cacache/node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/cacache/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -4097,6 +5972,21 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/chownr": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/cjs-module-lexer": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+            "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+            "license": "MIT"
+        },
         "node_modules/clawql-api": {
             "resolved": "packages/clawql-api",
             "link": true
@@ -4133,6 +6023,10 @@
             "resolved": "packages/clawql-pageindex",
             "link": true
         },
+        "node_modules/clawql-provision": {
+            "resolved": "infra/pulumi",
+            "link": true
+        },
         "node_modules/clawql-release": {
             "resolved": "packages/clawql-release",
             "link": true
@@ -4153,6 +6047,15 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/cmd-shim": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
+            "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/color-convert": {
@@ -4193,6 +6096,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/common-ancestor-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
+            "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/confbox": {
@@ -4339,6 +6251,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/cssesc": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+            "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+            "license": "MIT",
+            "bin": {
+                "cssesc": "bin/cssesc"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/data-uri-to-buffer": {
@@ -4514,6 +6438,12 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "license": "MIT"
+        },
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -4565,6 +6495,21 @@
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
+        },
+        "node_modules/env-paths": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/err-code": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+            "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+            "license": "MIT"
         },
         "node_modules/es-define-property": {
             "version": "1.0.1",
@@ -4922,6 +6867,29 @@
                 "node": ">=18.0.0"
             }
         },
+        "node_modules/execa": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
         "node_modules/expect-type": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -4931,6 +6899,12 @@
             "engines": {
                 "node": ">=12.0.0"
             }
+        },
+        "node_modules/exponential-backoff": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+            "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+            "license": "Apache-2.0"
         },
         "node_modules/express": {
             "version": "5.2.1",
@@ -5067,7 +7041,6 @@
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
             "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12.0.0"
@@ -5194,6 +7167,34 @@
             "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==",
             "license": "MIT"
         },
+        "node_modules/foreground-child": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/foreground-child/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/form-data": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
@@ -5259,6 +7260,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/fs-minipass": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+            "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/fsevents": {
@@ -5331,6 +7344,39 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/glob-parent": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -5342,6 +7388,21 @@
             },
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/glob/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/google-proto-files": {
@@ -5357,6 +7418,12 @@
                 "node": ">=18"
             }
         },
+        "node_modules/google-protobuf": {
+            "version": "3.21.4",
+            "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
+            "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==",
+            "license": "(BSD-3-Clause AND Apache-2.0)"
+        },
         "node_modules/gopd": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5368,6 +7435,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "license": "ISC"
         },
         "node_modules/graphql": {
             "version": "16.14.2",
@@ -5512,6 +7585,18 @@
                 "node": ">=16.9.0"
             }
         },
+        "node_modules/hosted-git-info": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
+            "integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^10.0.1"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
         "node_modules/hpagent": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
@@ -5527,6 +7612,12 @@
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/http-cache-semantics": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+            "license": "BSD-2-Clause"
         },
         "node_modules/http-errors": {
             "version": "2.0.1",
@@ -5548,11 +7639,46 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/http2-client": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
             "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
             "license": "MIT"
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/human-signals": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
+            }
         },
         "node_modules/iconv-lite": {
             "version": "0.7.3",
@@ -5580,6 +7706,30 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/ignore-walk": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
+            "integrity": "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==",
+            "license": "ISC",
+            "dependencies": {
+                "minimatch": "^10.0.3"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/import-in-the-middle": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+            "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "acorn": "^8.14.0",
+                "acorn-import-attributes": "^1.9.5",
+                "cjs-module-lexer": "^1.2.2",
+                "module-details-from-path": "^1.0.3"
+            }
+        },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -5595,6 +7745,15 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "license": "ISC"
+        },
+        "node_modules/ini": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz",
+            "integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==",
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
         },
         "node_modules/ip-address": {
             "version": "10.1.1",
@@ -5612,6 +7771,21 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
+            }
+        },
+        "node_modules/is-core-module": {
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+            "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+            "license": "MIT",
+            "dependencies": {
+                "hasown": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-extglob": {
@@ -5651,6 +7825,18 @@
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
             "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
             "license": "MIT"
+        },
+        "node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -5704,6 +7890,21 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
             }
         },
         "node_modules/jose": {
@@ -5787,6 +7988,15 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-4.0.0.tgz",
+            "integrity": "sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA==",
+            "license": "MIT",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
         "node_modules/json-pointer": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.2.tgz",
@@ -5815,6 +8025,15 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/json-stringify-nice": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz",
+            "integrity": "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==",
+            "license": "ISC",
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/json5": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -5826,6 +8045,15 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/jsonparse": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+            "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+            "engines": [
+                "node >= 0.2.0"
+            ],
+            "license": "MIT"
         },
         "node_modules/jsonpath-plus": {
             "version": "10.4.0",
@@ -5844,6 +8072,18 @@
             "engines": {
                 "node": ">=18.0.0"
             }
+        },
+        "node_modules/just-diff": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/just-diff/-/just-diff-6.0.2.tgz",
+            "integrity": "sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==",
+            "license": "MIT"
+        },
+        "node_modules/just-diff-apply": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/just-diff-apply/-/just-diff-apply-5.5.0.tgz",
+            "integrity": "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw==",
+            "license": "MIT"
         },
         "node_modules/keyv": {
             "version": "4.5.4",
@@ -6253,6 +8493,12 @@
                 "tslib": "^2.0.3"
             }
         },
+        "node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "license": "ISC"
+        },
         "node_modules/magic-string": {
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6291,6 +8537,38 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/make-fetch-happen": {
+            "version": "15.0.6",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.6.tgz",
+            "integrity": "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==",
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@npmcli/agent": "^4.0.0",
+                "@npmcli/redact": "^4.0.0",
+                "cacache": "^20.0.1",
+                "http-cache-semantics": "^4.1.1",
+                "minipass": "^7.0.2",
+                "minipass-fetch": "^5.0.0",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "negotiator": "^1.0.0",
+                "proc-log": "^6.0.0",
+                "ssri": "^13.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/make-fetch-happen/node_modules/proc-log": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6325,6 +8603,24 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "license": "MIT"
+        },
+        "node_modules/mime": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+            "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+            "license": "MIT",
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
         "node_modules/mime-db": {
             "version": "1.54.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -6350,6 +8646,15 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/minimatch": {
             "version": "10.2.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -6365,6 +8670,137 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/minipass": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/minipass-collect": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+            "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/minipass-fetch": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
+            "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.0.3",
+                "minipass-sized": "^2.0.0",
+                "minizlib": "^3.0.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            },
+            "optionalDependencies": {
+                "iconv-lite": "^0.7.2"
+            }
+        },
+        "node_modules/minipass-flush": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+            "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/minipass-flush/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-flush/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "license": "ISC"
+        },
+        "node_modules/minipass-pipeline": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+            "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-pipeline/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-pipeline/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "license": "ISC"
+        },
+        "node_modules/minipass-sized": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
+            "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minizlib": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
         "node_modules/mlly": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -6377,6 +8813,12 @@
                 "pkg-types": "^1.3.1",
                 "ufo": "^1.6.3"
             }
+        },
+        "node_modules/module-details-from-path": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+            "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+            "license": "MIT"
         },
         "node_modules/ms": {
             "version": "2.1.3",
@@ -6516,6 +8958,63 @@
                 "node": "4.x || >=6.0.0"
             }
         },
+        "node_modules/node-gyp": {
+            "version": "12.4.0",
+            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+            "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
+            "license": "MIT",
+            "dependencies": {
+                "env-paths": "^2.2.0",
+                "exponential-backoff": "^3.1.1",
+                "graceful-fs": "^4.2.6",
+                "nopt": "^9.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5",
+                "tar": "^7.5.4",
+                "tinyglobby": "^0.2.12",
+                "undici": "^6.25.0",
+                "which": "^6.0.0"
+            },
+            "bin": {
+                "node-gyp": "bin/node-gyp.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/node-gyp/node_modules/isexe": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+            "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/node-gyp/node_modules/proc-log": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/node-gyp/node_modules/which": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+            "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^4.0.0"
+            },
+            "bin": {
+                "node-which": "bin/which.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/node-html-markdown": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/node-html-markdown/-/node-html-markdown-2.0.0.tgz",
@@ -6545,6 +9044,247 @@
             "license": "MIT",
             "dependencies": {
                 "es6-promise": "^3.2.1"
+            }
+        },
+        "node_modules/nopt": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+            "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+            "license": "ISC",
+            "dependencies": {
+                "abbrev": "^4.0.0"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/normalize-package-data": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+            "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "hosted-git-info": "^7.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-license": "^3.0.4"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/normalize-package-data/node_modules/hosted-git-info": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+            "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^10.0.1"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/npm-bundled": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-5.0.0.tgz",
+            "integrity": "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==",
+            "license": "ISC",
+            "dependencies": {
+                "npm-normalize-package-bin": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm-install-checks": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-8.0.0.tgz",
+            "integrity": "sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "semver": "^7.1.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm-normalize-package-bin": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+            "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm-package-arg": {
+            "version": "13.0.2",
+            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+            "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
+            "license": "ISC",
+            "dependencies": {
+                "hosted-git-info": "^9.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-name": "^7.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm-package-arg/node_modules/hosted-git-info": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^11.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm-package-arg/node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/npm-package-arg/node_modules/proc-log": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm-packlist": {
+            "version": "10.0.4",
+            "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.4.tgz",
+            "integrity": "sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==",
+            "license": "ISC",
+            "dependencies": {
+                "ignore-walk": "^8.0.0",
+                "proc-log": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm-packlist/node_modules/proc-log": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm-pick-manifest": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-10.0.0.tgz",
+            "integrity": "sha512-r4fFa4FqYY8xaM7fHecQ9Z2nE9hgNfJR+EmoKv0+chvzWkBcORX3r0FpTByP+CbOVJDladMXnPQGVN8PBLGuTQ==",
+            "license": "ISC",
+            "dependencies": {
+                "npm-install-checks": "^7.1.0",
+                "npm-normalize-package-bin": "^4.0.0",
+                "npm-package-arg": "^12.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm-pick-manifest/node_modules/npm-install-checks": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-7.1.2.tgz",
+            "integrity": "sha512-z9HJBCYw9Zr8BqXcllKIs5nI+QggAImbBdHphOzVYrz2CB4iQ6FzWyKmlqDZua+51nAu7FcemlbTc9VgQN5XDQ==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "semver": "^7.1.1"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-4.0.0.tgz",
+            "integrity": "sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==",
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm-pick-manifest/node_modules/npm-package-arg": {
+            "version": "12.0.2",
+            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-12.0.2.tgz",
+            "integrity": "sha512-f1NpFjNI9O4VbKMOlA5QoBq/vSQPORHcTZ2feJpFkTHJ9eQkdlmZEKSjcAhxTGInC7RlEyScT9ui67NaOsjFWA==",
+            "license": "ISC",
+            "dependencies": {
+                "hosted-git-info": "^8.0.0",
+                "proc-log": "^5.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-name": "^6.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm-pick-manifest/node_modules/validate-npm-package-name": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-6.0.2.tgz",
+            "integrity": "sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm-registry-fetch": {
+            "version": "19.1.1",
+            "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-19.1.1.tgz",
+            "integrity": "sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==",
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/redact": "^4.0.0",
+                "jsonparse": "^1.3.1",
+                "make-fetch-happen": "^15.0.0",
+                "minipass": "^7.0.2",
+                "minipass-fetch": "^5.0.0",
+                "minizlib": "^3.0.1",
+                "npm-package-arg": "^13.0.0",
+                "proc-log": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm-registry-fetch/node_modules/proc-log": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm-run-path": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/nth-check": {
@@ -6721,6 +9461,21 @@
                 "wrappy": "1"
             }
         },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/openapi-types": {
             "version": "12.1.3",
             "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
@@ -6790,6 +9545,234 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/p-map": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
+            "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "license": "BlueOak-1.0.0"
+        },
+        "node_modules/pacote": {
+            "version": "21.5.1",
+            "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.1.tgz",
+            "integrity": "sha512-KvcJ9iy3crysCsgqc4+PknH/w6jkrp8JN36mpZBPwNaDRwTfMZD37YzRazNstiZUOhuF5pno9f78n9mEJBavwg==",
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@npmcli/git": "^7.0.0",
+                "@npmcli/installed-package-contents": "^4.0.0",
+                "@npmcli/package-json": "^7.0.0",
+                "@npmcli/promise-spawn": "^9.0.0",
+                "@npmcli/run-script": "^10.0.0",
+                "cacache": "^20.0.0",
+                "fs-minipass": "^3.0.0",
+                "minipass": "^7.0.2",
+                "npm-package-arg": "^13.0.0",
+                "npm-packlist": "^10.0.1",
+                "npm-pick-manifest": "^11.0.1",
+                "npm-registry-fetch": "^19.0.0",
+                "proc-log": "^6.0.0",
+                "sigstore": "^4.0.0",
+                "ssri": "^13.0.0",
+                "tar": "^7.4.3"
+            },
+            "bin": {
+                "pacote": "bin/index.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/pacote/node_modules/@npmcli/git": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.2.tgz",
+            "integrity": "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==",
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@npmcli/promise-spawn": "^9.0.0",
+                "ini": "^6.0.0",
+                "lru-cache": "^11.2.1",
+                "npm-pick-manifest": "^11.0.1",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5",
+                "which": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/pacote/node_modules/@npmcli/package-json": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.5.tgz",
+            "integrity": "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==",
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/git": "^7.0.0",
+                "glob": "^13.0.0",
+                "hosted-git-info": "^9.0.0",
+                "json-parse-even-better-errors": "^5.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.5.3",
+                "spdx-expression-parse": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/pacote/node_modules/@npmcli/promise-spawn": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
+            "integrity": "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==",
+            "license": "ISC",
+            "dependencies": {
+                "which": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/pacote/node_modules/glob": {
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/pacote/node_modules/hosted-git-info": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^11.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/pacote/node_modules/ini": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+            "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/pacote/node_modules/isexe": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+            "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/pacote/node_modules/json-parse-even-better-errors": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
+            "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/pacote/node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/pacote/node_modules/npm-pick-manifest": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
+            "integrity": "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==",
+            "license": "ISC",
+            "dependencies": {
+                "npm-install-checks": "^8.0.0",
+                "npm-normalize-package-bin": "^5.0.0",
+                "npm-package-arg": "^13.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/pacote/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/pacote/node_modules/proc-log": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/pacote/node_modules/spdx-expression-parse": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+            "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/pacote/node_modules/which": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+            "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^4.0.0"
+            },
+            "bin": {
+                "node-which": "bin/which.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/panguard-mcp-bridge": {
             "resolved": "packages/panguard-mcp-bridge",
             "link": true
@@ -6802,6 +9785,29 @@
             "dependencies": {
                 "dot-case": "^3.0.4",
                 "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/parse-conflict-json": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/parse-conflict-json/-/parse-conflict-json-5.0.1.tgz",
+            "integrity": "sha512-ZHEmNKMq1wyJXNwLxyHnluPfRAFSIliBvbK/UiOceROt4Xh9Pz0fq49NytIaeaCUf5VR86hwQ/34FCcNU5/LKQ==",
+            "license": "ISC",
+            "dependencies": {
+                "json-parse-even-better-errors": "^5.0.0",
+                "just-diff": "^6.0.0",
+                "just-diff-apply": "^5.2.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/parse-conflict-json/node_modules/json-parse-even-better-errors": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
+            "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/parseurl": {
@@ -6856,6 +9862,28 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "license": "MIT"
+        },
+        "node_modules/path-scurry": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/path-to-regexp": {
@@ -6975,7 +10003,6 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -7096,6 +10123,19 @@
                 }
             }
         },
+        "node_modules/postcss-selector-parser": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/postgres-array": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -7161,6 +10201,24 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
+        "node_modules/proc-log": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
+            "integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/proggy": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/proggy/-/proggy-4.0.0.tgz",
+            "integrity": "sha512-MbA4R+WQT76ZBm/5JUpV9yqcJt92175+Y0Bodg3HgiXzrmKu7Ggq+bpn6y6wHH+gN9NcyKn3yg1+d47VaKwNAQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/prom-client": {
             "version": "15.1.3",
             "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
@@ -7172,6 +10230,37 @@
             },
             "engines": {
                 "node": "^16 || ^18 || >=20"
+            }
+        },
+        "node_modules/promise-all-reject-late": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
+            "integrity": "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==",
+            "license": "ISC",
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/promise-call-limit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/promise-call-limit/-/promise-call-limit-3.0.2.tgz",
+            "integrity": "sha512-mRPQO2T1QQVw11E7+UdCJu7S61eJVWknzml9sC1heAdj1jxl0fWMBypIt9ZOcLFf8FkG995ZD7RnVk7HH72fZw==",
+            "license": "ISC",
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/promise-retry": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+            "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+            "license": "MIT",
+            "dependencies": {
+                "err-code": "^2.0.2",
+                "retry": "^0.12.0"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/protobufjs": {
@@ -7278,6 +10367,15 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/read-cmd-shim": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
+            "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/readdirp": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -7319,6 +10417,41 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/require-in-the-middle": {
+            "version": "7.5.2",
+            "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+            "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.5",
+                "module-details-from-path": "^1.0.3",
+                "resolve": "^1.22.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/resolve": {
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/resolve-from": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -7327,6 +10460,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/retry": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "node_modules/rfc4648": {
@@ -7440,7 +10582,6 @@
             "version": "7.8.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
             "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -7531,6 +10672,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/shimmer": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+            "license": "BSD-2-Clause"
         },
         "node_modules/should": {
             "version": "13.2.3",
@@ -7665,6 +10812,29 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "license": "ISC"
+        },
+        "node_modules/sigstore": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-4.1.1.tgz",
+            "integrity": "sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/bundle": "^4.0.0",
+                "@sigstore/core": "^3.2.1",
+                "@sigstore/protobuf-specs": "^0.5.0",
+                "@sigstore/sign": "^4.1.1",
+                "@sigstore/tuf": "^4.0.2",
+                "@sigstore/verify": "^3.1.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/smart-buffer": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -7733,6 +10903,57 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/source-map-support": {
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+            "license": "MIT",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/source-map-support/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/spdx-correct": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+            "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-exceptions": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+            "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+            "license": "CC-BY-3.0"
+        },
+        "node_modules/spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-license-ids": {
+            "version": "3.0.23",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+            "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+            "license": "CC0-1.0"
+        },
         "node_modules/split2": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -7747,6 +10968,18 @@
             "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
             "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
             "license": "MIT"
+        },
+        "node_modules/ssri": {
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+            "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
         },
         "node_modules/stackback": {
             "version": "0.0.2",
@@ -7805,6 +11038,21 @@
                 "node": ">=8"
             }
         },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -7815,6 +11063,28 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-final-newline": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/sucrase": {
@@ -7851,6 +11121,18 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/swagger2openapi": {
@@ -7907,6 +11189,22 @@
             "license": "ISC",
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/tar": {
+            "version": "7.5.19",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+            "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/fs-minipass": "^4.0.0",
+                "chownr": "^3.0.0",
+                "minipass": "^7.1.2",
+                "minizlib": "^3.1.0",
+                "yallist": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/tar-fs": {
@@ -8015,7 +11313,6 @@
             "version": "0.2.17",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
             "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
@@ -8075,6 +11372,15 @@
             "license": "MIT",
             "bin": {
                 "tree-kill": "cli.js"
+            }
+        },
+        "node_modules/treeverse": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-3.0.0.tgz",
+            "integrity": "sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/ts-api-utils": {
@@ -8182,6 +11488,20 @@
                 "fsevents": "~2.3.3"
             }
         },
+        "node_modules/tuf-js": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-4.1.0.tgz",
+            "integrity": "sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@tufjs/models": "4.1.0",
+                "debug": "^4.4.3",
+                "make-fetch-happen": "^15.0.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/turbo": {
             "version": "2.10.4",
             "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.10.4.tgz",
@@ -8254,7 +11574,7 @@
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
             "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -8295,6 +11615,15 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/undici": {
+            "version": "6.27.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+            "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.17"
+            }
+        },
         "node_modules/undici-types": {
             "version": "8.3.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
@@ -8308,6 +11637,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/upath": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+            "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4",
+                "yarn": "*"
             }
         },
         "node_modules/upper-case": {
@@ -8350,6 +11689,12 @@
             "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
             "license": "MIT"
         },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "license": "MIT"
+        },
         "node_modules/uuid": {
             "version": "14.0.1",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
@@ -8361,6 +11706,25 @@
             "license": "MIT",
             "bin": {
                 "uuid": "dist-node/bin/uuid"
+            }
+        },
+        "node_modules/validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "node_modules/validate-npm-package-name": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+            "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/vary": {
@@ -8540,6 +11904,15 @@
                 }
             }
         },
+        "node_modules/walk-up-path": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+            "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+            "license": "ISC",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
         "node_modules/walkdir": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
@@ -8633,11 +12006,53 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "license": "ISC"
+        },
+        "node_modules/write-file-atomic": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+            "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+            "license": "ISC",
+            "dependencies": {
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/write-file-atomic/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/ws": {
             "version": "8.21.0",
@@ -8676,6 +12091,15 @@
             "license": "ISC",
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/yallist": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "node": ">=22"
     },
     "workspaces": [
-        "packages/*"
+        "packages/*",
+        "infra/pulumi"
     ],
     "repository": {
         "type": "git",

--- a/packages/clawql-api/src/spec/spec-loader.ts
+++ b/packages/clawql-api/src/spec/spec-loader.ts
@@ -23,7 +23,10 @@ import { convertObj } from "swagger2openapi";
 import type { Operation, ParameterInfo } from "./operation-types.js";
 import { loadGraphqlNativeOperationsFromConfigs } from "./graphql-native-loader.js";
 import { mergeNativeProtocolOperations } from "./native-protocol-merge.js";
-import { shouldLoadCustomProvidersOnly, resolveBundledGraphqlFromCustomEnv } from "./native-protocol-env.js";
+import {
+  shouldLoadCustomProvidersOnly,
+  resolveBundledGraphqlFromCustomEnv,
+} from "./native-protocol-env.js";
 import { resetNativeProtocolRegistry } from "./native-protocol-registry.js";
 import { resetMcpSourceRegistry } from "./mcp-source-registry.js";
 import { operationsFromOpenAPI } from "./openapi-operations.js";

--- a/packer/README.md
+++ b/packer/README.md
@@ -1,0 +1,54 @@
+# ClawQL golden host images (Packer)
+
+Immutable VM images with ClawQL installed and `~/.ClawQL` prepared for boot-time team vault seeding.
+
+## Targets
+
+| Build name | Cloud | Artifact |
+|------------|-------|----------|
+| `validate.docker.clawql` | Docker (CI) | Syntax + bake smoke |
+| `aws-ami.amazon-ebs.clawql` | AWS | AMI per region |
+| `gcp-image.googlecompute.clawql` | GCP | Custom Compute image |
+
+Cloudflare managed tier uses `scripts/packer/cloudflare-bootstrap.sh` at Worker/container boot (verified R2 state — no AMI).
+
+## Bake vs boot
+
+- **Bake (Packer):** `scripts/packer/bake-clawql.sh` — Node 22, ClawQL install, `sync.json` template, no secrets.
+- **Boot (runtime):** `scripts/packer/bootstrap-team-vault.sh` — inject credentials, `clawql sync pull` (SHA-256 verified), `clawql doctor --smoke`.
+
+## Local validate (CI uses the same)
+
+```bash
+bash scripts/packer/test-golden-host-scripts.sh
+```
+
+## Build examples
+
+```bash
+cd packer
+packer init .
+
+# CI / PR — docker validate only
+packer build -only=validate.docker.clawql -var 'clawql_version=latest' .
+
+# AWS (requires credentials)
+packer build -only=aws-ami.amazon-ebs.clawql \
+  -var 'clawql_version=7.0.0' \
+  -var 'aws_region=us-east-1' .
+
+# GCP (requires project)
+packer build -only=gcp-image.googlecompute.clawql \
+  -var 'clawql_version=7.0.0' \
+  -var 'gcp_project_id=my-project' .
+```
+
+## Tier seeding
+
+| Tier | Boot configuration |
+|------|-------------------|
+| Shared | `CLAWQL_SYNC_PREFIX=shared/` + tenant isolation via operator |
+| Dedicated | `CLAWQL_SYNC_PREFIX=tenant/{id}/` from instance metadata |
+| Enterprise | Customer bucket + Vault; image unchanged |
+
+See [docs/getting-started/golden-host-images.md](../docs/getting-started/golden-host-images.md) and [ADR 0006](../docs/adr/0006-golden-host-images-packer.md).

--- a/packer/clawql-golden-host.pkr.hcl
+++ b/packer/clawql-golden-host.pkr.hcl
@@ -1,0 +1,148 @@
+packer {
+  required_version = ">= 1.10.0"
+  required_plugins {
+    amazon = {
+      version = ">= 1.3.0"
+      source  = "github.com/hashicorp/amazon"
+    }
+    googlecompute = {
+      version = ">= 1.1.0"
+      source  = "github.com/hashicorp/googlecompute"
+    }
+    docker = {
+      version = ">= 1.0.8"
+      source  = "github.com/hashicorp/docker"
+    }
+  }
+}
+
+variable "clawql_version" {
+  type        = string
+  default     = "latest"
+  description = "npm dist-tag or semver for clawql-mcp install"
+}
+
+variable "sync_prefix" {
+  type        = string
+  default     = "teams/shared/"
+  description = "Default team bucket prefix written to sync.json at bake time"
+}
+
+variable "sync_provider" {
+  type        = string
+  default     = "r2"
+  description = "Object storage provider in bake-time sync.json (r2|s3|gcs)"
+}
+
+variable "aws_region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "gcp_project_id" {
+  type        = string
+  default     = "packer-validate-placeholder"
+  description = "GCP project for image build (placeholder ok for validate-only)"
+}
+
+variable "gcp_zone" {
+  type    = string
+  default = "us-central1-a"
+}
+
+locals {
+  scripts_dir = "${path.root}/../scripts/packer"
+}
+
+# CI validate — no cloud credentials required.
+source "docker" "validate" {
+  image  = "ubuntu:24.04"
+  discard = true
+}
+
+source "amazon-ebs" "clawql" {
+  region        = var.aws_region
+  instance_type = "t3.medium"
+  ssh_username  = "ubuntu"
+  ami_name      = "clawql-golden-host-${var.clawql_version}-{{timestamp}}"
+
+  source_ami_filter {
+    filters = {
+      name                = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    owners      = ["099720109477"]
+    most_recent = true
+  }
+
+  tags = {
+    Name        = "clawql-golden-host"
+    ClawQL      = var.clawql_version
+    ManagedBy   = "packer"
+  }
+}
+
+source "googlecompute" "clawql" {
+  project_id              = var.gcp_project_id
+  zone                    = var.gcp_zone
+  machine_type            = "e2-medium"
+  ssh_username            = "ubuntu"
+  disk_size               = 20
+  image_name              = "clawql-golden-host-${var.clawql_version}-{{timestamp}}"
+  image_family            = "clawql-golden-host"
+  source_image_family     = "ubuntu-2404-lts-amd64"
+  source_image_project_id = ["ubuntu-os-cloud"]
+
+  image_labels = {
+    clawql_version = replace(var.clawql_version, ".", "-")
+    managed_by     = "packer"
+  }
+}
+
+build {
+  name = "clawql-golden-host"
+
+  sources = [
+    "source.docker.validate",
+    "source.amazon-ebs.clawql",
+    "source.googlecompute.clawql",
+  ]
+
+  provisioner "shell" {
+    environment_vars = [
+      "CLAWQL_VERSION=${var.clawql_version}",
+      "CLAWQL_SYNC_PREFIX=${var.sync_prefix}",
+      "CLAWQL_SYNC_PROVIDER=${var.sync_provider}",
+    ]
+    scripts = ["${local.scripts_dir}/bake-clawql.sh"]
+  }
+
+  provisioner "file" {
+    source      = "${local.scripts_dir}/bootstrap-team-vault.sh"
+    destination = "/tmp/bootstrap-team-vault.sh"
+  }
+
+  provisioner "file" {
+    source      = "${local.scripts_dir}/cloudflare-bootstrap.sh"
+    destination = "/tmp/cloudflare-bootstrap.sh"
+  }
+
+  provisioner "shell" {
+    inline = [
+      "install -m 0755 /tmp/bootstrap-team-vault.sh /usr/local/bin/bootstrap-team-vault.sh",
+      "install -m 0755 /tmp/cloudflare-bootstrap.sh /usr/local/bin/cloudflare-bootstrap.sh",
+      "rm -f /tmp/bootstrap-team-vault.sh /tmp/cloudflare-bootstrap.sh",
+    ]
+  }
+
+  # Post-bake gate on docker validate target (doctor may warn without credentials).
+  provisioner "shell" {
+    only = ["source.docker.validate"]
+    inline = [
+      "test -f /root/.ClawQL/sync.json",
+      "grep -q CONFIGURE_AT_BOOT /root/.ClawQL/sync.json",
+      "command -v clawql",
+    ]
+  }
+}

--- a/scripts/packer/bake-clawql.sh
+++ b/scripts/packer/bake-clawql.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Bake-time provisioner: install ClawQL and prepare ~/.ClawQL skeleton (no team secrets).
+# Used by Packer golden-host builds and Docker validate target.
+set -euo pipefail
+
+CLAWQL_VERSION="${CLAWQL_VERSION:-latest}"
+CLAWQL_HOME="${CLAWQL_HOME:-/root/.ClawQL}"
+SYNC_PREFIX="${CLAWQL_SYNC_PREFIX:-teams/shared/}"
+SYNC_PROVIDER="${CLAWQL_SYNC_PROVIDER:-r2}"
+SYNC_BUCKET_PLACEHOLDER="${CLAWQL_SYNC_BUCKET_PLACEHOLDER:-CONFIGURE_AT_BOOT}"
+
+export DEBIAN_FRONTEND=noninteractive
+
+echo "[bake-clawql] Node + ClawQL install (version=${CLAWQL_VERSION})"
+
+if ! command -v node >/dev/null 2>&1; then
+  apt-get update -qq
+  apt-get install -y -qq curl ca-certificates
+  curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+  apt-get install -y -qq nodejs
+fi
+
+NODE_MAJOR="$(node -p "process.versions.node.split('.')[0]")"
+if [ "${NODE_MAJOR}" -lt 22 ]; then
+  echo "[bake-clawql] Node >= 22 required (found $(node -v))" >&2
+  exit 1
+fi
+
+export CLAWQL_VERSION
+curl -fsSL https://clawql.com/install | bash
+
+mkdir -p "${CLAWQL_HOME}/Memory" "${CLAWQL_HOME}/sources" "${CLAWQL_HOME}/Dashboard/chats"
+
+# sync.json: bucket/prefix only — credentials injected at boot (instance metadata / Vault agent).
+cat >"${CLAWQL_HOME}/sync.json" <<EOF
+{
+  "version": 1,
+  "provider": "${SYNC_PROVIDER}",
+  "bucket": "${SYNC_BUCKET_PLACEHOLDER}",
+  "prefix": "${SYNC_PREFIX}"
+}
+EOF
+
+if command -v clawql >/dev/null 2>&1; then
+  clawql onboard --non-interactive || true
+  clawql doctor || true
+else
+  echo "[bake-clawql] clawql CLI not on PATH after install" >&2
+  exit 1
+fi
+
+echo "[bake-clawql] Golden base ready at ${CLAWQL_HOME} (team pull runs at boot)"

--- a/scripts/packer/bootstrap-team-vault.sh
+++ b/scripts/packer/bootstrap-team-vault.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Boot-time: pull team vault from object storage, verify manifest SHA-256s, doctor smoke gate.
+# Credentials must be in env (R2/S3/GCS keys) — never baked into the image.
+set -euo pipefail
+
+CLAWQL_HOME="${CLAWQL_HOME:-${HOME}/.ClawQL}"
+export CLAWQL_HOME
+
+if [ -z "${CLAWQL_SYNC_BUCKET:-}" ] || [ "${CLAWQL_SYNC_BUCKET}" = "CONFIGURE_AT_BOOT" ]; then
+  echo "[bootstrap-team-vault] CLAWQL_SYNC_BUCKET is required at boot" >&2
+  exit 1
+fi
+
+if [ -f "${CLAWQL_HOME}/sync.json" ]; then
+  # Merge runtime bucket/prefix over bake template when env overrides are set.
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "${CLAWQL_HOME}/sync.json" <<'PY'
+import json
+import os
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as f:
+    data = json.load(f)
+if os.environ.get("CLAWQL_SYNC_BUCKET"):
+    data["bucket"] = os.environ["CLAWQL_SYNC_BUCKET"]
+if os.environ.get("CLAWQL_SYNC_PREFIX"):
+    data["prefix"] = os.environ["CLAWQL_SYNC_PREFIX"]
+if os.environ.get("CLAWQL_SYNC_PROVIDER"):
+    data["provider"] = os.environ["CLAWQL_SYNC_PROVIDER"]
+with open(path, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+PY
+  fi
+fi
+
+echo "[bootstrap-team-vault] Pulling team vault from ${CLAWQL_SYNC_PROVIDER:-r2}://${CLAWQL_SYNC_BUCKET}/${CLAWQL_SYNC_PREFIX:-}"
+
+if ! command -v clawql >/dev/null 2>&1; then
+  echo "[bootstrap-team-vault] clawql CLI missing" >&2
+  exit 1
+fi
+
+clawql sync pull
+clawql doctor --smoke
+
+echo "[bootstrap-team-vault] Team vault seeded and verified"

--- a/scripts/packer/cloudflare-bootstrap.sh
+++ b/scripts/packer/cloudflare-bootstrap.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Cloudflare managed tier bootstrap: same team pull + doctor gate as VM hosts.
+# Workers/containers run this on first invocation; verified R2 state is the boot artifact.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${ROOT}/bootstrap-team-vault.sh" "$@"

--- a/scripts/packer/test-golden-host-scripts.sh
+++ b/scripts/packer/test-golden-host-scripts.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# CI + local: validate Packer templates and golden-host shell scripts.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT}"
+
+PACKER_DIR="${ROOT}/packer"
+
+echo "==> ShellCheck packer scripts"
+shellcheck scripts/packer/*.sh
+
+echo "==> Golden-host script smoke (bake dry structure)"
+test -x scripts/packer/bake-clawql.sh
+test -x scripts/packer/bootstrap-team-vault.sh
+test -x scripts/packer/cloudflare-bootstrap.sh
+
+# Bootstrap must fail without bucket (no silent success)
+if CLAWQL_SYNC_BUCKET='' scripts/packer/bootstrap-team-vault.sh 2>/dev/null; then
+  echo "bootstrap-team-vault.sh should fail when CLAWQL_SYNC_BUCKET is empty" >&2
+  exit 1
+fi
+
+echo "==> Packer init + validate (docker validate target)"
+if ! command -v packer >/dev/null 2>&1; then
+  echo "packer not installed — installing HashiCorp packer"
+  PACKER_VERSION="${PACKER_VERSION:-1.11.2}"
+  curl -fsSL "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip" -o /tmp/packer.zip
+  unzip -qo /tmp/packer.zip -d /tmp
+  export PATH="/tmp:${PATH}"
+fi
+
+cd "${PACKER_DIR}"
+packer init .
+packer validate .
+
+echo "==> packer golden-host checks passed"

--- a/scripts/pulumi/test-provision-unit.sh
+++ b/scripts/pulumi/test-provision-unit.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# CI + local: unit tests and TypeScript build for infra/pulumi (no cloud credentials).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PULUMI_DIR="${ROOT}/infra/pulumi"
+
+cd "${PULUMI_DIR}"
+
+echo "==> Install infra/pulumi dependencies"
+if [[ -f package-lock.json ]]; then
+  npm ci
+else
+  npm install
+fi
+
+echo "==> Pulumi provision unit tests"
+npm test
+
+echo "==> Pulumi provision TypeScript build"
+npm run build
+
+echo "==> pulumi provision checks passed"

--- a/src/home-sync/engine.ts
+++ b/src/home-sync/engine.ts
@@ -14,6 +14,7 @@ import type {
   SyncRunResult,
 } from "./types.js";
 import type { ObjectStorageClient } from "./object-storage.js";
+import { assertManifestSha256 } from "./verify.js";
 
 export type SyncRunOptions = {
   dryRun?: boolean;
@@ -96,9 +97,11 @@ async function applyDownloads(
   config: ResolvedHomeSyncConfig,
   home: string,
   actions: SyncPlanEntry[],
-  dryRun: boolean
+  dryRun: boolean,
+  remote: SyncManifest | null
 ): Promise<number> {
   let count = 0;
+  const remoteFiles = remote?.files ?? {};
   for (const a of actions) {
     if (a.action !== "download") continue;
     const key = objectKeyForRelPath(config.prefix ?? "", a.path);
@@ -108,6 +111,10 @@ async function applyDownloads(
     }
     const body = await client.getBytes(key);
     if (!body) continue;
+    const expected = remoteFiles[a.path]?.sha256;
+    if (expected) {
+      assertManifestSha256(a.path, body, expected);
+    }
     const abs = absPathForRel(home, a.path);
     await mkdir(dirname(abs), { recursive: true });
     await writeFile(abs, body);
@@ -151,7 +158,7 @@ export async function runSyncPull(opts: SyncRunOptions = {}): Promise<SyncRunRes
   const localHashes = new Map([...local.entries()].map(([k, v]) => [k, { sha256: v.sha256 }]));
   const actions = planPull(localHashes, remote, Boolean(opts.force));
   const dryRun = Boolean(opts.dryRun);
-  const downloaded = await applyDownloads(client, config, config.home, actions, dryRun);
+  const downloaded = await applyDownloads(client, config, config.home, actions, dryRun, remote);
   return summarize(config, actions, 0, downloaded, dryRun);
 }
 

--- a/src/home-sync/home-sync.test.ts
+++ b/src/home-sync/home-sync.test.ts
@@ -151,3 +151,18 @@ describe("resolveHomeSyncConfig", () => {
     }
   });
 });
+
+describe("sync pull manifest verification", () => {
+  it("assertManifestSha256 passes matching digest", async () => {
+    const { assertManifestSha256, sha256HexBuffer } = await import("./verify.js");
+    const body = Buffer.from("# note\n", "utf8");
+    assertManifestSha256("Memory/note.md", body, sha256HexBuffer(body));
+  });
+
+  it("assertManifestSha256 throws on mismatch", async () => {
+    const { assertManifestSha256 } = await import("./verify.js");
+    expect(() =>
+      assertManifestSha256("Memory/note.md", Buffer.from("tampered"), "a".repeat(64))
+    ).toThrow(/Team sync verification failed/);
+  });
+});

--- a/src/home-sync/verify.ts
+++ b/src/home-sync/verify.ts
@@ -1,0 +1,19 @@
+import { createHash } from "node:crypto";
+
+/** SHA-256 hex digest of a buffer (team sync manifest uses lowercase hex). */
+export function sha256HexBuffer(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+/**
+ * Fail closed when downloaded bytes do not match the remote manifest entry.
+ * Used by `sync pull` and golden-host bootstrap before trusting team vault data.
+ */
+export function assertManifestSha256(path: string, body: Buffer, expectedSha256: string): void {
+  const actual = sha256HexBuffer(body);
+  if (actual !== expectedSha256) {
+    throw new Error(
+      `Team sync verification failed for ${path}: manifest expects sha256 ${expectedSha256}, got ${actual}`
+    );
+  }
+}

--- a/src/spec-loader-native-only.test.ts
+++ b/src/spec-loader-native-only.test.ts
@@ -78,25 +78,21 @@ describe("spec-loader bundled provider routing from custom env", () => {
     resetSpecCache();
   });
 
-  it(
-    "routes Linear custom env with a missing schemaPath to bundled linear",
-    async () => {
-      process.env.CLAWQL_GRAPHQL_SOURCES = JSON.stringify([
-        {
-          name: "linear",
-          endpoint: "https://api.linear.app/graphql",
-          schemaPath: "/definitely/missing/linear.graphql",
-        },
-      ]);
+  it("routes Linear custom env with a missing schemaPath to bundled linear", async () => {
+    process.env.CLAWQL_GRAPHQL_SOURCES = JSON.stringify([
+      {
+        name: "linear",
+        endpoint: "https://api.linear.app/graphql",
+        schemaPath: "/definitely/missing/linear.graphql",
+      },
+    ]);
 
-      const err = vi.spyOn(console, "error").mockImplementation(() => {});
-      const loaded = await loadSpec();
-      err.mockRestore();
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const loaded = await loadSpec();
+    err.mockRestore();
 
-      expect(String(loaded.rawSource["bundledGraphqlProvider"] ?? "")).toBe("linear");
-      expect(loaded.operations.some((o) => o.resource === "viewer")).toBe(true);
-      expect(loaded.operations.some((o) => o.specLabel === "cloudflare")).toBe(false);
-    },
-    180_000
-  );
+    expect(String(loaded.rawSource["bundledGraphqlProvider"] ?? "")).toBe("linear");
+    expect(loaded.operations.some((o) => o.resource === "viewer")).toBe(true);
+    expect(loaded.operations.some((o) => o.specLabel === "cloudflare")).toBe(false);
+  }, 180_000);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Pulumi** infrastructure provisioning alongside the existing **Packer** golden-host pipeline — Packer builds the artifact; Pulumi provisions the cloud resources that run it.

### Pulumi (`infra/pulumi`)

- TypeScript package `clawql-provision` with AWS EC2, GCP GCE, and Cloudflare R2 targets
- Tier helpers: `shared/`, `tenant/{id}/`, enterprise custom prefix
- Boot user-data generation (delegates to `bootstrap-team-vault.sh` on golden images)
- **Automation API** wrapper for future `clawql operator provision`
- 11 unit tests (tiers, user-data, stack naming) — no cloud credentials in CI

### Docs

- [ADR 0007](docs/adr/0007-pulumi-provisioning-managed-tiers.md) — Pulumi vs Terraform rationale, **self-hosted state only (R2 preferred, S3 alternative; no Pulumi Cloud)**
- Updated [golden-host-images.md](docs/getting-started/golden-host-images.md) quick start

### CI

- `make pulumi-provision-tests` (wired into `lint-k8s-manifests` / workflow-scripts job)

## State backend

**No Pulumi Cloud.** Stack state on self-hosted **R2** (preferred) or **S3**:

```bash
pulumi login 's3://clawql-pulumi-state?region=auto&endpoint=https://<accountid>.r2.cloudflarestorage.com&awssdk=v2'
```

## Test plan

- [x] `npm test` in `infra/pulumi` (11 tests)
- [x] `npm run build` in `infra/pulumi`
- [x] `bash scripts/pulumi/test-provision-unit.sh`
- [x] Existing Packer tests unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4ece-0a09-7eba-8f80-55d043ac694b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4ece-0a09-7eba-8f80-55d043ac694b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

