### PR TITLE
feat(inference): P0-G call store + logs/trace/spend observability (#556)

### DIFF
--- a/docs/inference/clawql-inference.md
+++ b/docs/inference/clawql-inference.md
@@ -29,8 +29,8 @@ LiteLLM routes inference. ClawQL closes the loop: **infer → observe → evalua
 - **`ConfiguredInferenceGateway`** — provider plugin registry + routing to `provider/model` backends
 - **Provider plugins** — OpenAI, Anthropic, Ollama built-ins via `composeDefaultProviderPlugins()`; third-party extensions use the same contract ([inference providers plugin](../plugins/inference-providers.md))
 - **`clawql inference serve`** — OpenAI-compatible `/v1/chat/completions` + `/healthz`
-- **`clawql inference complete`** — one-shot CLI completion
-- **`clawql-ouroboros`** optional routing hooks (`EngineCallContext`)
+- **`clawql inference logs` / `trace` / `spend`** — query the call store by model, `correlation_id`, or token rollup
+- **Call store** — JSONL at `$CLAWQL_HOME/Inference/calls.jsonl` (or `memory` / `off` via env)
 
 ## Planned modules
 
@@ -210,7 +210,7 @@ clawql inference policy show    # Manifest inference block (tiers, cache TTL, ex
 | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **P0-D** ✅ | `routing/` + ouroboros hooks ([#560](https://github.com/danielsmithdevelopment/ClawQL/issues/560))                                                                                            |
 | **P0-F** ✅ | Gateway MVP: `serve`, `complete`, OpenAI / Anthropic / Ollama adapters                                                                                                                        |
-| **P0-G**    | `store/` + `observability/` — log every call with `correlation_id`                                                                                                                            |
+| **P0-G** ✅ | `store/` + observability — log every call with `correlation_id`; `logs`, `trace`, `spend` CLI                                                                                                 |
 | **P0-H**    | `export/` — verdict-filtered JSONL + Presidio + dataset manifest                                                                                                                              |
 | **P0-I**    | `finetune/` — Anthropic/OpenAI job API + `register-as` tier                                                                                                                                   |
 | **P1**      | `pipeline enable` — scheduled auto-export + promote                                                                                                                                           |

--- a/packages/clawql-inference/src/api/openai-compat.ts
+++ b/packages/clawql-inference/src/api/openai-compat.ts
@@ -5,7 +5,16 @@ import type { ChatMessage, InferenceGateway } from "../gateway.js";
 type OpenAiChatCompletionRequest = {
   model?: string;
   messages?: Array<{ role?: string; content?: string }>;
+  user?: string;
 };
+
+function readCorrelationId(req: Request): string | undefined {
+  const header =
+    req.header("x-correlation-id") ??
+    req.header("x-clawql-correlation-id") ??
+    req.header("correlation-id");
+  return header?.trim() || undefined;
+}
 
 export function createOpenAiCompatRouter(gateway: InferenceGateway): express.Router {
   const router = express.Router();
@@ -28,7 +37,11 @@ export function createOpenAiCompatRouter(gateway: InferenceGateway): express.Rou
     }));
 
     try {
-      const result = await gateway.complete({ model, messages });
+      const result = await gateway.complete({
+        model,
+        messages,
+        correlationId: readCorrelationId(req),
+      });
       const created = Math.floor(Date.now() / 1000);
       res.json({
         id: `chatcmpl-${randomUUID()}`,

--- a/packages/clawql-inference/src/cli/observability.ts
+++ b/packages/clawql-inference/src/cli/observability.ts
@@ -1,0 +1,110 @@
+import { createInferenceStore } from "../store/create.js";
+import { parseSinceDuration } from "../observability/parse-since.js";
+import type { SpendGroupBy } from "../store/types.js";
+
+export type InferenceLogsOptions = {
+  model?: string;
+  provider?: string;
+  tier?: string;
+  since?: string;
+  limit?: number;
+  json?: boolean;
+  env?: NodeJS.ProcessEnv;
+};
+
+export async function runInferenceLogs(options: InferenceLogsOptions = {}): Promise<number> {
+  const store = createInferenceStore({ env: options.env });
+  if (!store) {
+    console.error("Inference store is disabled (CLAWQL_INFERENCE_STORE=off)");
+    return 1;
+  }
+  const records = await store.list({
+    modelId: options.model,
+    provider: options.provider,
+    tier: options.tier,
+    since: parseSinceDuration(options.since),
+    limit: options.limit ?? 50,
+  });
+  if (options.json) {
+    console.log(JSON.stringify(records, null, 2));
+    return 0;
+  }
+  if (!records.length) {
+    console.log("No inference records found.");
+    return 0;
+  }
+  for (const record of records) {
+    console.log(
+      `${record.timestamp}  ${record.modelId}  ${record.latencyMs}ms  tokens=${record.usage?.inputTokens ?? 0}/${record.usage?.outputTokens ?? 0}  corr=${record.correlationId ?? "-"}`
+    );
+  }
+  return 0;
+}
+
+export type InferenceTraceOptions = {
+  correlationId: string;
+  json?: boolean;
+  env?: NodeJS.ProcessEnv;
+};
+
+export async function runInferenceTrace(options: InferenceTraceOptions): Promise<number> {
+  if (!options.correlationId?.trim()) {
+    console.error("Usage: clawql inference trace --correlation-id <id>");
+    return 1;
+  }
+  const store = createInferenceStore({ env: options.env });
+  if (!store) {
+    console.error("Inference store is disabled (CLAWQL_INFERENCE_STORE=off)");
+    return 1;
+  }
+  const records = await store.getByCorrelationId(options.correlationId.trim());
+  if (options.json) {
+    console.log(JSON.stringify(records, null, 2));
+    return 0;
+  }
+  if (!records.length) {
+    console.log(`No records for correlation_id=${options.correlationId}`);
+    return 0;
+  }
+  for (const record of records) {
+    console.log(`--- ${record.id} @ ${record.timestamp} ---`);
+    console.log(`model: ${record.modelId}  latency: ${record.latencyMs}ms`);
+    console.log(
+      `response: ${record.response.slice(0, 200)}${record.response.length > 200 ? "…" : ""}`
+    );
+  }
+  return 0;
+}
+
+export type InferenceSpendOptions = {
+  groupBy?: SpendGroupBy;
+  since?: string;
+  json?: boolean;
+  env?: NodeJS.ProcessEnv;
+};
+
+export async function runInferenceSpend(options: InferenceSpendOptions = {}): Promise<number> {
+  const store = createInferenceStore({ env: options.env });
+  if (!store) {
+    console.error("Inference store is disabled (CLAWQL_INFERENCE_STORE=off)");
+    return 1;
+  }
+  const rows = await store.spendRollup({
+    groupBy: options.groupBy ?? "model",
+    since: parseSinceDuration(options.since),
+  });
+  if (options.json) {
+    console.log(JSON.stringify(rows, null, 2));
+    return 0;
+  }
+  if (!rows.length) {
+    console.log("No spend data.");
+    return 0;
+  }
+  for (const row of rows) {
+    console.log(
+      `${row.key.padEnd(28)}  calls=${row.calls}  in=${row.inputTokens}  out=${row.outputTokens}`
+    );
+  }
+  return 0;
+}

--- a/packages/clawql-inference/src/gateway.ts
+++ b/packages/clawql-inference/src/gateway.ts
@@ -3,6 +3,9 @@ import { parseModelId } from "./providers/parse-model-id.js";
 import { createProviderRegistry, getProviderAdapter } from "./providers/registry.js";
 import type { InferenceProviderPlugin, ProviderRegistry } from "./providers/types.js";
 import { composeDefaultProviderPlugins } from "./plugin/compose.js";
+import { withInferenceStore } from "./observability/observed-gateway.js";
+import { createInferenceStore } from "./store/create.js";
+import type { InferenceStore } from "./store/types.js";
 
 export type ChatRole = "system" | "user" | "assistant";
 
@@ -51,6 +54,7 @@ export type CreateInferenceGatewayOptions = {
   providers?: ProviderRegistry;
   providerPlugins?: readonly InferenceProviderPlugin[];
   env?: NodeJS.ProcessEnv;
+  store?: InferenceStore | null;
 };
 
 export class ConfiguredInferenceGateway implements InferenceGateway {
@@ -80,12 +84,15 @@ export class ConfiguredInferenceGateway implements InferenceGateway {
 
 export function createInferenceGateway(
   options: CreateInferenceGatewayOptions = {}
-): ConfiguredInferenceGateway {
+): InferenceGateway {
+  const env = options.env;
   const providers =
     options.providers ??
     createProviderRegistry({
-      env: options.env,
+      env,
       plugins: options.providerPlugins ?? composeDefaultProviderPlugins(),
     });
-  return new ConfiguredInferenceGateway(providers);
+  const inner = new ConfiguredInferenceGateway(providers);
+  const store = options.store === undefined ? createInferenceStore({ env }) : options.store;
+  return withInferenceStore(inner, store);
 }

--- a/packages/clawql-inference/src/index.ts
+++ b/packages/clawql-inference/src/index.ts
@@ -32,6 +32,24 @@ export {
   createInferenceGateway,
 } from "./gateway.js";
 
+export type {
+  InferenceRecord,
+  InferenceStore,
+  InferenceListQuery,
+  SpendGroupBy,
+} from "./store/types.js";
+export {
+  createInferenceStore,
+  resolveInferenceStoreBackend,
+  resolveInferenceStorePath,
+  type CreateInferenceStoreOptions,
+} from "./store/create.js";
+export { InMemoryInferenceStore } from "./store/in-memory.js";
+export { JsonlInferenceStore } from "./store/jsonl.js";
+export { ObservedInferenceGateway, withInferenceStore } from "./observability/observed-gateway.js";
+export { parseSinceDuration } from "./observability/parse-since.js";
+export { runInferenceLogs, runInferenceTrace, runInferenceSpend } from "./cli/observability.js";
+
 export { parseModelId } from "./providers/parse-model-id.js";
 export type {
   InferenceProviderAdapter,

--- a/packages/clawql-inference/src/observability/observed-gateway.test.ts
+++ b/packages/clawql-inference/src/observability/observed-gateway.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { ConfiguredInferenceGateway } from "../gateway.js";
+import { createOpenAiAdapter } from "../plugin/adapters/openai.js";
+import { ObservedInferenceGateway } from "./observed-gateway.js";
+import { InMemoryInferenceStore } from "../store/in-memory.js";
+
+describe("ObservedInferenceGateway", () => {
+  it("appends a record after successful completion", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          model: "gpt-4o",
+          choices: [{ message: { content: "logged" } }],
+          usage: { prompt_tokens: 2, completion_tokens: 3 },
+        }),
+      }))
+    );
+
+    const inner = new ConfiguredInferenceGateway(
+      new Map([
+        ["openai", createOpenAiAdapter({ apiKey: "k", baseUrl: "https://api.openai.com/v1" })],
+      ])
+    );
+    const store = new InMemoryInferenceStore();
+    const gateway = new ObservedInferenceGateway(inner, store);
+    await gateway.complete({
+      model: "openai/gpt-4o",
+      messages: [{ role: "user", content: "hi" }],
+      correlationId: "seed_abc_gen_2",
+    });
+
+    const records = store.snapshot();
+    expect(records).toHaveLength(1);
+    expect(records[0]?.correlationId).toBe("seed_abc_gen_2");
+    expect(records[0]?.response).toBe("logged");
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/clawql-inference/src/observability/observed-gateway.ts
+++ b/packages/clawql-inference/src/observability/observed-gateway.ts
@@ -1,0 +1,39 @@
+import { randomUUID } from "node:crypto";
+import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../gateway.js";
+import { parseModelId } from "../providers/parse-model-id.js";
+import { buildInferenceRecord } from "../store/types.js";
+import type { InferenceStore } from "../store/types.js";
+
+/** Gateway decorator that persists every successful completion to an {@link InferenceStore}. */
+export class ObservedInferenceGateway implements InferenceGateway {
+  constructor(
+    private readonly inner: InferenceGateway,
+    private readonly store: InferenceStore
+  ) {}
+
+  async complete(request: InferenceRequest): Promise<InferenceResponse> {
+    const started = Date.now();
+    const response = await this.inner.complete(request);
+    const modelId = request.model ?? request.routing?.modelId ?? response.model;
+    const { provider, model } = parseModelId(modelId);
+    await this.store.append(
+      buildInferenceRecord({
+        id: randomUUID(),
+        request,
+        response,
+        provider,
+        model,
+        latencyMs: Date.now() - started,
+      })
+    );
+    return response;
+  }
+}
+
+export function withInferenceStore(
+  gateway: InferenceGateway,
+  store: InferenceStore | null | undefined
+): InferenceGateway {
+  if (!store) return gateway;
+  return new ObservedInferenceGateway(gateway, store);
+}

--- a/packages/clawql-inference/src/observability/parse-since.test.ts
+++ b/packages/clawql-inference/src/observability/parse-since.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { parseSinceDuration } from "./parse-since.js";
+
+describe("parseSinceDuration", () => {
+  it("parses hour and day windows", () => {
+    const hour = parseSinceDuration("24h");
+    expect(hour).toBeDefined();
+    expect(Date.now() - hour!.getTime()).toBeGreaterThan(23 * 3_600_000);
+
+    const week = parseSinceDuration("7d");
+    expect(week).toBeDefined();
+    expect(Date.now() - week!.getTime()).toBeGreaterThan(6 * 86_400_000);
+  });
+
+  it("returns undefined for invalid input", () => {
+    expect(parseSinceDuration("")).toBeUndefined();
+    expect(parseSinceDuration("nope")).toBeUndefined();
+  });
+});

--- a/packages/clawql-inference/src/observability/parse-since.ts
+++ b/packages/clawql-inference/src/observability/parse-since.ts
@@ -1,0 +1,17 @@
+/** Parse durations like `24h`, `7d`, `30m` into a Date floor. */
+export function parseSinceDuration(raw: string | undefined): Date | undefined {
+  if (!raw?.trim()) return undefined;
+  const match = /^(\d+)([smhd])$/i.exec(raw.trim());
+  if (!match) return undefined;
+  const amount = Number.parseInt(match[1]!, 10);
+  const unit = match[2]!.toLowerCase();
+  const ms =
+    unit === "s"
+      ? amount * 1000
+      : unit === "m"
+        ? amount * 60_000
+        : unit === "h"
+          ? amount * 3_600_000
+          : amount * 86_400_000;
+  return new Date(Date.now() - ms);
+}

--- a/packages/clawql-inference/src/store/create.ts
+++ b/packages/clawql-inference/src/store/create.ts
@@ -1,0 +1,38 @@
+import { join } from "node:path";
+import { InMemoryInferenceStore } from "./in-memory.js";
+import { JsonlInferenceStore } from "./jsonl.js";
+import type { InferenceStore, InferenceStoreBackend } from "./types.js";
+
+export type CreateInferenceStoreOptions = {
+  env?: NodeJS.ProcessEnv;
+  backend?: InferenceStoreBackend;
+  jsonlPath?: string;
+};
+
+export function resolveInferenceStoreBackend(
+  env: NodeJS.ProcessEnv = process.env
+): InferenceStoreBackend {
+  const raw = env.CLAWQL_INFERENCE_STORE?.trim().toLowerCase();
+  if (raw === "off" || raw === "0" || raw === "false") return "off";
+  if (raw === "memory") return "memory";
+  if (raw === "jsonl" || raw === "file") return "jsonl";
+  if (env.CLAWQL_HOME?.trim() || env.CLAWQL_INFERENCE_STORE_PATH?.trim()) return "jsonl";
+  return "memory";
+}
+
+export function resolveInferenceStorePath(env: NodeJS.ProcessEnv = process.env): string {
+  const explicit = env.CLAWQL_INFERENCE_STORE_PATH?.trim();
+  if (explicit) return explicit;
+  const home = env.CLAWQL_HOME?.trim() || join(process.env.HOME ?? "", ".ClawQL");
+  return join(home, "Inference", "calls.jsonl");
+}
+
+export function createInferenceStore(
+  options: CreateInferenceStoreOptions = {}
+): InferenceStore | null {
+  const env = options.env ?? process.env;
+  const backend = options.backend ?? resolveInferenceStoreBackend(env);
+  if (backend === "off") return null;
+  if (backend === "memory") return new InMemoryInferenceStore();
+  return new JsonlInferenceStore(options.jsonlPath ?? resolveInferenceStorePath(env));
+}

--- a/packages/clawql-inference/src/store/in-memory.test.ts
+++ b/packages/clawql-inference/src/store/in-memory.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryInferenceStore } from "./in-memory.js";
+import { buildInferenceRecord } from "./types.js";
+
+describe("InMemoryInferenceStore", () => {
+  it("lists, traces, and rolls up spend", async () => {
+    const store = new InMemoryInferenceStore();
+    const record = buildInferenceRecord({
+      id: "r1",
+      request: {
+        messages: [{ role: "user", content: "hi" }],
+        model: "openai/gpt-4o",
+        correlationId: "corr-1",
+      },
+      response: {
+        content: "hello",
+        model: "openai/gpt-4o",
+        usage: { inputTokens: 1, outputTokens: 2 },
+      },
+      provider: "openai",
+      model: "gpt-4o",
+      latencyMs: 42,
+    });
+    await store.append(record);
+
+    expect((await store.list({ limit: 10 })).length).toBe(1);
+    expect((await store.getByCorrelationId("corr-1")).length).toBe(1);
+    const spend = await store.spendRollup({ groupBy: "model" });
+    expect(spend[0]?.calls).toBe(1);
+    expect(spend[0]?.inputTokens).toBe(1);
+  });
+});

--- a/packages/clawql-inference/src/store/in-memory.ts
+++ b/packages/clawql-inference/src/store/in-memory.ts
@@ -1,0 +1,62 @@
+import type { InferenceListQuery, InferenceRecord, InferenceStore, SpendRow } from "./types.js";
+
+function matchesQuery(record: InferenceRecord, query: InferenceListQuery): boolean {
+  if (query.modelId && record.modelId !== query.modelId) return false;
+  if (query.provider && record.provider !== query.provider) return false;
+  if (query.tier && record.tier !== query.tier) return false;
+  if (query.correlationId && record.correlationId !== query.correlationId) return false;
+  if (query.since && new Date(record.timestamp) < query.since) return false;
+  return true;
+}
+
+function sortNewestFirst(records: InferenceRecord[]): InferenceRecord[] {
+  return [...records].sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+}
+
+export class InMemoryInferenceStore implements InferenceStore {
+  private readonly records: InferenceRecord[] = [];
+
+  async append(record: InferenceRecord): Promise<void> {
+    this.records.push(record);
+  }
+
+  async list(query: InferenceListQuery = {}): Promise<InferenceRecord[]> {
+    const filtered = this.records.filter((r) => matchesQuery(r, query));
+    const sorted = sortNewestFirst(filtered);
+    return query.limit ? sorted.slice(0, query.limit) : sorted;
+  }
+
+  async getByCorrelationId(correlationId: string): Promise<InferenceRecord[]> {
+    return sortNewestFirst(this.records.filter((r) => r.correlationId === correlationId));
+  }
+
+  async spendRollup(
+    options: {
+      since?: Date;
+      groupBy?: import("./types.js").SpendGroupBy;
+    } = {}
+  ): Promise<SpendRow[]> {
+    const groupBy = options.groupBy ?? "model";
+    const rows = new Map<string, SpendRow>();
+    for (const record of this.records) {
+      if (options.since && new Date(record.timestamp) < options.since) continue;
+      const key =
+        groupBy === "provider"
+          ? record.provider
+          : groupBy === "tier"
+            ? (record.tier ?? "unknown")
+            : record.modelId;
+      const row = rows.get(key) ?? { key, calls: 0, inputTokens: 0, outputTokens: 0 };
+      row.calls += 1;
+      row.inputTokens += record.usage?.inputTokens ?? 0;
+      row.outputTokens += record.usage?.outputTokens ?? 0;
+      rows.set(key, row);
+    }
+    return [...rows.values()].sort((a, b) => b.calls - a.calls);
+  }
+
+  /** Test helper */
+  snapshot(): InferenceRecord[] {
+    return [...this.records];
+  }
+}

--- a/packages/clawql-inference/src/store/jsonl.ts
+++ b/packages/clawql-inference/src/store/jsonl.ts
@@ -1,0 +1,72 @@
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { InMemoryInferenceStore } from "./in-memory.js";
+import type { InferenceListQuery, InferenceRecord, InferenceStore, SpendRow } from "./types.js";
+
+async function loadJsonlRecords(filePath: string): Promise<InferenceRecord[]> {
+  try {
+    const raw = await readFile(filePath, "utf8");
+    return raw
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as InferenceRecord);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+/**
+ * Append-only JSONL store for local durability without Postgres.
+ * Default path: `$CLAWQL_HOME/Inference/calls.jsonl` when set.
+ */
+export class JsonlInferenceStore implements InferenceStore {
+  private cache: InferenceRecord[] | null = null;
+
+  constructor(private readonly filePath: string) {}
+
+  private async load(): Promise<InferenceRecord[]> {
+    if (!this.cache) {
+      this.cache = await loadJsonlRecords(this.filePath);
+    }
+    return this.cache;
+  }
+
+  async append(record: InferenceRecord): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    await appendFile(this.filePath, `${JSON.stringify(record)}\n`, "utf8");
+    if (this.cache) {
+      this.cache.push(record);
+    }
+  }
+
+  async list(query: InferenceListQuery = {}): Promise<InferenceRecord[]> {
+    const memory = new InMemoryInferenceStore();
+    for (const record of await this.load()) {
+      await memory.append(record);
+    }
+    return memory.list(query);
+  }
+
+  async getByCorrelationId(correlationId: string): Promise<InferenceRecord[]> {
+    const memory = new InMemoryInferenceStore();
+    for (const record of await this.load()) {
+      await memory.append(record);
+    }
+    return memory.getByCorrelationId(correlationId);
+  }
+
+  async spendRollup(
+    options: {
+      since?: Date;
+      groupBy?: import("./types.js").SpendGroupBy;
+    } = {}
+  ): Promise<SpendRow[]> {
+    const memory = new InMemoryInferenceStore();
+    for (const record of await this.load()) {
+      await memory.append(record);
+    }
+    return memory.spendRollup(options);
+  }
+}

--- a/packages/clawql-inference/src/store/types.ts
+++ b/packages/clawql-inference/src/store/types.ts
@@ -1,0 +1,80 @@
+import type { ChatMessage, InferenceResponse, InferenceUsage } from "../gateway.js";
+import type { ModelEscalationDecision } from "../routing/types.js";
+
+export type EvaluatorVerdict = "passed" | "failed" | "none";
+
+/** Durable inference call record — feeds observability and export (epic #556). */
+export interface InferenceRecord {
+  id: string;
+  correlationId?: string;
+  timestamp: string;
+  modelId: string;
+  provider: string;
+  tier?: string;
+  messages: ChatMessage[];
+  response: string;
+  usage?: InferenceUsage;
+  latencyMs: number;
+  cacheHit?: boolean;
+  routing?: ModelEscalationDecision;
+  evaluatorVerdict: EvaluatorVerdict;
+  evaluatorScore?: number;
+  policyVersion?: string;
+}
+
+export type InferenceListQuery = {
+  modelId?: string;
+  provider?: string;
+  tier?: string;
+  correlationId?: string;
+  since?: Date;
+  limit?: number;
+};
+
+export type SpendGroupBy = "model" | "provider" | "tier";
+
+export type SpendRow = {
+  key: string;
+  calls: number;
+  inputTokens: number;
+  outputTokens: number;
+};
+
+export interface InferenceStore {
+  append(record: InferenceRecord): Promise<void>;
+  list(query?: InferenceListQuery): Promise<InferenceRecord[]>;
+  getByCorrelationId(correlationId: string): Promise<InferenceRecord[]>;
+  spendRollup(options?: { since?: Date; groupBy?: SpendGroupBy }): Promise<SpendRow[]>;
+}
+
+export type InferenceStoreBackend = "off" | "memory" | "jsonl";
+
+export function buildInferenceRecord(input: {
+  id: string;
+  request: {
+    messages: ChatMessage[];
+    model?: string;
+    routing?: ModelEscalationDecision;
+    correlationId?: string;
+  };
+  response: InferenceResponse;
+  provider: string;
+  model: string;
+  latencyMs: number;
+}): InferenceRecord {
+  return {
+    id: input.id,
+    correlationId: input.request.correlationId ?? input.response.correlationId,
+    timestamp: new Date().toISOString(),
+    modelId: input.response.model || input.request.model || `${input.provider}/${input.model}`,
+    provider: input.provider,
+    tier: input.request.routing?.tier ?? input.response.routing?.tier,
+    messages: input.request.messages,
+    response: input.response.content,
+    usage: input.response.usage,
+    latencyMs: input.latencyMs,
+    cacheHit: input.response.cacheHit,
+    routing: input.request.routing ?? input.response.routing,
+    evaluatorVerdict: "none",
+  };
+}

--- a/src/onboarding/cli.ts
+++ b/src/onboarding/cli.ts
@@ -27,7 +27,14 @@ import {
   runSandboxStatusCmd,
   runSandboxVerifyCmd,
 } from "./sandbox-cli.js";
-import { runInferenceCompleteCmd, runInferenceServeCmd } from "./inference-cli.js";
+import {
+  runInferenceCompleteCmd,
+  runInferenceLogsCmd,
+  runInferenceServeCmd,
+  runInferenceSpendCmd,
+  runInferenceTraceCmd,
+  type InferenceCliOptions,
+} from "./inference-cli.js";
 
 type Command =
   | "init"
@@ -94,6 +101,9 @@ function parse(argv: string[]): {
     else if (a === "--model") flags.model = argv[++i] ?? "";
     else if (a === "--message") flags.message = argv[++i] ?? "";
     else if (a === "--correlation-id") flags.correlationId = argv[++i] ?? "";
+    else if (a === "--since") flags.since = argv[++i] ?? "";
+    else if (a === "--limit") flags.limit = argv[++i] ?? "";
+    else if (a === "--group-by") flags.groupBy = argv[++i] ?? "";
     else if (a === "--skip-verify") flags.skipVerify = true;
     else if (a.startsWith("--image-digest=")) {
       const prev = typeof flags.imageDigest === "string" ? flags.imageDigest : "";
@@ -152,7 +162,8 @@ Usage:
   clawql release init | collect | manifest | publish | verify <path>
   clawql sync init | push | pull | status [--dry-run] [--force]
   clawql sandbox init | verify | status | edit --harness claude [--path DIR] [--skip-verify]
-  clawql inference serve [--port 8080] | complete --model <provider/model> --message <text> [--json]
+  clawql inference serve [--port 8080] | complete --model <provider/model> --message <text>
+  clawql inference logs [--model M] [--since 24h] [--limit 50] | trace --correlation-id <id> | spend [--group-by model]
   clawql claude | codex | cursor | opencode [-- harness args...]
   clawql operator status
 
@@ -223,7 +234,11 @@ mcp-config:
 inference (gateway MVP):
   serve           OpenAI-compatible HTTP gateway (/healthz, /v1/chat/completions)
   complete        One-shot completion for scripting/debug
+  logs            Recent inference records from the call store
+  trace           Records for a correlation_id (links to ouroboros / WORM lineage)
+  spend           Token usage rollup by model, provider, or tier
   Providers: openai, anthropic, ollama via provider/model ids (e.g. ollama/phi4)
+  Store: CLAWQL_INFERENCE_STORE=memory|jsonl|off (default jsonl when CLAWQL_HOME set)
   Env: OPENAI_API_KEY, ANTHROPIC_API_KEY, OLLAMA_BASE_URL, CLAWQL_INFERENCE_PORT
 
 Docs: https://docs.clawql.com/agent-setup
@@ -437,11 +452,21 @@ async function main(): Promise<void> {
   if (cmd === "inference") {
     const port =
       typeof flags.port === "string" && flags.port ? Number.parseInt(flags.port, 10) : undefined;
-    const inferenceOpts = {
+    const limit =
+      typeof flags.limit === "string" && flags.limit ? Number.parseInt(flags.limit, 10) : undefined;
+    const inferenceOpts: InferenceCliOptions = {
       port: Number.isFinite(port) ? port : undefined,
       model: typeof flags.model === "string" ? flags.model : undefined,
+      provider: typeof flags.provider === "string" ? flags.provider : undefined,
       message: typeof flags.message === "string" ? flags.message : undefined,
       correlationId: typeof flags.correlationId === "string" ? flags.correlationId : undefined,
+      since: typeof flags.since === "string" ? flags.since : undefined,
+      limit: Number.isFinite(limit) ? limit : undefined,
+      groupBy:
+        typeof flags.groupBy === "string" &&
+        (flags.groupBy === "model" || flags.groupBy === "provider" || flags.groupBy === "tier")
+          ? flags.groupBy
+          : undefined,
       json: Boolean(flags.json),
     };
     if (subcmd === "serve") {
@@ -452,8 +477,20 @@ async function main(): Promise<void> {
       process.exitCode = await runInferenceCompleteCmd(inferenceOpts);
       return;
     }
+    if (subcmd === "logs") {
+      process.exitCode = await runInferenceLogsCmd(inferenceOpts);
+      return;
+    }
+    if (subcmd === "trace") {
+      process.exitCode = await runInferenceTraceCmd(inferenceOpts);
+      return;
+    }
+    if (subcmd === "spend") {
+      process.exitCode = await runInferenceSpendCmd(inferenceOpts);
+      return;
+    }
     console.error(
-      "Usage: clawql inference serve [--port 8080] | clawql inference complete --model <id> --message <text>"
+      "Usage: clawql inference serve | complete | logs | trace --correlation-id <id> | spend"
     );
     process.exitCode = 1;
     return;

--- a/src/onboarding/inference-cli.ts
+++ b/src/onboarding/inference-cli.ts
@@ -2,14 +2,24 @@
  * `clawql inference` — thin wrapper over clawql-inference gateway MVP.
  */
 
-import { runInferenceComplete, runInferenceServe } from "clawql-inference";
+import {
+  runInferenceComplete,
+  runInferenceLogs,
+  runInferenceServe,
+  runInferenceSpend,
+  runInferenceTrace,
+} from "clawql-inference";
 
 export type InferenceCliOptions = {
   port?: number;
   host?: string;
   model?: string;
+  provider?: string;
   message?: string;
   correlationId?: string;
+  since?: string;
+  limit?: number;
+  groupBy?: "model" | "provider" | "tier";
   json?: boolean;
 };
 
@@ -37,4 +47,33 @@ export async function runInferenceCompleteCmd(opts: InferenceCliOptions): Promis
     console.error(error instanceof Error ? error.message : String(error));
     return 1;
   }
+}
+
+export async function runInferenceLogsCmd(opts: InferenceCliOptions): Promise<number> {
+  return runInferenceLogs({
+    model: opts.model,
+    provider: opts.provider,
+    since: opts.since,
+    limit: opts.limit,
+    json: opts.json,
+  });
+}
+
+export async function runInferenceTraceCmd(opts: InferenceCliOptions): Promise<number> {
+  if (!opts.correlationId?.trim()) {
+    console.error("Usage: clawql inference trace --correlation-id <id>");
+    return 1;
+  }
+  return runInferenceTrace({
+    correlationId: opts.correlationId,
+    json: opts.json,
+  });
+}
+
+export async function runInferenceSpendCmd(opts: InferenceCliOptions): Promise<number> {
+  return runInferenceSpend({
+    groupBy: opts.groupBy,
+    since: opts.since,
+    json: opts.json,
+  });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements **P0-G** — inference call store and observability on top of merged #574.

## Summary

- **`InferenceRecord`** — durable call shape with `correlation_id`, model/provider/tier, messages, response, usage, latency
- **`InferenceStore`** — in-memory (tests) + JSONL file backend (`$CLAWQL_HOME/Inference/calls.jsonl`)
- **`ObservedInferenceGateway`** — wraps gateway to append a record on every successful `complete()`
- **CLI:** `clawql inference logs`, `trace`, `spend`
- **HTTP:** `X-Correlation-Id` header forwarded on `/v1/chat/completions`

## Environment

| Variable | Default | Purpose |
|----------|---------|---------|
| `CLAWQL_INFERENCE_STORE` | `jsonl` when `CLAWQL_HOME` set, else `memory` | `memory` \| `jsonl` \| `off` |
| `CLAWQL_INFERENCE_STORE_PATH` | `$CLAWQL_HOME/Inference/calls.jsonl` | Override JSONL path |

## Usage

```bash
clawql inference complete --model openai/gpt-4o --message "hi" --correlation-id seed_abc_gen_2
clawql inference logs --since 24h --limit 20
clawql inference trace --correlation-id seed_abc_gen_2
clawql inference spend --group-by model --since 7d
```

## Tests

26 unit tests in `clawql-inference` (store, observed gateway, parse-since).

## Deferred

- Postgres store backend (ouroboros-style) — follow-on
- P0-H export / P0-I finetune flywheel
- `escalation show`, virtual keys, semantic cache
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

