### PR TITLE
feat(cloud-agent): R2 vault runbook, environment.json, Pulumi cloudflare fix

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,3 @@
+{
+  "install": "bash .cursor/scripts/cloud-agent-install.sh"
+}

--- a/.cursor/scripts/cloud-agent-install.sh
+++ b/.cursor/scripts/cloud-agent-install.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Cloud Agent install — idempotent; cached as environment snapshot after first run.
+# See docs/deployment/cloud-agent-r2-tailscale-runbook.md
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[cloud-agent-install] Node $(node -v)"
+
+# ClawQL MCP + workspace packages
+if [[ -f package-lock.json ]]; then
+  npm ci
+else
+  npm install
+fi
+npm run build
+
+# Pulumi provision package (R2 bucket tests)
+cd infra/pulumi
+if [[ -f package-lock.json ]]; then
+  npm ci
+else
+  npm install
+fi
+npm test
+npm run build
+cd "$ROOT"
+
+# Local ClawQL home for memory vault (ephemeral VM; durable notes via R2 sync)
+export CLAWQL_HOME="${CLAWQL_HOME:-$HOME/.ClawQL}"
+mkdir -p "$CLAWQL_HOME/Memory" "$CLAWQL_HOME/vault"
+
+if [[ ! -f "$CLAWQL_HOME/clawql.env" ]]; then
+  cat >"$CLAWQL_HOME/clawql.env" <<EOF
+CLAWQL_OBSIDIAN_VAULT_PATH=$CLAWQL_HOME
+CLAWQL_BUNDLED_OFFLINE=1
+CLAWQL_ENABLE_MEMORY=1
+CLAWQL_ENABLE_OUROBOROS=1
+CLAWQL_SYNC_PROVIDER=r2
+CLAWQL_SYNC_AUTO=1
+CLAWQL_SYNC_AUTO_PULL=1
+CLAWQL_SYNC_AUTO_PULL_ON_START=1
+EOF
+fi
+
+# Pull team vault from R2 when sync credentials are present (Cursor Secrets)
+if [[ -n "${CLAWQL_SYNC_BUCKET:-}" && -n "${CLAWQL_SYNC_ACCESS_KEY_ID:-}" && -n "${CLAWQL_SYNC_SECRET_ACCESS_KEY:-}" ]]; then
+  echo "[cloud-agent-install] R2 sync configured — pulling team vault"
+  npx clawql sync pull || echo "[cloud-agent-install] sync pull skipped (bucket empty or first run)"
+else
+  echo "[cloud-agent-install] R2 sync secrets not set — skipping pull (configure in Cursor Secrets)"
+fi
+
+echo "[cloud-agent-install] done"

--- a/docs/deployment/cloud-agent-r2-tailscale-runbook.md
+++ b/docs/deployment/cloud-agent-r2-tailscale-runbook.md
@@ -10,10 +10,10 @@ Run **ClawQL Cloud Agents** with a **durable memory vault on Cloudflare R2**, pr
 
 Cloud Agents and private phone access solve **different** problems. Use both:
 
