### PR TITLE
docs(ouroboros): upstream Q00 sync roadmap + GitHub epic #556

### DIFF
--- a/docs/ouroboros/clawql-ouroboros.md
+++ b/docs/ouroboros/clawql-ouroboros.md
@@ -2,7 +2,7 @@
 
 **npm consumers:** the **registry README** lives in [`packages/clawql-ouroboros/README.md`](../packages/clawql-ouroboros/README.md) (install, quick start, export table, scope vs Q00). This file is the **longer guide** with full examples.
 
-**Platform design:** [DAOS Unified Architecture v2.7](./daos-unified-architecture-specification-v2.7.md) · [Coordination layer](./daos-coordination-layer-specification.md) · [Build plan v2.7.1](./daos-build-plan-v2.7.1.md)
+**Platform design:** [DAOS Unified Architecture v2.7](./daos-unified-architecture-specification-v2.7.md) · [Coordination layer](./daos-coordination-layer-specification.md) · [Build plan v2.7.1](./daos-build-plan-v2.7.1.md) · [Upstream Q00 sync roadmap](./upstream-q00-sync-roadmap.md) (PAL, drift, MoA — planning)
 
 TypeScript workspace package at [`packages/clawql-ouroboros`](../packages/clawql-ouroboros): **specification-first** seeds, **Wonder / Reflect** hooks, an **evolutionary loop** over pluggable **Executor** / **Evaluator**, **ontology convergence** (similarity, stagnation, oscillation, regression gates), and optional **MCP-shaped tool definitions** for crystallizing document text into seeds.
 
@@ -227,6 +227,7 @@ stop();
 
 ## See also
 
