### PR TITLE
fix(website): site-wide docs table formatting for 2–8 columns

### DIFF
--- a/website/src/components/mdx.tsx
+++ b/website/src/components/mdx.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx'
 import Link from 'next/link'
+import { Children, isValidElement } from 'react'
 
 import { FeedbackClientIsland } from '@/components/FeedbackClientIsland'
 import { Heading } from '@/components/Heading'
@@ -106,15 +107,42 @@ export function Col({
   )
 }
 
+type TableRowProps = { children?: React.ReactNode }
+type TableSectionProps = { children?: React.ReactNode }
+
+/** Count columns from the first header/data row for responsive table layout. */
+function countTableColumns(children: React.ReactNode): number {
+  let cols = 0
+  Children.forEach(children, (section) => {
+    if (!isValidElement<TableSectionProps>(section)) return
+    Children.forEach(section.props.children, (row) => {
+      if (!isValidElement<TableRowProps>(row) || row.type !== 'tr') return
+      let rowCols = 0
+      Children.forEach(row.props.children, (cell) => {
+        if (isValidElement(cell) && (cell.type === 'th' || cell.type === 'td')) {
+          rowCols += 1
+        }
+      })
+      cols = Math.max(cols, rowCols)
+    })
+  })
+  return cols
+}
+
 /** Scrollable table wrapper — keeps column alignment on narrow viewports. */
 export function table({
   children,
   className,
   ...props
 }: React.ComponentPropsWithoutRef<'table'>) {
+  const cols = countTableColumns(children)
   return (
     <div className="docs-table-scroll not-prose">
-      <table className={clsx('docs-table', className)} {...props}>
+      <table
+        className={clsx('docs-table', cols ? `docs-table-cols-${cols}` : null, className)}
+        data-cols={cols > 0 ? cols : undefined}
+        {...props}
+      >
         {children}
       </table>
     </div>

--- a/website/src/components/mdx.tsx
+++ b/website/src/components/mdx.tsx
@@ -119,7 +119,10 @@ function countTableColumns(children: React.ReactNode): number {
       if (!isValidElement<TableRowProps>(row) || row.type !== 'tr') return
       let rowCols = 0
       Children.forEach(row.props.children, (cell) => {
-        if (isValidElement(cell) && (cell.type === 'th' || cell.type === 'td')) {
+        if (
+          isValidElement(cell) &&
+          (cell.type === 'th' || cell.type === 'td')
+        ) {
           rowCols += 1
         }
       })
@@ -139,7 +142,11 @@ export function table({
   return (
     <div className="docs-table-scroll not-prose">
       <table
-        className={clsx('docs-table', cols ? `docs-table-cols-${cols}` : null, className)}
+        className={clsx(
+          'docs-table',
+          cols ? `docs-table-cols-${cols}` : null,
+          className,
+        )}
         data-cols={cols > 0 ? cols : undefined}
         {...props}
       >

--- a/website/src/styles/tailwind.css
+++ b/website/src/styles/tailwind.css
@@ -111,41 +111,89 @@
     word-break: break-word;
   }
 
-  /* Two-column reference tables (Command | Purpose, Variable | Purpose, …) */
-  .prose
-    .docs-table:has(thead tr > th:nth-child(2):last-child)
-    :is(th, td):nth-child(1) {
+  /* Column layouts (data-cols set at build time in mdx.tsx `table`) */
+  .prose .docs-table[data-cols='2'] {
+    min-width: 22.5rem;
+  }
+
+  .prose .docs-table[data-cols='2'] :is(th, td):nth-child(1) {
     width: 42%;
     min-width: 10.5rem;
   }
 
-  .prose
-    .docs-table:has(thead tr > th:nth-child(2):last-child)
-    :is(th, td):nth-child(2) {
+  .prose .docs-table[data-cols='2'] :is(th, td):nth-child(2) {
     width: 58%;
     min-width: 12rem;
   }
 
-  .prose .docs-table:has(thead tr > th:nth-child(2):last-child) {
-    min-width: 22.5rem;
+  .prose .docs-table[data-cols='3'] {
+    min-width: 36rem;
   }
 
-  /* Four-column provider matrices — scroll instead of squashing */
-  .prose .docs-table:has(thead tr > th:nth-child(4):last-child) {
+  .prose .docs-table[data-cols='3'] :is(th, td) {
+    width: 33.333%;
+    min-width: 10rem;
+  }
+
+  .prose .docs-table[data-cols='4'] {
     min-width: 44rem;
   }
 
-  .prose .docs-table:has(thead tr > th:nth-child(4):last-child) :is(th, td) {
+  .prose .docs-table[data-cols='4'] :is(th, td) {
     width: 25%;
     min-width: 9rem;
   }
 
-  /* Three-column tables */
-  .prose
-    .docs-table:has(thead tr > th:nth-child(3):last-child):not(
-      :has(thead tr > th:nth-child(4))
-    )
-    :is(th, td) {
-    width: 33.333%;
+  .prose .docs-table[data-cols='5'] {
+    min-width: 52rem;
+  }
+
+  .prose .docs-table[data-cols='5'] :is(th, td) {
+    width: 20%;
+    min-width: 8.5rem;
+  }
+
+  .prose .docs-table[data-cols='6'] {
+    min-width: 60rem;
+  }
+
+  .prose .docs-table[data-cols='6'] :is(th, td) {
+    width: 16.666%;
+    min-width: 8.5rem;
+  }
+
+  .prose .docs-table[data-cols='7'] {
+    min-width: 72rem;
+  }
+
+  .prose .docs-table[data-cols='7'] :is(th, td) {
+    width: 14.285%;
+    min-width: 8rem;
+  }
+
+  /* Wide matrices (plugin registry, etc.) */
+  .prose .docs-table[data-cols='8'] {
+    min-width: 80rem;
+  }
+
+  .prose .docs-table[data-cols='8'] :is(th, td) {
+    width: 12.5%;
+    min-width: 7.5rem;
+  }
+
+  /* Fenced code blocks in prose — scroll instead of overflowing the page */
+  .prose :where(pre):not(:where([class~='not-prose'], [class~='not-prose'] *)) {
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  @media (width < 40rem) {
+    .prose
+      :where(pre):not(:where([class~='not-prose'], [class~='not-prose'] *)) {
+      margin-left: -1rem;
+      margin-right: -1rem;
+      border-radius: 0;
+    }
   }
 }

--- a/website/typography.ts
+++ b/website/typography.ts
@@ -310,6 +310,17 @@ export default {
             boxShadow: 'inset 0 0 0 1px var(--tw-prose-code-ring)',
             backgroundColor: 'var(--tw-prose-code-bg)',
             fontSize: theme('fontSize.2xs')[0],
+            overflowWrap: 'anywhere',
+            wordBreak: 'break-word',
+          },
+          pre: {
+            maxWidth: '100%',
+            overflowX: 'auto',
+          },
+          'pre code': {
+            whiteSpace: 'pre',
+            wordBreak: 'normal',
+            overflowWrap: 'normal',
           },
           ':is(a, h1, h2, h3, blockquote, thead th) code': {
             color: 'inherit',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audits and extends the docs table formatting fixes from #554/#555 so **all** MDX tables across the site get consistent mobile behavior—not just 2- and 4-column pages.

## Changes

- **`mdx.tsx`**: Count table columns at render time; set `data-cols` and `docs-table-cols-N` on every MDX table.
- **`tailwind.css`**: Column-specific min-widths and equal column distribution for **2–8** columns; retain overlap prevention (`max-width: 0`, code wrapping); add horizontal scroll for prose `pre` blocks on narrow viewports.
- **`typography.ts`**: Inline `code` wrapping and `pre` overflow-x for long fenced blocks.

## Audit coverage

Verified built HTML includes `docs-table-scroll` + `data-cols` on representative pages:

| Page | Columns |
|------|---------|
| `/getting-started/team-vault-sync` | 2, 4 |
| `/reference/plugins` | 7 |
| `/vision/slide-deck` | 2–6 |
| `/bundled-specs`, `/tools` | 3 |

All 64+ MDX pages route tables through the shared `table` component—no per-page edits required.

## Deploy

Merges to `main` trigger **Deploy docs (Cloudflare)**. After green, spot-check mobile layout on the pages above.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4ece-0a09-7eba-8f80-55d043ac694b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4ece-0a09-7eba-8f80-55d043ac694b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

