### PR TITLE
feat(inference): P0-H export + P0-I finetune (#556)

### DIFF
--- a/docs/inference/clawql-inference.md
+++ b/docs/inference/clawql-inference.md
@@ -21,15 +21,17 @@ Production traffic
 
 LiteLLM routes inference. ClawQL closes the loop: **infer → observe → evaluate → export → fine-tune → redeploy**.
 
-## Shipped today (#560, gateway MVP)
+## Shipped today (#560, gateway MVP, export/finetune)
 
 - **`AdaptiveRouter`** / **`TierEscalationRouter`** — frugal → standard → frontier, one-notch escalation
-- **Tier map** from environment (off by default)
+- **Tier map** from environment (off by default); **`tier-map.json`** overrides after `finetune register`
 - **Kill switches** — escalation disabled unless explicitly enabled; optional model pin
 - **`ConfiguredInferenceGateway`** — provider plugin registry + routing to `provider/model` backends
 - **Provider plugins** — OpenAI, Anthropic, Ollama built-ins via `composeDefaultProviderPlugins()`; third-party extensions use the same contract ([inference providers plugin](../plugins/inference-providers.md))
 - **`clawql inference serve`** — OpenAI-compatible `/v1/chat/completions` + `/healthz`
 - **`clawql inference logs` / `trace` / `spend`** — query the call store by model, `correlation_id`, or token rollup
+- **`clawql inference export`** — verdict-filtered JSONL + Presidio scrub + WORM dataset manifest
+- **`clawql inference finetune`** — OpenAI / Anthropic job submit, status, and tier registration
 - **Call store** — JSONL at `$CLAWQL_HOME/Inference/calls.jsonl` (or `memory` / `off` via env)
 
 ## Planned modules
@@ -211,8 +213,8 @@ clawql inference policy show    # Manifest inference block (tiers, cache TTL, ex
 | **P0-D** ✅ | `routing/` + ouroboros hooks ([#560](https://github.com/danielsmithdevelopment/ClawQL/issues/560))                                                                                            |
 | **P0-F** ✅ | Gateway MVP: `serve`, `complete`, OpenAI / Anthropic / Ollama adapters                                                                                                                        |
 | **P0-G** ✅ | `store/` + observability — log every call with `correlation_id`; `logs`, `trace`, `spend` CLI                                                                                                 |
-| **P0-H**    | `export/` — verdict-filtered JSONL + Presidio + dataset manifest                                                                                                                              |
-| **P0-I**    | `finetune/` — Anthropic/OpenAI job API + `register-as` tier                                                                                                                                   |
+| **P0-H** ✅ | `export/` — verdict-filtered JSONL + Presidio + dataset manifest                                                                                                                              |
+| **P0-I** ✅ | `finetune/` — Anthropic/OpenAI job API + `register-as` tier                                                                                                                                   |
 | **P1**      | `pipeline enable` — scheduled auto-export + promote                                                                                                                                           |
 | **P1**      | Model escalation audit events ([#561](https://github.com/danielsmithdevelopment/ClawQL/issues/561)), agent coordination ([#562](https://github.com/danielsmithdevelopment/ClawQL/issues/562)) |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12296,6 +12296,8 @@
             "version": "7.0.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "clawql-api": "7.0.0",
+                "clawql-core": "7.0.0",
                 "express": "^5.2.1",
                 "zod": "^4.3.6"
             },

--- a/packages/clawql-inference/README.md
+++ b/packages/clawql-inference/README.md
@@ -2,7 +2,7 @@
 
 TypeScript-native **inference gateway** for ClawQL: model tier escalation, cloud provider adapters, local runtimes (Ollama / vLLM / Llama.cpp), semantic caching, and WORM-auditable observability.
 
-**Status:** Gateway MVP shipped — model tier escalation (#560) + provider plugin architecture + `clawql inference serve|complete`.
+**Status:** Gateway MVP + export/finetune — model tier escalation (#560), provider plugins, call store, dataset export, and fine-tune job API.
 
 Built-in provider plugins (OpenAI, Anthropic, Ollama) register automatically. Third parties add backends via `InferenceProviderPlugin` — see [`docs/plugins/inference-providers.md`](../../docs/plugins/inference-providers.md).
 
@@ -18,6 +18,12 @@ clawql inference serve --port 8080
 curl -s http://127.0.0.1:8080/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{"model":"openai/gpt-4o","messages":[{"role":"user","content":"hi"}]}'
+
+# Export evaluator-passed samples for fine-tuning
+clawql inference export --output ./training.jsonl --verdict passed --format openai-jsonl
+
+# Submit fine-tune job (OpenAI)
+clawql inference finetune --dataset ./training.jsonl --base-model gpt-4o-mini --provider openai
 ```
 
 ## Model tier escalation

--- a/packages/clawql-inference/package.json
+++ b/packages/clawql-inference/package.json
@@ -33,6 +33,8 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "clawql-api": "7.0.0",
+    "clawql-core": "7.0.0",
     "express": "^5.2.1",
     "zod": "^4.3.6"
   },

--- a/packages/clawql-inference/src/cli/export.ts
+++ b/packages/clawql-inference/src/cli/export.ts
@@ -1,0 +1,56 @@
+import { runInferenceExport } from "../export/run-export.js";
+import type { ExportFormat } from "../export/types.js";
+import type { EvaluatorVerdict } from "../store/types.js";
+
+export type InferenceExportCliOptions = {
+  output?: string;
+  format?: ExportFormat;
+  model?: string;
+  provider?: string;
+  tier?: string;
+  verdict?: EvaluatorVerdict;
+  minScore?: number;
+  dateFrom?: string;
+  dateTo?: string;
+  maxLatencyMs?: number;
+  minTokenEfficiency?: number;
+  excludeCacheHits?: boolean;
+  noPiiScrub?: boolean;
+  writeManifest?: boolean;
+  policyVersion?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+export async function runInferenceExportCli(
+  options: InferenceExportCliOptions = {}
+): Promise<number> {
+  try {
+    const result = await runInferenceExport({
+      output: options.output ?? "",
+      format: options.format,
+      model: options.model,
+      provider: options.provider,
+      tier: options.tier,
+      verdict: options.verdict,
+      minScore: options.minScore,
+      dateFrom: options.dateFrom,
+      dateTo: options.dateTo,
+      maxLatencyMs: options.maxLatencyMs,
+      minTokenEfficiency: options.minTokenEfficiency,
+      excludeCacheHits: options.excludeCacheHits,
+      noPiiScrub: options.noPiiScrub,
+      writeManifest: options.writeManifest,
+      policyVersion: options.policyVersion,
+      env: options.env,
+    });
+    console.log(
+      `Exported ${result.rowCount} samples to ${result.outputPath}${
+        result.manifestPath ? ` (manifest: ${result.manifestPath})` : ""
+      }`
+    );
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}

--- a/packages/clawql-inference/src/cli/finetune.ts
+++ b/packages/clawql-inference/src/cli/finetune.ts
@@ -1,4 +1,8 @@
-import { getFinetuneJobStatus, registerFinetuneModel, submitFinetuneJob } from "../finetune/jobs.js";
+import {
+  getFinetuneJobStatus,
+  registerFinetuneModel,
+  submitFinetuneJob,
+} from "../finetune/jobs.js";
 import type { FinetuneProvider } from "../finetune/types.js";
 import type { ModelTier } from "../routing/types.js";
 
@@ -52,7 +56,9 @@ export async function runInferenceFinetuneStatus(
   options: InferenceFinetuneOptions
 ): Promise<number> {
   if (!options.jobId?.trim()) {
-    console.error("Usage: clawql inference finetune status --job-id <id> --provider openai|anthropic");
+    console.error(
+      "Usage: clawql inference finetune status --job-id <id> --provider openai|anthropic"
+    );
     return 1;
   }
   const provider = options.provider ?? "openai";

--- a/packages/clawql-inference/src/cli/finetune.ts
+++ b/packages/clawql-inference/src/cli/finetune.ts
@@ -1,0 +1,108 @@
+import { getFinetuneJobStatus, registerFinetuneModel, submitFinetuneJob } from "../finetune/jobs.js";
+import type { FinetuneProvider } from "../finetune/types.js";
+import type { ModelTier } from "../routing/types.js";
+
+export type InferenceFinetuneOptions = {
+  dataset?: string;
+  manifest?: string;
+  baseModel?: string;
+  provider?: FinetuneProvider;
+  registerAs?: string;
+  jobId?: string;
+  tier?: ModelTier;
+  alias?: string;
+  json?: boolean;
+  env?: NodeJS.ProcessEnv;
+};
+
+export async function runInferenceFinetune(options: InferenceFinetuneOptions): Promise<number> {
+  if (!options.dataset?.trim()) {
+    console.error(
+      "Usage: clawql inference finetune --dataset <path.jsonl> --base-model <model> --provider openai|anthropic"
+    );
+    return 1;
+  }
+  if (!options.baseModel?.trim()) {
+    console.error("Missing --base-model");
+    return 1;
+  }
+  const provider = options.provider ?? "openai";
+  try {
+    const job = await submitFinetuneJob({
+      datasetPath: options.dataset.trim(),
+      manifestPath: options.manifest,
+      baseModel: options.baseModel.trim(),
+      provider,
+      registerAs: options.registerAs,
+      env: options.env,
+    });
+    if (options.json) {
+      console.log(JSON.stringify(job, null, 2));
+    } else {
+      console.log(`Submitted ${provider} fine-tune job ${job.id} (status: ${job.status})`);
+    }
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
+export async function runInferenceFinetuneStatus(
+  options: InferenceFinetuneOptions
+): Promise<number> {
+  if (!options.jobId?.trim()) {
+    console.error("Usage: clawql inference finetune status --job-id <id> --provider openai|anthropic");
+    return 1;
+  }
+  const provider = options.provider ?? "openai";
+  try {
+    const job = await getFinetuneJobStatus({
+      jobId: options.jobId.trim(),
+      provider,
+      env: options.env,
+    });
+    if (options.json) {
+      console.log(JSON.stringify(job, null, 2));
+    } else {
+      console.log(
+        `${job.id}: ${job.status}${job.fineTunedModel ? ` → ${job.fineTunedModel}` : ""}${
+          job.error ? ` (${job.error})` : ""
+        }`
+      );
+    }
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
+export async function runInferenceFinetuneRegister(
+  options: InferenceFinetuneOptions
+): Promise<number> {
+  if (!options.jobId?.trim() || !options.tier || !options.alias?.trim()) {
+    console.error(
+      "Usage: clawql inference finetune register --job-id <id> --tier frugal|standard|frontier --alias <provider/model>"
+    );
+    return 1;
+  }
+  try {
+    const result = await registerFinetuneModel({
+      jobId: options.jobId.trim(),
+      tier: options.tier,
+      alias: options.alias.trim(),
+      provider: options.provider,
+      env: options.env,
+    });
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(`Registered ${result.modelId} as ${result.tier} tier (saved to ${result.path})`);
+    }
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}

--- a/packages/clawql-inference/src/export/filter.ts
+++ b/packages/clawql-inference/src/export/filter.ts
@@ -1,0 +1,33 @@
+import type { InferenceRecord } from "../store/types.js";
+import type { ExportFilter } from "./types.js";
+
+export function matchesExportFilter(record: InferenceRecord, filter: ExportFilter): boolean {
+  if (filter.modelId && record.modelId !== filter.modelId) return false;
+  if (filter.provider && record.provider !== filter.provider) return false;
+  if (filter.tier && record.tier !== filter.tier) return false;
+  if (filter.verdict && record.evaluatorVerdict !== filter.verdict) return false;
+  if (filter.minScore !== undefined) {
+    const score = record.evaluatorScore ?? 0;
+    if (score < filter.minScore) return false;
+  }
+  const ts = new Date(record.timestamp);
+  if (filter.dateFrom && ts < filter.dateFrom) return false;
+  if (filter.dateTo && ts > filter.dateTo) return false;
+  if (filter.maxLatencyMs !== undefined && record.latencyMs > filter.maxLatencyMs) return false;
+  if (filter.excludeCacheHits && record.cacheHit) return false;
+  if (filter.minTokenEfficiency !== undefined) {
+    const input = record.usage?.inputTokens ?? 0;
+    const output = record.usage?.outputTokens ?? 0;
+    if (input <= 0) return false;
+    const efficiency = output / input;
+    if (efficiency < filter.minTokenEfficiency) return false;
+  }
+  return true;
+}
+
+export function filterRecordsForExport(
+  records: InferenceRecord[],
+  filter: ExportFilter
+): InferenceRecord[] {
+  return records.filter((r) => matchesExportFilter(r, filter));
+}

--- a/packages/clawql-inference/src/export/format.ts
+++ b/packages/clawql-inference/src/export/format.ts
@@ -1,0 +1,47 @@
+import type { ChatMessage } from "../gateway.js";
+import type { InferenceRecord } from "../store/types.js";
+import type { ExportFormat } from "./types.js";
+
+function toOpenAiMessages(record: InferenceRecord): ChatMessage[] {
+  const messages = [...record.messages];
+  if (!messages.some((m) => m.role === "assistant")) {
+    messages.push({ role: "assistant", content: record.response });
+  }
+  return messages;
+}
+
+function toAnthropicMessages(record: InferenceRecord): Array<{ role: string; content: string }> {
+  return toOpenAiMessages(record).map((m) => ({
+    role: m.role === "assistant" ? "assistant" : m.role === "system" ? "system" : "user",
+    content: m.content,
+  }));
+}
+
+function toShareGpt(record: InferenceRecord): {
+  conversations: Array<{ from: string; value: string }>;
+} {
+  const conversations: Array<{ from: string; value: string }> = [];
+  for (const message of record.messages) {
+    if (message.role === "system") continue;
+    conversations.push({
+      from: message.role === "assistant" ? "gpt" : "human",
+      value: message.content,
+    });
+  }
+  conversations.push({ from: "gpt", value: record.response });
+  return { conversations };
+}
+
+export function formatExportLine(record: InferenceRecord, format: ExportFormat): string {
+  switch (format) {
+    case "openai-jsonl":
+      return JSON.stringify({ messages: toOpenAiMessages(record) });
+    case "anthropic-jsonl":
+      return JSON.stringify({ messages: toAnthropicMessages(record) });
+    case "sharegpt":
+      return JSON.stringify(toShareGpt(record));
+    case "raw-jsonl":
+    default:
+      return JSON.stringify(record);
+  }
+}

--- a/packages/clawql-inference/src/export/manifest.ts
+++ b/packages/clawql-inference/src/export/manifest.ts
@@ -1,6 +1,12 @@
 import { createHash } from "node:crypto";
 import { buildMerkleSnapshot } from "clawql-core";
-import type { DatasetManifest, ExportFilter, ExportFormat, ExportSampleLine, PiiScrubMode } from "./types.js";
+import type {
+  DatasetManifest,
+  ExportFilter,
+  ExportFormat,
+  ExportSampleLine,
+  PiiScrubMode,
+} from "./types.js";
 
 export function sha256Hex(text: string): string {
   return createHash("sha256").update(text, "utf8").digest("hex");

--- a/packages/clawql-inference/src/export/manifest.ts
+++ b/packages/clawql-inference/src/export/manifest.ts
@@ -1,0 +1,47 @@
+import { createHash } from "node:crypto";
+import { buildMerkleSnapshot } from "clawql-core";
+import type { DatasetManifest, ExportFilter, ExportFormat, ExportSampleLine, PiiScrubMode } from "./types.js";
+
+export function sha256Hex(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+export function buildSampleLines(lines: string[]): ExportSampleLine[] {
+  return lines.map((line) => ({ line, sha256: sha256Hex(line) }));
+}
+
+export function buildDatasetManifest(input: {
+  format: ExportFormat;
+  outputPath: string;
+  filters: ExportFilter;
+  samples: ExportSampleLine[];
+  policyVersion?: string;
+  piiScrub: PiiScrubMode;
+  presidioActive: boolean;
+}): DatasetManifest {
+  const byteSize = input.samples.reduce((sum, s) => sum + Buffer.byteLength(s.line, "utf8") + 1, 0);
+  const sampleHashes = input.samples.map((s) => s.sha256);
+  const merkleRoot = buildMerkleSnapshot(
+    sampleHashes.map((sha256, i) => ({
+      path: `export/sample/${i}`,
+      bodySha256Hex: sha256,
+    }))
+  ).rootHex;
+  return {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    format: input.format,
+    outputPath: input.outputPath,
+    filters: input.filters,
+    rowCount: input.samples.length,
+    byteSize,
+    sampleHashes,
+    merkleRoot,
+    policyVersion: input.policyVersion,
+    piiScrub: {
+      enabled: input.piiScrub !== "off",
+      provider: input.piiScrub,
+      presidioActive: input.presidioActive,
+    },
+  };
+}

--- a/packages/clawql-inference/src/export/pii.ts
+++ b/packages/clawql-inference/src/export/pii.ts
@@ -1,0 +1,35 @@
+import { maybePresidioRedactText, presidioEnabled } from "clawql-api";
+import type { PiiScrubMode } from "./types.js";
+
+export async function scrubExportLine(line: string, mode: PiiScrubMode): Promise<string> {
+  if (mode === "off") return line;
+  if (!presidioEnabled()) return line;
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    const scrubbed = await scrubJsonValue(parsed);
+    return JSON.stringify(scrubbed);
+  } catch {
+    return maybePresidioRedactText(line);
+  }
+}
+
+async function scrubJsonValue(value: unknown): Promise<unknown> {
+  if (typeof value === "string") {
+    return maybePresidioRedactText(value);
+  }
+  if (Array.isArray(value)) {
+    return Promise.all(value.map((v) => scrubJsonValue(v)));
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = await scrubJsonValue(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+export function resolvePiiScrubMode(noPiiScrub?: boolean): PiiScrubMode {
+  return noPiiScrub ? "off" : "presidio";
+}

--- a/packages/clawql-inference/src/export/run-export.test.ts
+++ b/packages/clawql-inference/src/export/run-export.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { buildInferenceRecord } from "../store/types.js";
+import { matchesExportFilter } from "./filter.js";
+import { formatExportLine } from "./format.js";
+import { sha256Hex } from "./manifest.js";
+
+function sampleRecord(overrides: Partial<ReturnType<typeof buildInferenceRecord>> = {}) {
+  return {
+    ...buildInferenceRecord({
+      id: "r1",
+      request: {
+        messages: [{ role: "user" as const, content: "hi" }],
+        model: "openai/gpt-4o",
+        correlationId: "corr-1",
+      },
+      response: {
+        content: "hello",
+        model: "openai/gpt-4o",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      },
+      provider: "openai",
+      model: "gpt-4o",
+      latencyMs: 100,
+    }),
+    evaluatorVerdict: "passed" as const,
+    evaluatorScore: 0.9,
+    ...overrides,
+  };
+}
+
+describe("export filter", () => {
+  it("filters by verdict and score", () => {
+    const passed = sampleRecord();
+    const failed = sampleRecord({ evaluatorVerdict: "failed", evaluatorScore: 0.2 });
+    expect(matchesExportFilter(passed, { verdict: "passed", minScore: 0.8 })).toBe(true);
+    expect(matchesExportFilter(failed, { verdict: "passed", minScore: 0.8 })).toBe(false);
+  });
+
+  it("filters cache hits and token efficiency", () => {
+    const cached = sampleRecord({ cacheHit: true });
+    const slow = sampleRecord({ latencyMs: 9000 });
+    expect(matchesExportFilter(cached, { excludeCacheHits: true })).toBe(false);
+    expect(matchesExportFilter(slow, { maxLatencyMs: 5000 })).toBe(false);
+    expect(matchesExportFilter(sampleRecord(), { minTokenEfficiency: 0.3 })).toBe(true);
+    expect(matchesExportFilter(sampleRecord(), { minTokenEfficiency: 0.9 })).toBe(false);
+  });
+});
+
+describe("export format", () => {
+  it("emits openai-jsonl messages", () => {
+    const line = formatExportLine(sampleRecord(), "openai-jsonl");
+    const parsed = JSON.parse(line) as { messages: Array<{ role: string; content: string }> };
+    expect(parsed.messages.at(-1)?.role).toBe("assistant");
+    expect(parsed.messages.at(-1)?.content).toBe("hello");
+  });
+
+  it("hashes sample lines", () => {
+    const line = formatExportLine(sampleRecord(), "raw-jsonl");
+    expect(sha256Hex(line)).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/packages/clawql-inference/src/export/run-export.ts
+++ b/packages/clawql-inference/src/export/run-export.ts
@@ -1,0 +1,133 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { createInferenceStore } from "../store/create.js";
+import type { EvaluatorVerdict, InferenceRecord } from "../store/types.js";
+import { filterRecordsForExport } from "./filter.js";
+import { formatExportLine } from "./format.js";
+import { buildDatasetManifest, buildSampleLines } from "./manifest.js";
+import { presidioEnabled } from "clawql-api";
+import { resolvePiiScrubMode, scrubExportLine } from "./pii.js";
+import type { ExportFormat, RunExportResult } from "./types.js";
+
+export type RunInferenceExportOptions = {
+  output: string;
+  format?: ExportFormat;
+  model?: string;
+  provider?: string;
+  tier?: string;
+  verdict?: EvaluatorVerdict;
+  minScore?: number;
+  dateFrom?: string;
+  dateTo?: string;
+  maxLatencyMs?: number;
+  minTokenEfficiency?: number;
+  excludeCacheHits?: boolean;
+  noPiiScrub?: boolean;
+  writeManifest?: boolean;
+  policyVersion?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+function parseDate(raw: string | undefined): Date | undefined {
+  if (!raw?.trim()) return undefined;
+  const d = new Date(raw.trim());
+  return Number.isNaN(d.getTime()) ? undefined : d;
+}
+
+export async function runInferenceExport(
+  options: RunInferenceExportOptions
+): Promise<RunExportResult> {
+  if (!options.output?.trim()) {
+    throw new Error("Usage: clawql inference export --output <path>");
+  }
+  const store = createInferenceStore({ env: options.env });
+  if (!store) {
+    throw new Error("Inference store is disabled (CLAWQL_INFERENCE_STORE=off)");
+  }
+
+  const filter = {
+    modelId: options.model,
+    provider: options.provider,
+    tier: options.tier,
+    verdict: options.verdict,
+    minScore: options.minScore,
+    dateFrom: parseDate(options.dateFrom),
+    dateTo: parseDate(options.dateTo),
+    maxLatencyMs: options.maxLatencyMs,
+    minTokenEfficiency: options.minTokenEfficiency,
+    excludeCacheHits: options.excludeCacheHits,
+  };
+
+  const records = filterRecordsForExport(await store.list({ limit: undefined }), filter);
+  const format = options.format ?? "openai-jsonl";
+  const piiMode = resolvePiiScrubMode(options.noPiiScrub);
+  const lines: string[] = [];
+  for (const record of records) {
+    const raw = formatExportLine(record, format);
+    lines.push(await scrubExportLine(raw, piiMode));
+  }
+
+  const outputPath = options.output.trim();
+  await mkdir(dirname(outputPath), { recursive: true });
+  const body = lines.length ? `${lines.join("\n")}\n` : "";
+  await writeFile(outputPath, body, "utf8");
+
+  const writeManifest = options.writeManifest !== false;
+  let manifestPath: string | undefined;
+  let manifest;
+  if (writeManifest) {
+    const samples = buildSampleLines(lines);
+    manifest = buildDatasetManifest({
+      format,
+      outputPath,
+      filters: filter,
+      samples,
+      policyVersion: options.policyVersion ?? records.find((r) => r.policyVersion)?.policyVersion,
+      piiScrub: piiMode,
+      presidioActive: piiMode === "presidio" && presidioEnabled(),
+    });
+    manifestPath = outputPath.replace(/\.jsonl$/i, ".manifest.json");
+    if (manifestPath === outputPath) manifestPath = `${outputPath}.manifest.json`;
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  }
+
+  return { rowCount: lines.length, outputPath, manifestPath, manifest };
+}
+
+/** Test helper — export in-memory records without a store. */
+export async function exportRecords(input: {
+  records: InferenceRecord[];
+  output: string;
+  format?: ExportFormat;
+  filter?: Parameters<typeof filterRecordsForExport>[1];
+  noPiiScrub?: boolean;
+  writeManifest?: boolean;
+}): Promise<RunExportResult> {
+  const records = filterRecordsForExport(input.records, input.filter ?? {});
+  const format = input.format ?? "openai-jsonl";
+  const piiMode = resolvePiiScrubMode(input.noPiiScrub);
+  const lines: string[] = [];
+  for (const record of records) {
+    const raw = formatExportLine(record, format);
+    lines.push(await scrubExportLine(raw, piiMode));
+  }
+  const outputPath = input.output;
+  await mkdir(dirname(outputPath), { recursive: true });
+  const body = lines.length ? `${lines.join("\n")}\n` : "";
+  await writeFile(outputPath, body, "utf8");
+  const samples = buildSampleLines(lines);
+  const manifest = buildDatasetManifest({
+    format,
+    outputPath,
+    filters: input.filter ?? {},
+    samples,
+    piiScrub: piiMode,
+    presidioActive: false,
+  });
+  if (input.writeManifest !== false) {
+    const manifestPath = `${outputPath}.manifest.json`;
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+    return { rowCount: lines.length, outputPath, manifestPath, manifest };
+  }
+  return { rowCount: lines.length, outputPath, manifest };
+}

--- a/packages/clawql-inference/src/export/types.ts
+++ b/packages/clawql-inference/src/export/types.ts
@@ -1,0 +1,48 @@
+import type { EvaluatorVerdict } from "../store/types.js";
+
+export type ExportFormat = "openai-jsonl" | "anthropic-jsonl" | "raw-jsonl" | "sharegpt";
+
+export type ExportFilter = {
+  modelId?: string;
+  provider?: string;
+  tier?: string;
+  verdict?: EvaluatorVerdict;
+  minScore?: number;
+  dateFrom?: Date;
+  dateTo?: Date;
+  maxLatencyMs?: number;
+  minTokenEfficiency?: number;
+  excludeCacheHits?: boolean;
+};
+
+export type PiiScrubMode = "presidio" | "off";
+
+export type ExportSampleLine = {
+  line: string;
+  sha256: string;
+};
+
+export type DatasetManifest = {
+  version: 1;
+  exportedAt: string;
+  format: ExportFormat;
+  outputPath: string;
+  filters: ExportFilter;
+  rowCount: number;
+  byteSize: number;
+  sampleHashes: string[];
+  merkleRoot: string;
+  policyVersion?: string;
+  piiScrub: {
+    enabled: boolean;
+    provider: PiiScrubMode;
+    presidioActive: boolean;
+  };
+};
+
+export type RunExportResult = {
+  rowCount: number;
+  outputPath: string;
+  manifestPath?: string;
+  manifest?: DatasetManifest;
+};

--- a/packages/clawql-inference/src/finetune/anthropic.ts
+++ b/packages/clawql-inference/src/finetune/anthropic.ts
@@ -1,0 +1,75 @@
+import { readHttpError } from "../providers/http.js";
+import type { FinetuneJob, FinetuneJobStatus } from "./types.js";
+
+type AnthropicJobResponse = {
+  id: string;
+  status: string;
+  base_model: string;
+  fine_tuned_model?: string | null;
+  created_at: string;
+  finished_at?: string | null;
+  error?: { message?: string } | null;
+};
+
+function mapAnthropicStatus(status: string): FinetuneJobStatus {
+  switch (status) {
+    case "queued":
+    case "running":
+    case "succeeded":
+    case "failed":
+    case "cancelled":
+      return status;
+    default:
+      return "queued";
+  }
+}
+
+function toFinetuneJob(body: AnthropicJobResponse): FinetuneJob {
+  return {
+    id: body.id,
+    provider: "anthropic",
+    status: mapAnthropicStatus(body.status),
+    baseModel: body.base_model,
+    fineTunedModel: body.fine_tuned_model ?? undefined,
+    createdAt: body.created_at,
+    finishedAt: body.finished_at ?? undefined,
+    error: body.error?.message,
+  };
+}
+
+const ANTHROPIC_FINETUNE_BASE = "https://api.anthropic.com/v1/fine_tuning";
+
+export async function submitAnthropicFinetuneJob(input: {
+  datasetPath: string;
+  baseModel: string;
+  apiKey: string;
+}): Promise<FinetuneJob> {
+  const res = await fetch(`${ANTHROPIC_FINETUNE_BASE}/jobs`, {
+    method: "POST",
+    headers: {
+      "x-api-key": input.apiKey,
+      "anthropic-version": "2023-06-01",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      base_model: input.baseModel,
+      training_file: input.datasetPath,
+    }),
+  });
+  if (!res.ok) throw new Error(await readHttpError(res));
+  return toFinetuneJob((await res.json()) as AnthropicJobResponse);
+}
+
+export async function getAnthropicFinetuneJob(
+  jobId: string,
+  apiKey: string
+): Promise<FinetuneJob> {
+  const res = await fetch(`${ANTHROPIC_FINETUNE_BASE}/jobs/${encodeURIComponent(jobId)}`, {
+    headers: {
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+  });
+  if (!res.ok) throw new Error(await readHttpError(res));
+  return toFinetuneJob((await res.json()) as AnthropicJobResponse);
+}

--- a/packages/clawql-inference/src/finetune/anthropic.ts
+++ b/packages/clawql-inference/src/finetune/anthropic.ts
@@ -60,10 +60,7 @@ export async function submitAnthropicFinetuneJob(input: {
   return toFinetuneJob((await res.json()) as AnthropicJobResponse);
 }
 
-export async function getAnthropicFinetuneJob(
-  jobId: string,
-  apiKey: string
-): Promise<FinetuneJob> {
+export async function getAnthropicFinetuneJob(jobId: string, apiKey: string): Promise<FinetuneJob> {
   const res = await fetch(`${ANTHROPIC_FINETUNE_BASE}/jobs/${encodeURIComponent(jobId)}`, {
     headers: {
       "x-api-key": apiKey,

--- a/packages/clawql-inference/src/finetune/jobs.ts
+++ b/packages/clawql-inference/src/finetune/jobs.ts
@@ -2,13 +2,15 @@ import type { ModelTier } from "../routing/types.js";
 import { getAnthropicFinetuneJob, submitAnthropicFinetuneJob } from "./anthropic.js";
 import { getOpenAiFinetuneJob, submitOpenAiFinetuneJob } from "./openai.js";
 import { registerModelToTier } from "./tier-registry.js";
-import type { FinetuneJob, FinetuneProvider, RegisterFinetuneModelInput, SubmitFinetuneJobInput } from "./types.js";
+import type {
+  FinetuneJob,
+  FinetuneProvider,
+  RegisterFinetuneModelInput,
+  SubmitFinetuneJobInput,
+} from "./types.js";
 
 function resolveApiKey(provider: FinetuneProvider, env: NodeJS.ProcessEnv): string {
-  const key =
-    provider === "openai"
-      ? env.OPENAI_API_KEY?.trim()
-      : env.ANTHROPIC_API_KEY?.trim();
+  const key = provider === "openai" ? env.OPENAI_API_KEY?.trim() : env.ANTHROPIC_API_KEY?.trim();
   if (!key) {
     throw new Error(
       provider === "openai"

--- a/packages/clawql-inference/src/finetune/jobs.ts
+++ b/packages/clawql-inference/src/finetune/jobs.ts
@@ -1,0 +1,75 @@
+import type { ModelTier } from "../routing/types.js";
+import { getAnthropicFinetuneJob, submitAnthropicFinetuneJob } from "./anthropic.js";
+import { getOpenAiFinetuneJob, submitOpenAiFinetuneJob } from "./openai.js";
+import { registerModelToTier } from "./tier-registry.js";
+import type { FinetuneJob, FinetuneProvider, RegisterFinetuneModelInput, SubmitFinetuneJobInput } from "./types.js";
+
+function resolveApiKey(provider: FinetuneProvider, env: NodeJS.ProcessEnv): string {
+  const key =
+    provider === "openai"
+      ? env.OPENAI_API_KEY?.trim()
+      : env.ANTHROPIC_API_KEY?.trim();
+  if (!key) {
+    throw new Error(
+      provider === "openai"
+        ? "OPENAI_API_KEY is required for OpenAI fine-tuning"
+        : "ANTHROPIC_API_KEY is required for Anthropic fine-tuning"
+    );
+  }
+  return key;
+}
+
+export async function submitFinetuneJob(input: SubmitFinetuneJobInput): Promise<FinetuneJob> {
+  const env = input.env ?? process.env;
+  const apiKey = resolveApiKey(input.provider, env);
+  const job =
+    input.provider === "openai"
+      ? await submitOpenAiFinetuneJob({
+          datasetPath: input.datasetPath,
+          baseModel: input.baseModel,
+          suffix: input.suffix ?? input.registerAs,
+          apiKey,
+        })
+      : await submitAnthropicFinetuneJob({
+          datasetPath: input.datasetPath,
+          baseModel: input.baseModel,
+          apiKey,
+        });
+
+  if (input.registerAs && job.fineTunedModel) {
+    await registerModelToTier("frugal", job.fineTunedModel, env);
+  }
+  return job;
+}
+
+export async function getFinetuneJobStatus(input: {
+  jobId: string;
+  provider: FinetuneProvider;
+  env?: NodeJS.ProcessEnv;
+}): Promise<FinetuneJob> {
+  const env = input.env ?? process.env;
+  const apiKey = resolveApiKey(input.provider, env);
+  return input.provider === "openai"
+    ? getOpenAiFinetuneJob(input.jobId, apiKey)
+    : getAnthropicFinetuneJob(input.jobId, apiKey);
+}
+
+export async function registerFinetuneModel(
+  input: RegisterFinetuneModelInput & { provider?: FinetuneProvider; modelId?: string }
+): Promise<{ tier: ModelTier; modelId: string; path: string }> {
+  const env = input.env ?? process.env;
+  let modelId = input.modelId ?? input.alias;
+  if (!modelId && input.provider) {
+    const job = await getFinetuneJobStatus({
+      jobId: input.jobId,
+      provider: input.provider,
+      env,
+    });
+    modelId = job.fineTunedModel ?? input.alias;
+  }
+  if (!modelId?.trim()) {
+    throw new Error("Model id is required (pass --alias or a succeeded job with fineTunedModel)");
+  }
+  const { path } = await registerModelToTier(input.tier, modelId.trim(), env);
+  return { tier: input.tier, modelId: modelId.trim(), path };
+}

--- a/packages/clawql-inference/src/finetune/openai.ts
+++ b/packages/clawql-inference/src/finetune/openai.ts
@@ -1,0 +1,89 @@
+import { readFile } from "node:fs/promises";
+import { readHttpError } from "../providers/http.js";
+import type { FinetuneJob, FinetuneJobStatus } from "./types.js";
+
+type OpenAiJobResponse = {
+  id: string;
+  status: string;
+  model: string;
+  fine_tuned_model?: string | null;
+  created_at: number;
+  finished_at?: number | null;
+  error?: { message?: string } | null;
+};
+
+function mapOpenAiStatus(status: string): FinetuneJobStatus {
+  switch (status) {
+    case "validating_files":
+    case "queued":
+    case "running":
+    case "succeeded":
+    case "failed":
+    case "cancelled":
+      return status;
+    default:
+      return "queued";
+  }
+}
+
+function toFinetuneJob(body: OpenAiJobResponse): FinetuneJob {
+  return {
+    id: body.id,
+    provider: "openai",
+    status: mapOpenAiStatus(body.status),
+    baseModel: body.model,
+    fineTunedModel: body.fine_tuned_model ?? undefined,
+    createdAt: new Date(body.created_at * 1000).toISOString(),
+    finishedAt: body.finished_at ? new Date(body.finished_at * 1000).toISOString() : undefined,
+    error: body.error?.message,
+  };
+}
+
+export async function uploadOpenAiTrainingFile(
+  datasetPath: string,
+  apiKey: string
+): Promise<string> {
+  const bytes = await readFile(datasetPath);
+  const form = new FormData();
+  form.append("purpose", "fine-tune");
+  form.append("file", new Blob([bytes]), datasetPath.split("/").pop() ?? "training.jsonl");
+  const res = await fetch("https://api.openai.com/v1/files", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}` },
+    body: form,
+  });
+  if (!res.ok) throw new Error(await readHttpError(res));
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+export async function submitOpenAiFinetuneJob(input: {
+  datasetPath: string;
+  baseModel: string;
+  suffix?: string;
+  apiKey: string;
+}): Promise<FinetuneJob> {
+  const fileId = await uploadOpenAiTrainingFile(input.datasetPath, input.apiKey);
+  const res = await fetch("https://api.openai.com/v1/fine_tuning/jobs", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${input.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      training_file: fileId,
+      model: input.baseModel,
+      suffix: input.suffix,
+    }),
+  });
+  if (!res.ok) throw new Error(await readHttpError(res));
+  return toFinetuneJob((await res.json()) as OpenAiJobResponse);
+}
+
+export async function getOpenAiFinetuneJob(jobId: string, apiKey: string): Promise<FinetuneJob> {
+  const res = await fetch(`https://api.openai.com/v1/fine_tuning/jobs/${encodeURIComponent(jobId)}`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+  if (!res.ok) throw new Error(await readHttpError(res));
+  return toFinetuneJob((await res.json()) as OpenAiJobResponse);
+}

--- a/packages/clawql-inference/src/finetune/openai.ts
+++ b/packages/clawql-inference/src/finetune/openai.ts
@@ -81,9 +81,12 @@ export async function submitOpenAiFinetuneJob(input: {
 }
 
 export async function getOpenAiFinetuneJob(jobId: string, apiKey: string): Promise<FinetuneJob> {
-  const res = await fetch(`https://api.openai.com/v1/fine_tuning/jobs/${encodeURIComponent(jobId)}`, {
-    headers: { Authorization: `Bearer ${apiKey}` },
-  });
+  const res = await fetch(
+    `https://api.openai.com/v1/fine_tuning/jobs/${encodeURIComponent(jobId)}`,
+    {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    }
+  );
   if (!res.ok) throw new Error(await readHttpError(res));
   return toFinetuneJob((await res.json()) as OpenAiJobResponse);
 }

--- a/packages/clawql-inference/src/finetune/tier-registry.test.ts
+++ b/packages/clawql-inference/src/finetune/tier-registry.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mergeTierMap, registerModelToTier, loadTierMapOverrides } from "./tier-registry.js";
+
+describe("tier-registry", () => {
+  it("registers and reloads tier overrides", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "clawql-tier-"));
+    const env = { CLAWQL_HOME: dir };
+    try {
+      const { path, tierMap } = await registerModelToTier("frugal", "ollama/phi4-custom", env);
+      expect(path).toContain("tier-map.json");
+      expect(tierMap.frugal).toBe("ollama/phi4-custom");
+      const loaded = await loadTierMapOverrides(env);
+      expect(loaded.frugal).toBe("ollama/phi4-custom");
+      const raw = await readFile(path, "utf8");
+      expect(raw).toContain("phi4-custom");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("merges overrides onto base tier map", () => {
+    const merged = mergeTierMap(
+      { frugal: "a", standard: "b", frontier: "c" },
+      { frugal: "custom" }
+    );
+    expect(merged.frugal).toBe("custom");
+    expect(merged.standard).toBe("b");
+  });
+});

--- a/packages/clawql-inference/src/finetune/tier-registry.ts
+++ b/packages/clawql-inference/src/finetune/tier-registry.ts
@@ -1,0 +1,53 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { ModelTier, ModelTierMap } from "../routing/types.js";
+
+export type TierMapOverrides = Partial<ModelTierMap>;
+
+const FILE_NAME = "tier-map.json";
+
+export function resolveTierMapPath(env: NodeJS.ProcessEnv = process.env): string {
+  const home = env.CLAWQL_HOME?.trim() || join(process.cwd(), ".clawql");
+  return join(home, "Inference", FILE_NAME);
+}
+
+export async function loadTierMapOverrides(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<TierMapOverrides> {
+  try {
+    const raw = await readFile(resolveTierMapPath(env), "utf8");
+    const parsed = JSON.parse(raw) as TierMapOverrides;
+    return parsed ?? {};
+  } catch {
+    return {};
+  }
+}
+
+export async function saveTierMapOverrides(
+  overrides: TierMapOverrides,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<string> {
+  const path = resolveTierMapPath(env);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(overrides, null, 2)}\n`, "utf8");
+  return path;
+}
+
+export async function registerModelToTier(
+  tier: ModelTier,
+  modelId: string,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<{ path: string; tierMap: TierMapOverrides }> {
+  const current = await loadTierMapOverrides(env);
+  const next = { ...current, [tier]: modelId };
+  const path = await saveTierMapOverrides(next, env);
+  return { path, tierMap: next };
+}
+
+export function mergeTierMap(base: ModelTierMap, overrides: TierMapOverrides): ModelTierMap {
+  return {
+    frugal: overrides.frugal ?? base.frugal,
+    standard: overrides.standard ?? base.standard,
+    frontier: overrides.frontier ?? base.frontier,
+  };
+}

--- a/packages/clawql-inference/src/finetune/types.ts
+++ b/packages/clawql-inference/src/finetune/types.ts
@@ -1,0 +1,39 @@
+import type { ModelTier } from "../routing/types.js";
+
+export type FinetuneProvider = "openai" | "anthropic";
+
+export type FinetuneJobStatus =
+  | "validating_files"
+  | "queued"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "cancelled";
+
+export type FinetuneJob = {
+  id: string;
+  provider: FinetuneProvider;
+  status: FinetuneJobStatus;
+  baseModel: string;
+  fineTunedModel?: string;
+  createdAt: string;
+  finishedAt?: string;
+  error?: string;
+};
+
+export type SubmitFinetuneJobInput = {
+  datasetPath: string;
+  manifestPath?: string;
+  baseModel: string;
+  provider: FinetuneProvider;
+  registerAs?: string;
+  suffix?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+export type RegisterFinetuneModelInput = {
+  jobId: string;
+  tier: ModelTier;
+  alias: string;
+  env?: NodeJS.ProcessEnv;
+};

--- a/packages/clawql-inference/src/finetune/types.ts
+++ b/packages/clawql-inference/src/finetune/types.ts
@@ -3,12 +3,7 @@ import type { ModelTier } from "../routing/types.js";
 export type FinetuneProvider = "openai" | "anthropic";
 
 export type FinetuneJobStatus =
-  | "validating_files"
-  | "queued"
-  | "running"
-  | "succeeded"
-  | "failed"
-  | "cancelled";
+  "validating_files" | "queued" | "running" | "succeeded" | "failed" | "cancelled";
 
 export type FinetuneJob = {
   id: string;

--- a/packages/clawql-inference/src/index.ts
+++ b/packages/clawql-inference/src/index.ts
@@ -11,6 +11,7 @@ export {
   MODEL_TIER_ORDER,
   nextModelTier,
   loadModelEscalationConfig,
+  loadModelEscalationConfigAsync,
   createModelEscalationRouter,
   TierEscalationRouter,
   type ModelEscalationConfig,
@@ -49,6 +50,18 @@ export { JsonlInferenceStore } from "./store/jsonl.js";
 export { ObservedInferenceGateway, withInferenceStore } from "./observability/observed-gateway.js";
 export { parseSinceDuration } from "./observability/parse-since.js";
 export { runInferenceLogs, runInferenceTrace, runInferenceSpend } from "./cli/observability.js";
+export { runInferenceExportCli, type InferenceExportCliOptions } from "./cli/export.js";
+export {
+  runInferenceFinetune,
+  runInferenceFinetuneStatus,
+  runInferenceFinetuneRegister,
+  type InferenceFinetuneOptions,
+} from "./cli/finetune.js";
+export { runInferenceExport, type RunInferenceExportOptions } from "./export/run-export.js";
+export type { ExportFormat, DatasetManifest } from "./export/types.js";
+export { submitFinetuneJob, getFinetuneJobStatus, registerFinetuneModel } from "./finetune/jobs.js";
+export type { FinetuneJob, FinetuneProvider } from "./finetune/types.js";
+export { registerModelToTier, loadTierMapOverrides } from "./finetune/tier-registry.js";
 
 export { parseModelId } from "./providers/parse-model-id.js";
 export type {

--- a/packages/clawql-inference/src/routing/config.ts
+++ b/packages/clawql-inference/src/routing/config.ts
@@ -1,6 +1,7 @@
 import type { ModelTierMap } from "./types.js";
 import { TierEscalationRouter } from "./tier-escalation-router.js";
 import type { AdaptiveRouter } from "./types.js";
+import { loadTierMapOverrides, mergeTierMap } from "../finetune/tier-registry.js";
 
 export interface ModelEscalationConfig {
   /** When false and no model pin, model escalation is disabled. */
@@ -22,12 +23,13 @@ function parseTruthy(value: string | undefined): boolean {
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
-function readTierMap(env: NodeJS.ProcessEnv): ModelTierMap {
-  return {
+function readTierMap(env: NodeJS.ProcessEnv, overrides?: Partial<ModelTierMap>): ModelTierMap {
+  const base = {
     frugal: env.CLAWQL_INFERENCE_MODEL_FRUGAL?.trim() || DEFAULT_TIER_MAP.frugal,
     standard: env.CLAWQL_INFERENCE_MODEL_STANDARD?.trim() || DEFAULT_TIER_MAP.standard,
     frontier: env.CLAWQL_INFERENCE_MODEL_FRONTIER?.trim() || DEFAULT_TIER_MAP.frontier,
   };
+  return overrides ? mergeTierMap(base, overrides) : base;
 }
 
 /**
@@ -46,6 +48,20 @@ export function loadModelEscalationConfig(
   return {
     enabled,
     tierMap: readTierMap(env),
+    modelPin,
+  };
+}
+
+/** Async variant that merges tier-map.json overrides from $CLAWQL_HOME/Inference. */
+export async function loadModelEscalationConfigAsync(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<ModelEscalationConfig> {
+  const overrides = await loadTierMapOverrides(env);
+  const modelPin = env.CLAWQL_INFERENCE_MODEL_PIN?.trim() || undefined;
+  const enabled = parseTruthy(env.CLAWQL_INFERENCE_ROUTING_ENABLED) || modelPin !== undefined;
+  return {
+    enabled,
+    tierMap: readTierMap(env, overrides),
     modelPin,
   };
 }

--- a/src/onboarding/cli.ts
+++ b/src/onboarding/cli.ts
@@ -29,6 +29,10 @@ import {
 } from "./sandbox-cli.js";
 import {
   runInferenceCompleteCmd,
+  runInferenceExportCmd,
+  runInferenceFinetuneCmd,
+  runInferenceFinetuneRegisterCmd,
+  runInferenceFinetuneStatusCmd,
   runInferenceLogsCmd,
   runInferenceServeCmd,
   runInferenceSpendCmd,
@@ -104,6 +108,25 @@ function parse(argv: string[]): {
     else if (a === "--since") flags.since = argv[++i] ?? "";
     else if (a === "--limit") flags.limit = argv[++i] ?? "";
     else if (a === "--group-by") flags.groupBy = argv[++i] ?? "";
+    else if (a === "--output") flags.output = argv[++i] ?? "";
+    else if (a === "--format") flags.format = argv[++i] ?? "";
+    else if (a === "--verdict") flags.verdict = argv[++i] ?? "";
+    else if (a === "--min-score") flags.minScore = argv[++i] ?? "";
+    else if (a === "--date-from") flags.dateFrom = argv[++i] ?? "";
+    else if (a === "--date-to") flags.dateTo = argv[++i] ?? "";
+    else if (a === "--max-latency-ms") flags.maxLatencyMs = argv[++i] ?? "";
+    else if (a === "--min-token-efficiency") flags.minTokenEfficiency = argv[++i] ?? "";
+    else if (a === "--exclude-cache-hits") flags.excludeCacheHits = true;
+    else if (a === "--no-pii-scrub") flags.noPiiScrub = true;
+    else if (a === "--write-manifest") flags.writeManifest = true;
+    else if (a === "--no-write-manifest") flags.writeManifest = false;
+    else if (a === "--dataset") flags.dataset = argv[++i] ?? "";
+    else if (a === "--manifest") flags.manifest = argv[++i] ?? "";
+    else if (a === "--base-model") flags.baseModel = argv[++i] ?? "";
+    else if (a === "--register-as") flags.registerAs = argv[++i] ?? "";
+    else if (a === "--job-id") flags.jobId = argv[++i] ?? "";
+    else if (a === "--tier") flags.tier = argv[++i] ?? "";
+    else if (a === "--alias") flags.alias = argv[++i] ?? "";
     else if (a === "--skip-verify") flags.skipVerify = true;
     else if (a.startsWith("--image-digest=")) {
       const prev = typeof flags.imageDigest === "string" ? flags.imageDigest : "";
@@ -164,6 +187,9 @@ Usage:
   clawql sandbox init | verify | status | edit --harness claude [--path DIR] [--skip-verify]
   clawql inference serve [--port 8080] | complete --model <provider/model> --message <text>
   clawql inference logs [--model M] [--since 24h] [--limit 50] | trace --correlation-id <id> | spend [--group-by model]
+  clawql inference export --output <path.jsonl> [--verdict passed] [--format openai-jsonl]
+  clawql inference finetune --dataset <path> --base-model <model> [--provider openai|anthropic]
+  clawql inference finetune status --job-id <id> | register --job-id <id> --tier frugal --alias <model>
   clawql claude | codex | cursor | opencode [-- harness args...]
   clawql operator status
 
@@ -237,6 +263,8 @@ inference (gateway MVP):
   logs            Recent inference records from the call store
   trace           Records for a correlation_id (links to ouroboros / WORM lineage)
   spend           Token usage rollup by model, provider, or tier
+  export          Verdict-filtered dataset export with optional Presidio scrub + manifest
+  finetune        Submit fine-tuning job; subcommands: status, register
   Providers: openai, anthropic, ollama via provider/model ids (e.g. ollama/phi4)
   Store: CLAWQL_INFERENCE_STORE=memory|jsonl|off (default jsonl when CLAWQL_HOME set)
   Env: OPENAI_API_KEY, ANTHROPIC_API_KEY, OLLAMA_BASE_URL, CLAWQL_INFERENCE_PORT
@@ -454,6 +482,41 @@ async function main(): Promise<void> {
       typeof flags.port === "string" && flags.port ? Number.parseInt(flags.port, 10) : undefined;
     const limit =
       typeof flags.limit === "string" && flags.limit ? Number.parseInt(flags.limit, 10) : undefined;
+    const minScore =
+      typeof flags.minScore === "string" && flags.minScore
+        ? Number.parseFloat(flags.minScore)
+        : undefined;
+    const maxLatencyMs =
+      typeof flags.maxLatencyMs === "string" && flags.maxLatencyMs
+        ? Number.parseInt(flags.maxLatencyMs, 10)
+        : undefined;
+    const minTokenEfficiency =
+      typeof flags.minTokenEfficiency === "string" && flags.minTokenEfficiency
+        ? Number.parseFloat(flags.minTokenEfficiency)
+        : undefined;
+    const finetuneProvider =
+      typeof flags.provider === "string" &&
+      (flags.provider === "openai" || flags.provider === "anthropic")
+        ? flags.provider
+        : undefined;
+    const tier =
+      typeof flags.tier === "string" &&
+      (flags.tier === "frugal" || flags.tier === "standard" || flags.tier === "frontier")
+        ? flags.tier
+        : undefined;
+    const verdict =
+      typeof flags.verdict === "string" &&
+      (flags.verdict === "passed" || flags.verdict === "failed" || flags.verdict === "none")
+        ? flags.verdict
+        : undefined;
+    const format =
+      typeof flags.format === "string" &&
+      (flags.format === "openai-jsonl" ||
+        flags.format === "anthropic-jsonl" ||
+        flags.format === "raw-jsonl" ||
+        flags.format === "sharegpt")
+        ? flags.format
+        : undefined;
     const inferenceOpts: InferenceCliOptions = {
       port: Number.isFinite(port) ? port : undefined,
       model: typeof flags.model === "string" ? flags.model : undefined,
@@ -468,6 +531,25 @@ async function main(): Promise<void> {
           ? flags.groupBy
           : undefined,
       json: Boolean(flags.json),
+      output: typeof flags.output === "string" ? flags.output : undefined,
+      format,
+      verdict,
+      minScore: Number.isFinite(minScore) ? minScore : undefined,
+      dateFrom: typeof flags.dateFrom === "string" ? flags.dateFrom : undefined,
+      dateTo: typeof flags.dateTo === "string" ? flags.dateTo : undefined,
+      maxLatencyMs: Number.isFinite(maxLatencyMs) ? maxLatencyMs : undefined,
+      minTokenEfficiency: Number.isFinite(minTokenEfficiency) ? minTokenEfficiency : undefined,
+      excludeCacheHits: Boolean(flags.excludeCacheHits),
+      noPiiScrub: Boolean(flags.noPiiScrub),
+      writeManifest: flags.writeManifest === false ? false : undefined,
+      dataset: typeof flags.dataset === "string" ? flags.dataset : undefined,
+      manifest: typeof flags.manifest === "string" ? flags.manifest : undefined,
+      baseModel: typeof flags.baseModel === "string" ? flags.baseModel : undefined,
+      finetuneProvider,
+      registerAs: typeof flags.registerAs === "string" ? flags.registerAs : undefined,
+      jobId: typeof flags.jobId === "string" ? flags.jobId : undefined,
+      tier,
+      alias: typeof flags.alias === "string" ? flags.alias : undefined,
     };
     if (subcmd === "serve") {
       process.exitCode = await runInferenceServeCmd(inferenceOpts);
@@ -489,8 +571,25 @@ async function main(): Promise<void> {
       process.exitCode = await runInferenceSpendCmd(inferenceOpts);
       return;
     }
+    if (subcmd === "export") {
+      process.exitCode = await runInferenceExportCmd(inferenceOpts);
+      return;
+    }
+    if (subcmd === "finetune") {
+      const finetuneAction = rest[0];
+      if (finetuneAction === "status") {
+        process.exitCode = await runInferenceFinetuneStatusCmd(inferenceOpts);
+        return;
+      }
+      if (finetuneAction === "register") {
+        process.exitCode = await runInferenceFinetuneRegisterCmd(inferenceOpts);
+        return;
+      }
+      process.exitCode = await runInferenceFinetuneCmd(inferenceOpts);
+      return;
+    }
     console.error(
-      "Usage: clawql inference serve | complete | logs | trace --correlation-id <id> | spend"
+      "Usage: clawql inference serve | complete | logs | trace --correlation-id <id> | spend | export | finetune [status|register]"
     );
     process.exitCode = 1;
     return;

--- a/src/onboarding/inference-cli.ts
+++ b/src/onboarding/inference-cli.ts
@@ -4,11 +4,18 @@
 
 import {
   runInferenceComplete,
+  runInferenceExportCli,
+  runInferenceFinetune,
+  runInferenceFinetuneRegister,
+  runInferenceFinetuneStatus,
   runInferenceLogs,
   runInferenceServe,
   runInferenceSpend,
   runInferenceTrace,
+  type ExportFormat,
+  type FinetuneProvider,
 } from "clawql-inference";
+import type { ModelTier } from "clawql-inference";
 
 export type InferenceCliOptions = {
   port?: number;
@@ -21,6 +28,25 @@ export type InferenceCliOptions = {
   limit?: number;
   groupBy?: "model" | "provider" | "tier";
   json?: boolean;
+  output?: string;
+  format?: ExportFormat;
+  verdict?: "passed" | "failed" | "none";
+  minScore?: number;
+  dateFrom?: string;
+  dateTo?: string;
+  maxLatencyMs?: number;
+  minTokenEfficiency?: number;
+  excludeCacheHits?: boolean;
+  noPiiScrub?: boolean;
+  writeManifest?: boolean;
+  dataset?: string;
+  manifest?: string;
+  baseModel?: string;
+  finetuneProvider?: FinetuneProvider;
+  registerAs?: string;
+  jobId?: string;
+  tier?: ModelTier;
+  alias?: string;
 };
 
 export async function runInferenceServeCmd(opts: InferenceCliOptions): Promise<number> {
@@ -74,6 +100,54 @@ export async function runInferenceSpendCmd(opts: InferenceCliOptions): Promise<n
   return runInferenceSpend({
     groupBy: opts.groupBy,
     since: opts.since,
+    json: opts.json,
+  });
+}
+
+export async function runInferenceExportCmd(opts: InferenceCliOptions): Promise<number> {
+  return runInferenceExportCli({
+    output: opts.output,
+    format: opts.format,
+    model: opts.model,
+    provider: opts.provider,
+    tier: opts.tier,
+    verdict: opts.verdict,
+    minScore: opts.minScore,
+    dateFrom: opts.dateFrom,
+    dateTo: opts.dateTo,
+    maxLatencyMs: opts.maxLatencyMs,
+    minTokenEfficiency: opts.minTokenEfficiency,
+    excludeCacheHits: opts.excludeCacheHits,
+    noPiiScrub: opts.noPiiScrub,
+    writeManifest: opts.writeManifest,
+  });
+}
+
+export async function runInferenceFinetuneCmd(opts: InferenceCliOptions): Promise<number> {
+  return runInferenceFinetune({
+    dataset: opts.dataset,
+    manifest: opts.manifest,
+    baseModel: opts.baseModel,
+    provider: opts.finetuneProvider,
+    registerAs: opts.registerAs,
+    json: opts.json,
+  });
+}
+
+export async function runInferenceFinetuneStatusCmd(opts: InferenceCliOptions): Promise<number> {
+  return runInferenceFinetuneStatus({
+    jobId: opts.jobId,
+    provider: opts.finetuneProvider,
+    json: opts.json,
+  });
+}
+
+export async function runInferenceFinetuneRegisterCmd(opts: InferenceCliOptions): Promise<number> {
+  return runInferenceFinetuneRegister({
+    jobId: opts.jobId,
+    tier: opts.tier,
+    alias: opts.alias,
+    provider: opts.finetuneProvider,
     json: opts.json,
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the next two inference roadmap phases on epic #556:

- **P0-H `export/`** — verdict-filtered dataset export from the call store with `openai-jsonl`, `anthropic-jsonl`, `raw-jsonl`, and `sharegpt` formats; optional Presidio scrub (via `clawql-api`); WORM dataset manifest with per-line SHA-256 and Merkle root (`clawql-core`).
- **P0-I `finetune/`** — OpenAI fine-tuning (file upload + job API), Anthropic job submit/status, and `finetune register` to persist tier overrides at `$CLAWQL_HOME/Inference/tier-map.json` (merged by `loadModelEscalationConfigAsync`).

## CLI

```bash
clawql inference export --output ./training.jsonl --verdict passed --format openai-jsonl
clawql inference finetune --dataset ./training.jsonl --base-model gpt-4o-mini --provider openai
clawql inference finetune status --job-id ftjob_abc --provider openai
clawql inference finetune register --job-id ftjob_abc --tier frugal --alias openai/ft-model
```

## Tests

- 32 tests in `clawql-inference` (export filter/format, tier registry)

## Docs

- Updated `docs/inference/clawql-inference.md` phasing table (P0-H/P0-I ✅)
- Updated package README quick start

## Remaining (P1+)

- `pipeline enable` scheduled auto-export
- Model escalation audit (#561), agent coordination trigger (#562)
- `escalation show/set-tier`, keys, policy CLI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

