### PR TITLE
feat(inference): per-tier and per-model fallback chains (#556)

### DIFF
--- a/docs/inference/clawql-inference.md
+++ b/docs/inference/clawql-inference.md
@@ -33,6 +33,7 @@ LiteLLM routes inference. ClawQL closes the loop: **infer → observe → evalua
 - **`clawql inference export`** — verdict-filtered JSONL + Presidio scrub + WORM dataset manifest
 - **`clawql inference finetune`** — OpenAI / Anthropic job submit, status, and tier registration
 - **Semantic cache** — optional embedding similarity cache (`CLAWQL_INFERENCE_SEMANTIC_CACHE=1`); hits set `cache_hit` on inference records
+- **Fallback chains** — per-tier / per-model provider alternates when primary fails (`CLAWQL_INFERENCE_FALLBACK_ENABLED=1`)
 
 ## Planned modules
 
@@ -43,7 +44,7 @@ LiteLLM routes inference. ClawQL closes the loop: **infer → observe → evalua
 | `local/`         | Ollama, vLLM, Llama.cpp                                                                             |
 | `cache/`         | Semantic cache — embedding similarity, TTL, per-model keys (**shipped**)                            |
 | `observability/` | Langfuse (ADR 0005), OpenTelemetry, WORM `correlation_id`                                           |
-| `fallback/`      | Per-tier provider chains                                                                            |
+| `fallback/`      | Per-tier provider chains — try alternates before failing (**shipped**)                              |
 | `keys/`          | Virtual keys, per-team budgets                                                                      |
 | `api/`           | OpenAI-compatible `/v1/chat/completions`, `/v1/models`, SSE streaming (**shipped**)                 |
 | `store/`         | Inference call log (Postgres) — prompt, response, tier, tokens, verdict                             |

--- a/packages/clawql-inference/README.md
+++ b/packages/clawql-inference/README.md
@@ -59,6 +59,22 @@ clawql inference serve
 
 Cache hits return stored responses with `cache_hit: true` in the call store. Embedding API failures fail open to live inference.
 
+## Fallback chains
+
+Try alternate providers/models within the same tier before surfacing an error — pairs with model tier escalation:
+
+```bash
+export CLAWQL_INFERENCE_FALLBACK_ENABLED=1
+export CLAWQL_INFERENCE_FALLBACK_FRUGAL=ollama/phi4,openai/gpt-4o-mini
+export CLAWQL_INFERENCE_FALLBACK_STANDARD=groq/llama-3.3-70b,anthropic/claude-haiku-4
+
+# Or persist chains at $CLAWQL_HOME/Inference/fallback-chains.json
+clawql inference fallback
+clawql inference serve
+```
+
+Responses include `fallback.attempted` and `fallback.succeeded` when a backup model handles the request.
+
 ## Quick start
 
 ```bash
@@ -144,6 +160,10 @@ Subpath: `clawql-inference/plugin` for builtin factories and compose helpers.
 | `CLAWQL_INFERENCE_CACHE_TTL`         | `24h`                       | Cache entry TTL (`24h`, `7d`, or `_MS` variant)  |
 | `CLAWQL_INFERENCE_CACHE_MAX_ENTRIES` | `1000`                      | In-memory cache size cap                         |
 | `CLAWQL_EMBEDDING_MODEL`             | `text-embedding-3-small`    | Embeddings model for semantic cache              |
+| `CLAWQL_INFERENCE_FALLBACK_ENABLED`  | off                         | Enable per-tier / per-model fallback chains      |
+| `CLAWQL_INFERENCE_FALLBACK_FRUGAL`   | —                           | Comma-separated fallback chain for frugal tier   |
+| `CLAWQL_INFERENCE_FALLBACK_STANDARD` | —                           | Fallback chain for standard tier                 |
+| `CLAWQL_INFERENCE_FALLBACK_FRONTIER` | —                           | Fallback chain for frontier tier                 |
 
 Model ids use `provider/model` (e.g. `ollama/phi4`, `anthropic/claude-sonnet-4`).
 

--- a/packages/clawql-inference/src/cli/fallback.ts
+++ b/packages/clawql-inference/src/cli/fallback.ts
@@ -1,0 +1,41 @@
+import { loadFallbackConfig, resolveFallbackChainsPath } from "../fallback/config.js";
+
+export type InferenceFallbackShowOptions = {
+  json?: boolean;
+  env?: NodeJS.ProcessEnv;
+};
+
+export async function runInferenceFallbackShow(
+  options: InferenceFallbackShowOptions = {}
+): Promise<number> {
+  const env = options.env ?? process.env;
+  const config = loadFallbackConfig(env);
+  const payload = {
+    ...config,
+    chainsPath: resolveFallbackChainsPath(env),
+  };
+
+  if (options.json) {
+    console.log(JSON.stringify(payload, null, 2));
+    return 0;
+  }
+
+  console.log(`fallback_enabled: ${config.enabled}`);
+  console.log(`chains_file: ${payload.chainsPath}`);
+  if (Object.keys(config.chains.byTier).length) {
+    console.log("by_tier:");
+    for (const [tier, chain] of Object.entries(config.chains.byTier)) {
+      console.log(`  ${tier}: ${chain?.join(" → ")}`);
+    }
+  }
+  if (Object.keys(config.chains.byModel).length) {
+    console.log("by_model:");
+    for (const [model, chain] of Object.entries(config.chains.byModel)) {
+      console.log(`  ${model}: ${chain.join(" → ")}`);
+    }
+  }
+  if (!Object.keys(config.chains.byTier).length && !Object.keys(config.chains.byModel).length) {
+    console.log("No fallback chains configured.");
+  }
+  return 0;
+}

--- a/packages/clawql-inference/src/fallback/config.test.ts
+++ b/packages/clawql-inference/src/fallback/config.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadFallbackConfig, saveFallbackChainsFile } from "./config.js";
+
+describe("fallback config", () => {
+  it("merges env tier chains with file overrides", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "clawql-fallback-"));
+    const env = {
+      CLAWQL_HOME: dir,
+      CLAWQL_INFERENCE_FALLBACK_ENABLED: "1",
+      CLAWQL_INFERENCE_FALLBACK_FRUGAL: "ollama/phi4,openai/gpt-4o-mini",
+    };
+    try {
+      await saveFallbackChainsFile(
+        {
+          byTier: {},
+          byModel: { "openai/gpt-4o": ["openai/gpt-4o", "anthropic/claude-sonnet-4"] },
+        },
+        env
+      );
+      const config = loadFallbackConfig(env);
+      expect(config.enabled).toBe(true);
+      expect(config.chains.byTier.frugal).toEqual(["ollama/phi4", "openai/gpt-4o-mini"]);
+      expect(config.chains.byModel["openai/gpt-4o"]).toHaveLength(2);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/clawql-inference/src/fallback/config.ts
+++ b/packages/clawql-inference/src/fallback/config.ts
@@ -1,0 +1,100 @@
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { ModelTier } from "../routing/types.js";
+import type { FallbackChainMap, FallbackConfig } from "./types.js";
+
+const FILE_NAME = "fallback-chains.json";
+
+function parseTruthy(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+function parseModelList(raw: string | undefined): string[] {
+  if (!raw?.trim()) return [];
+  return raw
+    .split(",")
+    .map((id) => id.trim())
+    .filter(Boolean);
+}
+
+export function resolveFallbackChainsPath(env: NodeJS.ProcessEnv = process.env): string {
+  const home = env.CLAWQL_HOME?.trim() || join(process.cwd(), ".clawql");
+  return join(home, "Inference", FILE_NAME);
+}
+
+export async function loadFallbackChainsFile(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<Partial<FallbackChainMap>> {
+  return loadFallbackChainsFileSync(env);
+}
+
+function loadFallbackChainsFileSync(
+  env: NodeJS.ProcessEnv = process.env
+): Partial<FallbackChainMap> {
+  try {
+    const path = resolveFallbackChainsPath(env);
+    if (!existsSync(path)) return { byTier: {}, byModel: {} };
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<FallbackChainMap>;
+    return {
+      byTier: parsed.byTier ?? {},
+      byModel: parsed.byModel ?? {},
+    };
+  } catch {
+    return { byTier: {}, byModel: {} };
+  }
+}
+
+export async function saveFallbackChainsFile(
+  chains: FallbackChainMap,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<string> {
+  const path = resolveFallbackChainsPath(env);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(chains, null, 2)}\n`, "utf8");
+  return path;
+}
+
+function readTierChainsFromEnv(env: NodeJS.ProcessEnv): Partial<Record<ModelTier, string[]>> {
+  const tiers: ModelTier[] = ["frugal", "standard", "frontier"];
+  const byTier: Partial<Record<ModelTier, string[]>> = {};
+  for (const tier of tiers) {
+    const key = `CLAWQL_INFERENCE_FALLBACK_${tier.toUpperCase()}` as keyof NodeJS.ProcessEnv;
+    const list = parseModelList(env[key]);
+    if (list.length) byTier[tier] = list;
+  }
+  return byTier;
+}
+
+function mergeChains(base: FallbackChainMap, overlay: Partial<FallbackChainMap>): FallbackChainMap {
+  return {
+    byTier: { ...base.byTier, ...overlay.byTier },
+    byModel: { ...base.byModel, ...overlay.byModel },
+  };
+}
+
+export function loadFallbackConfig(env: NodeJS.ProcessEnv = process.env): FallbackConfig {
+  const enabled = parseTruthy(env.CLAWQL_INFERENCE_FALLBACK_ENABLED);
+  const envChains: FallbackChainMap = {
+    byTier: readTierChainsFromEnv(env),
+    byModel: {},
+  };
+  const file = loadFallbackChainsFileSync(env);
+  return {
+    enabled,
+    chains: mergeChains(envChains, file),
+  };
+}
+
+/** @deprecated Use {@link loadFallbackConfig} (sync). */
+export async function loadFallbackConfigAsync(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<FallbackConfig> {
+  return loadFallbackConfig(env);
+}
+
+export function loadFallbackConfigSync(env: NodeJS.ProcessEnv = process.env): FallbackConfig {
+  return loadFallbackConfig(env);
+}

--- a/packages/clawql-inference/src/fallback/fallback-gateway.test.ts
+++ b/packages/clawql-inference/src/fallback/fallback-gateway.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../gateway.js";
+import { FallbackChainGateway } from "./fallback-gateway.js";
+
+class StubGateway implements InferenceGateway {
+  constructor(private readonly outcomes: Record<string, InferenceResponse | Error>) {}
+
+  async complete(request: InferenceRequest): Promise<InferenceResponse> {
+    const model = request.model ?? "unknown";
+    const outcome = this.outcomes[model];
+    if (!outcome) throw new Error(`no stub for ${model}`);
+    if (outcome instanceof Error) throw outcome;
+    return outcome;
+  }
+}
+
+describe("FallbackChainGateway", () => {
+  it("tries fallbacks in order after primary failure", async () => {
+    const inner = new StubGateway({
+      "openai/gpt-4o": new Error("rate limited"),
+      "anthropic/claude-sonnet-4": { content: "backup", model: "anthropic/claude-sonnet-4" },
+    });
+    const gateway = new FallbackChainGateway(inner, {
+      enabled: true,
+      chains: {
+        byModel: {
+          "openai/gpt-4o": ["openai/gpt-4o", "anthropic/claude-sonnet-4"],
+        },
+        byTier: {},
+      },
+    });
+
+    const result = await gateway.complete({
+      model: "openai/gpt-4o",
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(result.content).toBe("backup");
+    expect(result.fallback?.succeeded).toBe("anthropic/claude-sonnet-4");
+    expect(result.fallback?.attempted).toEqual(["openai/gpt-4o", "anthropic/claude-sonnet-4"]);
+  });
+
+  it("passes through when disabled", async () => {
+    const complete = vi.fn(async () => ({ content: "ok", model: "m" }));
+    const gateway = new FallbackChainGateway({ complete } as InferenceGateway, {
+      enabled: false,
+      chains: { byTier: {}, byModel: {} },
+    });
+    await gateway.complete({ model: "m", messages: [{ role: "user", content: "x" }] });
+    expect(complete).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/clawql-inference/src/fallback/fallback-gateway.ts
+++ b/packages/clawql-inference/src/fallback/fallback-gateway.ts
@@ -1,0 +1,63 @@
+import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../gateway.js";
+import type { FallbackConfig } from "./types.js";
+import { resolveFallbackChain } from "./resolve.js";
+
+export class FallbackChainGateway implements InferenceGateway {
+  constructor(
+    private readonly inner: InferenceGateway,
+    private readonly config: FallbackConfig
+  ) {}
+
+  async complete(request: InferenceRequest): Promise<InferenceResponse> {
+    if (!this.config.enabled) {
+      return this.inner.complete(request);
+    }
+
+    const chain = resolveFallbackChain(request, this.config.chains);
+    if (chain.length <= 1) {
+      return this.inner.complete(request);
+    }
+
+    const attempted: string[] = [];
+    let lastError: unknown;
+
+    for (const modelId of chain) {
+      attempted.push(modelId);
+      try {
+        const response = await this.inner.complete({ ...request, model: modelId });
+        const primary = request.model ?? request.routing?.modelId ?? modelId;
+        if (modelId === primary) {
+          return response;
+        }
+        return {
+          ...response,
+          model: response.model || modelId,
+          fallback: { attempted, succeeded: modelId },
+        };
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    if (lastError instanceof Error) throw lastError;
+    throw new Error(`All fallback models failed (${attempted.join(" → ")}): ${String(lastError)}`);
+  }
+}
+
+export type WithFallbackChainOptions = {
+  env?: NodeJS.ProcessEnv;
+  config?: FallbackConfig;
+};
+
+export function withFallbackChain(
+  gateway: InferenceGateway,
+  options: WithFallbackChainOptions = {}
+): InferenceGateway {
+  const config = options.config;
+  if (!config?.enabled) return gateway;
+  return new FallbackChainGateway(gateway, config);
+}
+
+export function isFallbackChainGateway(gateway: InferenceGateway): gateway is FallbackChainGateway {
+  return gateway instanceof FallbackChainGateway;
+}

--- a/packages/clawql-inference/src/fallback/resolve.test.ts
+++ b/packages/clawql-inference/src/fallback/resolve.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { normalizeFallbackChain, resolveFallbackChain } from "./resolve.js";
+
+describe("resolveFallbackChain", () => {
+  const chains = {
+    byTier: {
+      frugal: ["ollama/phi4", "openai/gpt-4o-mini"],
+      standard: ["groq/llama", "anthropic/claude-haiku-4"],
+    },
+    byModel: {
+      "openai/gpt-4o": ["openai/gpt-4o", "anthropic/claude-sonnet-4"],
+    },
+  };
+
+  it("uses model-specific chain when defined", () => {
+    const chain = resolveFallbackChain(
+      { model: "openai/gpt-4o", messages: [{ role: "user", content: "hi" }] },
+      chains
+    );
+    expect(chain).toEqual(["openai/gpt-4o", "anthropic/claude-sonnet-4"]);
+  });
+
+  it("uses tier chain with primary first", () => {
+    const chain = resolveFallbackChain(
+      {
+        model: "ollama/phi4",
+        routing: { tier: "frugal", modelId: "ollama/phi4", retryAttempt: 0 },
+        messages: [{ role: "user", content: "hi" }],
+      },
+      chains
+    );
+    expect(chain).toEqual(["ollama/phi4", "openai/gpt-4o-mini"]);
+  });
+
+  it("dedupes chain entries", () => {
+    expect(normalizeFallbackChain("a", ["a", "b", "b"])).toEqual(["a", "b"]);
+  });
+});

--- a/packages/clawql-inference/src/fallback/resolve.ts
+++ b/packages/clawql-inference/src/fallback/resolve.ts
@@ -1,0 +1,38 @@
+import type { InferenceRequest } from "../gateway.js";
+import type { ModelTier } from "../routing/types.js";
+import type { FallbackChainMap } from "./types.js";
+
+export function normalizeFallbackChain(primaryModelId: string, chain: string[]): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  const push = (id: string) => {
+    const trimmed = id.trim();
+    if (!trimmed || seen.has(trimmed)) return;
+    seen.add(trimmed);
+    ordered.push(trimmed);
+  };
+  push(primaryModelId);
+  for (const id of chain) push(id);
+  return ordered;
+}
+
+export function resolveFallbackChain(
+  request: InferenceRequest,
+  chains: FallbackChainMap
+): string[] {
+  const primary = request.model ?? request.routing?.modelId;
+  if (!primary?.trim()) return [];
+
+  const primaryTrimmed = primary.trim();
+  const modelChain = chains.byModel[primaryTrimmed];
+  if (modelChain?.length) {
+    return normalizeFallbackChain(primaryTrimmed, modelChain);
+  }
+
+  const tier = request.routing?.tier as ModelTier | undefined;
+  if (tier && chains.byTier[tier]?.length) {
+    return normalizeFallbackChain(primaryTrimmed, chains.byTier[tier]!);
+  }
+
+  return [primaryTrimmed];
+}

--- a/packages/clawql-inference/src/fallback/types.ts
+++ b/packages/clawql-inference/src/fallback/types.ts
@@ -1,0 +1,16 @@
+import type { ModelTier } from "../routing/types.js";
+
+export type FallbackChainMap = {
+  byTier: Partial<Record<ModelTier, string[]>>;
+  byModel: Record<string, string[]>;
+};
+
+export type FallbackConfig = {
+  enabled: boolean;
+  chains: FallbackChainMap;
+};
+
+export type FallbackAttempt = {
+  attempted: string[];
+  succeeded: string;
+};

--- a/packages/clawql-inference/src/gateway.ts
+++ b/packages/clawql-inference/src/gateway.ts
@@ -1,4 +1,5 @@
 import type { ModelEscalationDecision } from "./routing/types.js";
+import type { FallbackAttempt } from "./fallback/types.js";
 import { parseModelId } from "./providers/parse-model-id.js";
 import { createProviderRegistry, getProviderAdapter } from "./providers/registry.js";
 import type { InferenceProviderPlugin, ProviderRegistry } from "./providers/types.js";
@@ -7,6 +8,8 @@ import { withInferenceStore } from "./observability/observed-gateway.js";
 import { createInferenceStore } from "./store/create.js";
 import type { InferenceStore } from "./store/types.js";
 import { withSemanticCache, type WithSemanticCacheOptions } from "./cache/cached-gateway.js";
+import { loadFallbackConfig } from "./fallback/config.js";
+import { withFallbackChain, type WithFallbackChainOptions } from "./fallback/fallback-gateway.js";
 
 export type ChatRole = "system" | "user" | "assistant";
 
@@ -34,6 +37,7 @@ export interface InferenceResponse {
   cacheHit?: boolean;
   routing?: ModelEscalationDecision;
   correlationId?: string;
+  fallback?: FallbackAttempt;
 }
 
 /**
@@ -57,6 +61,7 @@ export type CreateInferenceGatewayOptions = {
   env?: NodeJS.ProcessEnv;
   store?: InferenceStore | null;
   semanticCache?: WithSemanticCacheOptions | false;
+  fallback?: WithFallbackChainOptions | false;
 };
 
 export class ConfiguredInferenceGateway implements InferenceGateway {
@@ -95,10 +100,16 @@ export function createInferenceGateway(
       plugins: options.providerPlugins ?? composeDefaultProviderPlugins(),
     });
   const inner = new ConfiguredInferenceGateway(providers);
+  const fallbackConfig =
+    options.fallback === false ? null : (options.fallback?.config ?? loadFallbackConfig(env));
+  const withFallback =
+    options.fallback === false || !fallbackConfig
+      ? inner
+      : withFallbackChain(inner, { config: fallbackConfig });
   const cached =
     options.semanticCache === false
-      ? inner
-      : withSemanticCache(inner, { env, ...options.semanticCache });
+      ? withFallback
+      : withSemanticCache(withFallback, { env, ...options.semanticCache });
   const store = options.store === undefined ? createInferenceStore({ env }) : options.store;
   return withInferenceStore(cached, store);
 }

--- a/packages/clawql-inference/src/index.ts
+++ b/packages/clawql-inference/src/index.ts
@@ -135,6 +135,21 @@ export {
 } from "./cache/types.js";
 export { cosineSimilarity, resolveInferenceEmbeddingConfig } from "./cache/embedding.js";
 export { buildCacheSignatureText, hashSystemPrompt } from "./cache/signature.js";
+export {
+  withFallbackChain,
+  FallbackChainGateway,
+  isFallbackChainGateway,
+  type WithFallbackChainOptions,
+} from "./fallback/fallback-gateway.js";
+export {
+  loadFallbackConfig,
+  loadFallbackConfigAsync,
+  resolveFallbackChainsPath,
+  saveFallbackChainsFile,
+} from "./fallback/config.js";
+export { resolveFallbackChain, normalizeFallbackChain } from "./fallback/resolve.js";
+export type { FallbackAttempt, FallbackChainMap, FallbackConfig } from "./fallback/types.js";
+export { runInferenceFallbackShow, type InferenceFallbackShowOptions } from "./cli/fallback.js";
 
 /** Optional context passed to host engines (Wonder / Reflect / Execute). */
 export interface EngineCallContext {

--- a/src/onboarding/cli.ts
+++ b/src/onboarding/cli.ts
@@ -29,6 +29,7 @@ import {
 } from "./sandbox-cli.js";
 import {
   runInferenceCacheStatusCmd,
+  runInferenceFallbackShowCmd,
   runInferenceCompleteCmd,
   runInferenceEscalationSetTierCmd,
   runInferenceEscalationShowCmd,
@@ -282,9 +283,11 @@ inference (gateway MVP):
   escalation      show tier map | set-tier --tier <tier> --model <id>
   pipeline        enable | status | disable | run (scheduled auto-export config)
   cache           Semantic cache config (CLAWQL_INFERENCE_SEMANTIC_CACHE=1)
+  fallback        Per-tier / per-model provider fallback chains
   Providers: openai, anthropic, ollama via provider/model ids (e.g. ollama/phi4)
   Store: CLAWQL_INFERENCE_STORE=memory|jsonl|off (default jsonl when CLAWQL_HOME set)
   Cache: CLAWQL_INFERENCE_SEMANTIC_CACHE=1, CLAWQL_INFERENCE_CACHE_THRESHOLD=0.92
+  Fallback: CLAWQL_INFERENCE_FALLBACK_ENABLED=1, CLAWQL_INFERENCE_FALLBACK_FRUGAL=a,b
   Env: OPENAI_API_KEY, ANTHROPIC_API_KEY, OLLAMA_BASE_URL, CLAWQL_INFERENCE_PORT
 
 Docs: https://docs.clawql.com/agent-setup
@@ -652,8 +655,12 @@ async function main(): Promise<void> {
       process.exitCode = await runInferenceCacheStatusCmd(inferenceOpts);
       return;
     }
+    if (subcmd === "fallback") {
+      process.exitCode = await runInferenceFallbackShowCmd(inferenceOpts);
+      return;
+    }
     console.error(
-      "Usage: clawql inference serve | complete | logs | trace | spend | export | finetune | escalation | pipeline | cache"
+      "Usage: clawql inference serve | complete | logs | trace | spend | export | finetune | escalation | pipeline | cache | fallback"
     );
     process.exitCode = 1;
     return;

--- a/src/onboarding/inference-cli.ts
+++ b/src/onboarding/inference-cli.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  runInferenceFallbackShow,
   runInferenceCacheStatus,
   runInferenceComplete,
   runInferenceEscalationSetTier,
@@ -205,4 +206,8 @@ export async function runInferencePipelineRunCmd(opts: InferenceCliOptions): Pro
 
 export async function runInferenceCacheStatusCmd(opts: InferenceCliOptions): Promise<number> {
   return runInferenceCacheStatus({ json: opts.json });
+}
+
+export async function runInferenceFallbackShowCmd(opts: InferenceCliOptions): Promise<number> {
+  return runInferenceFallbackShow({ json: opts.json });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **fallback chains** to the inference gateway — when the primary provider/model fails, the gateway tries configured alternates before surfacing an error.

Epic [#556](https://github.com/danielsmithdevelopment/ClawQL/issues/556) priority **#3**.

## Changes

- **`FallbackChainGateway`** decorator on the gateway stack: `Configured → Fallback → SemanticCache → ObservedStore`
- Chain resolution from env (`CLAWQL_INFERENCE_FALLBACK_*`) or `$CLAWQL_HOME/Inference/fallback-chains.json` (`byTier` / `byModel`)
- `InferenceResponse.fallback` metadata: `{ attempted, succeeded }`
- **`clawql inference fallback`** CLI to inspect active chains
- Tests for config loading, chain resolution, and gateway retry behavior

## Configuration

```bash
CLAWQL_INFERENCE_FALLBACK_ENABLED=1
CLAWQL_INFERENCE_FALLBACK_FRUGAL=ollama/phi4,openai/gpt-4o-mini
CLAWQL_INFERENCE_FALLBACK_STANDARD=...
CLAWQL_INFERENCE_FALLBACK_FRONTIER=...
```

## Test plan

- [x] `npm test` in `packages/clawql-inference` (49 tests)
- [x] `npm run format:check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

