### PR TITLE
feat(ouroboros): drift convergence gate — block converge when combined > 0.3 (#558)

### DIFF
--- a/docs/ouroboros/clawql-ouroboros.md
+++ b/docs/ouroboros/clawql-ouroboros.md
@@ -54,7 +54,9 @@ npm install clawql-ouroboros
 1. **Seed** — Validated object (`SeedSchema`): goal, task type, brownfield context, constraints, acceptance criteria, ontology fields, evaluation principles, exit conditions, metadata (`seed_id`, lineage).
 2. **Generation** — One pass: **execute**(seed) → string output → **evaluate**(output, seed) → `EvaluationSummary` (per–acceptance-criterion results + optional score).
 3. **Wonder / Reflect** — From generation 2 onward: **wonder**(seed, prior eval) suggests insights; **reflect** produces `Partial<Seed>` updates and a new `seed_id` (child of previous).
-4. **EventStore** — Append-only events; **`getLineage(rootSeedId)`** rebuilds `OntologyLineage` for convergence. **`InMemoryEventStore`** is included for tests and prototypes.
+4. **EventStore** — Append-only events; **`getLineage(rootSeedId)`** rebuilds `OntologyLineage` for convergence (includes **`latest_drift`** from `drift_measured` events). **`InMemoryEventStore`** is included for tests and prototypes.
+
+**Drift convergence gate ([#558](https://github.com/danielsmithdevelopment/ClawQL/issues/558)):** when **`combined_drift > 0.3`**, `ConvergenceCriteria` blocks premature converge (similarity, stagnation, oscillation) with reason **`drift_exceeded`** — prefer Reflect / further generations.
 5. **Convergence** — `ConvergenceCriteria` compares ontology between completed generations (weighted field similarity), optional eval/regression/wonder gates, stagnation and oscillation shortcuts, and a hard **max generations** cap.
 
 ---

--- a/docs/ouroboros/clawql-ouroboros.md
+++ b/docs/ouroboros/clawql-ouroboros.md
@@ -56,8 +56,7 @@ npm install clawql-ouroboros
 3. **Wonder / Reflect** — From generation 2 onward: **wonder**(seed, prior eval) suggests insights; **reflect** produces `Partial<Seed>` updates and a new `seed_id` (child of previous).
 4. **EventStore** — Append-only events; **`getLineage(rootSeedId)`** rebuilds `OntologyLineage` for convergence (includes **`latest_drift`** from `drift_measured` events). **`InMemoryEventStore`** is included for tests and prototypes.
 
-**Drift convergence gate ([#558](https://github.com/danielsmithdevelopment/ClawQL/issues/558)):** when **`combined_drift > 0.3`**, `ConvergenceCriteria` blocks premature converge (similarity, stagnation, oscillation) with reason **`drift_exceeded`** — prefer Reflect / further generations.
-5. **Convergence** — `ConvergenceCriteria` compares ontology between completed generations (weighted field similarity), optional eval/regression/wonder gates, stagnation and oscillation shortcuts, and a hard **max generations** cap.
+**Drift convergence gate ([#558](https://github.com/danielsmithdevelopment/ClawQL/issues/558)):** when **`combined_drift > 0.3`**, `ConvergenceCriteria` blocks premature converge (similarity, stagnation, oscillation) with reason **`drift_exceeded`** — prefer Reflect / further generations. 5. **Convergence** — `ConvergenceCriteria` compares ontology between completed generations (weighted field similarity), optional eval/regression/wonder gates, stagnation and oscillation shortcuts, and a hard **max generations** cap.
 
 ---
 

--- a/docs/ouroboros/upstream-q00-sync-roadmap.md
+++ b/docs/ouroboros/upstream-q00-sync-roadmap.md
@@ -119,7 +119,7 @@ Every PAL escalation and MoA trigger writes an auditable event (`pal_escalation`
 | Phase    | Ticket                                                              | Deliverable                                                                          | Depends on                 |
 | -------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------- |
 | **P0-A** | [#557](https://github.com/danielsmithdevelopment/ClawQL/issues/557) | Drift evaluator + `ouroboros_measure_drift` MCP tool + `drift_measured` events       | — **shipped**              |
-| **P0-B** | [#558](https://github.com/danielsmithdevelopment/ClawQL/issues/558) | Convergence gate: `combined_drift > 0.3` blocks premature converge; triggers reflect | P0-A                       |
+| **P0-B** | [#558](https://github.com/danielsmithdevelopment/ClawQL/issues/558) | Convergence gate: `combined_drift > 0.3` blocks premature converge; triggers reflect | P0-A **shipped**           |
 | **P0-C** | [#559](https://github.com/danielsmithdevelopment/ClawQL/issues/559) | Stagnation taxonomy reason codes on `ConvergenceSignal`                              | —                          |
 | **P0-D** | [#560](https://github.com/danielsmithdevelopment/ClawQL/issues/560) | PAL tier map + `AdaptiveRouter` interface; inject into Wonder/Reflect/Execute        | Layer 8 config sketch      |
 | **P0-E** | [#561](https://github.com/danielsmithdevelopment/ClawQL/issues/561) | `pal_escalation` + token attribution events in Postgres event store                  | P0-D                       |

--- a/packages/clawql-ouroboros/src/convergence.test.ts
+++ b/packages/clawql-ouroboros/src/convergence.test.ts
@@ -183,4 +183,46 @@ describe("ConvergenceCriteria", () => {
     expect(sig.converged).toBe(false);
     expect(sig.reason).toContain("Oscillation blocked by Eval gate");
   });
+
+  it("blocks similarity convergence when combined drift exceeds threshold", () => {
+    const fields = [
+      { name: "a", field_type: "string", description: "identical description text", required: true },
+    ];
+    const lin = lineageFromFieldsList("id-drift", [fields, fields]);
+    const c = new ConvergenceCriteria({
+      minGenerations: 2,
+      convergenceThreshold: 0.9,
+      driftGateEnabled: true,
+      driftMaxCombined: 0.3,
+    });
+    const latest = lin.generations[1].evaluation_summary!;
+    const sig = c.evaluate(lin, { requires_evolution: false }, latest, undefined, {
+      combined_drift: 0.42,
+      band: "exceeded",
+    });
+    expect(sig.converged).toBe(false);
+    expect(sig.reason).toContain("drift_exceeded");
+    expect(sig.combined_drift).toBe(0.42);
+    expect(sig.drift_band).toBe("exceeded");
+  });
+
+  it("allows similarity convergence when drift is within threshold", () => {
+    const fields = [
+      { name: "a", field_type: "string", description: "identical description text", required: true },
+    ];
+    const lin = lineageFromFieldsList("id-drift-ok", [fields, fields]);
+    const c = new ConvergenceCriteria({
+      minGenerations: 2,
+      convergenceThreshold: 0.9,
+      driftGateEnabled: true,
+      driftMaxCombined: 0.3,
+    });
+    const latest = lin.generations[1].evaluation_summary!;
+    const sig = c.evaluate(lin, { requires_evolution: false }, latest, undefined, {
+      combined_drift: 0.12,
+      band: "excellent",
+    });
+    expect(sig.converged).toBe(true);
+    expect(sig.combined_drift).toBe(0.12);
+  });
 });

--- a/packages/clawql-ouroboros/src/convergence.ts
+++ b/packages/clawql-ouroboros/src/convergence.ts
@@ -1,4 +1,4 @@
-import type { OntologyLineage, EvaluationSummary, ACResult, DriftSummary } from "./lineage.js";
+import type { OntologyLineage, ACResult } from "./lineage.js";
 import type { OntologyField } from "./seed.js";
 import { DRIFT_THRESHOLD_ACCEPTABLE, type DriftBand, type DriftReport } from "./drift.js";
 

--- a/packages/clawql-ouroboros/src/convergence.ts
+++ b/packages/clawql-ouroboros/src/convergence.ts
@@ -1,5 +1,6 @@
-import type { OntologyLineage, ACResult } from "./lineage.js";
+import type { OntologyLineage, EvaluationSummary, ACResult, DriftSummary } from "./lineage.js";
 import type { OntologyField } from "./seed.js";
+import { DRIFT_THRESHOLD_ACCEPTABLE, type DriftBand, type DriftReport } from "./drift.js";
 
 export interface ConvergenceSignal {
   converged: boolean;
@@ -7,6 +8,8 @@ export interface ConvergenceSignal {
   ontology_similarity: number;
   generation: number;
   failed_acs?: number[];
+  combined_drift?: number;
+  drift_band?: DriftBand;
 }
 
 export interface RegressionResult {
@@ -24,6 +27,9 @@ export interface ConvergenceConfig {
   evalMinScore: number;
   regressionGateEnabled: boolean;
   validationGateEnabled: boolean;
+  /** Block converge when combined drift exceeds threshold (upstream Q00 gate). */
+  driftGateEnabled: boolean;
+  driftMaxCombined: number;
 }
 
 const DEFAULT_CONFIG: ConvergenceConfig = {
@@ -36,6 +42,8 @@ const DEFAULT_CONFIG: ConvergenceConfig = {
   evalMinScore: 0.7,
   regressionGateEnabled: true,
   validationGateEnabled: true,
+  driftGateEnabled: true,
+  driftMaxCombined: DRIFT_THRESHOLD_ACCEPTABLE,
 };
 
 // ---------------------------------------------------------------------------
@@ -68,7 +76,7 @@ export class RegressionDetector {
     for (const failedAc of failedNow) {
       const everPassed = prior.some((gen) => {
         const match = gen.evaluation_summary?.ac_results?.find(
-          (ac) => ac.ac_index === failedAc.ac_index,
+          (ac) => ac.ac_index === failedAc.ac_index
         );
         return match?.passed === true;
       });
@@ -108,7 +116,7 @@ function wordOverlap(a: string, b: string): number {
 
 function computeOntologySimilarity(
   prevFields: OntologyField[],
-  currFields: OntologyField[],
+  currFields: OntologyField[]
 ): number {
   if (prevFields.length === 0 && currFields.length === 0) return 1.0;
   if (prevFields.length === 0 || currFields.length === 0) return 0.0;
@@ -141,7 +149,7 @@ function ontologyFingerprint(fields: OntologyField[]): string {
   return JSON.stringify(
     [...fields]
       .sort((a, b) => a.name.localeCompare(b.name))
-      .map((f) => ({ name: f.name, field_type: f.field_type, required: f.required })),
+      .map((f) => ({ name: f.name, field_type: f.field_type, required: f.required }))
   );
 }
 
@@ -163,6 +171,7 @@ export class ConvergenceCriteria {
     latestWonder?: { requires_evolution?: boolean },
     latestEvaluation?: { final_approved: boolean; score?: number; ac_results: ACResult[] },
     validationOutput?: string,
+    latestDrift?: Pick<DriftReport, "combined_drift" | "band">
   ): ConvergenceSignal {
     const completed = lineage.generations.filter((g) => g.phase === "completed");
     const numCompleted = completed.length;
@@ -224,11 +233,25 @@ export class ConvergenceCriteria {
         }
       }
 
+      const driftBlock = this._driftGateFailure(latestDrift);
+      if (driftBlock) {
+        return {
+          converged: false,
+          reason: driftBlock.reason,
+          ontology_similarity: latestSim,
+          generation: currentGen,
+          combined_drift: driftBlock.combined_drift,
+          drift_band: driftBlock.drift_band,
+        };
+      }
+
       return {
         converged: true,
         reason: `Ontology converged: similarity ${latestSim.toFixed(3)} >= ${this.config.convergenceThreshold}`,
         ontology_similarity: latestSim,
         generation: currentGen,
+        combined_drift: latestDrift?.combined_drift,
+        drift_band: latestDrift?.band,
       };
     }
 
@@ -242,11 +265,24 @@ export class ConvergenceCriteria {
           failed_acs: evalGateFailure.failedAcs,
         };
       }
+      const driftBlock = this._driftGateFailure(latestDrift);
+      if (driftBlock) {
+        return {
+          converged: false,
+          reason: `Stagnation blocked by ${driftBlock.reason}`,
+          ontology_similarity: latestSim,
+          generation: currentGen,
+          combined_drift: driftBlock.combined_drift,
+          drift_band: driftBlock.drift_band,
+        };
+      }
       return {
         converged: true,
         reason: `Stagnation: ontology unchanged for ${this.config.stagnationWindow} consecutive generations`,
         ontology_similarity: latestSim,
         generation: currentGen,
+        combined_drift: latestDrift?.combined_drift,
+        drift_band: latestDrift?.band,
       };
     }
 
@@ -264,11 +300,24 @@ export class ConvergenceCriteria {
           failed_acs: evalGateFailure.failedAcs,
         };
       }
+      const driftBlock = this._driftGateFailure(latestDrift);
+      if (driftBlock) {
+        return {
+          converged: false,
+          reason: `Oscillation blocked by ${driftBlock.reason}`,
+          ontology_similarity: latestSim,
+          generation: currentGen,
+          combined_drift: driftBlock.combined_drift,
+          drift_band: driftBlock.drift_band,
+        };
+      }
       return {
         converged: true,
         reason: "Oscillation: ontology cycling between two states (A→B→A)",
         ontology_similarity: latestSim,
         generation: currentGen,
+        combined_drift: latestDrift?.combined_drift,
+        drift_band: latestDrift?.band,
       };
     }
 
@@ -322,9 +371,11 @@ export class ConvergenceCriteria {
     return simAC >= 0.9 && simBC < 0.7;
   }
 
-  private _evalGateFailure(
-    latestEvaluation?: { final_approved: boolean; score?: number; ac_results: ACResult[] },
-  ): { reason: string; failedAcs?: number[] } | null {
+  private _evalGateFailure(latestEvaluation?: {
+    final_approved: boolean;
+    score?: number;
+    ac_results: ACResult[];
+  }): { reason: string; failedAcs?: number[] } | null {
     if (!this.config.evalGateEnabled || !latestEvaluation) {
       return null;
     }
@@ -351,6 +402,22 @@ export class ConvergenceCriteria {
       };
     }
 
+    return null;
+  }
+
+  private _driftGateFailure(
+    latestDrift?: Pick<DriftReport, "combined_drift" | "band">
+  ): { reason: string; combined_drift: number; drift_band: DriftBand } | null {
+    if (!this.config.driftGateEnabled || !latestDrift) {
+      return null;
+    }
+    if (latestDrift.combined_drift > this.config.driftMaxCombined) {
+      return {
+        reason: `drift_exceeded: combined ${latestDrift.combined_drift.toFixed(3)} > ${this.config.driftMaxCombined}`,
+        combined_drift: latestDrift.combined_drift,
+        drift_band: latestDrift.band,
+      };
+    }
     return null;
   }
 }

--- a/packages/clawql-ouroboros/src/evolutionary-loop.test.ts
+++ b/packages/clawql-ouroboros/src/evolutionary-loop.test.ts
@@ -57,7 +57,7 @@ describe("EvolutionaryLoop", () => {
       {
         execute: async () => {
           calls++;
-          return "ok";
+          return "loop test field one description f1";
         },
       },
       {
@@ -130,5 +130,57 @@ describe("EvolutionaryLoop", () => {
     expect(result.generations.length).toBe(3);
     expect(result.converged).toBe(false);
     expect(result.lineage.status).toBe("exhausted");
+  });
+
+  it("does not converge early when execution output drifts from root goal", async () => {
+    const store = new InMemoryEventStore();
+    const root = fixtureSeed();
+    root.goal = "workflow rollback semver release";
+    root.ontology_schema = {
+      name: "ont",
+      description: "d",
+      fields: [
+        { name: "workflow", field_type: "string", description: "workflow field", required: true },
+      ],
+    };
+
+    const loop = new EvolutionaryLoop(
+      store,
+      {
+        wonder: async () => ({
+          insights: [],
+          suggested_refinements: [],
+          requires_evolution: false,
+        }),
+      },
+      {
+        reflect: async () => ({
+          newSeedData: {},
+          rationale: "noop",
+        }),
+      },
+      {
+        execute: async () => "unrelated analytics dashboard refactor only",
+      },
+      {
+        evaluate: async () => ({
+          final_approved: true,
+          score: 0.95,
+          ac_results: [{ ac_index: 0, ac_content: "always", passed: true, evidence: "ok" }],
+        }),
+      },
+      {
+        minGenerations: 2,
+        maxGenerations: 4,
+        convergenceThreshold: 0.9,
+        driftGateEnabled: true,
+        driftMaxCombined: 0.3,
+      },
+    );
+
+    const result = await loop.run(root, { maxGenerations: 4 });
+    expect(result.converged).toBe(false);
+    expect(result.generations.length).toBe(4);
+    expect(result.lineage.latest_drift?.band).toBe("exceeded");
   });
 });

--- a/packages/clawql-ouroboros/src/evolutionary-loop.ts
+++ b/packages/clawql-ouroboros/src/evolutionary-loop.ts
@@ -130,7 +130,7 @@ export class EvolutionaryLoop {
 
       const lineage = await this.eventStore.getLineage(seed.metadata.seed_id);
 
-      const signal = convergence.evaluate(lineage, latestWonder, evaluation);
+      const signal = convergence.evaluate(lineage, latestWonder, evaluation, undefined, driftReport);
 
       if (signal.converged) {
         await this.eventStore.append({

--- a/packages/clawql-ouroboros/src/glue/lineage-rebuild.test.ts
+++ b/packages/clawql-ouroboros/src/glue/lineage-rebuild.test.ts
@@ -34,4 +34,38 @@ describe("buildOntologyLineageFromEvents", () => {
     expect(lin.status).toBe("converged");
     expect(lin.current_generation).toBe(1);
   });
+
+  it("surfaces latest_drift from drift_measured events", () => {
+    const seedId = "seed_drift";
+    const events: StoredEvent[] = [
+      {
+        type: "drift_measured",
+        seed_id: seedId,
+        data: {
+          generation_number: 1,
+          combined_drift: 0.22,
+          band: "acceptable",
+          goal_drift: 0.1,
+          constraint_drift: 0.2,
+          ontology_drift: 0.4,
+        },
+      },
+      {
+        type: "drift_measured",
+        seed_id: seedId,
+        data: {
+          generation_number: 2,
+          combined_drift: 0.11,
+          band: "excellent",
+          goal_drift: 0.05,
+          constraint_drift: 0.1,
+          ontology_drift: 0.2,
+        },
+      },
+    ];
+    const lin = buildOntologyLineageFromEvents(seedId, events);
+    expect(lin.latest_drift?.combined_drift).toBe(0.11);
+    expect(lin.latest_drift?.band).toBe("excellent");
+    expect(lin.latest_drift?.generation_number).toBe(2);
+  });
 });

--- a/packages/clawql-ouroboros/src/glue/lineage-rebuild.ts
+++ b/packages/clawql-ouroboros/src/glue/lineage-rebuild.ts
@@ -2,7 +2,7 @@
  * Rebuild {@link OntologyLineage} from stored events (shared by in-memory semantics and Postgres).
  */
 
-import type { GenerationRecord, OntologyLineage } from "../lineage.js";
+import type { GenerationRecord, OntologyLineage, DriftSummary } from "../lineage.js";
 import type { Seed } from "../seed.js";
 import type { StoredEvent } from "../interfaces.js";
 
@@ -35,6 +35,28 @@ function isFinishedPayload(data: unknown): data is OuroborosFinishedPayload {
   if (typeof data !== "object" || data === null) return false;
   const d = data as Record<string, unknown>;
   return typeof d.converged === "boolean" && typeof d.generation_count === "number";
+}
+
+function parseDriftSummary(data: unknown): DriftSummary | undefined {
+  if (typeof data !== "object" || data === null) return undefined;
+  const d = data as Record<string, unknown>;
+  if (typeof d.combined_drift !== "number" || typeof d.band !== "string") return undefined;
+  return {
+    combined_drift: d.combined_drift,
+    band: d.band,
+    goal_drift: typeof d.goal_drift === "number" ? d.goal_drift : 0,
+    constraint_drift: typeof d.constraint_drift === "number" ? d.constraint_drift : 0,
+    ontology_drift: typeof d.ontology_drift === "number" ? d.ontology_drift : 0,
+    generation_number:
+      typeof d.generation_number === "number" ? d.generation_number : undefined,
+  };
+}
+
+export function latestDriftFromEvents(events: StoredEvent[]): DriftSummary | undefined {
+  const driftEvents = events.filter((e) => e.type === "drift_measured");
+  if (driftEvents.length === 0) return undefined;
+  const latest = driftEvents[driftEvents.length - 1];
+  return parseDriftSummary(latest.data);
 }
 
 export function buildOntologyLineageFromEvents(
@@ -76,5 +98,6 @@ export function buildOntologyLineageFromEvents(
     current_generation,
     generations,
     status,
+    latest_drift: latestDriftFromEvents(relevant),
   };
 }

--- a/packages/clawql-ouroboros/src/in-memory-event-store.ts
+++ b/packages/clawql-ouroboros/src/in-memory-event-store.ts
@@ -1,37 +1,6 @@
 import type { EventStore, StoredEvent } from "./interfaces.js";
-import type { GenerationRecord, OntologyLineage } from "./lineage.js";
-import type { Seed } from "./seed.js";
-
-interface GenerationCompletedPayload {
-  generation_number: number;
-  seed: Seed;
-  execution_output: string;
-  evaluation_summary: GenerationRecord["evaluation_summary"];
-  phase: GenerationRecord["phase"];
-  ontology_schema: Seed["ontology_schema"];
-}
-
-interface OuroborosFinishedPayload {
-  converged: boolean;
-  generation_count: number;
-}
-
-function isGenerationPayload(data: unknown): data is GenerationCompletedPayload {
-  if (typeof data !== "object" || data === null) return false;
-  const d = data as Record<string, unknown>;
-  return (
-    typeof d.generation_number === "number" &&
-    typeof d.seed === "object" &&
-    d.seed !== null &&
-    typeof d.phase === "string"
-  );
-}
-
-function isFinishedPayload(data: unknown): data is OuroborosFinishedPayload {
-  if (typeof data !== "object" || data === null) return false;
-  const d = data as Record<string, unknown>;
-  return typeof d.converged === "boolean" && typeof d.generation_count === "number";
-}
+import { buildOntologyLineageFromEvents } from "./glue/lineage-rebuild.js";
+import type { OntologyLineage } from "./lineage.js";
 
 /**
  * In-memory append log for tests and local development. Not durable across restarts.
@@ -48,41 +17,7 @@ export class InMemoryEventStore implements EventStore {
 
   async getLineage(seedId: string): Promise<OntologyLineage> {
     const relevant = this.events.filter((e) => e.seed_id === seedId);
-
-    const genEvents = relevant
-      .filter((e) => e.type === "generation_completed")
-      .filter((e) => isGenerationPayload(e.data));
-
-    const generations: GenerationRecord[] = genEvents
-      .map((e) => {
-        const d = e.data as GenerationCompletedPayload;
-        return {
-          generation_number: d.generation_number,
-          seed: d.seed,
-          execution_output: d.execution_output,
-          evaluation_summary: d.evaluation_summary,
-          phase: d.phase,
-          ontology_schema: d.ontology_schema,
-        };
-      })
-      .sort((a, b) => a.generation_number - b.generation_number);
-
-    const finished = [...relevant].reverse().find((e) => e.type === "ouroboros_finished");
-
-    let status: OntologyLineage["status"] = "active";
-    if (finished?.data !== undefined && isFinishedPayload(finished.data)) {
-      status = finished.data.converged ? "converged" : "exhausted";
-    }
-
-    const current_generation =
-      generations.length > 0 ? generations[generations.length - 1].generation_number : 0;
-
-    return {
-      seed_id: seedId,
-      current_generation,
-      generations,
-      status,
-    };
+    return buildOntologyLineageFromEvents(seedId, relevant);
   }
 
   /** Test helper: raw event log for a lineage root id. */

--- a/packages/clawql-ouroboros/src/index.ts
+++ b/packages/clawql-ouroboros/src/index.ts
@@ -15,6 +15,7 @@ export type {
   GenerationPhase,
   EvaluationSummary,
   ACResult,
+  DriftSummary,
 } from "./lineage.js";
 
 export type {

--- a/packages/clawql-ouroboros/src/lineage.ts
+++ b/packages/clawql-ouroboros/src/lineage.ts
@@ -34,9 +34,20 @@ export interface GenerationRecord {
   ontology_schema: Seed["ontology_schema"];
 }
 
+export interface DriftSummary {
+  combined_drift: number;
+  band: string;
+  goal_drift: number;
+  constraint_drift: number;
+  ontology_drift: number;
+  generation_number?: number;
+}
+
 export interface OntologyLineage {
   seed_id: string;
   current_generation: number;
   generations: GenerationRecord[];
   status: "active" | "converged" | "exhausted" | "aborted";
+  /** Latest `drift_measured` event for this lineage root, when present. */
+  latest_drift?: DriftSummary;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes **#558** (epic **#556** P0-B): wire drift into convergence so high-drift generations cannot exit early.

## Changes

- **`ConvergenceCriteria`** — `driftGateEnabled` (default `true`), `driftMaxCombined` (default `0.3`); blocks converge with **`drift_exceeded`** reason
- **Evolutionary loop** — passes `driftReport` into `evaluate()` each generation
- **Lineage** — `latest_drift` on `OntologyLineage` rebuilt from `drift_measured` events (`ouroboros_get_lineage_status`)
- **InMemoryEventStore** — refactored to use shared `buildOntologyLineageFromEvents`
- **Tests** — unit + integration: high-drift output runs full `maxGenerations` without early converge

## Next (P0-C)

**#559** — stagnation taxonomy reason codes on `ConvergenceSignal`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