-| Layer | What | Who can reach it |
-| --- | --- | --- |
-| **A — Cloud Agent** | Cursor VM runs `clawql-mcp` (stdio) + R2 sync | You (via Cursor app / web); MCP runs inside the agent VM |
-| **B — Tailscale host** | Your machine or golden host runs `clawql-mcp-http` + **Tailscale Serve** | Only devices on **your tailnet** (laptop, phone) |
+| Layer                  | What                                                                     | Who can reach it                                         |
+| ---------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------- |
+| **A — Cloud Agent**    | Cursor VM runs `clawql-mcp` (stdio) + R2 sync                            | You (via Cursor app / web); MCP runs inside the agent VM |
+| **B — Tailscale host** | Your machine or golden host runs `clawql-mcp-http` + **Tailscale Serve** | Only devices on **your tailnet** (laptop, phone)         |
 
 ```mermaid
 flowchart LR
@@ -109,27 +109,27 @@ Or run `pulumi preview` in the agent after configuring secrets (Phase 2).
 
 This repo ships:
 
-| File | Purpose |
-| --- | --- |
-| [`.cursor/environment.json`](../../.cursor/environment.json) | Build ClawQL + Pulumi; init `~/.ClawQL`; optional R2 pull |
-| [`.cursor/scripts/cloud-agent-install.sh`](../../.cursor/scripts/cloud-agent-install.sh) | Idempotent install script |
+| File                                                                                     | Purpose                                                   |
+| ---------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| [`.cursor/environment.json`](../../.cursor/environment.json)                             | Build ClawQL + Pulumi; init `~/.ClawQL`; optional R2 pull |
+| [`.cursor/scripts/cloud-agent-install.sh`](../../.cursor/scripts/cloud-agent-install.sh) | Idempotent install script                                 |
 
 ### 2a. Cursor Secrets (Dashboard → Cloud Agents → Secrets)
 
 Add these **runtime** secrets (names must match — the install script and MCP child read them):
 
-| Secret | Example / notes |
-| --- | --- |
-| `CLAWQL_HOME` | `/home/ubuntu/.ClawQL` (optional; install script defaults) |
-| `CLAWQL_R2_ACCOUNT_ID` | Cloudflare account id |
-| `CLAWQL_SYNC_BUCKET` | `clawql-team-vault` (or Pulumi output name) |
-| `CLAWQL_SYNC_PREFIX` | `tenant/your-handle/` (from Pulumi `syncPrefix`) |
-| `CLAWQL_SYNC_ACCESS_KEY_ID` | R2 S3 access key |
-| `CLAWQL_SYNC_SECRET_ACCESS_KEY` | R2 S3 secret |
-| `PULUMI_CONFIG_PASSPHRASE` | Pulumi stack encryption passphrase |
-| `AWS_ACCESS_KEY_ID` | Same R2 key (for Pulumi S3 state backend + AWS SDK) |
-| `AWS_SECRET_ACCESS_KEY` | Same R2 secret |
-| `CLOUDFLARE_API_TOKEN` | For `pulumi up` from the agent (optional) |
+| Secret                          | Example / notes                                            |
+| ------------------------------- | ---------------------------------------------------------- |
+| `CLAWQL_HOME`                   | `/home/ubuntu/.ClawQL` (optional; install script defaults) |
+| `CLAWQL_R2_ACCOUNT_ID`          | Cloudflare account id                                      |
+| `CLAWQL_SYNC_BUCKET`            | `clawql-team-vault` (or Pulumi output name)                |
+| `CLAWQL_SYNC_PREFIX`            | `tenant/your-handle/` (from Pulumi `syncPrefix`)           |
+| `CLAWQL_SYNC_ACCESS_KEY_ID`     | R2 S3 access key                                           |
+| `CLAWQL_SYNC_SECRET_ACCESS_KEY` | R2 S3 secret                                               |
+| `PULUMI_CONFIG_PASSPHRASE`      | Pulumi stack encryption passphrase                         |
+| `AWS_ACCESS_KEY_ID`             | Same R2 key (for Pulumi S3 state backend + AWS SDK)        |
+| `AWS_SECRET_ACCESS_KEY`         | Same R2 secret                                             |
+| `CLOUDFLARE_API_TOKEN`          | For `pulumi up` from the agent (optional)                  |
 
 **Provider API tokens** (GitHub, Cloudflare API execute, etc.): use `clawql secrets set` inside the agent session, or add recognized keys to the vault — never commit to git. See [local provider vault](../getting-started/local-provider-vault.md).
 
@@ -137,12 +137,12 @@ Add these **runtime** secrets (names must match — the install script and MCP c
 
 Add a **stdio** server (runs inside the Cloud Agent VM):
 
-| Field | Value |
-| --- | --- |
-| Name | `clawql` |
-| Command | `npx` |
-| Args | `["-p", "clawql-mcp", "clawql-mcp"]` |
-| Env | `CLAWQL_HOME=/home/ubuntu/.ClawQL` (match your VM user) |
+| Field   | Value                                                   |
+| ------- | ------------------------------------------------------- |
+| Name    | `clawql`                                                |
+| Command | `npx`                                                   |
+| Args    | `["-p", "clawql-mcp", "clawql-mcp"]`                    |
+| Env     | `CLAWQL_HOME=/home/ubuntu/.ClawQL` (match your VM user) |
 
 Enable **clawql** in the MCP dropdown when starting each agent run.
 
@@ -247,11 +247,11 @@ Enroll the MCP host with `--advertise-tags=tag:clawql-mcp` (see [headscale ACL s
 
 ### 3c. Cloudflare’s role
 
-| Service | Use | Public? |
-| --- | --- | --- |
-| **R2** | Durable vault + Pulumi state | **No** — S3 API with private keys only |
+| Service                                         | Use                                                | Public?                                                |
+| ----------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------ |
+| **R2**                                          | Durable vault + Pulumi state                       | **No** — S3 API with private keys only                 |
 | **Cloudflare Worker** (`cloudflare/mcp-proxy/`) | Optional CORS edge in front of a **remote** origin | Only if you deploy it; **not** needed for tailnet-only |
-| **Tailscale Serve** | Private HTTPS MCP | **Tailnet only** |
+| **Tailscale Serve**                             | Private HTTPS MCP                                  | **Tailnet only**                                       |
 
 Do **not** expose `clawql-mcp-http` on a public Cloudflare Worker without **Cloudflare Access** or equivalent — Tailscale is the simpler “only me” path.
 
@@ -259,26 +259,26 @@ Do **not** expose `clawql-mcp-http` on a public Cloudflare Worker without **Clou
 
 ## Phase 4 — End-to-end test checklist
 
-| Step | Command / action | Pass |
-| --- | --- | --- |
-| Pulumi R2 bucket | `pulumi up` (cloudflare stack) | `bucketName` in outputs |
-| R2 sync push | `clawql sync push` after `memory_ingest` | Object visible in R2 dashboard |
-| Cloud Agent MCP | `clawql doctor --smoke` in agent | Core tools OK |
-| Memory round-trip | `memory_recall` after new agent run | Note from R2 pull |
-| Tailscale health | `curl https://<host>.<tailnet>.ts.net/healthz` from phone | `status: ok` |
-| ACL | Second Tailscale user / unauthenticated host | Connection denied |
+| Step              | Command / action                                          | Pass                           |
+| ----------------- | --------------------------------------------------------- | ------------------------------ |
+| Pulumi R2 bucket  | `pulumi up` (cloudflare stack)                            | `bucketName` in outputs        |
+| R2 sync push      | `clawql sync push` after `memory_ingest`                  | Object visible in R2 dashboard |
+| Cloud Agent MCP   | `clawql doctor --smoke` in agent                          | Core tools OK                  |
+| Memory round-trip | `memory_recall` after new agent run                       | Note from R2 pull              |
+| Tailscale health  | `curl https://<host>.<tailnet>.ts.net/healthz` from phone | `status: ok`                   |
+| ACL               | Second Tailscale user / unauthenticated host              | Connection denied              |
 
 ---
 
 ## Troubleshooting
 
