### PR TITLE
fix(website): mobile table alignment in docs prose

### DIFF
--- a/website/src/components/mdx.tsx
+++ b/website/src/components/mdx.tsx
@@ -106,6 +106,21 @@ export function Col({
   )
 }
 
+/** Scrollable table wrapper — keeps column alignment on narrow viewports. */
+export function table({
+  children,
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<'table'>) {
+  return (
+    <div className="docs-table-scroll not-prose">
+      <table className={clsx('docs-table', className)} {...props}>
+        {children}
+      </table>
+    </div>
+  )
+}
+
 export function Properties({ children }: { children: React.ReactNode }) {
   return (
     <div className="my-6">

--- a/website/src/styles/tailwind.css
+++ b/website/src/styles/tailwind.css
@@ -69,3 +69,58 @@
     display: none;
   }
 }
+
+@layer components {
+  /* MDX tables: horizontal scroll + column widths on mobile (see mdx.tsx `table`) */
+  .docs-table-scroll {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
+    width: 100%;
+    max-width: none;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  @media (width < 40rem) {
+    .docs-table-scroll {
+      margin-left: -1rem;
+      margin-right: -1rem;
+      padding-left: 1rem;
+      padding-right: 1rem;
+    }
+  }
+
+  .prose .docs-table {
+    width: 100%;
+    min-width: 100%;
+    table-layout: fixed;
+    border-collapse: collapse;
+  }
+
+  /* Two-column reference tables (Command | Purpose, Variable | Purpose, …) */
+  .prose
+    .docs-table:has(thead tr > th:nth-child(2):last-child)
+    :is(th, td):nth-child(1) {
+    width: 38%;
+  }
+
+  .prose
+    .docs-table:has(thead tr > th:nth-child(2):last-child)
+    :is(th, td):nth-child(2) {
+    width: 62%;
+  }
+
+  /* Four-column provider matrices */
+  .prose .docs-table:has(thead tr > th:nth-child(4):last-child) :is(th, td) {
+    width: 25%;
+  }
+
+  /* Three-column tables */
+  .prose
+    .docs-table:has(thead tr > th:nth-child(3):last-child):not(
+      :has(thead tr > th:nth-child(4))
+    )
+    :is(th, td) {
+    width: 33.333%;
+  }
+}

--- a/website/typography.ts
+++ b/website/typography.ts
@@ -210,13 +210,13 @@ export default {
             marginTop: theme('spacing.2'),
           },
 
-          // Tables
+          // Tables (layout details in tailwind.css `.docs-table`)
           table: {
             width: '100%',
-            tableLayout: 'auto',
+            tableLayout: 'fixed',
             textAlign: 'left',
-            marginTop: theme('spacing.8'),
-            marginBottom: theme('spacing.8'),
+            marginTop: '0',
+            marginBottom: '0',
             lineHeight: theme('lineHeight.6'),
           },
           thead: {
@@ -230,6 +230,8 @@ export default {
             paddingRight: theme('spacing.2'),
             paddingBottom: theme('spacing.2'),
             paddingLeft: theme('spacing.2'),
+            wordBreak: 'break-word',
+            overflowWrap: 'anywhere',
           },
           'thead th:first-child': {
             paddingLeft: '0',
@@ -259,6 +261,9 @@ export default {
             paddingRight: theme('spacing.2'),
             paddingBottom: theme('spacing.2'),
             paddingLeft: theme('spacing.2'),
+            wordBreak: 'break-word',
+            overflowWrap: 'anywhere',
+            verticalAlign: 'top',
           },
           ':is(tbody, tfoot) td:first-child': {
             paddingLeft: '0',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On mobile (e.g. `/getting-started/team-vault-sync`), prose tables had broken alignment:

- Four-column **Providers** table: headers clustered left while **Credentials** floated to the screen edge with a large empty gap
- Two-column **Commands** / **Environment** tables: row borders did not span the full content width

## Fix

1. **MDX `table` wrapper** (`docs-table-scroll`) — horizontal scroll on narrow viewports with edge-to-edge swipe area
2. **`table-layout: fixed`** with column width rules:
   - 2 columns → 38% / 62%
   - 4 columns → 25% each
3. **`word-break` / `overflow-wrap`** on `th`/`td` so long endpoints and env var names wrap instead of stretching columns

Applies to all MDX-generated doc pages (team vault sync, golden hosts, local sandbox, etc.).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4ece-0a09-7eba-8f80-55d043ac694b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4ece-0a09-7eba-8f80-55d043ac694b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

