### PR TITLE
feat(inference): semantic cache with embedding similarity (#556)

### DIFF
--- a/docs/inference/clawql-inference.md
+++ b/docs/inference/clawql-inference.md
@@ -41,7 +41,7 @@ LiteLLM routes inference. ClawQL closes the loop: **infer → observe → evalua
 | `routing/`       | Model tier escalation + `ModelTierMap` (**shipped** foundation)                                     |
 | `providers/`     | **Provider plugins** — builtins (OpenAI, Anthropic, Ollama) + optional extensions (**shipped** MVP) |
 | `local/`         | Ollama, vLLM, Llama.cpp                                                                             |
-| `cache/`         | Semantic cache — embedding similarity, TTL, per-model keys (**shipped**)                          |
+| `cache/`         | Semantic cache — embedding similarity, TTL, per-model keys (**shipped**)                            |
 | `observability/` | Langfuse (ADR 0005), OpenTelemetry, WORM `correlation_id`                                           |
 | `fallback/`      | Per-tier provider chains                                                                            |
 | `keys/`          | Virtual keys, per-team budgets                                                                      |

--- a/docs/inference/clawql-inference.md
+++ b/docs/inference/clawql-inference.md
@@ -32,7 +32,7 @@ LiteLLM routes inference. ClawQL closes the loop: **infer → observe → evalua
 - **`clawql inference logs` / `trace` / `spend`** — query the call store by model, `correlation_id`, or token rollup
 - **`clawql inference export`** — verdict-filtered JSONL + Presidio scrub + WORM dataset manifest
 - **`clawql inference finetune`** — OpenAI / Anthropic job submit, status, and tier registration
-- **Call store** — JSONL at `$CLAWQL_HOME/Inference/calls.jsonl` (or `memory` / `off` via env)
+- **Semantic cache** — optional embedding similarity cache (`CLAWQL_INFERENCE_SEMANTIC_CACHE=1`); hits set `cache_hit` on inference records
 
 ## Planned modules
 
@@ -41,7 +41,7 @@ LiteLLM routes inference. ClawQL closes the loop: **infer → observe → evalua
 | `routing/`       | Model tier escalation + `ModelTierMap` (**shipped** foundation)                                     |
 | `providers/`     | **Provider plugins** — builtins (OpenAI, Anthropic, Ollama) + optional extensions (**shipped** MVP) |
 | `local/`         | Ollama, vLLM, Llama.cpp                                                                             |
-| `cache/`         | Semantic cache (embedding similarity, Manifest TTL)                                                 |
+| `cache/`         | Semantic cache — embedding similarity, TTL, per-model keys (**shipped**)                          |
 | `observability/` | Langfuse (ADR 0005), OpenTelemetry, WORM `correlation_id`                                           |
 | `fallback/`      | Per-tier provider chains                                                                            |
 | `keys/`          | Virtual keys, per-team budgets                                                                      |

--- a/packages/clawql-inference/README.md
+++ b/packages/clawql-inference/README.md
@@ -43,6 +43,22 @@ curl -N http://127.0.0.1:8080/v1/chat/completions \
 
 Set `X-Correlation-Id` on requests for WORM lineage; echoed on responses.
 
+## Semantic cache
+
+Skip repeat model calls when prompts are semantically similar (Layer 5 in [token efficiency](../../docs/architecture/clawql-token-efficiency.md)):
+
+```bash
+export CLAWQL_INFERENCE_SEMANTIC_CACHE=1
+export OPENAI_API_KEY=sk-...   # embeddings use same key (or CLAWQL_EMBEDDING_API_KEY)
+export CLAWQL_INFERENCE_CACHE_THRESHOLD=0.92   # cosine similarity floor (default 0.92)
+export CLAWQL_INFERENCE_CACHE_TTL=24h        # entry TTL (default 24h)
+
+clawql inference cache    # show active config
+clawql inference serve
+```
+
+Cache hits return stored responses with `cache_hit: true` in the call store. Embedding API failures fail open to live inference.
+
 ## Quick start
 
 ```bash
@@ -123,6 +139,11 @@ Subpath: `clawql-inference/plugin` for builtin factories and compose helpers.
 | `CLAWQL_INFERENCE_MODEL_STANDARD`    | `groq/llama-3.3-70b`        | Standard tier model id                           |
 | `CLAWQL_INFERENCE_MODEL_FRONTIER`    | `anthropic/claude-sonnet-4` | Frontier tier model id                           |
 | `CLAWQL_INFERENCE_MODEL_PIN`         | —                           | Pin a single model (bypasses ladder)             |
+| `CLAWQL_INFERENCE_SEMANTIC_CACHE`    | off                         | Enable embedding similarity cache                |
+| `CLAWQL_INFERENCE_CACHE_THRESHOLD`   | `0.92`                      | Cosine similarity floor for cache hits           |
+| `CLAWQL_INFERENCE_CACHE_TTL`         | `24h`                       | Cache entry TTL (`24h`, `7d`, or `_MS` variant)  |
+| `CLAWQL_INFERENCE_CACHE_MAX_ENTRIES` | `1000`                      | In-memory cache size cap                         |
+| `CLAWQL_EMBEDDING_MODEL`             | `text-embedding-3-small`    | Embeddings model for semantic cache              |
 
 Model ids use `provider/model` (e.g. `ollama/phi4`, `anthropic/claude-sonnet-4`).
 

--- a/packages/clawql-inference/src/cache/cached-gateway.test.ts
+++ b/packages/clawql-inference/src/cache/cached-gateway.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../gateway.js";
+import { SemanticCachedGateway, withSemanticCache } from "./cached-gateway.js";
+import { InMemorySemanticCacheStore } from "./in-memory.js";
+import type { SemanticCacheConfig } from "./types.js";
+
+class StubGateway implements InferenceGateway {
+  calls = 0;
+  constructor(private readonly content: string) {}
+
+  async complete(_request: InferenceRequest): Promise<InferenceResponse> {
+    this.calls += 1;
+    return { content: this.content, model: "openai/gpt-4o" };
+  }
+}
+
+const config: SemanticCacheConfig = {
+  enabled: true,
+  threshold: 0.99,
+  ttlMs: 60_000,
+  maxEntries: 100,
+};
+
+describe("SemanticCachedGateway", () => {
+  it("returns cached response on similar embedding without calling provider", async () => {
+    const inner = new StubGateway("live");
+    const cache = new InMemorySemanticCacheStore(config);
+    const embedder = {
+      embed: vi
+        .fn()
+        .mockResolvedValueOnce(Float32Array.from([1, 0, 0]))
+        .mockResolvedValueOnce(Float32Array.from([0.999, 0.001, 0])),
+    };
+    const gateway = new SemanticCachedGateway(inner, cache, config, embedder);
+    const request = {
+      model: "openai/gpt-4o",
+      messages: [{ role: "user" as const, content: "status of cluster A" }],
+    };
+
+    const first = await gateway.complete(request);
+    expect(first.content).toBe("live");
+    expect(inner.calls).toBe(1);
+
+    const second = await gateway.complete({
+      ...request,
+      messages: [{ role: "user", content: "cluster A status check" }],
+    });
+    expect(second.cacheHit).toBe(true);
+    expect(second.content).toBe("live");
+    expect(inner.calls).toBe(1);
+  });
+
+  it("is inactive when semantic cache env is off", async () => {
+    const inner = new StubGateway("live");
+    const gateway = withSemanticCache(inner, {
+      config: { ...config, enabled: false },
+      embedder: { embed: async () => Float32Array.from([1]) },
+    });
+    await gateway.complete({
+      model: "openai/gpt-4o",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    await gateway.complete({
+      model: "openai/gpt-4o",
+      messages: [{ role: "user", content: "hi again" }],
+    });
+    expect(inner.calls).toBe(2);
+  });
+});

--- a/packages/clawql-inference/src/cache/cached-gateway.ts
+++ b/packages/clawql-inference/src/cache/cached-gateway.ts
@@ -1,0 +1,110 @@
+import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../gateway.js";
+import { createEmbedder, resolveInferenceEmbeddingConfig, type Embedder } from "./embedding.js";
+import { createSemanticCacheEntry, InMemorySemanticCacheStore } from "./in-memory.js";
+import { buildCacheSignatureText, hashSystemPrompt } from "./signature.js";
+import {
+  loadSemanticCacheConfig,
+  type SemanticCacheConfig,
+  type SemanticCacheStore,
+} from "./types.js";
+
+export class SemanticCachedGateway implements InferenceGateway {
+  readonly cacheStore: SemanticCacheStore;
+
+  constructor(
+    private readonly inner: InferenceGateway,
+    cache: SemanticCacheStore,
+    private readonly config: SemanticCacheConfig,
+    private readonly embedder: Embedder
+  ) {
+    this.cacheStore = cache;
+  }
+
+  async complete(request: InferenceRequest): Promise<InferenceResponse> {
+    if (!this.config.enabled) {
+      return this.inner.complete(request);
+    }
+
+    const modelId = request.model ?? request.routing?.modelId;
+    if (!modelId) {
+      return this.inner.complete(request);
+    }
+
+    const signatureText = buildCacheSignatureText(request.messages);
+    let embedding: Float32Array;
+    try {
+      embedding = await this.embedder.embed(signatureText);
+    } catch {
+      return this.inner.complete(request);
+    }
+    if (!embedding.length) {
+      return this.inner.complete(request);
+    }
+
+    const hit = this.cacheStore.lookup({
+      modelId,
+      embedding,
+      threshold: this.config.threshold,
+    });
+    if (hit) {
+      return {
+        ...hit.entry.response,
+        model: hit.entry.response.model || modelId,
+        cacheHit: true,
+        routing: request.routing ?? hit.entry.response.routing,
+        correlationId: request.correlationId ?? hit.entry.response.correlationId,
+      };
+    }
+
+    const response = await this.inner.complete(request);
+    this.cacheStore.put(
+      createSemanticCacheEntry({
+        modelId,
+        signatureText,
+        systemPromptHash: hashSystemPrompt(request.messages),
+        embedding,
+        response: { ...response, cacheHit: false },
+        ttlMs: this.config.ttlMs,
+      })
+    );
+    return response;
+  }
+}
+
+export type WithSemanticCacheOptions = {
+  env?: NodeJS.ProcessEnv;
+  config?: SemanticCacheConfig;
+  cache?: SemanticCacheStore;
+  embedder?: Embedder;
+};
+
+export function createSemanticCacheStore(config: SemanticCacheConfig): InMemorySemanticCacheStore {
+  return new InMemorySemanticCacheStore({
+    enabled: config.enabled,
+    threshold: config.threshold,
+    ttlMs: config.ttlMs,
+    maxEntries: config.maxEntries,
+  });
+}
+
+export function withSemanticCache(
+  gateway: InferenceGateway,
+  options: WithSemanticCacheOptions = {}
+): InferenceGateway {
+  const env = options.env ?? process.env;
+  const config = options.config ?? loadSemanticCacheConfig(env);
+  if (!config.enabled) return gateway;
+
+  const embeddingConfig = resolveInferenceEmbeddingConfig(env);
+  if (!embeddingConfig && !options.embedder) return gateway;
+
+  const embedder = options.embedder ?? createEmbedder(embeddingConfig!);
+  const cache = options.cache ?? createSemanticCacheStore(config);
+  return new SemanticCachedGateway(gateway, cache, config, embedder);
+}
+
+export function isSemanticCachedGateway(
+  gateway: InferenceGateway
+): gateway is SemanticCachedGateway {
+  return gateway instanceof SemanticCachedGateway;
+}

--- a/packages/clawql-inference/src/cache/embedding.ts
+++ b/packages/clawql-inference/src/cache/embedding.ts
@@ -1,0 +1,74 @@
+export type EmbeddingConfig = {
+  baseUrl: string;
+  model: string;
+  apiKey: string;
+};
+
+const DEFAULT_BASE = "https://api.openai.com/v1";
+const DEFAULT_MODEL = "text-embedding-3-small";
+
+export function resolveInferenceEmbeddingConfig(
+  env: NodeJS.ProcessEnv = process.env
+): EmbeddingConfig | null {
+  const apiKey = env.CLAWQL_EMBEDDING_API_KEY?.trim() || env.OPENAI_API_KEY?.trim() || "";
+  if (!apiKey) return null;
+  return {
+    baseUrl: (env.CLAWQL_EMBEDDING_BASE_URL?.trim() || DEFAULT_BASE).replace(/\/$/, ""),
+    model: env.CLAWQL_EMBEDDING_MODEL?.trim() || DEFAULT_MODEL,
+    apiKey,
+  };
+}
+
+export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
+  if (a.length === 0 || b.length === 0 || a.length !== b.length) return 0;
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i]! * b[i]!;
+    na += a[i]! * a[i]!;
+    nb += b[i]! * b[i]!;
+  }
+  const denom = Math.sqrt(na) * Math.sqrt(nb);
+  if (denom === 0) return 0;
+  return dot / denom;
+}
+
+export async function embedTexts(
+  texts: string[],
+  config: EmbeddingConfig
+): Promise<Float32Array[]> {
+  if (!texts.length) return [];
+  const res = await fetch(`${config.baseUrl}/embeddings`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${config.apiKey}`,
+    },
+    body: JSON.stringify({ model: config.model, input: texts }),
+  });
+  if (!res.ok) {
+    const errText = await res.text().catch(() => "");
+    throw new Error(`embeddings HTTP ${res.status}: ${errText.slice(0, 400)}`);
+  }
+  const json = (await res.json()) as {
+    data?: Array<{ embedding?: number[]; index?: number }>;
+  };
+  const rows = [...(json.data ?? [])].sort((x, y) => (x.index ?? 0) - (y.index ?? 0));
+  return rows.map((row) => Float32Array.from(row.embedding ?? []));
+}
+
+export async function embedQuery(text: string, config: EmbeddingConfig): Promise<Float32Array> {
+  const vectors = await embedTexts([text], config);
+  return vectors[0] ?? new Float32Array(0);
+}
+
+export type Embedder = {
+  embed(text: string): Promise<Float32Array>;
+};
+
+export function createEmbedder(config: EmbeddingConfig): Embedder {
+  return {
+    embed: (text) => embedQuery(text, config),
+  };
+}