-| Symptom | Fix |
-| --- | --- |
-| MCP tools missing in Cloud Agent | Enable **clawql** in MCP dropdown; confirm stdio server in dashboard |
-| `sync pull` skipped | Set `CLAWQL_SYNC_*` + `CLAWQL_R2_ACCOUNT_ID` in Cursor Secrets |
-| `pulumi up` fails on cloudflare | Set `cloudflare:apiToken` + `cloudflare:accountId`; no `goldenImageId` needed |
-| Phone cannot reach MCP | Tailscale on phone must be **Connected**; use Serve HTTPS URL, not `localhost` |
-| Cloud Agent cannot use tailnet HTTP MCP | Expected — use stdio MCP in agent; tailnet URL is for laptop/phone direct |
+| Symptom                                 | Fix                                                                            |
+| --------------------------------------- | ------------------------------------------------------------------------------ |
+| MCP tools missing in Cloud Agent        | Enable **clawql** in MCP dropdown; confirm stdio server in dashboard           |
+| `sync pull` skipped                     | Set `CLAWQL_SYNC_*` + `CLAWQL_R2_ACCOUNT_ID` in Cursor Secrets                 |
+| `pulumi up` fails on cloudflare         | Set `cloudflare:apiToken` + `cloudflare:accountId`; no `goldenImageId` needed  |
+| Phone cannot reach MCP                  | Tailscale on phone must be **Connected**; use Serve HTTPS URL, not `localhost` |
+| Cloud Agent cannot use tailnet HTTP MCP | Expected — use stdio MCP in agent; tailnet URL is for laptop/phone direct      |
 
 ---
 