+- **[Upstream Q00 sync roadmap](./upstream-q00-sync-roadmap.md)** — what to port from [Q00/ouroboros](https://github.com/Q00/ouroboros) v0.50.3+ (PAL Router, drift measurement, PAL+MoA sequencing) and linked GitHub tickets.
 - **[`docs/adr/0001-ouroboros-workflow-engine.md`](../adr/0001-ouroboros-workflow-engine.md)** — architecture decision record for in-process routing, seed contract, and persistence model ([#110](https://github.com/danielsmithdevelopment/ClawQL/issues/110)).
 - **[`docs/mcp/mcp-tools.md`](../mcp/mcp-tools.md)** — ClawQL MCP tools, including optional **`ouroboros_*`** wiring.
 - **[`packages/mcp-grpc-transport/README.md`](../packages/mcp-grpc-transport/README.md)** — other publishable workspace package.

--- a/docs/ouroboros/upstream-q00-sync-roadmap.md
+++ b/docs/ouroboros/upstream-q00-sync-roadmap.md
@@ -20,17 +20,17 @@ This document separates **what to port** from **what to leave alone**, defines p
 
 ## Gap analysis (shipped today)
 
-| Capability | `clawql-ouroboros` | Q00 v0.50.3 |
-| --- | --- | --- |
-| Wonder / Reflect / Execute / Evaluate | Shipped | Shipped |
-| Ontology similarity convergence | Shipped (`convergence.ts`) | Shipped (different math) |
-| Stagnation / oscillation detection | Shipped (fingerprint window) | Shipped (4 named patterns) |
+| Capability                                                                    | `clawql-ouroboros`                                         | Q00 v0.50.3                         |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------- | ----------------------------------- |
+| Wonder / Reflect / Execute / Evaluate                                         | Shipped                                                    | Shipped                             |
+| Ontology similarity convergence                                               | Shipped (`convergence.ts`)                                 | Shipped (different math)            |
+| Stagnation / oscillation detection                                            | Shipped (fingerprint window)                               | Shipped (4 named patterns)          |
 | 3-component drift (Goal 50% / Constraint 30% / Ontology 20%, threshold ≤ 0.3) | **Not shipped** — `ambiguity_score` on Seed unused in loop | Shipped (`ouroboros_measure_drift`) |
-| PAL / model-tier routing | **Not shipped** — documented omission | **Shipped** (headline v0.50.3) |
-| Frugality proof / per-AC token attribution | **Not shipped** | Shipped |
-| MoA / multi-model consensus | **Not shipped** — DAOS §6.7 roadmap | Shipped (Stage 3 + tiers) |
-| NSV / SGDOP | **Not shipped** — DAOS P3 roadmap | Partial (consensus triggers) |
-| Routing | `clawql_execute` / `clawql_search` API hints | LLM tier + runtime routing |
+| PAL / model-tier routing                                                      | **Not shipped** — documented omission                      | **Shipped** (headline v0.50.3)      |
+| Frugality proof / per-AC token attribution                                    | **Not shipped**                                            | Shipped                             |
+| MoA / multi-model consensus                                                   | **Not shipped** — DAOS §6.7 roadmap                        | Shipped (Stage 3 + tiers)           |
+| NSV / SGDOP                                                                   | **Not shipped** — DAOS P3 roadmap                          | Partial (consensus triggers)        |
+| Routing                                                                       | `clawql_execute` / `clawql_search` API hints               | LLM tier + runtime routing          |
 
 **Marketing gap:** [`docs/posts/introducing-clawql-ouroboros.md`](../posts/introducing-clawql-ouroboros.md) claims ontological drift tracking; implementation must catch up or copy be revised.
 
@@ -64,15 +64,15 @@ flowchart TB
   D --> ES
 ```
 
-| Piece | Package / layer | Rationale |
-| --- | --- | --- |
-| Drift evaluator | `clawql-ouroboros` | Seed-native; per-generation |
-| Stagnation taxonomy | `clawql-ouroboros` | Extend `ConvergenceSignal.reason` |
-| PAL tier ladder | Layer 8 / new `clawql-inference-routing` (TBD) | Shared across ouroboros, agent chat, schedule |
-| Frugality audit events | `clawql-ouroboros` event store + WORM envelope | Same lineage stream |
-| MoA fan-out | Hermes runtime / gateway adapter | External ensemble; not in-loop Python port |
-| NSV/SGDOP model pick | DAOS coordination (build plan P3) | Needs embeddings + Coordinator |
-| Active Conductor menus | MCP event meta on lineage | Host judgment; proposed upstream RFC |
+| Piece                  | Package / layer                                | Rationale                                     |
+| ---------------------- | ---------------------------------------------- | --------------------------------------------- |
+| Drift evaluator        | `clawql-ouroboros`                             | Seed-native; per-generation                   |
+| Stagnation taxonomy    | `clawql-ouroboros`                             | Extend `ConvergenceSignal.reason`             |
+| PAL tier ladder        | Layer 8 / new `clawql-inference-routing` (TBD) | Shared across ouroboros, agent chat, schedule |
+| Frugality audit events | `clawql-ouroboros` event store + WORM envelope | Same lineage stream                           |
+| MoA fan-out            | Hermes runtime / gateway adapter               | External ensemble; not in-loop Python port    |
+| NSV/SGDOP model pick   | DAOS coordination (build plan P3)              | Needs embeddings + Coordinator                |
+| Active Conductor menus | MCP event meta on lineage                      | Host judgment; proposed upstream RFC          |
 
 ---
 
@@ -116,17 +116,17 @@ Every PAL escalation and MoA trigger writes an auditable event (`pal_escalation`
 
 ## Implementation sequencing
 
-| Phase | Ticket | Deliverable | Depends on |
-| --- | --- | --- | --- |
-| **P0-A** | [#557](https://github.com/danielsmithdevelopment/ClawQL/issues/557) | Drift evaluator + `ouroboros_measure_drift` MCP tool + `drift_measured` events | — |
-| **P0-B** | [#558](https://github.com/danielsmithdevelopment/ClawQL/issues/558) | Convergence gate: `combined_drift > 0.3` blocks premature converge; triggers reflect | P0-A |
-| **P0-C** | [#559](https://github.com/danielsmithdevelopment/ClawQL/issues/559) | Stagnation taxonomy reason codes on `ConvergenceSignal` | — |
-| **P0-D** | [#560](https://github.com/danielsmithdevelopment/ClawQL/issues/560) | PAL tier map + `AdaptiveRouter` interface; inject into Wonder/Reflect/Execute | Layer 8 config sketch |
-| **P0-E** | [#561](https://github.com/danielsmithdevelopment/ClawQL/issues/561) | `pal_escalation` + token attribution events in Postgres event store | P0-D |
-| **P1-A** | [#562](https://github.com/danielsmithdevelopment/ClawQL/issues/562) | PAL → MoA trigger at Standard failure + drift tripwire | P0-A, P0-D, Hermes adapter |
-| **P1-B** | [#563](https://github.com/danielsmithdevelopment/ClawQL/issues/563) | Align introducing post / clawql-ouroboros.md with shipped drift behavior | P0-A |
-| **P2** | DAOS P3 | NSV/SGDOP-directed MoA model family selection | Coordinator, embeddings |
-| **P3** | [#564](https://github.com/danielsmithdevelopment/ClawQL/issues/564) | Active Conductor attention menus on MCP lineage stream | P0-E events |
+| Phase    | Ticket                                                              | Deliverable                                                                          | Depends on                 |
+| -------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------- |
+| **P0-A** | [#557](https://github.com/danielsmithdevelopment/ClawQL/issues/557) | Drift evaluator + `ouroboros_measure_drift` MCP tool + `drift_measured` events       | —                          |
+| **P0-B** | [#558](https://github.com/danielsmithdevelopment/ClawQL/issues/558) | Convergence gate: `combined_drift > 0.3` blocks premature converge; triggers reflect | P0-A                       |
+| **P0-C** | [#559](https://github.com/danielsmithdevelopment/ClawQL/issues/559) | Stagnation taxonomy reason codes on `ConvergenceSignal`                              | —                          |
+| **P0-D** | [#560](https://github.com/danielsmithdevelopment/ClawQL/issues/560) | PAL tier map + `AdaptiveRouter` interface; inject into Wonder/Reflect/Execute        | Layer 8 config sketch      |
+| **P0-E** | [#561](https://github.com/danielsmithdevelopment/ClawQL/issues/561) | `pal_escalation` + token attribution events in Postgres event store                  | P0-D                       |
+| **P1-A** | [#562](https://github.com/danielsmithdevelopment/ClawQL/issues/562) | PAL → MoA trigger at Standard failure + drift tripwire                               | P0-A, P0-D, Hermes adapter |
+| **P1-B** | [#563](https://github.com/danielsmithdevelopment/ClawQL/issues/563) | Align introducing post / clawql-ouroboros.md with shipped drift behavior             | P0-A                       |
+| **P2**   | DAOS P3                                                             | NSV/SGDOP-directed MoA model family selection                                        | Coordinator, embeddings    |
+| **P3**   | [#564](https://github.com/danielsmithdevelopment/ClawQL/issues/564) | Active Conductor attention menus on MCP lineage stream                               | P0-E events                |
 
 **P0-A is the recommended first PR** — small surface, closes marketing/implementation gap, gives PAL/MoA a concrete failure signal.
 

--- a/docs/ouroboros/upstream-q00-sync-roadmap.md
+++ b/docs/ouroboros/upstream-q00-sync-roadmap.md
@@ -1,0 +1,160 @@
+# Upstream Q00/ouroboros sync roadmap
+
+**Status:** Planning · July 2026  
+**Upstream baseline:** [Q00/ouroboros v0.50.3](https://github.com/Q00/ouroboros/releases/tag/v0.50.3) (PAL / model-tier routing, frugality proof machinery)  
+**ClawQL target:** `clawql-ouroboros` evolutionary loop + Layer 8 inference routing + Hermes MoA (DAOS §6.7)
+
+**Related:** [clawql-ouroboros guide](./clawql-ouroboros.md) · [DAOS unified spec v2.7](./daos-unified-architecture-specification-v2.7.md) · [Token efficiency Layer 8](../architecture/clawql-token-efficiency.md) · [GitHub epic #556](https://github.com/danielsmithdevelopment/ClawQL/issues/556)
+
+---
+
+## Context
+
+`clawql-ouroboros` is a TypeScript port of the evolutionary loop from [Q00/ouroboros](https://github.com/Q00/ouroboros), maintained in friendly coordination with upstream (JQ Lee). Upstream has diverged since the initial port — notably **PAL Router** (frugal → standard → frontier with per-retry escalation), **3-component drift measurement**, and **frugality proof events**.
+
+ClawQL adds governance primitives upstream does not ship: WORM audit, PEP/ATR, Manifest policy blocks, and (roadmap) **NSV/SGDOP** swarm coordination. The differentiated stack is **PAL (vertical cost routing) + Hermes MoA (horizontal ensemble) + SGDOP (blind-spot direction) + WORM (auditable tier decisions)**.
+
+This document separates **what to port** from **what to leave alone**, defines package boundaries, and sequences implementation tickets.
+
+---
+
+## Gap analysis (shipped today)
+
+| Capability | `clawql-ouroboros` | Q00 v0.50.3 |
+| --- | --- | --- |
+| Wonder / Reflect / Execute / Evaluate | Shipped | Shipped |
+| Ontology similarity convergence | Shipped (`convergence.ts`) | Shipped (different math) |
+| Stagnation / oscillation detection | Shipped (fingerprint window) | Shipped (4 named patterns) |
+| 3-component drift (Goal 50% / Constraint 30% / Ontology 20%, threshold ≤ 0.3) | **Not shipped** — `ambiguity_score` on Seed unused in loop | Shipped (`ouroboros_measure_drift`) |
+| PAL / model-tier routing | **Not shipped** — documented omission | **Shipped** (headline v0.50.3) |
+| Frugality proof / per-AC token attribution | **Not shipped** | Shipped |
+| MoA / multi-model consensus | **Not shipped** — DAOS §6.7 roadmap | Shipped (Stage 3 + tiers) |
+| NSV / SGDOP | **Not shipped** — DAOS P3 roadmap | Partial (consensus triggers) |
+| Routing | `clawql_execute` / `clawql_search` API hints | LLM tier + runtime routing |
+
+**Marketing gap:** [`docs/posts/introducing-clawql-ouroboros.md`](../posts/introducing-clawql-ouroboros.md) claims ontological drift tracking; implementation must catch up or copy be revised.
+
+---
+
+## Architecture: where each piece lives
+
+```mermaid
+flowchart TB
+  subgraph loop ["clawql-ouroboros"]
+    W[Wonder] --> R[Reflect] --> E[Execute] --> EV[Evaluate]
+    EV --> D[DriftMeasure]
+    D --> C[ConvergenceCriteria]
+  end
+
+  subgraph routing ["Adaptive routing — new / extended"]
+    PAL[PAL Router — Layer 8 or clawql-inference-routing]
+    MOA[Hermes MoA adapter]
+    NSV[NSV/SGDOP — DAOS coordination P3]
+  end
+
+  subgraph audit ["Audit"]
+    ES[Postgres ouroboros events / WORM]
+  end
+
+  E --> PAL
+  PAL -->|tier exhausted or drift tripwire| MOA
+  MOA --> NSV
+  PAL --> ES
+  MOA --> ES
+  D --> ES
+```
+
+| Piece | Package / layer | Rationale |
+| --- | --- | --- |
+| Drift evaluator | `clawql-ouroboros` | Seed-native; per-generation |
+| Stagnation taxonomy | `clawql-ouroboros` | Extend `ConvergenceSignal.reason` |
+| PAL tier ladder | Layer 8 / new `clawql-inference-routing` (TBD) | Shared across ouroboros, agent chat, schedule |
+| Frugality audit events | `clawql-ouroboros` event store + WORM envelope | Same lineage stream |
+| MoA fan-out | Hermes runtime / gateway adapter | External ensemble; not in-loop Python port |
+| NSV/SGDOP model pick | DAOS coordination (build plan P3) | Needs embeddings + Coordinator |
+| Active Conductor menus | MCP event meta on lineage | Host judgment; proposed upstream RFC |
+
+---
+
+## Adaptive routing flow (target)
+
+```
+Request → PAL: Frugal solo (Phi-4 class)
+  → success? done (min cost)
+  → failure? Standard solo (Qwen class)
+    → success? done
+    → failure OR combined_drift > 0.3 OR NSV below nsv_crit?
+      → MoA fan-out (Hermes: reference models + aggregator)
+      → SGDOP informs which families to include (when shipped)
+      → ensemble converges? done
+      → still failing? Frontier solo → HITL / Command Deck
+```
+
+Every PAL escalation and MoA trigger writes an auditable event (`pal_escalation`, `moa_fanout`, `drift_measured`) with failure signal, tier before/after, and token attribution when available.
+
+---
+
+## Port / adapt / skip
+
+### Port or adapt (tickets below)
+
+1. **3-component drift measurement** — upstream weighting; new evaluator + convergence gate; MCP `ouroboros_measure_drift`.
+2. **PAL Router** — tier map in Manifest or Layer 8 config; one-notch escalation per retry; decomposed-child vs top-level initial tier.
+3. **Frugality proof events** — per-generation token attribution + escalation audit (fail-closed admission rules per upstream spirit).
+4. **Stagnation taxonomy** — named reasons: `spinning`, `oscillation`, `no_drift`, `diminishing_returns` mapped onto existing detectors.
+5. **PAL → MoA coupling** — MoA at Standard-tier exhaustion, not immediate Frontier single-model jump.
+6. **Active Conductor (later)** — `attention_required` + `recommended_host_actions` on lineage events (upstream RFC proposed, not in v0.50.3 binaries).
+
+### Skip (intentionally)
+
+- Python TUI, `ooo` CLI, LiteLLM integration, Codex warm-thread workarounds
+- Direct port of TraceGuard prose validators (reimplement against ClawQL eval pipeline)
+- Full `~/.ouroboros/mcp_servers.yaml` auto-discovery (ClawQL `sources` / provider model is sufficient; cherry-pick resume-durable config fingerprint if needed later)
+- Double Diamond subprocess orchestration (host delegates via MCP hints today)
+
+---
+
+## Implementation sequencing
+
+| Phase | Ticket | Deliverable | Depends on |
+| --- | --- | --- | --- |
+| **P0-A** | [#557](https://github.com/danielsmithdevelopment/ClawQL/issues/557) | Drift evaluator + `ouroboros_measure_drift` MCP tool + `drift_measured` events | — |
+| **P0-B** | [#558](https://github.com/danielsmithdevelopment/ClawQL/issues/558) | Convergence gate: `combined_drift > 0.3` blocks premature converge; triggers reflect | P0-A |
+| **P0-C** | [#559](https://github.com/danielsmithdevelopment/ClawQL/issues/559) | Stagnation taxonomy reason codes on `ConvergenceSignal` | — |
+| **P0-D** | [#560](https://github.com/danielsmithdevelopment/ClawQL/issues/560) | PAL tier map + `AdaptiveRouter` interface; inject into Wonder/Reflect/Execute | Layer 8 config sketch |
+| **P0-E** | [#561](https://github.com/danielsmithdevelopment/ClawQL/issues/561) | `pal_escalation` + token attribution events in Postgres event store | P0-D |
+| **P1-A** | [#562](https://github.com/danielsmithdevelopment/ClawQL/issues/562) | PAL → MoA trigger at Standard failure + drift tripwire | P0-A, P0-D, Hermes adapter |
+| **P1-B** | [#563](https://github.com/danielsmithdevelopment/ClawQL/issues/563) | Align introducing post / clawql-ouroboros.md with shipped drift behavior | P0-A |
+| **P2** | DAOS P3 | NSV/SGDOP-directed MoA model family selection | Coordinator, embeddings |
+| **P3** | [#564](https://github.com/danielsmithdevelopment/ClawQL/issues/564) | Active Conductor attention menus on MCP lineage stream | P0-E events |
+
+**P0-A is the recommended first PR** — small surface, closes marketing/implementation gap, gives PAL/MoA a concrete failure signal.
+
+---
+
+## TypeScript contracts (sketch)
+
+See epic issue body for `ModelTierMap`, `AdaptiveRouter`, `PalRoutingDecision`, `MoaRoutingDecision`, and `RoutingAuditEvent` types. Implementation packages should export these from a single module to avoid drift between gateway and ouroboros.
+
+---
+
+## Upstream coordination (JQ Lee)
+
+Before locking weighting assumptions, confirm:
+
+1. Drift 50/30/20 when Wonder and Reflect run on different tiers in one generation.
+2. Frugality proof baseline thresholds for enterprise audit (`insufficient_data` vs `fail_no_frugality`).
+3. MoA vs Frontier — upstream failure signal preference.
+4. Active Conductor S1 (attention classification) timeline.
+5. SGDOP math changes since last ClawQL PHE iteration.
+
+---
+
+## References
+
+- Q00 release: [v0.50.3 — Frugality-first execution](https://github.com/Q00/ouroboros/releases/tag/v0.50.3)
+- Upstream drift skill: [skills/status/SKILL.md](https://github.com/Q00/ouroboros/blob/main/skills/status/SKILL.md)
+- Upstream Active Conductor RFC: [docs/rfc/active-conductor.md](https://github.com/Q00/ouroboros/blob/main/docs/rfc/active-conductor.md) (proposed)
+- ClawQL Layer 8: [clawql-token-efficiency.md § Layer 8](../architecture/clawql-token-efficiency.md)
+- DAOS MoA: [daos-unified-architecture-specification-v2.7.md § 6.7](./daos-unified-architecture-specification-v2.7.md)
+- Shipped loop code: [`packages/clawql-ouroboros/src/convergence.ts`](../../packages/clawql-ouroboros/src/convergence.ts)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a planning document for re-syncing `clawql-ouroboros` with upstream [Q00/ouroboros v0.50.3+](https://github.com/Q00/ouroboros/releases/tag/v0.50.3) (PAL Router, 3-component drift, frugality proof events) and composing with ClawQL layers (Layer 8 routing, Hermes MoA, WORM audit).

GitHub epic and child issues were created to track implementation:

- **Epic [#556](https://github.com/danielsmithdevelopment/ClawQL/issues/556)** — Upstream Q00/ouroboros sync
- [#557](https://github.com/danielsmithdevelopment/ClawQL/issues/557) P0-A: Drift measurement + `ouroboros_measure_drift`
- [#558](https://github.com/danielsmithdevelopment/ClawQL/issues/558) P0-B: Drift convergence gate
- [#559](https://github.com/danielsmithdevelopment/ClawQL/issues/559) P0-C: Stagnation taxonomy
- [#560](https://github.com/danielsmithdevelopment/ClawQL/issues/560) P0-D: PAL Router / Layer 8
- [#561](https://github.com/danielsmithdevelopment/ClawQL/issues/561) P0-E: Frugality audit events
- [#562](https://github.com/danielsmithdevelopment/ClawQL/issues/562) P1-A: PAL → MoA (Hermes)
- [#563](https://github.com/danielsmithdevelopment/ClawQL/issues/563) P1-B: Docs alignment
- [#564](https://github.com/danielsmithdevelopment/ClawQL/issues/564) P3: Active Conductor events

## Changes

- New `docs/ouroboros/upstream-q00-sync-roadmap.md` — gap analysis, architecture boundaries, sequencing, JQ coordination questions
- Link from `docs/ouroboros/clawql-ouroboros.md`

## Recommended next step

Implement **#557** (drift evaluator) as the first code PR — smallest surface, unblocks PAL/MoA failure signals.

## Test plan

- [x] Doc-only change; links verified
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