--- a/packages/clawql-inference/src/cache/in-memory.ts
+++ b/packages/clawql-inference/src/cache/in-memory.ts
@@ -1,0 +1,112 @@
+import { randomUUID } from "node:crypto";
+import { cosineSimilarity } from "./embedding.js";
+import type {
+  SemanticCacheEntry,
+  SemanticCacheLookupResult,
+  SemanticCacheStats,
+  SemanticCacheStore,
+} from "./types.js";
+
+export class InMemorySemanticCacheStore implements SemanticCacheStore {
+  private readonly entries: SemanticCacheEntry[] = [];
+  private hits = 0;
+  private misses = 0;
+  private readonly enabled: boolean;
+  private readonly threshold: number;
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+
+  constructor(
+    options: {
+      enabled?: boolean;
+      threshold?: number;
+      ttlMs?: number;
+      maxEntries?: number;
+    } = {}
+  ) {
+    this.enabled = options.enabled ?? true;
+    this.threshold = options.threshold ?? 0.92;
+    this.ttlMs = options.ttlMs ?? 86_400_000;
+    this.maxEntries = options.maxEntries ?? 1000;
+  }
+
+  lookup(input: {
+    modelId: string;
+    embedding: Float32Array;
+    threshold: number;
+    now?: number;
+  }): SemanticCacheLookupResult | null {
+    const now = input.now ?? Date.now();
+    this.prune(now);
+    let best: SemanticCacheLookupResult | null = null;
+    for (const entry of this.entries) {
+      if (entry.modelId !== input.modelId) continue;
+      if (entry.expiresAt <= now) continue;
+      const similarity = cosineSimilarity(input.embedding, entry.embedding);
+      if (similarity < input.threshold) continue;
+      if (!best || similarity > best.similarity) {
+        best = { entry, similarity };
+      }
+    }
+    if (best) {
+      this.hits += 1;
+      return best;
+    }
+    this.misses += 1;
+    return null;
+  }
+
+  put(entry: SemanticCacheEntry): void {
+    this.entries.push(entry);
+    if (this.entries.length > this.maxEntries) {
+      this.entries.sort((a, b) => a.createdAt - b.createdAt);
+      this.entries.splice(0, this.entries.length - this.maxEntries);
+    }
+  }
+
+  stats(): SemanticCacheStats {
+    return {
+      entries: this.entries.length,
+      hits: this.hits,
+      misses: this.misses,
+      enabled: this.enabled,
+      threshold: this.threshold,
+      ttlMs: this.ttlMs,
+    };
+  }
+
+  prune(now: number = Date.now()): number {
+    const before = this.entries.length;
+    const kept = this.entries.filter((e) => e.expiresAt > now);
+    this.entries.length = 0;
+    this.entries.push(...kept);
+    return before - kept.length;
+  }
+
+  /** Test helper */
+  snapshot(): SemanticCacheEntry[] {
+    return [...this.entries];
+  }
+}
+
+export function createSemanticCacheEntry(input: {
+  modelId: string;
+  signatureText: string;
+  systemPromptHash?: string;
+  embedding: Float32Array;
+  response: import("../gateway.js").InferenceResponse;
+  ttlMs: number;
+  now?: number;
+}): SemanticCacheEntry {
+  const now = input.now ?? Date.now();
+  return {
+    id: randomUUID(),
+    modelId: input.modelId,
+    signatureText: input.signatureText,
+    systemPromptHash: input.systemPromptHash,
+    embedding: input.embedding,
+    response: input.response,
+    createdAt: now,
+    expiresAt: now + input.ttlMs,
+  };
+}

