### PR TITLE
Ouroboros P0-C: Stagnation taxonomy reason codes (#559)

### DIFF
--- a/docs/ouroboros/clawql-ouroboros.md
+++ b/docs/ouroboros/clawql-ouroboros.md
@@ -56,7 +56,11 @@ npm install clawql-ouroboros
 3. **Wonder / Reflect** — From generation 2 onward: **wonder**(seed, prior eval) suggests insights; **reflect** produces `Partial<Seed>` updates and a new `seed_id` (child of previous).
 4. **EventStore** — Append-only events; **`getLineage(rootSeedId)`** rebuilds `OntologyLineage` for convergence (includes **`latest_drift`** from `drift_measured` events). **`InMemoryEventStore`** is included for tests and prototypes.
 
-**Drift convergence gate ([#558](https://github.com/danielsmithdevelopment/ClawQL/issues/558)):** when **`combined_drift > 0.3`**, `ConvergenceCriteria` blocks premature converge (similarity, stagnation, oscillation) with reason **`drift_exceeded`** — prefer Reflect / further generations. 5. **Convergence** — `ConvergenceCriteria` compares ontology between completed generations (weighted field similarity), optional eval/regression/wonder gates, stagnation and oscillation shortcuts, and a hard **max generations** cap.
+**Drift convergence gate ([#558](https://github.com/danielsmithdevelopment/ClawQL/issues/558)):** when **`combined_drift > 0.3`**, `ConvergenceCriteria` blocks premature converge (similarity, stagnation, oscillation) with **`reason_code: drift_exceeded`** — prefer Reflect / further generations.
+
+**Stagnation taxonomy ([#559](https://github.com/danielsmithdevelopment/ClawQL/issues/559)):** `ConvergenceSignal.reason_code` names upstream patterns — `no_drift` (unchanged ontology fingerprint window), `oscillation` (A→B→A), `spinning` (repeated execution output), `diminishing_returns` (flat/declining eval scores). `ouroboros_get_lineage_status` exposes **`latest_convergence.reason_code`** from `ouroboros_finished` events.
+
+5. **Convergence** — `ConvergenceCriteria` compares ontology between completed generations (weighted field similarity), optional eval/regression/wonder gates, stagnation and oscillation shortcuts, and a hard **max generations** cap.
 
 ---
 

--- a/docs/ouroboros/upstream-q00-sync-roadmap.md
+++ b/docs/ouroboros/upstream-q00-sync-roadmap.md
@@ -120,7 +120,7 @@ Every PAL escalation and MoA trigger writes an auditable event (`pal_escalation`
 | -------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------- |
 | **P0-A** | [#557](https://github.com/danielsmithdevelopment/ClawQL/issues/557) | Drift evaluator + `ouroboros_measure_drift` MCP tool + `drift_measured` events       | — **shipped**              |
 | **P0-B** | [#558](https://github.com/danielsmithdevelopment/ClawQL/issues/558) | Convergence gate: `combined_drift > 0.3` blocks premature converge; triggers reflect | P0-A **shipped**           |
-| **P0-C** | [#559](https://github.com/danielsmithdevelopment/ClawQL/issues/559) | Stagnation taxonomy reason codes on `ConvergenceSignal`                              | —                          |
+| **P0-C** | [#559](https://github.com/danielsmithdevelopment/ClawQL/issues/559) | Stagnation taxonomy reason codes on `ConvergenceSignal`                              | — **shipped**              |
 | **P0-D** | [#560](https://github.com/danielsmithdevelopment/ClawQL/issues/560) | PAL tier map + `AdaptiveRouter` interface; inject into Wonder/Reflect/Execute        | Layer 8 config sketch      |
 | **P0-E** | [#561](https://github.com/danielsmithdevelopment/ClawQL/issues/561) | `pal_escalation` + token attribution events in Postgres event store                  | P0-D                       |
 | **P1-A** | [#562](https://github.com/danielsmithdevelopment/ClawQL/issues/562) | PAL → MoA trigger at Standard failure + drift tripwire                               | P0-A, P0-D, Hermes adapter |

--- a/packages/clawql-ouroboros/src/convergence.test.ts
+++ b/packages/clawql-ouroboros/src/convergence.test.ts
@@ -37,15 +37,20 @@ function minimalSeed(overrides: Partial<Seed> = {}): Seed {
 function lineageFromFieldsList(
   seedId: string,
   fieldSets: Seed["ontology_schema"]["fields"][],
+  options?: {
+    scores?: number[];
+    executionOutputs?: string[];
+  },
 ): OntologyLineage {
   const generations = fieldSets.map((fields, i) => ({
     generation_number: i + 1,
     seed: minimalSeed({ ontology_schema: { name: "o", description: "d", fields } }),
     phase: "completed" as const,
     ontology_schema: { name: "o", description: "d", fields },
+    execution_output: options?.executionOutputs?.[i],
     evaluation_summary: {
       final_approved: true,
-      score: 0.95,
+      score: options?.scores?.[i] ?? 0.95,
       ac_results: [{ ac_index: 0, ac_content: "c", passed: true, evidence: "e" }],
     },
   }));
@@ -116,6 +121,7 @@ describe("ConvergenceCriteria", () => {
     const latest = lin.generations[1].evaluation_summary!;
     const sig = c.evaluate(lin, { requires_evolution: false }, latest);
     expect(sig.converged).toBe(true);
+    expect(sig.reason_code).toBe("similarity");
     expect(sig.ontology_similarity).toBeGreaterThanOrEqual(0.9);
   });
 
@@ -224,5 +230,87 @@ describe("ConvergenceCriteria", () => {
     });
     expect(sig.converged).toBe(true);
     expect(sig.combined_drift).toBe(0.12);
+  });
+
+  it("converges via no_drift when ontology fingerprint is unchanged across the window", () => {
+    const f1 = [{ name: "a", field_type: "string", description: "alpha one", required: true }];
+    const f2 = [{ name: "a", field_type: "string", description: "bravo two", required: true }];
+    const f3 = [{ name: "a", field_type: "string", description: "charlie three", required: true }];
+    const lin = lineageFromFieldsList("id-no-drift", [f1, f2, f3]);
+    const c = new ConvergenceCriteria({
+      minGenerations: 2,
+      stagnationWindow: 3,
+      convergenceThreshold: 0.999,
+      evalGateEnabled: true,
+      evalMinScore: 0.5,
+    });
+    const latest = lin.generations[2].evaluation_summary!;
+    const sig = c.evaluate(lin, { requires_evolution: false }, latest);
+    expect(sig.converged).toBe(true);
+    expect(sig.reason_code).toBe("no_drift");
+    expect(sig.reason).toContain("Stagnation");
+  });
+
+  it("converges via oscillation when ontology cycles A→B→A", () => {
+    const fA = [{ name: "a", field_type: "string", description: "alpha", required: true }];
+    const fB = [{ name: "b", field_type: "string", description: "beta", required: true }];
+    const lin = lineageFromFieldsList("id-osc-ok", [fA, fB, fA]);
+    const c = new ConvergenceCriteria({
+      minGenerations: 2,
+      convergenceThreshold: 0.999,
+      enableOscillationDetection: true,
+      evalGateEnabled: true,
+      evalMinScore: 0.5,
+    });
+    const latest = lin.generations[2].evaluation_summary!;
+    const sig = c.evaluate(lin, { requires_evolution: false }, latest);
+    expect(sig.converged).toBe(true);
+    expect(sig.reason_code).toBe("oscillation");
+    expect(sig.reason).toContain("Oscillation");
+  });
+
+  it("converges via spinning when execution output repeats across the window", () => {
+    const f1 = [{ name: "a", field_type: "string", description: "gen1", required: true }];
+    const f2 = [{ name: "b", field_type: "string", description: "gen2", required: true }];
+    const f3 = [{ name: "c", field_type: "string", description: "gen3", required: true }];
+    const lin = lineageFromFieldsList("id-spin", [f1, f2, f3], {
+      executionOutputs: ["same-output", "same-output", "same-output"],
+    });
+    const c = new ConvergenceCriteria({
+      minGenerations: 2,
+      stagnationWindow: 3,
+      convergenceThreshold: 0.999,
+      enableSpinningDetection: true,
+      enableOscillationDetection: false,
+      evalGateEnabled: true,
+      evalMinScore: 0.5,
+    });
+    const latest = lin.generations[2].evaluation_summary!;
+    const sig = c.evaluate(lin, { requires_evolution: false }, latest);
+    expect(sig.converged).toBe(true);
+    expect(sig.reason_code).toBe("spinning");
+  });
+
+  it("converges via diminishing_returns when eval scores plateau", () => {
+    const f1 = [{ name: "a", field_type: "string", description: "gen1", required: true }];
+    const f2 = [{ name: "b", field_type: "string", description: "gen2", required: true }];
+    const f3 = [{ name: "c", field_type: "string", description: "gen3", required: true }];
+    const lin = lineageFromFieldsList("id-dim", [f1, f2, f3], {
+      scores: [0.8, 0.795, 0.79],
+    });
+    const c = new ConvergenceCriteria({
+      minGenerations: 2,
+      stagnationWindow: 3,
+      convergenceThreshold: 0.999,
+      enableDiminishingReturnsDetection: true,
+      enableSpinningDetection: false,
+      enableOscillationDetection: false,
+      evalGateEnabled: true,
+      evalMinScore: 0.5,
+    });
+    const latest = lin.generations[2].evaluation_summary!;
+    const sig = c.evaluate(lin, { requires_evolution: false }, latest);
+    expect(sig.converged).toBe(true);
+    expect(sig.reason_code).toBe("diminishing_returns");
   });
 });

--- a/packages/clawql-ouroboros/src/convergence.ts
+++ b/packages/clawql-ouroboros/src/convergence.ts
@@ -2,9 +2,28 @@ import type { OntologyLineage, ACResult } from "./lineage.js";
 import type { OntologyField } from "./seed.js";
 import { DRIFT_THRESHOLD_ACCEPTABLE, type DriftBand, type DriftReport } from "./drift.js";
 
+/** Upstream Q00 stagnation taxonomy + loop exit codes (epic #556 / #559). */
+export type ConvergenceReasonCode =
+  | "similarity"
+  | "no_drift"
+  | "oscillation"
+  | "spinning"
+  | "diminishing_returns"
+  | "max_generations"
+  | "drift_exceeded"
+  | "eval_gate"
+  | "ac_gate"
+  | "approval_gate"
+  | "regression_gate"
+  | "evolution_required"
+  | "validation_gate"
+  | "continuing";
+
 export interface ConvergenceSignal {
   converged: boolean;
   reason: string;
+  /** Named stagnation / exit code when a detector or gate applies. */
+  reason_code?: ConvergenceReasonCode;
   ontology_similarity: number;
   generation: number;
   failed_acs?: number[];
@@ -23,6 +42,12 @@ export interface ConvergenceConfig {
   minGenerations: number;
   maxGenerations: number;
   enableOscillationDetection: boolean;
+  /** Detect repeated execution output (upstream SPINNING). */
+  enableSpinningDetection: boolean;
+  /** Detect flat or declining eval scores (upstream DIMINISHING_RETURNS). */
+  enableDiminishingReturnsDetection: boolean;
+  /** Minimum per-generation score improvement to avoid diminishing_returns. */
+  diminishingReturnsMinDelta: number;
   evalGateEnabled: boolean;
   evalMinScore: number;
   regressionGateEnabled: boolean;
@@ -38,6 +63,9 @@ const DEFAULT_CONFIG: ConvergenceConfig = {
   minGenerations: 2,
   maxGenerations: 30,
   enableOscillationDetection: true,
+  enableSpinningDetection: true,
+  enableDiminishingReturnsDetection: true,
+  diminishingReturnsMinDelta: 0.01,
   evalGateEnabled: true,
   evalMinScore: 0.7,
   regressionGateEnabled: true,
@@ -182,6 +210,7 @@ export class ConvergenceCriteria {
       return {
         converged: false,
         reason: `Below minimum generations (${numCompleted}/${this.config.minGenerations})`,
+        reason_code: "continuing",
         ontology_similarity: 0,
         generation: currentGen,
       };
@@ -194,6 +223,7 @@ export class ConvergenceCriteria {
         return {
           converged: false,
           reason: evalGateFailure.reason,
+          reason_code: evalGateFailure.reason_code,
           ontology_similarity: latestSim,
           generation: currentGen,
           failed_acs: evalGateFailure.failedAcs,
@@ -206,6 +236,7 @@ export class ConvergenceCriteria {
           return {
             converged: false,
             reason: `Regression gate: ACs [${regression.regressed_ac_indices.join(", ")}] regressed from prior passing state`,
+            reason_code: "regression_gate",
             ontology_similarity: latestSim,
             generation: currentGen,
             failed_acs: regression.regressed_ac_indices,
@@ -217,6 +248,7 @@ export class ConvergenceCriteria {
         return {
           converged: false,
           reason: "Evolution-required gate: Wonder engine signals further refinement needed",
+          reason_code: "evolution_required",
           ontology_similarity: latestSim,
           generation: currentGen,
         };
@@ -227,6 +259,7 @@ export class ConvergenceCriteria {
           return {
             converged: false,
             reason: "Validation gate: empty validation output",
+            reason_code: "validation_gate",
             ontology_similarity: latestSim,
             generation: currentGen,
           };
@@ -238,6 +271,7 @@ export class ConvergenceCriteria {
         return {
           converged: false,
           reason: driftBlock.reason,
+          reason_code: "drift_exceeded",
           ontology_similarity: latestSim,
           generation: currentGen,
           combined_drift: driftBlock.combined_drift,
@@ -248,6 +282,7 @@ export class ConvergenceCriteria {
       return {
         converged: true,
         reason: `Ontology converged: similarity ${latestSim.toFixed(3)} >= ${this.config.convergenceThreshold}`,
+        reason_code: "similarity",
         ontology_similarity: latestSim,
         generation: currentGen,
         combined_drift: latestDrift?.combined_drift,
@@ -260,6 +295,7 @@ export class ConvergenceCriteria {
         return {
           converged: false,
           reason: `Stagnation blocked by ${evalGateFailure.reason}`,
+          reason_code: "no_drift",
           ontology_similarity: latestSim,
           generation: currentGen,
           failed_acs: evalGateFailure.failedAcs,
@@ -270,6 +306,7 @@ export class ConvergenceCriteria {
         return {
           converged: false,
           reason: `Stagnation blocked by ${driftBlock.reason}`,
+          reason_code: "no_drift",
           ontology_similarity: latestSim,
           generation: currentGen,
           combined_drift: driftBlock.combined_drift,
@@ -279,6 +316,7 @@ export class ConvergenceCriteria {
       return {
         converged: true,
         reason: `Stagnation: ontology unchanged for ${this.config.stagnationWindow} consecutive generations`,
+        reason_code: "no_drift",
         ontology_similarity: latestSim,
         generation: currentGen,
         combined_drift: latestDrift?.combined_drift,
@@ -295,6 +333,7 @@ export class ConvergenceCriteria {
         return {
           converged: false,
           reason: `Oscillation blocked by ${evalGateFailure.reason}`,
+          reason_code: "oscillation",
           ontology_similarity: latestSim,
           generation: currentGen,
           failed_acs: evalGateFailure.failedAcs,
@@ -305,6 +344,7 @@ export class ConvergenceCriteria {
         return {
           converged: false,
           reason: `Oscillation blocked by ${driftBlock.reason}`,
+          reason_code: "oscillation",
           ontology_similarity: latestSim,
           generation: currentGen,
           combined_drift: driftBlock.combined_drift,
@@ -314,6 +354,83 @@ export class ConvergenceCriteria {
       return {
         converged: true,
         reason: "Oscillation: ontology cycling between two states (A→B→A)",
+        reason_code: "oscillation",
+        ontology_similarity: latestSim,
+        generation: currentGen,
+        combined_drift: latestDrift?.combined_drift,
+        drift_band: latestDrift?.band,
+      };
+    }
+
+    if (
+      this.config.enableSpinningDetection &&
+      numCompleted >= this.config.stagnationWindow &&
+      this._checkSpinning(lineage)
+    ) {
+      if (evalGateFailure) {
+        return {
+          converged: false,
+          reason: `Spinning blocked by ${evalGateFailure.reason}`,
+          reason_code: "spinning",
+          ontology_similarity: latestSim,
+          generation: currentGen,
+          failed_acs: evalGateFailure.failedAcs,
+        };
+      }
+      const driftBlock = this._driftGateFailure(latestDrift);
+      if (driftBlock) {
+        return {
+          converged: false,
+          reason: `Spinning blocked by ${driftBlock.reason}`,
+          reason_code: "spinning",
+          ontology_similarity: latestSim,
+          generation: currentGen,
+          combined_drift: driftBlock.combined_drift,
+          drift_band: driftBlock.drift_band,
+        };
+      }
+      return {
+        converged: true,
+        reason: `Spinning: identical execution output for ${this.config.stagnationWindow} consecutive generations`,
+        reason_code: "spinning",
+        ontology_similarity: latestSim,
+        generation: currentGen,
+        combined_drift: latestDrift?.combined_drift,
+        drift_band: latestDrift?.band,
+      };
+    }
+
+    if (
+      this.config.enableDiminishingReturnsDetection &&
+      numCompleted >= this.config.stagnationWindow &&
+      this._checkDiminishingReturns(lineage)
+    ) {
+      if (evalGateFailure) {
+        return {
+          converged: false,
+          reason: `Diminishing returns blocked by ${evalGateFailure.reason}`,
+          reason_code: "diminishing_returns",
+          ontology_similarity: latestSim,
+          generation: currentGen,
+          failed_acs: evalGateFailure.failedAcs,
+        };
+      }
+      const driftBlock = this._driftGateFailure(latestDrift);
+      if (driftBlock) {
+        return {
+          converged: false,
+          reason: `Diminishing returns blocked by ${driftBlock.reason}`,
+          reason_code: "diminishing_returns",
+          ontology_similarity: latestSim,
+          generation: currentGen,
+          combined_drift: driftBlock.combined_drift,
+          drift_band: driftBlock.drift_band,
+        };
+      }
+      return {
+        converged: true,
+        reason: `Diminishing returns: eval score improvement below ${this.config.diminishingReturnsMinDelta} for ${this.config.stagnationWindow} generations`,
+        reason_code: "diminishing_returns",
         ontology_similarity: latestSim,
         generation: currentGen,
         combined_drift: latestDrift?.combined_drift,
@@ -325,6 +442,7 @@ export class ConvergenceCriteria {
       return {
         converged: false,
         reason: `Exhausted at max generations (${this.config.maxGenerations})`,
+        reason_code: "max_generations",
         ontology_similarity: latestSim,
         generation: currentGen,
         failed_acs: evalGateFailure?.failedAcs,
@@ -334,6 +452,7 @@ export class ConvergenceCriteria {
     return {
       converged: false,
       reason: `Continuing: similarity ${latestSim.toFixed(3)} < ${this.config.convergenceThreshold}`,
+      reason_code: "continuing",
       ontology_similarity: latestSim,
       generation: currentGen,
     };
@@ -371,11 +490,38 @@ export class ConvergenceCriteria {
     return simAC >= 0.9 && simBC < 0.7;
   }
 
+  /** Same execution output repeated across the stagnation window (upstream SPINNING). */
+  private _checkSpinning(lineage: OntologyLineage): boolean {
+    const completed = lineage.generations.filter((g) => g.phase === "completed");
+    const window = completed.slice(-this.config.stagnationWindow);
+    if (window.length < this.config.stagnationWindow) return false;
+
+    const outputs = window.map((g) => g.execution_output ?? "");
+    const first = outputs[0];
+    return first.length > 0 && outputs.every((o) => o === first);
+  }
+
+  /** Eval score improvement below threshold for the stagnation window (upstream DIMINISHING_RETURNS). */
+  private _checkDiminishingReturns(lineage: OntologyLineage): boolean {
+    const completed = lineage.generations.filter((g) => g.phase === "completed");
+    const window = completed.slice(-this.config.stagnationWindow);
+    if (window.length < this.config.stagnationWindow) return false;
+
+    const scores = window.map((g) => g.evaluation_summary?.score);
+    if (scores.some((s) => s === undefined)) return false;
+
+    for (let i = 1; i < scores.length; i++) {
+      const delta = scores[i]! - scores[i - 1]!;
+      if (delta >= this.config.diminishingReturnsMinDelta) return false;
+    }
+    return true;
+  }
+
   private _evalGateFailure(latestEvaluation?: {
     final_approved: boolean;
     score?: number;
     ac_results: ACResult[];
-  }): { reason: string; failedAcs?: number[] } | null {
+  }): { reason: string; reason_code: ConvergenceReasonCode; failedAcs?: number[] } | null {
     if (!this.config.evalGateEnabled || !latestEvaluation) {
       return null;
     }
@@ -383,6 +529,7 @@ export class ConvergenceCriteria {
     if (latestEvaluation.score !== undefined && latestEvaluation.score < this.config.evalMinScore) {
       return {
         reason: `Eval gate: score ${latestEvaluation.score.toFixed(3)} < minimum ${this.config.evalMinScore}`,
+        reason_code: "eval_gate",
       };
     }
 
@@ -392,6 +539,7 @@ export class ConvergenceCriteria {
     if (failedAcs.length > 0) {
       return {
         reason: `AC gate: ${failedAcs.length} acceptance criteria failing`,
+        reason_code: "ac_gate",
         failedAcs,
       };
     }
@@ -399,6 +547,7 @@ export class ConvergenceCriteria {
     if (latestEvaluation.final_approved === false) {
       return {
         reason: "Approval gate: final_approved is false",
+        reason_code: "approval_gate",
       };
     }
 

--- a/packages/clawql-ouroboros/src/evolutionary-loop.ts
+++ b/packages/clawql-ouroboros/src/evolutionary-loop.ts
@@ -136,7 +136,13 @@ export class EvolutionaryLoop {
         await this.eventStore.append({
           type: "ouroboros_finished",
           seed_id: seed.metadata.seed_id,
-          data: { converged: true, generation_count: generations.length },
+          data: {
+            converged: true,
+            generation_count: generations.length,
+            reason_code: signal.reason_code,
+            reason: signal.reason,
+            ontology_similarity: signal.ontology_similarity,
+          },
           timestamp: new Date(),
         });
         const finalLineage = await this.eventStore.getLineage(seed.metadata.seed_id);
@@ -149,7 +155,12 @@ export class EvolutionaryLoop {
     await this.eventStore.append({
       type: "ouroboros_finished",
       seed_id: seed.metadata.seed_id,
-      data: { converged: false, generation_count: generations.length },
+      data: {
+        converged: false,
+        generation_count: generations.length,
+        reason_code: "max_generations",
+        reason: `Exhausted at max generations (${convergence.config.maxGenerations})`,
+      },
       timestamp: new Date(),
     });
     const lineage = await this.eventStore.getLineage(seed.metadata.seed_id);

--- a/packages/clawql-ouroboros/src/glue/lineage-rebuild.test.ts
+++ b/packages/clawql-ouroboros/src/glue/lineage-rebuild.test.ts
@@ -68,4 +68,26 @@ describe("buildOntologyLineageFromEvents", () => {
     expect(lin.latest_drift?.band).toBe("excellent");
     expect(lin.latest_drift?.generation_number).toBe(2);
   });
+
+  it("surfaces latest_convergence from ouroboros_finished events", () => {
+    const seedId = "seed_conv";
+    const events: StoredEvent[] = [
+      {
+        type: "ouroboros_finished",
+        seed_id: seedId,
+        data: {
+          converged: true,
+          generation_count: 3,
+          reason_code: "oscillation",
+          reason: "Oscillation: ontology cycling between two states (A→B→A)",
+          ontology_similarity: 0.42,
+        },
+      },
+    ];
+    const lin = buildOntologyLineageFromEvents(seedId, events);
+    expect(lin.latest_convergence?.reason_code).toBe("oscillation");
+    expect(lin.latest_convergence?.converged).toBe(true);
+    expect(lin.latest_convergence?.generation_count).toBe(3);
+    expect(lin.latest_convergence?.ontology_similarity).toBe(0.42);
+  });
 });

--- a/packages/clawql-ouroboros/src/glue/lineage-rebuild.ts
+++ b/packages/clawql-ouroboros/src/glue/lineage-rebuild.ts
@@ -2,7 +2,7 @@
  * Rebuild {@link OntologyLineage} from stored events (shared by in-memory semantics and Postgres).
  */
 
-import type { GenerationRecord, OntologyLineage, DriftSummary } from "../lineage.js";
+import type { GenerationRecord, OntologyLineage, DriftSummary, ConvergenceSummary } from "../lineage.js";
 import type { Seed } from "../seed.js";
 import type { StoredEvent } from "../interfaces.js";
 
@@ -18,6 +18,9 @@ interface GenerationCompletedPayload {
 interface OuroborosFinishedPayload {
   converged: boolean;
   generation_count: number;
+  reason_code?: string;
+  reason?: string;
+  ontology_similarity?: number;
 }
 
 function isGenerationPayload(data: unknown): data is GenerationCompletedPayload {
@@ -35,6 +38,20 @@ function isFinishedPayload(data: unknown): data is OuroborosFinishedPayload {
   if (typeof data !== "object" || data === null) return false;
   const d = data as Record<string, unknown>;
   return typeof d.converged === "boolean" && typeof d.generation_count === "number";
+}
+
+function parseConvergenceSummary(data: unknown): ConvergenceSummary | undefined {
+  if (typeof data !== "object" || data === null) return undefined;
+  const d = data as Record<string, unknown>;
+  if (typeof d.converged !== "boolean" || typeof d.generation_count !== "number") return undefined;
+  return {
+    converged: d.converged,
+    generation_count: d.generation_count,
+    reason_code: typeof d.reason_code === "string" ? d.reason_code : undefined,
+    reason: typeof d.reason === "string" ? d.reason : undefined,
+    ontology_similarity:
+      typeof d.ontology_similarity === "number" ? d.ontology_similarity : undefined,
+  };
 }
 
 function parseDriftSummary(data: unknown): DriftSummary | undefined {
@@ -99,5 +116,7 @@ export function buildOntologyLineageFromEvents(
     generations,
     status,
     latest_drift: latestDriftFromEvents(relevant),
+    latest_convergence:
+      finished?.data !== undefined ? parseConvergenceSummary(finished.data) : undefined,
   };
 }

--- a/packages/clawql-ouroboros/src/index.ts
+++ b/packages/clawql-ouroboros/src/index.ts
@@ -16,6 +16,7 @@ export type {
   EvaluationSummary,
   ACResult,
   DriftSummary,
+  ConvergenceSummary,
 } from "./lineage.js";
 
 export type {
@@ -33,6 +34,7 @@ export { ConvergenceCriteria, RegressionDetector } from "./convergence.js";
 export type {
   ConvergenceSignal,
   ConvergenceConfig,
+  ConvergenceReasonCode,
   RegressionResult,
 } from "./convergence.js";
 

--- a/packages/clawql-ouroboros/src/lineage.ts
+++ b/packages/clawql-ouroboros/src/lineage.ts
@@ -43,6 +43,14 @@ export interface DriftSummary {
   generation_number?: number;
 }
 
+export interface ConvergenceSummary {
+  converged: boolean;
+  reason_code?: string;
+  reason?: string;
+  ontology_similarity?: number;
+  generation_count?: number;
+}
+
 export interface OntologyLineage {
   seed_id: string;
   current_generation: number;
@@ -50,4 +58,6 @@ export interface OntologyLineage {
   status: "active" | "converged" | "exhausted" | "aborted";
   /** Latest `drift_measured` event for this lineage root, when present. */
   latest_drift?: DriftSummary;
+  /** Latest `ouroboros_finished` convergence outcome, when present. */
+  latest_convergence?: ConvergenceSummary;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #559 (epic #556 P0-C).

## Summary

Maps upstream Q00 stagnation taxonomy onto `ConvergenceCriteria` detectors and exposes named exit codes on lineage status.

## Changes

- Add `ConvergenceReasonCode` and optional `reason_code` on `ConvergenceSignal` (human `reason` string preserved).
- Map detectors:
  - **`no_drift`** — unchanged ontology fingerprint across stagnation window (existing stagnation check)
  - **`oscillation`** — A→B→A cycling (existing oscillation check)
  - **`spinning`** — identical `execution_output` repeated across window
  - **`diminishing_returns`** — eval score improvement below 0.01 for window
- Persist `reason_code`, `reason`, and `ontology_similarity` on `ouroboros_finished` events.
- Rebuild `latest_convergence` on `OntologyLineage` for `ouroboros_get_lineage_status`.
- Tests cover oscillation → `oscillation`, fingerprint window → `no_drift`, spinning, diminishing returns, and lineage rebuild.

## Docs

- Mark P0-C shipped in `upstream-q00-sync-roadmap.md`
- Document taxonomy in `clawql-ouroboros.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