--- a/docs/deployment/cloud-agent-r2-tailscale-runbook.md
+++ b/docs/deployment/cloud-agent-r2-tailscale-runbook.md
@@ -1,0 +1,288 @@
+# Cloud Agent + Pulumi R2 + Tailscale (private MCP)
+
+Run **ClawQL Cloud Agents** with a **durable memory vault on Cloudflare R2**, provision the bucket with **Pulumi**, and expose a **phone-reachable MCP endpoint** only on your **Tailscale tailnet** — not on the public internet.
+
+**Related:** [Team vault sync (R2)](../getting-started/team-vault-sync.md) · [Pulumi provision](../../infra/pulumi/README.md) · [Tailscale beginner guide](./tailscale-and-headscale-for-clawql.md) · [ADR 0007](../adr/0007-pulumi-provisioning-managed-tiers.md)
+
+---
+
+## Architecture (two layers)
+
+Cloud Agents and private phone access solve **different** problems. Use both:
+
+| Layer | What | Who can reach it |
+| --- | --- | --- |
+| **A — Cloud Agent** | Cursor VM runs `clawql-mcp` (stdio) + R2 sync | You (via Cursor app / web); MCP runs inside the agent VM |
+| **B — Tailscale host** | Your machine or golden host runs `clawql-mcp-http` + **Tailscale Serve** | Only devices on **your tailnet** (laptop, phone) |
+
+```mermaid
+flowchart LR
+  subgraph cf [Cloudflare — private object storage]
+    R2[(R2 team vault bucket)]
+    STATE[(Pulumi state bucket optional)]
+  end
+
+  subgraph cursor [Cursor Cloud Agent VM]
+    MCP[clawql-mcp stdio]
+    VAULT[~/.ClawQL local vault]
+    SYNC[clawql sync auto]
+  end
+
+  subgraph tailnet [Your tailnet only]
+    PHONE[Phone Tailscale app]
+    LAPTOP[Laptop Cursor IDE]
+    HOST[Mac / VM clawql-mcp-http]
+    SERVE[Tailscale Serve HTTPS]
+  end
+
+  PULUMI[Pulumi up] --> R2
+  PULUMI --> STATE
+  SYNC <-->|S3 API| R2
+  MCP --> VAULT
+  VAULT --> SYNC
+  HOST --> SERVE
+  SERVE --> PHONE
+  SERVE --> LAPTOP
+  HOST --> SYNC
+```
+
+**Important:** Cursor Cloud Agents **cannot** use HTTP MCP URLs on `100.x` tailnet addresses — HTTP MCP is proxied through Cursor’s backend, which is **not** on your tailnet. For phone + private URL, use **Layer B** (Tailscale Serve on a host you control). Layer A gives you **durable memory in R2** while the agent VM is ephemeral.
+
+---
+
+## Phase 1 — Cloudflare R2 + Pulumi (team vault bucket)
+
+### 1a. Prerequisites (your Cloudflare account)
+
+1. **R2** enabled on the account.
+2. **Two buckets** (recommended):
+   - `clawql-team-vault` — memory notes (`Memory/`, `sources/`, …)
+   - `clawql-pulumi-state` — Pulumi stack state (optional but preferred per ADR 0007)
+3. **R2 API token** with Object Read & Write on those buckets.
+4. **Cloudflare API token** for Pulumi with **R2 Edit** (and account read) — used only at provision time, not stored in git.
+
+Create R2 S3 credentials in: Cloudflare Dashboard → R2 → Manage R2 API tokens.
+
+### 1b. Pulumi state backend (one-time, your laptop or Cloud Agent)
+
+```bash
+export AWS_ACCESS_KEY_ID="<r2-access-key>"
+export AWS_SECRET_ACCESS_KEY="<r2-secret>"
+pulumi login 's3://clawql-pulumi-state?region=auto&endpoint=https://<accountid>.r2.cloudflarestorage.com&awssdk=v2'
+```
+
+Set a passphrase when prompted — store it as **`PULUMI_CONFIG_PASSPHRASE`** in Cursor Secrets.
+
+### 1c. Provision the team vault bucket
+
+```bash
+cd infra/pulumi
+cp Pulumi.cloudflare.example.yaml Pulumi.dev-r2.yaml
+pulumi stack init dev-r2
+
+pulumi config set cloudflare:apiToken --secret    # Cloudflare API token
+pulumi config set cloudflare:accountId <account-id>
+pulumi config set clawql:cloud cloudflare
+pulumi config set clawql:tier dedicated
+pulumi config set clawql:tenantId <your-handle>
+pulumi config set clawql:syncBucket clawql-team-vault
+
+pulumi preview
+pulumi up
+```
+
+Outputs: `bucketName`, `syncPrefix` (e.g. `tenant/<your-handle>/`).
+
+**Note:** Pulumi creates the **bucket only** — not R2 API tokens. Create sync credentials manually (step 1a) and store them in Cursor Secrets.
+
+### 1d. Verify from a Cloud Agent
+
+Ask the agent:
+
+> Run `cd infra/pulumi && pulumi stack output` and confirm `bucketName` matches the R2 bucket.
+
+Or run `pulumi preview` in the agent after configuring secrets (Phase 2).
+
+---
+
+## Phase 2 — Cursor Cloud Agent configuration
+
+This repo ships:
+
+| File | Purpose |
+| --- | --- |
+| [`.cursor/environment.json`](../../.cursor/environment.json) | Build ClawQL + Pulumi; init `~/.ClawQL`; optional R2 pull |
+| [`.cursor/scripts/cloud-agent-install.sh`](../../.cursor/scripts/cloud-agent-install.sh) | Idempotent install script |
+
+### 2a. Cursor Secrets (Dashboard → Cloud Agents → Secrets)
+
+Add these **runtime** secrets (names must match — the install script and MCP child read them):
+
+| Secret | Example / notes |
+| --- | --- |
+| `CLAWQL_HOME` | `/home/ubuntu/.ClawQL` (optional; install script defaults) |
+| `CLAWQL_R2_ACCOUNT_ID` | Cloudflare account id |
+| `CLAWQL_SYNC_BUCKET` | `clawql-team-vault` (or Pulumi output name) |
+| `CLAWQL_SYNC_PREFIX` | `tenant/your-handle/` (from Pulumi `syncPrefix`) |
+| `CLAWQL_SYNC_ACCESS_KEY_ID` | R2 S3 access key |
+| `CLAWQL_SYNC_SECRET_ACCESS_KEY` | R2 S3 secret |
+| `PULUMI_CONFIG_PASSPHRASE` | Pulumi stack encryption passphrase |
+| `AWS_ACCESS_KEY_ID` | Same R2 key (for Pulumi S3 state backend + AWS SDK) |
+| `AWS_SECRET_ACCESS_KEY` | Same R2 secret |
+| `CLOUDFLARE_API_TOKEN` | For `pulumi up` from the agent (optional) |
+
+**Provider API tokens** (GitHub, Cloudflare API execute, etc.): use `clawql secrets set` inside the agent session, or add recognized keys to the vault — never commit to git. See [local provider vault](../getting-started/local-provider-vault.md).
+
+### 2b. MCP server (Dashboard → Integrations & MCP)
+
+Add a **stdio** server (runs inside the Cloud Agent VM):
+
+| Field | Value |
+| --- | --- |
+| Name | `clawql` |
+| Command | `npx` |
+| Args | `["-p", "clawql-mcp", "clawql-mcp"]` |
+| Env | `CLAWQL_HOME=/home/ubuntu/.ClawQL` (match your VM user) |
+
+Enable **clawql** in the MCP dropdown when starting each agent run.
+
+Optional feature flags (add to Secrets or `~/.ClawQL/clawql.env`):
+
+```bash
+CLAWQL_ENABLE_OUROBOROS=1
+CLAWQL_ENABLE_MEMORY=1
+CLAWQL_BUNDLED_OFFLINE=1
+```
+
+### 2c. Start an agent
+
+1. Open [cursor.com/agents](https://cursor.com/agents) → select this repo.
+2. Confirm environment snapshot built (first run runs `install`; later runs reuse snapshot).
+3. Enable **clawql** MCP.
+4. Prompt example:
+
+   > Run `clawql doctor --smoke`, then `memory_ingest` a test note, then `memory_recall` for it. Confirm `clawql sync push` uploaded to R2.
+
+### 2d. Pulumi login inside the agent (for provision tests)
+
+If you want the **agent** to run `pulumi up`, also set in Secrets:
+
+```bash
+PULUMI_BACKEND_URL=s3://clawql-pulumi-state?region=auto&endpoint=https://<accountid>.r2.cloudflarestorage.com&awssdk=v2
+```
+
+Then in the agent session:
+
+```bash
+cd infra/pulumi && pulumi stack select dev-r2 && pulumi preview
+```
+
+---
+
+## Phase 3 — Tailscale + phone (private MCP URL)
+
+Use this when you want **`https://…/mcp`** reachable from your **phone** without public exposure.
+
+### 3a. Managed Tailscale (fastest)
+
+1. Install [Tailscale](https://tailscale.com/download) on:
+   - The host running MCP (Mac, Linux VM, or Pulumi AWS/GCP golden host later)
+   - Your **phone**
+   - Your laptop
+2. Admin console → enable **MagicDNS**.
+3. On the MCP host, run HTTP MCP:
+
+   ```bash
+   PORT=8080 CLAWQL_OBSIDIAN_VAULT_PATH=~/.ClawQL npx -p clawql-mcp clawql-mcp-http
+   ```
+
+4. Expose with **Tailscale Serve** (HTTPS on tailnet only):
+
+   ```bash
+   tailscale serve --bg --https=443 http://127.0.0.1:8080
+   ```
+
+   Your MCP URL becomes something like:
+
+   `https://<hostname>.<tailnet>.ts.net/mcp`
+
+5. Point **local Cursor** (laptop) MCP at that URL via `~/.cursor/mcp.json`:
+
+   ```json
+   {
+     "mcpServers": {
+       "clawql": {
+         "url": "${env:CLAWQL_MCP_URL}"
+       }
+     }
+   }
+   ```
+
+   Set `CLAWQL_MCP_URL` in your shell to the Serve URL.
+
+6. **Phone:** install Tailscale, stay on tailnet. Use a browser or HTTP client on the phone to hit `https://<host>.<tailnet>.ts.net/healthz` — you should see `{"status":"ok"…}`. (Cursor mobile uses the cloud agent UI; direct MCP from phone is for health checks or future clients.)
+
+### 3b. Lock down to only you (ACL)
+
+In Tailscale admin → **Access controls**, replace open defaults with a single-user policy:
+
+```json
+{
+  "tagOwners": {
+    "tag:clawql-mcp": ["your-tailscale-login@example.com"]
+  },
+  "acls": [
+    {
+      "action": "accept",
+      "src": ["your-tailscale-login@example.com"],
+      "dst": ["tag:clawql-mcp:443,8080"]
+    }
+  ]
+}
+```
+
+Enroll the MCP host with `--advertise-tags=tag:clawql-mcp` (see [headscale ACL starter](./headscale-acls-clawql.hujson) for the multi-user pattern).
+
+**Result:** only identities you list can reach MCP ports. Everyone else — including the public internet — has no route.
+
+### 3c. Cloudflare’s role
+
+| Service | Use | Public? |
+| --- | --- | --- |
+| **R2** | Durable vault + Pulumi state | **No** — S3 API with private keys only |
+| **Cloudflare Worker** (`cloudflare/mcp-proxy/`) | Optional CORS edge in front of a **remote** origin | Only if you deploy it; **not** needed for tailnet-only |
+| **Tailscale Serve** | Private HTTPS MCP | **Tailnet only** |
+
+Do **not** expose `clawql-mcp-http` on a public Cloudflare Worker without **Cloudflare Access** or equivalent — Tailscale is the simpler “only me” path.
+
+---
+
+## Phase 4 — End-to-end test checklist
+
+| Step | Command / action | Pass |
+| --- | --- | --- |
+| Pulumi R2 bucket | `pulumi up` (cloudflare stack) | `bucketName` in outputs |
+| R2 sync push | `clawql sync push` after `memory_ingest` | Object visible in R2 dashboard |
+| Cloud Agent MCP | `clawql doctor --smoke` in agent | Core tools OK |
+| Memory round-trip | `memory_recall` after new agent run | Note from R2 pull |
+| Tailscale health | `curl https://<host>.<tailnet>.ts.net/healthz` from phone | `status: ok` |
+| ACL | Second Tailscale user / unauthenticated host | Connection denied |
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| MCP tools missing in Cloud Agent | Enable **clawql** in MCP dropdown; confirm stdio server in dashboard |
+| `sync pull` skipped | Set `CLAWQL_SYNC_*` + `CLAWQL_R2_ACCOUNT_ID` in Cursor Secrets |
+| `pulumi up` fails on cloudflare | Set `cloudflare:apiToken` + `cloudflare:accountId`; no `goldenImageId` needed |
+| Phone cannot reach MCP | Tailscale on phone must be **Connected**; use Serve HTTPS URL, not `localhost` |
+| Cloud Agent cannot use tailnet HTTP MCP | Expected — use stdio MCP in agent; tailnet URL is for laptop/phone direct |
+
+---
+
+## Related issues
+
+- Epic [#556](https://github.com/danielsmithdevelopment/ClawQL/issues/556) — Ouroboros upstream sync (optional with `CLAWQL_ENABLE_OUROBOROS=1`)
+- [#206](https://github.com/danielsmithdevelopment/ClawQL/issues/206) / [#211](https://github.com/danielsmithdevelopment/ClawQL/issues/211) / [#213](https://github.com/danielsmithdevelopment/ClawQL/issues/213) — Tailscale / Headscale

--- a/docs/readme/deployment.md
+++ b/docs/readme/deployment.md
@@ -23,6 +23,7 @@ PORT=8080 npm run start:http
 Endpoints:
 
 - MCP: **`make local-k8s-up`** (Helm `values-docker-desktop.yaml`): **`http://clawql-mcp.localhost/mcp`** (**Ingress**, same pattern as prod) — **docker-compose**: `http://localhost:8080/mcp`
+- **Cloud Agent + R2 + private Tailscale MCP:** [cloud-agent-r2-tailscale-runbook.md](../deployment/cloud-agent-r2-tailscale-runbook.md)
 - Health: `http://localhost:8080/healthz` — set **`CLAWQL_HEALTHZ_NATIVE_PROTOCOL_METRICS=1`** to include **`nativeProtocolMetrics`** in the JSON body: aggregate merge counts and execute ok/err totals for native HTTP GraphQL and gRPC unary, plus **`graphqlBySource`** and **`grpcBySource`** objects keyed by each native **`sourceLabel`** (merge counts refreshed at spec load; execute counters cumulative per label). ([#191](https://github.com/danielsmithdevelopment/ClawQL/issues/191))
 - **Prometheus:** `http://localhost:8080/metrics` — OpenMetrics text for native-protocol gauges/counters (**`prom-client`**); scrape this target from Prometheus rather than parsing **`/healthz`**. Set **`CLAWQL_ENABLE_HTTP_METRICS=0`** only if the route must be omitted (rare). Optional Grafana dashboard: **[`docs/grafana/clawql-core-observability.json`](../grafana/clawql-core-observability.json)** + **[`docs/grafana/README.md`](../grafana/README.md)** ([#210](https://github.com/danielsmithdevelopment/ClawQL/issues/210)).
 - GraphQL debug endpoint: `http://localhost:8080/graphql`

--- a/infra/pulumi/Pulumi.cloudflare.example.yaml
+++ b/infra/pulumi/Pulumi.cloudflare.example.yaml
@@ -1,0 +1,16 @@
+# Example stack config — copy to Pulumi.<stack>.yaml (do not commit secrets).
+#
+#   cd infra/pulumi
+#   cp Pulumi.cloudflare.example.yaml Pulumi.dev-r2.yaml
+#   pulumi stack init dev-r2
+#   pulumi config set cloudflare:apiToken --secret
+#   pulumi config set cloudflare:accountId <account-id>
+#   pulumi preview && pulumi up
+#
+config:
+  clawql:cloud: cloudflare
+  clawql:tier: dedicated
+  clawql:tenantId: your-handle
+  clawql:syncBucket: clawql-team-vault
+  clawql:syncProvider: r2
+  cloudflare:accountId: "<cloudflare-account-id>"

--- a/infra/pulumi/README.md
+++ b/infra/pulumi/README.md
@@ -27,14 +27,24 @@ export AWS_ACCESS_KEY_ID=...
 export AWS_SECRET_ACCESS_KEY=...
 pulumi login 's3://clawql-pulumi-state?region=auto&endpoint=https://<accountid>.r2.cloudflarestorage.com&awssdk=v2'
 
-# Configure stack (copy and edit)
+# Cloudflare R2 only (no VM / no golden image)
+cp Pulumi.cloudflare.example.yaml Pulumi.dev-r2.yaml
+pulumi stack init dev-r2
+pulumi config set cloudflare:apiToken --secret
+pulumi config set cloudflare:accountId <account-id>
+pulumi config set clawql:cloud cloudflare
+pulumi config set clawql:tier dedicated
+pulumi config set clawql:tenantId <your-handle>
+pulumi config set clawql:syncBucket clawql-team-vault
+pulumi preview && pulumi up
+
+# AWS / GCP golden host (requires Packer AMI / image)
 cp Pulumi.example.yaml Pulumi.dev.yaml
 pulumi stack init dev
 pulumi config set clawql:cloud aws
 pulumi config set clawql:tier shared
 pulumi config set clawql:syncBucket acme-clawql-team
 pulumi config set clawql:goldenImageId ami-xxxxxxxx   # from Packer output
-
 pulumi preview   # needs cloud credentials
 ```
 
@@ -42,9 +52,10 @@ pulumi preview   # needs cloud credentials
 
 | Tier | Required config | Sync prefix |
 |------|-----------------|-------------|
-| `shared` | `syncBucket`, `goldenImageId` | `shared/` |
+| `shared` | `syncBucket`, `goldenImageId` (AWS/GCP only) | `shared/` |
 | `dedicated` | + `tenantId` | `tenant/{tenantId}/` |
 | `enterprise` | + `syncPrefix` | custom |
+| `cloudflare` (R2 only) | `syncBucket`, `cloudflare:accountId` — **no** `goldenImageId` | per tier |
 
 Dedicated AWS stacks default `useSsmSecrets=true`; user-data reads sync credentials from SSM at boot.
 
@@ -86,6 +97,7 @@ Future: `clawql operator provision --tier dedicated --tenant acme`.
 
 ## Related
 
+- [Cloud Agent + R2 + Tailscale runbook](../../docs/deployment/cloud-agent-r2-tailscale-runbook.md)
 - [Golden host images (Packer)](../../docs/getting-started/golden-host-images.md)
 - [ADR 0006: Packer](../../docs/adr/0006-golden-host-images-packer.md)
 - [ADR 0007: Pulumi](../../docs/adr/0007-pulumi-provisioning-managed-tiers.md)

--- a/infra/pulumi/src/automation.ts
+++ b/infra/pulumi/src/automation.ts
@@ -16,7 +16,8 @@ export type AutomationStackConfig = {
   syncBucket: string;
   syncProvider?: SyncProvider;
   syncPrefix?: string;
-  goldenImageId: string;
+  /** Required for `aws` / `gcp`; omit for `cloudflare` R2-only stacks. */
+  goldenImageId?: string;
   region?: string;
   instanceType?: string;
   useSsmSecrets?: boolean;
@@ -38,8 +39,8 @@ function toPulumiConfig(cfg: AutomationStackConfig): Record<string, string> {
     "clawql:tier": cfg.tier,
     "clawql:syncBucket": cfg.syncBucket,
     "clawql:syncProvider": cfg.syncProvider ?? "r2",
-    "clawql:goldenImageId": cfg.goldenImageId,
   };
+  if (cfg.goldenImageId) out["clawql:goldenImageId"] = cfg.goldenImageId;
   if (cfg.tenantId) out["clawql:tenantId"] = cfg.tenantId;
   if (cfg.syncPrefix) out["clawql:syncPrefix"] = cfg.syncPrefix;
   if (cfg.region) out["clawql:region"] = cfg.region;

--- a/infra/pulumi/src/pulumi-config.ts
+++ b/infra/pulumi/src/pulumi-config.ts
@@ -22,7 +22,8 @@ export function loadProvisionInputs(): ProvisionInputs {
     customPrefix: cfg.get("syncPrefix") ?? undefined,
   });
 
-  const goldenImageId = cfg.require("goldenImageId");
+  const goldenImageId =
+    cloud === "cloudflare" ? (cfg.get("goldenImageId") ?? undefined) : cfg.require("goldenImageId");
   const region = cfg.get("region") ?? (cloud === "aws" ? "us-east-1" : "us-central1");
   const instanceType = cfg.get("instanceType") ?? DEFAULT_INSTANCE_TYPES[cloud];
 

--- a/infra/pulumi/src/types.ts
+++ b/infra/pulumi/src/types.ts
@@ -17,7 +17,8 @@ export type ProvisionInputs = {
   syncBucket: string;
   syncProvider: SyncProvider;
   syncPrefix?: string;
-  goldenImageId: string;
+  /** Required for `aws` / `gcp` golden-host stacks; omitted for `cloudflare` (R2-only). */
+  goldenImageId?: string;
   instanceType: string;
   region: string;
   /** When true, user-data fetches sync credentials from SSM at boot (AWS). */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a complete runbook and repo artifacts for testing **Pulumi Cloudflare R2 provisioning** + **Cursor Cloud Agents** with durable memory vault sync, plus **Tailscale Serve** for phone/laptop-only private MCP access.

## Changes

- **`docs/deployment/cloud-agent-r2-tailscale-runbook.md`** — phased setup (Pulumi → Cloud Agent secrets/MCP → Tailscale ACL)
- **`.cursor/environment.json`** + **`cloud-agent-install.sh`** — build ClawQL + Pulumi; init `~/.ClawQL`; optional R2 pull on start
- **`infra/pulumi/Pulumi.cloudflare.example.yaml`** — copy-paste stack for R2-only provision
- **Pulumi fix:** `goldenImageId` optional for `cloudflare` stacks (was blocking R2-only `pulumi up`)

## Architecture note

Cloud Agents use **stdio MCP** (runs in VM) + **R2 sync** for durable memory. **Tailscale Serve** on a separate host gives phone access — HTTP MCP to tailnet URLs does not work through Cursor's cloud proxy.

## Tracking

- Ops checklist: #567

## Test plan

- [x] `npm test` in `infra/pulumi`
- [ ] Manual: Cursor Secrets + MCP dashboard + `pulumi up` (operator)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

