### PR TITLE
feat(inference): P1 pipeline, escalation CLI, audit + agent coordination (#556)

### DIFF
--- a/docs/inference/clawql-inference.md
+++ b/docs/inference/clawql-inference.md
@@ -215,8 +215,8 @@ clawql inference policy show    # Manifest inference block (tiers, cache TTL, ex
 | **P0-G** ✅ | `store/` + observability — log every call with `correlation_id`; `logs`, `trace`, `spend` CLI                                                                                                 |
 | **P0-H** ✅ | `export/` — verdict-filtered JSONL + Presidio + dataset manifest                                                                                                                              |
 | **P0-I** ✅ | `finetune/` — Anthropic/OpenAI job API + `register-as` tier                                                                                                                                   |
-| **P1**      | `pipeline enable` — scheduled auto-export + promote                                                                                                                                           |
-| **P1**      | Model escalation audit events ([#561](https://github.com/danielsmithdevelopment/ClawQL/issues/561)), agent coordination ([#562](https://github.com/danielsmithdevelopment/ClawQL/issues/562)) |
+| **P1** ✅   | `pipeline enable` — config + `pipeline run` auto-export when sample threshold met                                                                                                             |
+| **P1** ✅   | Model escalation audit event builders ([#561](https://github.com/danielsmithdevelopment/ClawQL/issues/561)), agent coordination trigger ([#562](https://github.com/danielsmithdevelopment/ClawQL/issues/562)) |
 
 ## Differentiation vs LiteLLM
 

--- a/docs/inference/clawql-inference.md
+++ b/docs/inference/clawql-inference.md
@@ -208,14 +208,14 @@ clawql inference policy show    # Manifest inference block (tiers, cache TTL, ex
 
 ## Implementation phasing
 
-| Phase       | Deliverable                                                                                                                                                                                   |
-| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **P0-D** ✅ | `routing/` + ouroboros hooks ([#560](https://github.com/danielsmithdevelopment/ClawQL/issues/560))                                                                                            |
-| **P0-F** ✅ | Gateway MVP: `serve`, `complete`, OpenAI / Anthropic / Ollama adapters                                                                                                                        |
-| **P0-G** ✅ | `store/` + observability — log every call with `correlation_id`; `logs`, `trace`, `spend` CLI                                                                                                 |
-| **P0-H** ✅ | `export/` — verdict-filtered JSONL + Presidio + dataset manifest                                                                                                                              |
-| **P0-I** ✅ | `finetune/` — Anthropic/OpenAI job API + `register-as` tier                                                                                                                                   |
-| **P1** ✅   | `pipeline enable` — config + `pipeline run` auto-export when sample threshold met                                                                                                             |
+| Phase       | Deliverable                                                                                                                                                                                                   |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **P0-D** ✅ | `routing/` + ouroboros hooks ([#560](https://github.com/danielsmithdevelopment/ClawQL/issues/560))                                                                                                            |
+| **P0-F** ✅ | Gateway MVP: `serve`, `complete`, OpenAI / Anthropic / Ollama adapters                                                                                                                                        |
+| **P0-G** ✅ | `store/` + observability — log every call with `correlation_id`; `logs`, `trace`, `spend` CLI                                                                                                                 |
+| **P0-H** ✅ | `export/` — verdict-filtered JSONL + Presidio + dataset manifest                                                                                                                                              |
+| **P0-I** ✅ | `finetune/` — Anthropic/OpenAI job API + `register-as` tier                                                                                                                                                   |
+| **P1** ✅   | `pipeline enable` — config + `pipeline run` auto-export when sample threshold met                                                                                                                             |
 | **P1** ✅   | Model escalation audit event builders ([#561](https://github.com/danielsmithdevelopment/ClawQL/issues/561)), agent coordination trigger ([#562](https://github.com/danielsmithdevelopment/ClawQL/issues/562)) |
 
 ## Differentiation vs LiteLLM

--- a/packages/clawql-inference/src/audit/events.test.ts
+++ b/packages/clawql-inference/src/audit/events.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { buildModelEscalationAuditEntry } from "./events.js";
+
+describe("inference audit events", () => {
+  it("builds model_escalation audit entry", () => {
+    const entry = buildModelEscalationAuditEntry({
+      before: { tier: "frugal", modelId: "ollama/phi4", retryAttempt: 0 },
+      after: {
+        tier: "standard",
+        modelId: "groq/llama",
+        retryAttempt: 1,
+        escalatedFrom: "frugal",
+        trigger: { kind: "eval_below_min", detail: { score: 0.2 }, generation: 1 },
+      },
+      correlationId: "seed_abc_gen_2",
+      usage: { inputTokens: 10, outputTokens: 5 },
+    });
+    expect(entry.action).toBe("model_escalation");
+    expect(entry.payload.event).toBe("model_escalation");
+    expect(entry.correlationId).toBe("seed_abc_gen_2");
+  });
+});

--- a/packages/clawql-inference/src/audit/events.ts
+++ b/packages/clawql-inference/src/audit/events.ts
@@ -1,0 +1,84 @@
+import type { ModelEscalationDecision, RoutingFailureSignal } from "../routing/types.js";
+
+export type InferenceAuditCategory = "inference";
+
+export type ModelEscalationAuditPayload = {
+  event: "model_escalation";
+  tierBefore: string;
+  tierAfter: string;
+  modelBefore: string;
+  modelAfter: string;
+  trigger?: RoutingFailureSignal;
+  retryAttempt: number;
+  inputTokens?: number;
+  outputTokens?: number;
+};
+
+export type AgentCoordinationAuditPayload = {
+  event: "agent_coordination";
+  tier: string;
+  modelId: string;
+  driftCombined?: number;
+  failureCount: number;
+  triggers: RoutingFailureSignal[];
+};
+
+export type InferenceAuditEntry = {
+  ts: string;
+  category: InferenceAuditCategory;
+  action: "model_escalation" | "agent_coordination";
+  summary: string;
+  correlationId?: string;
+  payload: ModelEscalationAuditPayload | AgentCoordinationAuditPayload;
+};
+
+export function buildModelEscalationAuditEntry(input: {
+  before: ModelEscalationDecision;
+  after: ModelEscalationDecision;
+  correlationId?: string;
+  usage?: { inputTokens?: number; outputTokens?: number };
+}): InferenceAuditEntry {
+  const summary = `Model tier escalation ${input.before.tier}→${input.after.tier} (${input.before.modelId} → ${input.after.modelId})`;
+  return {
+    ts: new Date().toISOString(),
+    category: "inference",
+    action: "model_escalation",
+    summary,
+    correlationId: input.correlationId,
+    payload: {
+      event: "model_escalation",
+      tierBefore: input.before.tier,
+      tierAfter: input.after.tier,
+      modelBefore: input.before.modelId,
+      modelAfter: input.after.modelId,
+      trigger: input.after.trigger,
+      retryAttempt: input.after.retryAttempt,
+      inputTokens: input.usage?.inputTokens,
+      outputTokens: input.usage?.outputTokens,
+    },
+  };
+}
+
+export function buildAgentCoordinationAuditEntry(input: {
+  decision: ModelEscalationDecision;
+  signals: RoutingFailureSignal[];
+  driftCombined?: number;
+  correlationId?: string;
+}): InferenceAuditEntry {
+  const summary = `Agent coordination triggered at ${input.decision.tier} (drift=${input.driftCombined ?? "n/a"})`;
+  return {
+    ts: new Date().toISOString(),
+    category: "inference",
+    action: "agent_coordination",
+    summary,
+    correlationId: input.correlationId,
+    payload: {
+      event: "agent_coordination",
+      tier: input.decision.tier,
+      modelId: input.decision.modelId,
+      driftCombined: input.driftCombined,
+      failureCount: input.signals.length,
+      triggers: input.signals,
+    },
+  };
+}

--- a/packages/clawql-inference/src/cli/escalation.ts
+++ b/packages/clawql-inference/src/cli/escalation.ts
@@ -1,0 +1,54 @@
+import { loadModelEscalationConfigAsync } from "../routing/config.js";
+import { registerModelToTier } from "../finetune/tier-registry.js";
+import type { ModelTier } from "../routing/types.js";
+
+export type InferenceEscalationShowOptions = {
+  json?: boolean;
+  env?: NodeJS.ProcessEnv;
+};
+
+export async function runInferenceEscalationShow(
+  options: InferenceEscalationShowOptions = {}
+): Promise<number> {
+  const config = await loadModelEscalationConfigAsync(options.env);
+  if (options.json) {
+    console.log(JSON.stringify(config, null, 2));
+    return 0;
+  }
+  console.log(`enabled: ${config.enabled}`);
+  if (config.modelPin) console.log(`model_pin: ${config.modelPin}`);
+  console.log("tier_map:");
+  for (const [tier, modelId] of Object.entries(config.tierMap)) {
+    console.log(`  ${tier.padEnd(10)} ${modelId}`);
+  }
+  return 0;
+}
+
+export type InferenceEscalationSetTierOptions = {
+  tier?: ModelTier;
+  model?: string;
+  json?: boolean;
+  env?: NodeJS.ProcessEnv;
+};
+
+export async function runInferenceEscalationSetTier(
+  options: InferenceEscalationSetTierOptions
+): Promise<number> {
+  if (!options.tier || !options.model?.trim()) {
+    console.error(
+      "Usage: clawql inference escalation set-tier --tier frugal|standard|frontier --model <provider/model>"
+    );
+    return 1;
+  }
+  const { path, tierMap } = await registerModelToTier(
+    options.tier,
+    options.model.trim(),
+    options.env
+  );
+  if (options.json) {
+    console.log(JSON.stringify({ path, tierMap }, null, 2));
+  } else {
+    console.log(`Set ${options.tier} → ${options.model.trim()} (saved to ${path})`);
+  }
+  return 0;
+}

--- a/packages/clawql-inference/src/cli/pipeline.ts
+++ b/packages/clawql-inference/src/cli/pipeline.ts
@@ -1,0 +1,117 @@
+import { buildPipelineConfig, loadPipelineConfig, savePipelineConfig } from "../pipeline/config.js";
+import { runPipelineOnce } from "../pipeline/run.js";
+import type { InferencePipelineConfig } from "../pipeline/types.js";
+import type { EvaluatorVerdict } from "../store/types.js";
+import type { ExportFormat } from "../export/types.js";
+import type { FinetuneProvider } from "../finetune/types.js";
+import type { ModelTier } from "../routing/types.js";
+
+export type InferencePipelineCliOptions = {
+  schedule?: string;
+  minSamples?: number;
+  verdict?: EvaluatorVerdict;
+  targetTier?: ModelTier;
+  baseModel?: string;
+  provider?: FinetuneProvider;
+  format?: ExportFormat;
+  evaluateBeforePromote?: boolean;
+  outputDir?: string;
+  json?: boolean;
+  env?: NodeJS.ProcessEnv;
+};
+
+export async function runInferencePipelineEnable(
+  options: InferencePipelineCliOptions = {}
+): Promise<number> {
+  const config = buildPipelineConfig({
+    enabled: true,
+    schedule: options.schedule,
+    minSamples: options.minSamples,
+    verdict: options.verdict,
+    targetTier: options.targetTier,
+    baseModel: options.baseModel,
+    provider: options.provider,
+    format: options.format,
+    evaluateBeforePromote: options.evaluateBeforePromote,
+    outputDir: options.outputDir,
+  });
+  const path = await savePipelineConfig(config, options.env);
+  if (options.json) {
+    console.log(JSON.stringify({ path, config }, null, 2));
+  } else {
+    console.log(`Pipeline enabled (config: ${path}, schedule: ${config.schedule})`);
+  }
+  return 0;
+}
+
+export async function runInferencePipelineStatus(
+  options: InferencePipelineCliOptions = {}
+): Promise<number> {
+  const config = await loadPipelineConfig(options.env);
+  if (!config) {
+    console.log("Pipeline is not configured.");
+    return 0;
+  }
+  if (options.json) {
+    console.log(JSON.stringify(config, null, 2));
+  } else {
+    console.log(`enabled: ${config.enabled}`);
+    console.log(`schedule: ${config.schedule}`);
+    console.log(`min_samples: ${config.minSamples}`);
+    console.log(`verdict: ${config.verdict}`);
+    console.log(`target_tier: ${config.targetTier}`);
+    console.log(`base_model: ${config.baseModel}`);
+    console.log(`provider: ${config.provider}`);
+    console.log(`updated_at: ${config.updatedAt}`);
+  }
+  return 0;
+}
+
+export async function runInferencePipelineDisable(
+  options: InferencePipelineCliOptions = {}
+): Promise<number> {
+  const existing = await loadPipelineConfig(options.env);
+  const config: InferencePipelineConfig = buildPipelineConfig({
+    ...(existing ?? {}),
+    enabled: false,
+  });
+  const path = await savePipelineConfig(config, options.env);
+  if (options.json) {
+    console.log(JSON.stringify({ path, config }, null, 2));
+  } else {
+    console.log(`Pipeline disabled (config: ${path})`);
+  }
+  return 0;
+}
+
+export async function runInferencePipelineRun(
+  options: InferencePipelineCliOptions = {}
+): Promise<number> {
+  const config = await loadPipelineConfig(options.env);
+  if (!config?.enabled) {
+    console.error("Pipeline is not enabled. Run: clawql inference pipeline enable ...");
+    return 1;
+  }
+  try {
+    const result = await runPipelineOnce(config, options.env);
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+      return 0;
+    }
+    if (!result.exported) {
+      console.log(
+        `Pipeline skipped: ${result.skippedReason ?? "unknown"} (${result.sampleCount} samples)`
+      );
+      return 0;
+    }
+    console.log(
+      `Pipeline exported ${result.sampleCount} samples → ${result.outputPath}${
+        result.finetuneJobId ? ` (finetune job: ${result.finetuneJobId})` : ""
+      }`
+    );
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}

--- a/packages/clawql-inference/src/index.ts
+++ b/packages/clawql-inference/src/index.ts
@@ -63,6 +63,23 @@ export { submitFinetuneJob, getFinetuneJobStatus, registerFinetuneModel } from "
 export type { FinetuneJob, FinetuneProvider } from "./finetune/types.js";
 export { registerModelToTier, loadTierMapOverrides } from "./finetune/tier-registry.js";
 
+export {
+  buildModelEscalationAuditEntry,
+  buildAgentCoordinationAuditEntry,
+  type InferenceAuditEntry,
+} from "./audit/events.js";
+export { runInferenceEscalationShow, runInferenceEscalationSetTier } from "./cli/escalation.js";
+export {
+  runInferencePipelineEnable,
+  runInferencePipelineStatus,
+  runInferencePipelineDisable,
+  runInferencePipelineRun,
+} from "./cli/pipeline.js";
+export { AGENT_COORDINATION_DRIFT_TRIPWIRE } from "./routing/tier-escalation-router.js";
+export { loadPipelineConfig, savePipelineConfig } from "./pipeline/config.js";
+export { runPipelineOnce } from "./pipeline/run.js";
+export type { InferencePipelineConfig } from "./pipeline/types.js";
+
 export { parseModelId } from "./providers/parse-model-id.js";
 export type {
   InferenceProviderAdapter,

--- a/packages/clawql-inference/src/pipeline/config.test.ts
+++ b/packages/clawql-inference/src/pipeline/config.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildPipelineConfig, loadPipelineConfig, savePipelineConfig } from "./config.js";
+
+describe("pipeline config", () => {
+  it("saves and loads pipeline config", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "clawql-pipeline-"));
+    const env = { CLAWQL_HOME: dir };
+    try {
+      const config = buildPipelineConfig({ enabled: true, minSamples: 100 });
+      const path = await savePipelineConfig(config, env);
+      expect(path).toContain("pipeline.json");
+      const loaded = await loadPipelineConfig(env);
+      expect(loaded?.enabled).toBe(true);
+      expect(loaded?.minSamples).toBe(100);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/clawql-inference/src/pipeline/config.ts
+++ b/packages/clawql-inference/src/pipeline/config.ts
@@ -1,0 +1,41 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { DEFAULT_PIPELINE_CONFIG, type InferencePipelineConfig } from "./types.js";
+
+const FILE_NAME = "pipeline.json";
+
+export function resolvePipelineConfigPath(env: NodeJS.ProcessEnv = process.env): string {
+  const home = env.CLAWQL_HOME?.trim() || join(process.cwd(), ".clawql");
+  return join(home, "Inference", FILE_NAME);
+}
+
+export async function loadPipelineConfig(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<InferencePipelineConfig | null> {
+  try {
+    const raw = await readFile(resolvePipelineConfigPath(env), "utf8");
+    return JSON.parse(raw) as InferencePipelineConfig;
+  } catch {
+    return null;
+  }
+}
+
+export async function savePipelineConfig(
+  config: InferencePipelineConfig,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<string> {
+  const path = resolvePipelineConfigPath(env);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  return path;
+}
+
+export function buildPipelineConfig(
+  input: Partial<InferencePipelineConfig> = {}
+): InferencePipelineConfig {
+  return {
+    ...DEFAULT_PIPELINE_CONFIG,
+    ...input,
+    updatedAt: new Date().toISOString(),
+  };
+}

--- a/packages/clawql-inference/src/pipeline/run.ts
+++ b/packages/clawql-inference/src/pipeline/run.ts
@@ -1,0 +1,77 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { createInferenceStore } from "../store/create.js";
+import { filterRecordsForExport } from "../export/filter.js";
+import { runInferenceExport } from "../export/run-export.js";
+import { submitFinetuneJob } from "../finetune/jobs.js";
+import { registerModelToTier } from "../finetune/tier-registry.js";
+import type { InferencePipelineConfig } from "./types.js";
+
+export type PipelineRunResult = {
+  sampleCount: number;
+  exported: boolean;
+  outputPath?: string;
+  manifestPath?: string;
+  finetuneJobId?: string;
+  skippedReason?: string;
+};
+
+export async function runPipelineOnce(
+  config: InferencePipelineConfig,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<PipelineRunResult> {
+  const store = createInferenceStore({ env });
+  if (!store) {
+    return { sampleCount: 0, exported: false, skippedReason: "inference store disabled" };
+  }
+
+  const records = filterRecordsForExport(await store.list({}), {
+    verdict: config.verdict,
+    tier: config.targetTier,
+  });
+  if (records.length < config.minSamples) {
+    return {
+      sampleCount: records.length,
+      exported: false,
+      skippedReason: `below min-samples (${records.length} < ${config.minSamples})`,
+    };
+  }
+
+  const stamp = new Date().toISOString().slice(0, 10);
+  const outputDir = config.outputDir.startsWith("/")
+    ? config.outputDir
+    : join(env.CLAWQL_HOME?.trim() || join(process.cwd(), ".clawql"), config.outputDir);
+  await mkdir(outputDir, { recursive: true });
+  const outputPath = join(outputDir, `export-${stamp}.jsonl`);
+
+  const exportResult = await runInferenceExport({
+    output: outputPath,
+    format: config.format,
+    verdict: config.verdict,
+    tier: config.targetTier,
+    env,
+  });
+
+  let finetuneJobId: string | undefined;
+  if (!config.evaluateBeforePromote) {
+    const job = await submitFinetuneJob({
+      datasetPath: exportResult.outputPath,
+      manifestPath: exportResult.manifestPath,
+      baseModel: config.baseModel,
+      provider: config.provider,
+      env,
+    });
+    finetuneJobId = job.id;
+    if (job.fineTunedModel) {
+      await registerModelToTier(config.targetTier, job.fineTunedModel, env);
+    }
+  }
+
+  return {
+    sampleCount: records.length,
+    exported: true,
+    outputPath: exportResult.outputPath,
+    manifestPath: exportResult.manifestPath,
+    finetuneJobId,
+  };
+}

--- a/packages/clawql-inference/src/pipeline/types.ts
+++ b/packages/clawql-inference/src/pipeline/types.ts
@@ -1,0 +1,31 @@
+import type { EvaluatorVerdict } from "../store/types.js";
+import type { ExportFormat } from "../export/types.js";
+import type { FinetuneProvider } from "../finetune/types.js";
+import type { ModelTier } from "../routing/types.js";
+
+export type InferencePipelineConfig = {
+  enabled: boolean;
+  schedule: string;
+  minSamples: number;
+  verdict: EvaluatorVerdict;
+  targetTier: ModelTier;
+  baseModel: string;
+  provider: FinetuneProvider;
+  format: ExportFormat;
+  evaluateBeforePromote: boolean;
+  outputDir: string;
+  updatedAt: string;
+};
+
+export const DEFAULT_PIPELINE_CONFIG: Omit<InferencePipelineConfig, "updatedAt"> = {
+  enabled: false,
+  schedule: "0 2 * * 0",
+  minSamples: 500,
+  verdict: "passed",
+  targetTier: "frugal",
+  baseModel: "gpt-4o-mini",
+  provider: "openai",
+  format: "openai-jsonl",
+  evaluateBeforePromote: false,
+  outputDir: "training-data",
+};

--- a/packages/clawql-inference/src/routing/tier-escalation-router.test.ts
+++ b/packages/clawql-inference/src/routing/tier-escalation-router.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { TierEscalationRouter } from "./tier-escalation-router.js";
+import {
+  TierEscalationRouter,
+  AGENT_COORDINATION_DRIFT_TRIPWIRE,
+} from "./tier-escalation-router.js";
 import type { RoutingFailureSignal } from "./types.js";
 import type { ModelEscalationConfig } from "./config.js";
 
@@ -75,9 +78,26 @@ describe("TierEscalationRouter.escalate", () => {
 });
 
 describe("TierEscalationRouter.shouldTriggerAgentCoordination", () => {
-  it("returns false until agent coordination coupling ships (#562)", () => {
+  it("returns false without failure signals", () => {
     const r = router();
     const d = r.initialTier({ isDecomposedChild: false, seedId: "s" });
-    expect(r.shouldTriggerAgentCoordination(d, [failure], { combined: 0.5 })).toBe(false);
+    expect(r.shouldTriggerAgentCoordination(d, [], { combined: 0.5 })).toBe(false);
+  });
+
+  it("triggers on drift tripwire", () => {
+    const r = router();
+    const d = r.initialTier({ isDecomposedChild: true, seedId: "s" });
+    expect(d.tier).toBe("frugal");
+    expect(r.shouldTriggerAgentCoordination(d, [failure], { combined: 0.5 })).toBe(true);
+    expect(r.shouldTriggerAgentCoordination(d, [failure], { combined: 0.2 })).toBe(false);
+    expect(AGENT_COORDINATION_DRIFT_TRIPWIRE).toBe(0.3);
+  });
+
+  it("triggers at standard-tier failure", () => {
+    const r = router();
+    const d = r.initialTier({ isDecomposedChild: false, seedId: "s" });
+    expect(d.tier).toBe("standard");
+    expect(r.shouldTriggerAgentCoordination(d, [failure])).toBe(true);
+    expect(r.shouldTriggerAgentCoordination(d, [failure], { combined: 0.2 })).toBe(true);
   });
 });

--- a/packages/clawql-inference/src/routing/tier-escalation-router.ts
+++ b/packages/clawql-inference/src/routing/tier-escalation-router.ts
@@ -9,6 +9,9 @@ import { nextModelTier } from "./tiers.js";
 
 export type { ModelEscalationConfig };
 
+/** Combined drift threshold for agent coordination tripwire (#562). */
+export const AGENT_COORDINATION_DRIFT_TRIPWIRE = 0.3;
+
 export class TierEscalationRouter implements AdaptiveRouter {
   constructor(private readonly config: ModelEscalationConfig) {}
 
@@ -59,12 +62,15 @@ export class TierEscalationRouter implements AdaptiveRouter {
     };
   }
 
-  /** Agent coordination at standard-tier exhaustion — implemented in #562. */
+  /** Agent coordination at standard-tier exhaustion + drift tripwire (#562). */
   shouldTriggerAgentCoordination(
-    _decision: ModelEscalationDecision,
-    _signals: RoutingFailureSignal[],
-    _drift?: { combined: number }
+    decision: ModelEscalationDecision,
+    signals: RoutingFailureSignal[],
+    drift?: { combined: number }
   ): boolean {
-    return false;
+    if (!signals.length) return false;
+    const driftTripwire = (drift?.combined ?? 0) > AGENT_COORDINATION_DRIFT_TRIPWIRE;
+    const standardTierFailure = decision.tier === "standard" && signals.length > 0;
+    return driftTripwire || standardTierFailure;
   }
 }

--- a/src/onboarding/cli.ts
+++ b/src/onboarding/cli.ts
@@ -29,11 +29,17 @@ import {
 } from "./sandbox-cli.js";
 import {
   runInferenceCompleteCmd,
+  runInferenceEscalationSetTierCmd,
+  runInferenceEscalationShowCmd,
   runInferenceExportCmd,
   runInferenceFinetuneCmd,
   runInferenceFinetuneRegisterCmd,
   runInferenceFinetuneStatusCmd,
   runInferenceLogsCmd,
+  runInferencePipelineDisableCmd,
+  runInferencePipelineEnableCmd,
+  runInferencePipelineRunCmd,
+  runInferencePipelineStatusCmd,
   runInferenceServeCmd,
   runInferenceSpendCmd,
   runInferenceTraceCmd,
@@ -127,6 +133,11 @@ function parse(argv: string[]): {
     else if (a === "--job-id") flags.jobId = argv[++i] ?? "";
     else if (a === "--tier") flags.tier = argv[++i] ?? "";
     else if (a === "--alias") flags.alias = argv[++i] ?? "";
+    else if (a === "--schedule") flags.schedule = argv[++i] ?? "";
+    else if (a === "--min-samples") flags.minSamples = argv[++i] ?? "";
+    else if (a === "--target-tier") flags.targetTier = argv[++i] ?? "";
+    else if (a === "--evaluate-before-promote") flags.evaluateBeforePromote = true;
+    else if (a === "--output-dir") flags.outputDir = argv[++i] ?? "";
     else if (a === "--skip-verify") flags.skipVerify = true;
     else if (a.startsWith("--image-digest=")) {
       const prev = typeof flags.imageDigest === "string" ? flags.imageDigest : "";
@@ -189,6 +200,8 @@ Usage:
   clawql inference logs [--model M] [--since 24h] [--limit 50] | trace --correlation-id <id> | spend [--group-by model]
   clawql inference export --output <path.jsonl> [--verdict passed] [--format openai-jsonl]
   clawql inference finetune --dataset <path> --base-model <model> [--provider openai|anthropic]
+  clawql inference escalation show | set-tier --tier frugal --model ollama/phi4-custom
+  clawql inference pipeline enable [--schedule "0 2 * * 0"] [--min-samples 500] | status | disable | run
   clawql inference finetune status --job-id <id> | register --job-id <id> --tier frugal --alias <model>
   clawql claude | codex | cursor | opencode [-- harness args...]
   clawql operator status
@@ -265,6 +278,10 @@ inference (gateway MVP):
   spend           Token usage rollup by model, provider, or tier
   export          Verdict-filtered dataset export with optional Presidio scrub + manifest
   finetune        Submit fine-tuning job; subcommands: status, register
+  escalation      show tier map | set-tier --tier <tier> --model <id>
+  pipeline        enable | status | disable | run (scheduled auto-export config)
+  escalation      show tier map | set-tier --tier <tier> --model <id>
+  pipeline        enable | status | disable | run (scheduled auto-export config)
   Providers: openai, anthropic, ollama via provider/model ids (e.g. ollama/phi4)
   Store: CLAWQL_INFERENCE_STORE=memory|jsonl|off (default jsonl when CLAWQL_HOME set)
   Env: OPENAI_API_KEY, ANTHROPIC_API_KEY, OLLAMA_BASE_URL, CLAWQL_INFERENCE_PORT
@@ -494,6 +511,17 @@ async function main(): Promise<void> {
       typeof flags.minTokenEfficiency === "string" && flags.minTokenEfficiency
         ? Number.parseFloat(flags.minTokenEfficiency)
         : undefined;
+    const minSamples =
+      typeof flags.minSamples === "string" && flags.minSamples
+        ? Number.parseInt(flags.minSamples, 10)
+        : undefined;
+    const targetTier =
+      typeof flags.targetTier === "string" &&
+      (flags.targetTier === "frugal" ||
+        flags.targetTier === "standard" ||
+        flags.targetTier === "frontier")
+        ? flags.targetTier
+        : undefined;
     const finetuneProvider =
       typeof flags.provider === "string" &&
       (flags.provider === "openai" || flags.provider === "anthropic")
@@ -550,6 +578,11 @@ async function main(): Promise<void> {
       jobId: typeof flags.jobId === "string" ? flags.jobId : undefined,
       tier,
       alias: typeof flags.alias === "string" ? flags.alias : undefined,
+      schedule: typeof flags.schedule === "string" ? flags.schedule : undefined,
+      minSamples: Number.isFinite(minSamples) ? minSamples : undefined,
+      targetTier,
+      evaluateBeforePromote: Boolean(flags.evaluateBeforePromote),
+      outputDir: typeof flags.outputDir === "string" ? flags.outputDir : undefined,
     };
     if (subcmd === "serve") {
       process.exitCode = await runInferenceServeCmd(inferenceOpts);
@@ -588,8 +621,34 @@ async function main(): Promise<void> {
       process.exitCode = await runInferenceFinetuneCmd(inferenceOpts);
       return;
     }
+    if (subcmd === "escalation") {
+      const escalationAction = rest[0];
+      if (escalationAction === "set-tier") {
+        process.exitCode = await runInferenceEscalationSetTierCmd(inferenceOpts);
+        return;
+      }
+      process.exitCode = await runInferenceEscalationShowCmd(inferenceOpts);
+      return;
+    }
+    if (subcmd === "pipeline") {
+      const pipelineAction = rest[0];
+      if (pipelineAction === "status") {
+        process.exitCode = await runInferencePipelineStatusCmd(inferenceOpts);
+        return;
+      }
+      if (pipelineAction === "disable") {
+        process.exitCode = await runInferencePipelineDisableCmd(inferenceOpts);
+        return;
+      }
+      if (pipelineAction === "run") {
+        process.exitCode = await runInferencePipelineRunCmd(inferenceOpts);
+        return;
+      }
+      process.exitCode = await runInferencePipelineEnableCmd(inferenceOpts);
+      return;
+    }
     console.error(
-      "Usage: clawql inference serve | complete | logs | trace --correlation-id <id> | spend | export | finetune [status|register]"
+      "Usage: clawql inference serve | complete | logs | trace | spend | export | finetune | escalation | pipeline"
     );
     process.exitCode = 1;
     return;

--- a/src/onboarding/inference-cli.ts
+++ b/src/onboarding/inference-cli.ts
@@ -167,9 +167,7 @@ export async function runInferenceEscalationShowCmd(opts: InferenceCliOptions): 
   return runInferenceEscalationShow({ json: opts.json });
 }
 
-export async function runInferenceEscalationSetTierCmd(
-  opts: InferenceCliOptions
-): Promise<number> {
+export async function runInferenceEscalationSetTierCmd(opts: InferenceCliOptions): Promise<number> {
   return runInferenceEscalationSetTier({
     tier: opts.tier,
     model: opts.model,

--- a/src/onboarding/inference-cli.ts
+++ b/src/onboarding/inference-cli.ts
@@ -4,11 +4,17 @@
 
 import {
   runInferenceComplete,
+  runInferenceEscalationSetTier,
+  runInferenceEscalationShow,
   runInferenceExportCli,
   runInferenceFinetune,
   runInferenceFinetuneRegister,
   runInferenceFinetuneStatus,
   runInferenceLogs,
+  runInferencePipelineDisable,
+  runInferencePipelineEnable,
+  runInferencePipelineRun,
+  runInferencePipelineStatus,
   runInferenceServe,
   runInferenceSpend,
   runInferenceTrace,
@@ -47,6 +53,11 @@ export type InferenceCliOptions = {
   jobId?: string;
   tier?: ModelTier;
   alias?: string;
+  schedule?: string;
+  minSamples?: number;
+  targetTier?: ModelTier;
+  evaluateBeforePromote?: boolean;
+  outputDir?: string;
 };
 
 export async function runInferenceServeCmd(opts: InferenceCliOptions): Promise<number> {
@@ -150,4 +161,45 @@ export async function runInferenceFinetuneRegisterCmd(opts: InferenceCliOptions)
     provider: opts.finetuneProvider,
     json: opts.json,
   });
+}
+
+export async function runInferenceEscalationShowCmd(opts: InferenceCliOptions): Promise<number> {
+  return runInferenceEscalationShow({ json: opts.json });
+}
+
+export async function runInferenceEscalationSetTierCmd(
+  opts: InferenceCliOptions
+): Promise<number> {
+  return runInferenceEscalationSetTier({
+    tier: opts.tier,
+    model: opts.model,
+    json: opts.json,
+  });
+}
+
+export async function runInferencePipelineEnableCmd(opts: InferenceCliOptions): Promise<number> {
+  return runInferencePipelineEnable({
+    schedule: opts.schedule,
+    minSamples: opts.minSamples,
+    verdict: opts.verdict,
+    targetTier: opts.targetTier,
+    baseModel: opts.baseModel,
+    provider: opts.finetuneProvider,
+    format: opts.format,
+    evaluateBeforePromote: opts.evaluateBeforePromote,
+    outputDir: opts.outputDir,
+    json: opts.json,
+  });
+}
+
+export async function runInferencePipelineStatusCmd(opts: InferenceCliOptions): Promise<number> {
+  return runInferencePipelineStatus({ json: opts.json });
+}
+
+export async function runInferencePipelineDisableCmd(opts: InferenceCliOptions): Promise<number> {
+  return runInferencePipelineDisable({ json: opts.json });
+}
+
+export async function runInferencePipelineRunCmd(opts: InferenceCliOptions): Promise<number> {
+  return runInferencePipelineRun({ json: opts.json });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes P1 inference roadmap items on epic #556:

- **`clawql inference escalation show|set-tier`** — inspect tier map (env + `tier-map.json` overrides) and persist tier assignments
- **`clawql inference pipeline enable|status|disable|run`** — persisted pipeline config at `$CLAWQL_HOME/Inference/pipeline.json`; `run` exports when sample threshold met and optionally submits finetune
- **Audit event builders (#561)** — `buildModelEscalationAuditEntry`, `buildAgentCoordinationAuditEntry` for WORM/ouroboros integration
- **Agent coordination trigger (#562)** — `shouldTriggerAgentCoordination` at standard-tier failure or `combined_drift > 0.3`

## Tests

36 tests in `clawql-inference` (audit, pipeline config, updated router tests)

## Remaining (deferred)

- Postgres event store wiring for audit events in ouroboros (#561 full)
- Hermes adapter for live agent coordination ensemble (#562 full)
- `keys`, `policy` enterprise CLI
- Cron scheduler integration (pipeline config stores schedule; operator/automation can invoke `pipeline run`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