--- a/packages/clawql-inference/src/cache/signature.test.ts
+++ b/packages/clawql-inference/src/cache/signature.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { buildCacheSignatureText, hashSystemPrompt } from "./signature.js";
+
+describe("cache signature", () => {
+  it("builds stable signature text", () => {
+    const text = buildCacheSignatureText([
+      { role: "system", content: "You are helpful" },
+      { role: "user", content: "hello" },
+    ]);
+    expect(text).toContain("system:You are helpful");
+    expect(text).toContain("user:hello");
+  });
+
+  it("hashes system prompt", () => {
+    const hash = hashSystemPrompt([{ role: "system", content: "policy v1" }]);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/packages/clawql-inference/src/cache/signature.ts
+++ b/packages/clawql-inference/src/cache/signature.ts
@@ -1,0 +1,15 @@
+import { createHash } from "node:crypto";
+import type { ChatMessage } from "../gateway.js";
+
+export function buildCacheSignatureText(messages: ChatMessage[]): string {
+  return messages.map((m) => `${m.role}:${m.content}`).join("\n");
+}
+
+export function hashSystemPrompt(messages: ChatMessage[]): string | undefined {
+  const system = messages
+    .filter((m) => m.role === "system")
+    .map((m) => m.content)
+    .join("\n\n");
+  if (!system) return undefined;
+  return createHash("sha256").update(system, "utf8").digest("hex");
+}

--- a/packages/clawql-inference/src/cache/types.ts
+++ b/packages/clawql-inference/src/cache/types.ts
@@ -1,0 +1,89 @@
+import type { InferenceResponse } from "../gateway.js";
+import { parseSinceDuration } from "../observability/parse-since.js";
+import { resolveInferenceEmbeddingConfig } from "./embedding.js";
+
+export type SemanticCacheConfig = {
+  enabled: boolean;
+  threshold: number;
+  ttlMs: number;
+  maxEntries: number;
+};
+
+const DEFAULT_THRESHOLD = 0.92;
+const DEFAULT_TTL_MS = 86_400_000;
+const DEFAULT_MAX_ENTRIES = 1000;
+
+function parseTruthy(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+function parseTtlMs(env: NodeJS.ProcessEnv): number {
+  const duration = env.CLAWQL_INFERENCE_CACHE_TTL?.trim();
+  if (duration) {
+    const since = parseSinceDuration(duration);
+    if (since) return Date.now() - since.getTime();
+  }
+  const rawMs = env.CLAWQL_INFERENCE_CACHE_TTL_MS?.trim();
+  if (rawMs) {
+    const ms = Number.parseInt(rawMs, 10);
+    if (Number.isFinite(ms) && ms > 0) return ms;
+  }
+  return DEFAULT_TTL_MS;
+}
+
+export function loadSemanticCacheConfig(env: NodeJS.ProcessEnv = process.env): SemanticCacheConfig {
+  const thresholdRaw = env.CLAWQL_INFERENCE_CACHE_THRESHOLD?.trim();
+  const threshold = thresholdRaw ? Number.parseFloat(thresholdRaw) : DEFAULT_THRESHOLD;
+  const maxRaw = env.CLAWQL_INFERENCE_CACHE_MAX_ENTRIES?.trim();
+  const maxEntries = maxRaw ? Number.parseInt(maxRaw, 10) : DEFAULT_MAX_ENTRIES;
+  return {
+    enabled: parseTruthy(env.CLAWQL_INFERENCE_SEMANTIC_CACHE),
+    threshold: Number.isFinite(threshold) ? threshold : DEFAULT_THRESHOLD,
+    ttlMs: parseTtlMs(env),
+    maxEntries: Number.isFinite(maxEntries) && maxEntries > 0 ? maxEntries : DEFAULT_MAX_ENTRIES,
+  };
+}
+
+export function semanticCacheActive(env: NodeJS.ProcessEnv = process.env): boolean {
+  const config = loadSemanticCacheConfig(env);
+  return config.enabled && resolveInferenceEmbeddingConfig(env) !== null;
+}
+
+export type SemanticCacheEntry = {
+  id: string;
+  modelId: string;
+  signatureText: string;
+  systemPromptHash?: string;
+  embedding: Float32Array;
+  response: InferenceResponse;
+  createdAt: number;
+  expiresAt: number;
+};
+
+export type SemanticCacheLookupResult = {
+  entry: SemanticCacheEntry;
+  similarity: number;
+};
+
+export type SemanticCacheStats = {
+  entries: number;
+  hits: number;
+  misses: number;
+  enabled: boolean;
+  threshold: number;
+  ttlMs: number;
+};
+
+export interface SemanticCacheStore {
+  lookup(input: {
+    modelId: string;
+    embedding: Float32Array;
+    threshold: number;
+    now?: number;
+  }): SemanticCacheLookupResult | null;
+  put(entry: SemanticCacheEntry): void;
+  stats(): SemanticCacheStats;
+  prune(now?: number): number;
+}

--- a/packages/clawql-inference/src/cli/cache.ts
+++ b/packages/clawql-inference/src/cli/cache.ts
@@ -1,0 +1,34 @@
+import { loadSemanticCacheConfig, semanticCacheActive } from "../cache/types.js";
+import { resolveInferenceEmbeddingConfig } from "../cache/embedding.js";
+
+export type InferenceCacheStatusOptions = {
+  json?: boolean;
+  env?: NodeJS.ProcessEnv;
+};
+
+export async function runInferenceCacheStatus(
+  options: InferenceCacheStatusOptions = {}
+): Promise<number> {
+  const env = options.env ?? process.env;
+  const config = loadSemanticCacheConfig(env);
+  const embedding = resolveInferenceEmbeddingConfig(env);
+
+  const payload = {
+    active: semanticCacheActive(env),
+    config,
+    embeddingConfigured: embedding !== null,
+    embeddingModel: embedding?.model,
+  };
+
+  if (options.json) {
+    console.log(JSON.stringify(payload, null, 2));
+    return 0;
+  }
+
+  console.log(`semantic_cache: ${payload.active ? "on" : "off"}`);
+  console.log(`threshold: ${config.threshold}`);
+  console.log(`ttl_ms: ${config.ttlMs}`);
+  console.log(`max_entries: ${config.maxEntries}`);
+  console.log(`embedding: ${embedding ? embedding.model : "not configured (need OPENAI_API_KEY)"}`);
+  return 0;
+}

--- a/packages/clawql-inference/src/gateway.ts
+++ b/packages/clawql-inference/src/gateway.ts
@@ -6,6 +6,7 @@ import { composeDefaultProviderPlugins } from "./plugin/compose.js";
 import { withInferenceStore } from "./observability/observed-gateway.js";
 import { createInferenceStore } from "./store/create.js";
 import type { InferenceStore } from "./store/types.js";
+import { withSemanticCache, type WithSemanticCacheOptions } from "./cache/cached-gateway.js";
 
 export type ChatRole = "system" | "user" | "assistant";
 
@@ -55,6 +56,7 @@ export type CreateInferenceGatewayOptions = {
   providerPlugins?: readonly InferenceProviderPlugin[];
   env?: NodeJS.ProcessEnv;
   store?: InferenceStore | null;
+  semanticCache?: WithSemanticCacheOptions | false;
 };
 
 export class ConfiguredInferenceGateway implements InferenceGateway {
@@ -93,6 +95,10 @@ export function createInferenceGateway(
       plugins: options.providerPlugins ?? composeDefaultProviderPlugins(),
     });
   const inner = new ConfiguredInferenceGateway(providers);
+  const cached =
+    options.semanticCache === false
+      ? inner
+      : withSemanticCache(inner, { env, ...options.semanticCache });
   const store = options.store === undefined ? createInferenceStore({ env }) : options.store;
-  return withInferenceStore(inner, store);
+  return withInferenceStore(cached, store);
 }

--- a/packages/clawql-inference/src/index.ts
+++ b/packages/clawql-inference/src/index.ts
@@ -119,6 +119,22 @@ export { collectListedModels } from "./api/models.js";
 
 export { runInferenceServe } from "./cli/serve.js";
 export { runInferenceComplete, type InferenceCompleteOptions } from "./cli/complete.js";
+export { runInferenceCacheStatus, type InferenceCacheStatusOptions } from "./cli/cache.js";
+export {
+  withSemanticCache,
+  SemanticCachedGateway,
+  isSemanticCachedGateway,
+  createSemanticCacheStore,
+  type WithSemanticCacheOptions,
+} from "./cache/cached-gateway.js";
+export {
+  loadSemanticCacheConfig,
+  semanticCacheActive,
+  type SemanticCacheConfig,
+  type SemanticCacheStats,
+} from "./cache/types.js";
+export { cosineSimilarity, resolveInferenceEmbeddingConfig } from "./cache/embedding.js";
+export { buildCacheSignatureText, hashSystemPrompt } from "./cache/signature.js";
 
 /** Optional context passed to host engines (Wonder / Reflect / Execute). */
 export interface EngineCallContext {

--- a/src/onboarding/cli.ts
+++ b/src/onboarding/cli.ts
@@ -28,6 +28,7 @@ import {
   runSandboxVerifyCmd,
 } from "./sandbox-cli.js";
 import {
+  runInferenceCacheStatusCmd,
   runInferenceCompleteCmd,
   runInferenceEscalationSetTierCmd,
   runInferenceEscalationShowCmd,
@@ -280,10 +281,10 @@ inference (gateway MVP):
   finetune        Submit fine-tuning job; subcommands: status, register
   escalation      show tier map | set-tier --tier <tier> --model <id>
   pipeline        enable | status | disable | run (scheduled auto-export config)
-  escalation      show tier map | set-tier --tier <tier> --model <id>
-  pipeline        enable | status | disable | run (scheduled auto-export config)
+  cache           Semantic cache config (CLAWQL_INFERENCE_SEMANTIC_CACHE=1)
   Providers: openai, anthropic, ollama via provider/model ids (e.g. ollama/phi4)
   Store: CLAWQL_INFERENCE_STORE=memory|jsonl|off (default jsonl when CLAWQL_HOME set)
+  Cache: CLAWQL_INFERENCE_SEMANTIC_CACHE=1, CLAWQL_INFERENCE_CACHE_THRESHOLD=0.92
   Env: OPENAI_API_KEY, ANTHROPIC_API_KEY, OLLAMA_BASE_URL, CLAWQL_INFERENCE_PORT
 
 Docs: https://docs.clawql.com/agent-setup
@@ -647,8 +648,12 @@ async function main(): Promise<void> {
       process.exitCode = await runInferencePipelineEnableCmd(inferenceOpts);
       return;
     }
+    if (subcmd === "cache") {
+      process.exitCode = await runInferenceCacheStatusCmd(inferenceOpts);
+      return;
+    }
     console.error(
-      "Usage: clawql inference serve | complete | logs | trace | spend | export | finetune | escalation | pipeline"
+      "Usage: clawql inference serve | complete | logs | trace | spend | export | finetune | escalation | pipeline | cache"
     );
     process.exitCode = 1;
     return;

--- a/src/onboarding/inference-cli.ts
+++ b/src/onboarding/inference-cli.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  runInferenceCacheStatus,
   runInferenceComplete,
   runInferenceEscalationSetTier,
   runInferenceEscalationShow,
@@ -200,4 +201,8 @@ export async function runInferencePipelineDisableCmd(opts: InferenceCliOptions):
 
 export async function runInferencePipelineRunCmd(opts: InferenceCliOptions): Promise<number> {
   return runInferencePipelineRun({ json: opts.json });
+}
+
+export async function runInferenceCacheStatusCmd(opts: InferenceCliOptions): Promise<number> {
+  return runInferenceCacheStatus({ json: opts.json });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **semantic caching** (Layer 5 in token efficiency) — the #2 priority after the OpenAI REST surface.

When `CLAWQL_INFERENCE_SEMANTIC_CACHE=1`, the gateway embeds incoming prompts via OpenAI-compatible `/embeddings`, compares cosine similarity against cached entries for the same model, and returns stored responses on hits without calling the provider.

## Features

- `SemanticCachedGateway` decorator wired into `createInferenceGateway()` (before call store observability)
- Per-model cache keys, configurable threshold (default `0.92`), TTL (default `24h`), max entries (`1000`)
- Fail-open: embedding API errors fall through to live inference
- Cache hits set `cache_hit: true` on inference records (export filter `--exclude-cache-hits` already supported)
- `clawql inference cache` — show active config

## Env

```bash
CLAWQL_INFERENCE_SEMANTIC_CACHE=1
CLAWQL_INFERENCE_CACHE_THRESHOLD=0.92
CLAWQL_INFERENCE_CACHE_TTL=24h
OPENAI_API_KEY=sk-...   # or CLAWQL_EMBEDDING_API_KEY
```

## Tests

43 tests in `clawql-inference` (+ cache signature, cached gateway)

## Next

Fallback chains (#3), virtual keys (#4)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

