### PR TITLE
fix(website): stop table cell content overlap on mobile

### DIFF
--- a/website/src/styles/tailwind.css
+++ b/website/src/styles/tailwind.css
@@ -97,22 +97,47 @@
     border-collapse: collapse;
   }
 
+  /* Force cell content to respect column bounds (prevents overlap). */
+  .prose .docs-table :is(th, td) {
+    max-width: 0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    hyphens: auto;
+  }
+
+  .prose .docs-table code {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
   /* Two-column reference tables (Command | Purpose, Variable | Purpose, …) */
   .prose
     .docs-table:has(thead tr > th:nth-child(2):last-child)
     :is(th, td):nth-child(1) {
-    width: 38%;
+    width: 42%;
+    min-width: 10.5rem;
   }
 
   .prose
     .docs-table:has(thead tr > th:nth-child(2):last-child)
     :is(th, td):nth-child(2) {
-    width: 62%;
+    width: 58%;
+    min-width: 12rem;
   }
 
-  /* Four-column provider matrices */
+  .prose .docs-table:has(thead tr > th:nth-child(2):last-child) {
+    min-width: 22.5rem;
+  }
+
+  /* Four-column provider matrices — scroll instead of squashing */
+  .prose .docs-table:has(thead tr > th:nth-child(4):last-child) {
+    min-width: 44rem;
+  }
+
   .prose .docs-table:has(thead tr > th:nth-child(4):last-child) :is(th, td) {
     width: 25%;
+    min-width: 9rem;
   }
 
   /* Three-column tables */

--- a/website/typography.ts
+++ b/website/typography.ts
@@ -265,6 +265,11 @@ export default {
             overflowWrap: 'anywhere',
             verticalAlign: 'top',
           },
+          ':is(.docs-table th, .docs-table td) code': {
+            whiteSpace: 'normal',
+            wordBreak: 'break-word',
+            overflowWrap: 'anywhere',
+          },
           ':is(tbody, tfoot) td:first-child': {
             paddingLeft: '0',
           },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After the table width fix (#554), columns aligned better but **cell content still overlapped** on mobile — especially:

- **Environment** table: long `CLAWQL_*` variable names bleeding into the Purpose column
- **Providers** table: endpoint/credential text colliding across columns

Root cause: `table-layout: fixed` with percentage widths did not constrain overflowing inline `<code>` (no wrapping).

## Fix

1. **`max-width: 0` on `th`/`td`** — standard fixed-table trick to force content to wrap within assigned column width
2. **`white-space: normal` + `overflow-wrap: anywhere` on `code` inside tables**
3. **Minimum table/column widths** — 4-column provider tables scroll at `44rem` with `9rem` min per column; 2-column tables use `42%`/`58%` with floor widths

Fixes overlap on `/getting-started/team-vault-sync` and all other MDX doc tables.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4ece-0a09-7eba-8f80-55d043ac694b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4ece-0a09-7eba-8f80-55d043ac694b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

