### PR TITLE
feat(inference): virtual keys with per-team budgets (#556)

### DIFF
--- a/docs/inference/clawql-inference.md
+++ b/docs/inference/clawql-inference.md
@@ -34,6 +34,7 @@ LiteLLM routes inference. ClawQL closes the loop: **infer → observe → evalua
 - **`clawql inference finetune`** — OpenAI / Anthropic job submit, status, and tier registration
 - **Semantic cache** — optional embedding similarity cache (`CLAWQL_INFERENCE_SEMANTIC_CACHE=1`); hits set `cache_hit` on inference records
 - **Fallback chains** — per-tier / per-model provider alternates when primary fails (`CLAWQL_INFERENCE_FALLBACK_ENABLED=1`)
+- **Virtual keys** — per-team API keys with budget and rate limits (`CLAWQL_INFERENCE_KEYS_ENABLED=1`)
 
 ## Planned modules
 
@@ -45,7 +46,7 @@ LiteLLM routes inference. ClawQL closes the loop: **infer → observe → evalua
 | `cache/`         | Semantic cache — embedding similarity, TTL, per-model keys (**shipped**)                            |
 | `observability/` | Langfuse (ADR 0005), OpenTelemetry, WORM `correlation_id`                                           |
 | `fallback/`      | Per-tier provider chains — try alternates before failing (**shipped**)                              |
-| `keys/`          | Virtual keys, per-team budgets                                                                      |
+| `keys/`          | Virtual keys, per-team budgets (**shipped**)                                                        |
 | `api/`           | OpenAI-compatible `/v1/chat/completions`, `/v1/models`, SSE streaming (**shipped**)                 |
 | `store/`         | Inference call log (Postgres) — prompt, response, tier, tokens, verdict                             |
 | `export/`        | Filtered dataset export + PII scrub (Presidio) + WORM dataset manifests (**shipped**)               |

--- a/packages/clawql-inference/README.md
+++ b/packages/clawql-inference/README.md
@@ -75,6 +75,29 @@ clawql inference serve
 
 Responses include `fallback.attempted` and `fallback.succeeded` when a backup model handles the request.
 
+## Virtual keys
+
+Issue per-team API keys with optional USD budgets and rate limits. Keys persist at `$CLAWQL_HOME/Inference/virtual-keys.json`:
+
+```bash
+export CLAWQL_INFERENCE_KEYS_ENABLED=1
+
+clawql inference keys create --team eng --budget-usd 500 --rate-limit 100rpm
+clawql inference keys list
+clawql inference keys revoke --id vk_abc123
+
+# Clients authenticate like OpenAI (Bearer or x-api-key)
+curl -s http://127.0.0.1:8080/v1/chat/completions \
+  -H "Authorization: Bearer sk-clawql-..." \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}'
+
+# Spend by team
+clawql inference spend --group-by team
+```
+
+When keys are enabled (or any active key exists), `/v1/*` requires a valid virtual key. `/healthz` stays open.
+
 ## Quick start
 
 ```bash
@@ -142,28 +165,30 @@ Subpath: `clawql-inference/plugin` for builtin factories and compose helpers.
 
 ### Environment
 
-| Variable                             | Default                     | Purpose                                          |
-| ------------------------------------ | --------------------------- | ------------------------------------------------ |
-| `CLAWQL_INFERENCE_PROVIDERS`         | all builtins                | Allowlist provider plugins (comma-separated ids) |
-| `CLAWQL_INFERENCE_DISABLE_PROVIDERS` | —                           | Denylist provider plugins                        |
-| `OPENAI_API_KEY`                     | —                           | OpenAI chat completions                          |
-| `ANTHROPIC_API_KEY`                  | —                           | Anthropic messages API                           |
-| `OLLAMA_BASE_URL`                    | `http://127.0.0.1:11434`    | Local Ollama runtime                             |
-| `CLAWQL_INFERENCE_PORT`              | `8080`                      | `clawql inference serve` listen port             |
-| `CLAWQL_INFERENCE_ROUTING_ENABLED`   | off                         | Enable frugal → standard → frontier escalation   |
-| `CLAWQL_INFERENCE_MODEL_FRUGAL`      | `ollama/phi4`               | Frugal tier model id                             |
-| `CLAWQL_INFERENCE_MODEL_STANDARD`    | `groq/llama-3.3-70b`        | Standard tier model id                           |
-| `CLAWQL_INFERENCE_MODEL_FRONTIER`    | `anthropic/claude-sonnet-4` | Frontier tier model id                           |
-| `CLAWQL_INFERENCE_MODEL_PIN`         | —                           | Pin a single model (bypasses ladder)             |
-| `CLAWQL_INFERENCE_SEMANTIC_CACHE`    | off                         | Enable embedding similarity cache                |
-| `CLAWQL_INFERENCE_CACHE_THRESHOLD`   | `0.92`                      | Cosine similarity floor for cache hits           |
-| `CLAWQL_INFERENCE_CACHE_TTL`         | `24h`                       | Cache entry TTL (`24h`, `7d`, or `_MS` variant)  |
-| `CLAWQL_INFERENCE_CACHE_MAX_ENTRIES` | `1000`                      | In-memory cache size cap                         |
-| `CLAWQL_EMBEDDING_MODEL`             | `text-embedding-3-small`    | Embeddings model for semantic cache              |
-| `CLAWQL_INFERENCE_FALLBACK_ENABLED`  | off                         | Enable per-tier / per-model fallback chains      |
-| `CLAWQL_INFERENCE_FALLBACK_FRUGAL`   | —                           | Comma-separated fallback chain for frugal tier   |
-| `CLAWQL_INFERENCE_FALLBACK_STANDARD` | —                           | Fallback chain for standard tier                 |
-| `CLAWQL_INFERENCE_FALLBACK_FRONTIER` | —                           | Fallback chain for frontier tier                 |
+| Variable                             | Default                      | Purpose                                              |
+| ------------------------------------ | ---------------------------- | ---------------------------------------------------- |
+| `CLAWQL_INFERENCE_PROVIDERS`         | all builtins                 | Allowlist provider plugins (comma-separated ids)     |
+| `CLAWQL_INFERENCE_DISABLE_PROVIDERS` | —                            | Denylist provider plugins                            |
+| `OPENAI_API_KEY`                     | —                            | OpenAI chat completions                              |
+| `ANTHROPIC_API_KEY`                  | —                            | Anthropic messages API                               |
+| `OLLAMA_BASE_URL`                    | `http://127.0.0.1:11434`     | Local Ollama runtime                                 |
+| `CLAWQL_INFERENCE_PORT`              | `8080`                       | `clawql inference serve` listen port                 |
+| `CLAWQL_INFERENCE_ROUTING_ENABLED`   | off                          | Enable frugal → standard → frontier escalation       |
+| `CLAWQL_INFERENCE_MODEL_FRUGAL`      | `ollama/phi4`                | Frugal tier model id                                 |
+| `CLAWQL_INFERENCE_MODEL_STANDARD`    | `groq/llama-3.3-70b`         | Standard tier model id                               |
+| `CLAWQL_INFERENCE_MODEL_FRONTIER`    | `anthropic/claude-sonnet-4`  | Frontier tier model id                               |
+| `CLAWQL_INFERENCE_MODEL_PIN`         | —                            | Pin a single model (bypasses ladder)                 |
+| `CLAWQL_INFERENCE_SEMANTIC_CACHE`    | off                          | Enable embedding similarity cache                    |
+| `CLAWQL_INFERENCE_CACHE_THRESHOLD`   | `0.92`                       | Cosine similarity floor for cache hits               |
+| `CLAWQL_INFERENCE_CACHE_TTL`         | `24h`                        | Cache entry TTL (`24h`, `7d`, or `_MS` variant)      |
+| `CLAWQL_INFERENCE_CACHE_MAX_ENTRIES` | `1000`                       | In-memory cache size cap                             |
+| `CLAWQL_EMBEDDING_MODEL`             | `text-embedding-3-small`     | Embeddings model for semantic cache                  |
+| `CLAWQL_INFERENCE_FALLBACK_ENABLED`  | off                          | Enable per-tier / per-model fallback chains          |
+| `CLAWQL_INFERENCE_FALLBACK_FRUGAL`   | —                            | Comma-separated fallback chain for frugal tier       |
+| `CLAWQL_INFERENCE_FALLBACK_STANDARD` | —                            | Fallback chain for standard tier                     |
+| `CLAWQL_INFERENCE_FALLBACK_FRONTIER` | —                            | Fallback chain for frontier tier                     |
+| `CLAWQL_INFERENCE_KEYS_ENABLED`      | off                          | Require virtual keys on `/v1/*` (or when keys exist) |
+| `CLAWQL_INFERENCE_STORE`             | jsonl when `CLAWQL_HOME` set | Inference call store backend                         |
 
 Model ids use `provider/model` (e.g. `ollama/phi4`, `anthropic/claude-sonnet-4`).
 

--- a/packages/clawql-inference/README.md
+++ b/packages/clawql-inference/README.md
@@ -88,7 +88,7 @@ clawql inference keys revoke --id vk_abc123
 
 # Clients authenticate like OpenAI (Bearer or x-api-key)
 curl -s http://127.0.0.1:8080/v1/chat/completions \
-  -H "Authorization: Bearer sk-clawql-..." \
+  -H "Authorization: Bearer <virtual-key>" \
   -H 'Content-Type: application/json' \
   -d '{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}'
 

--- a/packages/clawql-inference/src/api/auth.ts
+++ b/packages/clawql-inference/src/api/auth.ts
@@ -1,0 +1,41 @@
+import type { NextFunction, Request, Response } from "express";
+import { sendOpenAiError } from "./openai-errors.js";
+import { keysEnforcementActive } from "../keys/store.js";
+import { extractPresentedApiKey, validateVirtualKey } from "../keys/validate.js";
+import type { VirtualKeyContext } from "../keys/types.js";
+
+export type VirtualKeyRequest = Request & {
+  virtualKey?: VirtualKeyContext;
+};
+
+export type CreateVirtualKeyAuthMiddlewareOptions = {
+  env?: NodeJS.ProcessEnv;
+};
+
+export function createVirtualKeyAuthMiddleware(
+  options: CreateVirtualKeyAuthMiddlewareOptions = {}
+) {
+  const env = options.env ?? process.env;
+  return (req: VirtualKeyRequest, res: Response, next: NextFunction): void => {
+    if (!keysEnforcementActive(env)) {
+      next();
+      return;
+    }
+
+    const path = req.path;
+    if (path === "/healthz" || path === "/v1") {
+      next();
+      return;
+    }
+
+    const secret = extractPresentedApiKey(req.headers);
+    const result = validateVirtualKey(secret, env);
+    if (!result.ok) {
+      sendOpenAiError(res, result.status, result.message, result.type);
+      return;
+    }
+
+    req.virtualKey = result.context;
+    next();
+  };
+}

--- a/packages/clawql-inference/src/api/openai-compat.ts
+++ b/packages/clawql-inference/src/api/openai-compat.ts
@@ -3,6 +3,7 @@ import express, { type Request, type Response } from "express";
 import type { ChatMessage, InferenceGateway } from "../gateway.js";
 import { getProviderAdapter } from "../providers/registry.js";
 import type { ProviderRegistry } from "../providers/types.js";
+import type { VirtualKeyRequest } from "./auth.js";
 import { resolveRequestModel } from "./model-resolve.js";
 import { createModelsHandlers } from "./models.js";
 import { sendOpenAiError } from "./openai-errors.js";
@@ -52,9 +53,10 @@ export function createOpenAiCompatRouter(options: CreateOpenAiCompatRouterOption
     router.get("/v1/models/:id", models.get);
   }
 
-  router.post("/v1/chat/completions", async (req: Request, res: Response) => {
+  router.post("/v1/chat/completions", async (req: VirtualKeyRequest, res: Response) => {
     const body = req.body as OpenAiChatCompletionRequest;
     const correlationId = readCorrelationId(req, body);
+    const keyContext = req.virtualKey;
     const modelRaw = body.model?.trim();
     if (!modelRaw) {
       sendOpenAiError(res, 400, "model is required", "invalid_request_error");
@@ -106,6 +108,8 @@ export function createOpenAiCompatRouter(options: CreateOpenAiCompatRouterOption
           model: gatewayModelId,
           messages,
           correlationId,
+          team: keyContext?.team,
+          virtualKeyId: keyContext?.id,
         });
         await streamBufferedCompletion(res, {
           model: publicModelId,
@@ -119,6 +123,8 @@ export function createOpenAiCompatRouter(options: CreateOpenAiCompatRouterOption
         model: gatewayModelId,
         messages,
         correlationId,
+        team: keyContext?.team,
+        virtualKeyId: keyContext?.id,
       });
 
       if (correlationId) res.setHeader("X-Correlation-Id", correlationId);

--- a/packages/clawql-inference/src/api/server.test.ts
+++ b/packages/clawql-inference/src/api/server.test.ts
@@ -16,14 +16,16 @@ function closeHttpServer(server: Server): Promise<void> {
 
 async function httpJson(
   url: string,
-  init?: { method?: string; body?: string }
+  init?: { method?: string; body?: string; headers?: Record<string, string> }
 ): Promise<{ status: number; body: unknown }> {
   return new Promise((resolve, reject) => {
+    const headers: Record<string, string> = { ...init?.headers };
+    if (init?.body) headers["Content-Type"] = "application/json";
     const req = request(
       url,
       {
         method: init?.method ?? "GET",
-        headers: init?.body ? { "Content-Type": "application/json" } : undefined,
+        headers: Object.keys(headers).length ? headers : undefined,
       },
       (res) => {
         let data = "";
@@ -110,6 +112,69 @@ describe("createInferenceHttpApp", () => {
         choices: Array<{ message: { content: string } }>;
       };
       expect(body.choices[0]?.message.content).toBe("pong");
+    } finally {
+      await closeHttpServer(server);
+    }
+  });
+
+  it("requires virtual key when keys enforcement is active", async () => {
+    const { mkdtemp } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const { createVirtualKey } = await import("../keys/store.js");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          model: "gpt-4o",
+          choices: [{ message: { content: "pong" } }],
+          usage: { prompt_tokens: 1, completion_tokens: 1 },
+        }),
+      }))
+    );
+
+    const dir = await mkdtemp(join(tmpdir(), "clawql-auth-"));
+    const env = { CLAWQL_HOME: dir, CLAWQL_INFERENCE_KEYS_ENABLED: "1" };
+    const created = await createVirtualKey({ team: "eng" }, env);
+
+    const gateway = new ConfiguredInferenceGateway(
+      new Map([
+        [
+          "openai",
+          createOpenAiAdapter({ apiKey: "test-key", baseUrl: "https://api.openai.com/v1" }),
+        ],
+      ])
+    );
+    const app = createInferenceHttpApp({ gateway, env });
+    const server = createServer(app);
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected bound TCP port");
+    }
+
+    try {
+      const denied = await httpJson(`http://127.0.0.1:${address.port}/v1/chat/completions`, {
+        method: "POST",
+        body: JSON.stringify({
+          model: "gpt-4o",
+          messages: [{ role: "user", content: "ping" }],
+        }),
+      });
+      expect(denied.status).toBe(401);
+
+      const allowed = await httpJson(`http://127.0.0.1:${address.port}/v1/chat/completions`, {
+        method: "POST",
+        body: JSON.stringify({
+          model: "gpt-4o",
+          messages: [{ role: "user", content: "ping" }],
+        }),
+        headers: { Authorization: `Bearer ${created.secret}` },
+      });
+      expect(allowed.status).toBe(200);
     } finally {
       await closeHttpServer(server);
     }

--- a/packages/clawql-inference/src/api/server.ts
+++ b/packages/clawql-inference/src/api/server.ts
@@ -3,6 +3,7 @@ import { createInferenceGateway } from "../gateway.js";
 import type { InferenceGateway } from "../gateway.js";
 import { createProviderRegistry } from "../providers/registry.js";
 import { composeDefaultProviderPlugins } from "../plugin/compose.js";
+import { createVirtualKeyAuthMiddleware } from "./auth.js";
 import { createOpenAiCompatRouter } from "./openai-compat.js";
 
 export type CreateInferenceHttpAppOptions = {
@@ -29,6 +30,7 @@ export function createInferenceHttpApp(options: CreateInferenceHttpAppOptions = 
       endpoints: ["/v1/chat/completions", "/v1/models"],
     });
   });
+  app.use(createVirtualKeyAuthMiddleware({ env }));
   app.use(createOpenAiCompatRouter({ gateway, registry, env }));
   return app;
 }

--- a/packages/clawql-inference/src/cli/keys.ts
+++ b/packages/clawql-inference/src/cli/keys.ts
@@ -1,0 +1,136 @@
+import {
+  createVirtualKey,
+  listVirtualKeys,
+  redactVirtualKey,
+  revokeVirtualKey,
+} from "../keys/store.js";
+import { loadKeysConfig, resolveVirtualKeysPath } from "../keys/config.js";
+
+export type InferenceKeysCreateOptions = {
+  team?: string;
+  budgetUsd?: number;
+  rateLimit?: string;
+  label?: string;
+  json?: boolean;
+  env?: NodeJS.ProcessEnv;
+};
+
+export async function runInferenceKeysCreate(
+  options: InferenceKeysCreateOptions = {}
+): Promise<number> {
+  if (!options.team?.trim()) {
+    console.error(
+      "Usage: clawql inference keys create --team <name> [--budget-usd N] [--rate-limit 100rpm] [--label NAME]"
+    );
+    return 1;
+  }
+
+  const env = options.env ?? process.env;
+  const { key, secret, path } = await createVirtualKey(
+    {
+      team: options.team,
+      budgetUsd: options.budgetUsd,
+      rateLimit: options.rateLimit,
+      label: options.label,
+    },
+    env
+  );
+
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        {
+          id: key.id,
+          team: key.team,
+          secret,
+          budgetUsd: key.budgetUsd,
+          rateLimit: key.rateLimit,
+          label: key.label,
+          path,
+        },
+        null,
+        2
+      )
+    );
+    return 0;
+  }
+
+  console.log(`Created virtual key ${key.id} for team "${key.team}"`);
+  console.log(`Secret (shown once): ${secret}`);
+  if (key.budgetUsd !== undefined) console.log(`Budget: $${key.budgetUsd}`);
+  if (key.rateLimit) {
+    console.log(`Rate limit: ${key.rateLimit.maxRequests} per ${key.rateLimit.windowMs}ms`);
+  }
+  console.log(`Saved to ${path}`);
+  return 0;
+}
+
+export type InferenceKeysListOptions = {
+  json?: boolean;
+  env?: NodeJS.ProcessEnv;
+};
+
+export async function runInferenceKeysList(
+  options: InferenceKeysListOptions = {}
+): Promise<number> {
+  const env = options.env ?? process.env;
+  const config = loadKeysConfig(env);
+  const keys = listVirtualKeys(env).map(redactVirtualKey);
+  const payload = {
+    enabled: config.enabled,
+    keysPath: resolveVirtualKeysPath(env),
+    keys,
+  };
+
+  if (options.json) {
+    console.log(JSON.stringify(payload, null, 2));
+    return 0;
+  }
+
+  console.log(`keys_enabled: ${config.enabled}`);
+  console.log(`keys_file: ${payload.keysPath}`);
+  if (!keys.length) {
+    console.log("No virtual keys configured.");
+    return 0;
+  }
+
+  for (const key of keys) {
+    const status = key.revokedAt ? "revoked" : "active";
+    const budget =
+      key.budgetUsd !== undefined ? `$${key.spentUsd.toFixed(4)}/$${key.budgetUsd}` : "unlimited";
+    console.log(
+      `${key.id}  team=${key.team}  status=${status}  budget=${budget}  created=${key.createdAt}`
+    );
+  }
+  return 0;
+}
+
+export type InferenceKeysRevokeOptions = {
+  id?: string;
+  json?: boolean;
+  env?: NodeJS.ProcessEnv;
+};
+
+export async function runInferenceKeysRevoke(
+  options: InferenceKeysRevokeOptions = {}
+): Promise<number> {
+  if (!options.id?.trim()) {
+    console.error("Usage: clawql inference keys revoke --id <vk_...>");
+    return 1;
+  }
+
+  const env = options.env ?? process.env;
+  const result = await revokeVirtualKey(options.id.trim(), env);
+  if (!result) {
+    console.error(`Virtual key not found: ${options.id}`);
+    return 1;
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify({ key: redactVirtualKey(result.key), path: result.path }, null, 2));
+    return 0;
+  }
+
+  console.log(`Revoked ${result.key.id} (saved to ${result.path})`);
+  return 0;
+}

--- a/packages/clawql-inference/src/gateway.ts
+++ b/packages/clawql-inference/src/gateway.ts
@@ -23,6 +23,8 @@ export interface InferenceRequest {
   model?: string;
   routing?: ModelEscalationDecision;
   correlationId?: string;
+  team?: string;
+  virtualKeyId?: string;
 }
 
 export interface InferenceUsage {
@@ -111,5 +113,5 @@ export function createInferenceGateway(
       ? withFallback
       : withSemanticCache(withFallback, { env, ...options.semanticCache });
   const store = options.store === undefined ? createInferenceStore({ env }) : options.store;
-  return withInferenceStore(cached, store);
+  return withInferenceStore(cached, store, env);
 }

--- a/packages/clawql-inference/src/index.ts
+++ b/packages/clawql-inference/src/index.ts
@@ -150,6 +150,25 @@ export {
 export { resolveFallbackChain, normalizeFallbackChain } from "./fallback/resolve.js";
 export type { FallbackAttempt, FallbackChainMap, FallbackConfig } from "./fallback/types.js";
 export { runInferenceFallbackShow, type InferenceFallbackShowOptions } from "./cli/fallback.js";
+export {
+  runInferenceKeysCreate,
+  runInferenceKeysList,
+  runInferenceKeysRevoke,
+  type InferenceKeysCreateOptions,
+  type InferenceKeysListOptions,
+  type InferenceKeysRevokeOptions,
+} from "./cli/keys.js";
+export { loadKeysConfig, resolveVirtualKeysPath } from "./keys/config.js";
+export {
+  createVirtualKey,
+  revokeVirtualKey,
+  listVirtualKeys,
+  keysEnforcementActive,
+  redactVirtualKey,
+} from "./keys/store.js";
+export { validateVirtualKey, extractPresentedApiKey } from "./keys/validate.js";
+export { createVirtualKeyAuthMiddleware, type VirtualKeyRequest } from "./api/auth.js";
+export type { VirtualKey, VirtualKeyContext, KeysConfig, RateLimitSpec } from "./keys/types.js";
 
 /** Optional context passed to host engines (Wonder / Reflect / Execute). */
 export interface EngineCallContext {

--- a/packages/clawql-inference/src/keys/budget.ts
+++ b/packages/clawql-inference/src/keys/budget.ts
@@ -1,0 +1,14 @@
+import type { InferenceUsage } from "../gateway.js";
+
+/** Rough USD estimate for budget enforcement (no provider-specific pricing yet). */
+export function estimateCostUsd(usage: InferenceUsage | undefined): number {
+  if (!usage) return 0;
+  const input = usage.inputTokens * 0.000_001;
+  const output = usage.outputTokens * 0.000_003;
+  return input + output;
+}
+
+export function isBudgetExceeded(spentUsd: number, budgetUsd: number | undefined): boolean {
+  if (budgetUsd === undefined || budgetUsd <= 0) return false;
+  return spentUsd >= budgetUsd;
+}

--- a/packages/clawql-inference/src/keys/config.ts
+++ b/packages/clawql-inference/src/keys/config.ts
@@ -1,0 +1,21 @@
+import { join } from "node:path";
+import type { KeysConfig } from "./types.js";
+
+const FILE_NAME = "virtual-keys.json";
+
+function parseTruthy(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+export function resolveVirtualKeysPath(env: NodeJS.ProcessEnv = process.env): string {
+  const home = env.CLAWQL_HOME?.trim() || join(process.cwd(), ".clawql");
+  return join(home, "Inference", FILE_NAME);
+}
+
+export function loadKeysConfig(env: NodeJS.ProcessEnv = process.env): KeysConfig {
+  return {
+    enabled: parseTruthy(env.CLAWQL_INFERENCE_KEYS_ENABLED),
+  };
+}

--- a/packages/clawql-inference/src/keys/rate-limit.ts
+++ b/packages/clawql-inference/src/keys/rate-limit.ts
@@ -1,0 +1,45 @@
+import type { RateLimitSpec } from "./types.js";
+
+const RPM_RE = /^(\d+)\s*rpm$/i;
+const RPS_RE = /^(\d+)\s*rps$/i;
+
+/** Parse `100rpm` or `10rps` into a rate limit spec. */
+export function parseRateLimit(raw: string | undefined): RateLimitSpec | undefined {
+  if (!raw?.trim()) return undefined;
+  const rpm = RPM_RE.exec(raw.trim());
+  if (rpm) {
+    const maxRequests = Number.parseInt(rpm[1]!, 10);
+    if (maxRequests > 0) return { maxRequests, windowMs: 60_000 };
+  }
+  const rps = RPS_RE.exec(raw.trim());
+  if (rps) {
+    const maxRequests = Number.parseInt(rps[1]!, 10);
+    if (maxRequests > 0) return { maxRequests, windowMs: 1_000 };
+  }
+  return undefined;
+}
+
+type WindowState = {
+  timestamps: number[];
+};
+
+const windows = new Map<string, WindowState>();
+
+/** In-memory sliding-window rate limiter (per process). */
+export function checkRateLimit(keyId: string, spec: RateLimitSpec, now = Date.now()): boolean {
+  const state = windows.get(keyId) ?? { timestamps: [] };
+  const cutoff = now - spec.windowMs;
+  state.timestamps = state.timestamps.filter((t) => t > cutoff);
+  if (state.timestamps.length >= spec.maxRequests) {
+    windows.set(keyId, state);
+    return false;
+  }
+  state.timestamps.push(now);
+  windows.set(keyId, state);
+  return true;
+}
+
+/** Test helper — reset in-memory rate limit state. */
+export function resetRateLimitState(): void {
+  windows.clear();
+}

--- a/packages/clawql-inference/src/keys/store.test.ts
+++ b/packages/clawql-inference/src/keys/store.test.ts
@@ -38,7 +38,7 @@ describe("virtual key store", () => {
       env
     );
     expect(created.key.id).toMatch(/^vk_/);
-    expect(created.secret).toMatch(/^sk-clawql-/);
+    expect(created.secret).toMatch(/^clawql-vk-/);
 
     const store = loadVirtualKeyStoreSync(env);
     const found = findKeyBySecret(store, created.secret);

--- a/packages/clawql-inference/src/keys/store.test.ts
+++ b/packages/clawql-inference/src/keys/store.test.ts
@@ -1,0 +1,54 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseRateLimit, checkRateLimit, resetRateLimitState } from "./rate-limit.js";
+
+describe("rate limit", () => {
+  it("parses rpm and rps", () => {
+    expect(parseRateLimit("100rpm")).toEqual({ maxRequests: 100, windowMs: 60_000 });
+    expect(parseRateLimit("10rps")).toEqual({ maxRequests: 10, windowMs: 1_000 });
+    expect(parseRateLimit("")).toBeUndefined();
+  });
+
+  it("enforces sliding window", () => {
+    resetRateLimitState();
+    const spec = { maxRequests: 2, windowMs: 1_000 };
+    expect(checkRateLimit("k1", spec, 1_000)).toBe(true);
+    expect(checkRateLimit("k1", spec, 1_100)).toBe(true);
+    expect(checkRateLimit("k1", spec, 1_200)).toBe(false);
+    expect(checkRateLimit("k1", spec, 2_100)).toBe(true);
+  });
+});
+
+describe("virtual key store", () => {
+  it("creates, lists, and revokes keys", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "clawql-keys-"));
+    const env = { CLAWQL_HOME: dir, CLAWQL_INFERENCE_KEYS_ENABLED: "1" };
+    const {
+      createVirtualKey,
+      listVirtualKeys,
+      revokeVirtualKey,
+      findKeyBySecret,
+      loadVirtualKeyStoreSync,
+    } = await import("./store.js");
+
+    const created = await createVirtualKey(
+      { team: "eng", budgetUsd: 50, rateLimit: "100rpm" },
+      env
+    );
+    expect(created.key.id).toMatch(/^vk_/);
+    expect(created.secret).toMatch(/^sk-clawql-/);
+
+    const store = loadVirtualKeyStoreSync(env);
+    const found = findKeyBySecret(store, created.secret);
+    expect(found?.team).toBe("eng");
+
+    expect(listVirtualKeys(env)).toHaveLength(1);
+
+    const revoked = await revokeVirtualKey(created.key.id, env);
+    expect(revoked?.key.revokedAt).toBeTruthy();
+    const reloaded = loadVirtualKeyStoreSync(env);
+    expect(findKeyBySecret(reloaded, created.secret)).toBeUndefined();
+  });
+});

--- a/packages/clawql-inference/src/keys/store.ts
+++ b/packages/clawql-inference/src/keys/store.ts
@@ -1,0 +1,135 @@
+import { createHash, randomBytes } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { loadKeysConfig, resolveVirtualKeysPath } from "./config.js";
+import { parseRateLimit } from "./rate-limit.js";
+import type { RateLimitSpec, VirtualKey, VirtualKeyStoreFile } from "./types.js";
+
+export function hashVirtualKeySecret(secret: string): string {
+  return createHash("sha256").update(secret).digest("hex");
+}
+
+export function generateVirtualKeyId(): string {
+  return `vk_${randomBytes(8).toString("hex")}`;
+}
+
+export function generateVirtualKeySecret(): string {
+  return `sk-clawql-${randomBytes(24).toString("base64url")}`;
+}
+
+function emptyStore(): VirtualKeyStoreFile {
+  return { keys: [] };
+}
+
+export function loadVirtualKeyStoreSync(env: NodeJS.ProcessEnv = process.env): VirtualKeyStoreFile {
+  try {
+    const path = resolveVirtualKeysPath(env);
+    if (!existsSync(path)) return emptyStore();
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as VirtualKeyStoreFile;
+    return { keys: parsed.keys ?? [] };
+  } catch {
+    return emptyStore();
+  }
+}
+
+export async function saveVirtualKeyStore(
+  store: VirtualKeyStoreFile,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<string> {
+  const path = resolveVirtualKeysPath(env);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(store, null, 2)}\n`, "utf8");
+  return path;
+}
+
+export function findKeyBySecret(
+  store: VirtualKeyStoreFile,
+  secret: string
+): VirtualKey | undefined {
+  const hash = hashVirtualKeySecret(secret);
+  return store.keys.find((k) => k.secretHash === hash && !k.revokedAt);
+}
+
+export function findKeyById(store: VirtualKeyStoreFile, id: string): VirtualKey | undefined {
+  return store.keys.find((k) => k.id === id);
+}
+
+export type CreateVirtualKeyInput = {
+  team: string;
+  label?: string;
+  budgetUsd?: number;
+  rateLimit?: string;
+};
+
+export type CreateVirtualKeyResult = {
+  key: VirtualKey;
+  secret: string;
+  path: string;
+};
+
+export async function createVirtualKey(
+  input: CreateVirtualKeyInput,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<CreateVirtualKeyResult> {
+  const store = loadVirtualKeyStoreSync(env);
+  const secret = generateVirtualKeySecret();
+  const rateLimit = parseRateLimit(input.rateLimit);
+  const key: VirtualKey = {
+    id: generateVirtualKeyId(),
+    team: input.team.trim(),
+    label: input.label?.trim() || undefined,
+    secretHash: hashVirtualKeySecret(secret),
+    budgetUsd: input.budgetUsd,
+    spentUsd: 0,
+    rateLimit,
+    createdAt: new Date().toISOString(),
+  };
+  store.keys.push(key);
+  const path = await saveVirtualKeyStore(store, env);
+  return { key, secret, path };
+}
+
+export async function revokeVirtualKey(
+  id: string,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<{ key: VirtualKey; path: string } | null> {
+  const store = loadVirtualKeyStoreSync(env);
+  const key = findKeyById(store, id);
+  if (!key) return null;
+  key.revokedAt = new Date().toISOString();
+  const path = await saveVirtualKeyStore(store, env);
+  return { key, path };
+}
+
+export async function recordKeySpend(
+  keyId: string,
+  amountUsd: number,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<void> {
+  if (amountUsd <= 0) return;
+  const store = loadVirtualKeyStoreSync(env);
+  const key = findKeyById(store, keyId);
+  if (!key) return;
+  key.spentUsd += amountUsd;
+  await saveVirtualKeyStore(store, env);
+}
+
+export function listVirtualKeys(env: NodeJS.ProcessEnv = process.env): VirtualKey[] {
+  return loadVirtualKeyStoreSync(env).keys;
+}
+
+export function keysEnforcementActive(env: NodeJS.ProcessEnv = process.env): boolean {
+  const config = loadKeysConfig(env);
+  if (config.enabled) return true;
+  const store = loadVirtualKeyStoreSync(env);
+  return store.keys.some((k) => !k.revokedAt);
+}
+
+export function redactVirtualKey(key: VirtualKey): Omit<VirtualKey, "secretHash"> & {
+  secretHash: undefined;
+  rateLimit?: RateLimitSpec;
+} {
+  const { secretHash: _secretHash, ...rest } = key;
+  return { ...rest, secretHash: undefined };
+}

--- a/packages/clawql-inference/src/keys/store.ts
+++ b/packages/clawql-inference/src/keys/store.ts
@@ -15,7 +15,7 @@ export function generateVirtualKeyId(): string {
 }
 
 export function generateVirtualKeySecret(): string {
-  return `sk-clawql-${randomBytes(24).toString("base64url")}`;
+  return `clawql-vk-${randomBytes(24).toString("base64url")}`;
 }
 
 function emptyStore(): VirtualKeyStoreFile {

--- a/packages/clawql-inference/src/keys/types.ts
+++ b/packages/clawql-inference/src/keys/types.ts
@@ -1,0 +1,38 @@
+export type RateLimitSpec = {
+  /** Maximum requests allowed in the window. */
+  maxRequests: number;
+  /** Window length in milliseconds. */
+  windowMs: number;
+};
+
+/** Persisted virtual key record (secret stored as hash only). */
+export type VirtualKey = {
+  id: string;
+  team: string;
+  label?: string;
+  secretHash: string;
+  budgetUsd?: number;
+  spentUsd: number;
+  rateLimit?: RateLimitSpec;
+  createdAt: string;
+  revokedAt?: string;
+};
+
+export type VirtualKeyStoreFile = {
+  keys: VirtualKey[];
+};
+
+export type KeysConfig = {
+  enabled: boolean;
+};
+
+/** Resolved key context attached to inference requests after auth. */
+export type VirtualKeyContext = {
+  id: string;
+  team: string;
+  budgetUsd?: number;
+};
+
+export type KeyValidationResult =
+  | { ok: true; context: VirtualKeyContext }
+  | { ok: false; status: 401 | 402 | 429; message: string; type: string };

--- a/packages/clawql-inference/src/keys/validate.test.ts
+++ b/packages/clawql-inference/src/keys/validate.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { extractPresentedApiKey, validateVirtualKey } from "./validate.js";
+import { resetRateLimitState } from "./rate-limit.js";
+
+describe("validateVirtualKey", () => {
+  it("extracts bearer and x-api-key headers", () => {
+    expect(extractPresentedApiKey({ authorization: "Bearer sk-test" })).toBe("sk-test");
+    expect(extractPresentedApiKey({ "x-api-key": "sk-header" })).toBe("sk-header");
+  });
+
+  it("rejects missing keys when enforcement is on", async () => {
+    const { mkdtemp } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const { createVirtualKey } = await import("./store.js");
+
+    const dir = await mkdtemp(join(tmpdir(), "clawql-validate-"));
+    const env = { CLAWQL_HOME: dir, CLAWQL_INFERENCE_KEYS_ENABLED: "1" };
+    const created = await createVirtualKey({ team: "eng" }, env);
+
+    expect(validateVirtualKey(undefined, env).ok).toBe(false);
+    expect(validateVirtualKey("wrong", env).ok).toBe(false);
+
+    const ok = validateVirtualKey(created.secret, env);
+    expect(ok.ok).toBe(true);
+    if (ok.ok) {
+      expect(ok.context.team).toBe("eng");
+    }
+  });
+
+  it("rejects when rate limit exceeded", async () => {
+    resetRateLimitState();
+    const { mkdtemp } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const { createVirtualKey } = await import("./store.js");
+
+    const dir = await mkdtemp(join(tmpdir(), "clawql-rl-"));
+    const env = { CLAWQL_HOME: dir, CLAWQL_INFERENCE_KEYS_ENABLED: "1" };
+    const created = await createVirtualKey({ team: "eng", rateLimit: "1rpm" }, env);
+
+    expect(validateVirtualKey(created.secret, env).ok).toBe(true);
+    const blocked = validateVirtualKey(created.secret, env);
+    expect(blocked.ok).toBe(false);
+    if (!blocked.ok) expect(blocked.status).toBe(429);
+  });
+});

--- a/packages/clawql-inference/src/keys/validate.ts
+++ b/packages/clawql-inference/src/keys/validate.ts
@@ -1,0 +1,73 @@
+import { isBudgetExceeded } from "./budget.js";
+import { checkRateLimit } from "./rate-limit.js";
+import { findKeyBySecret, loadVirtualKeyStoreSync } from "./store.js";
+import type { KeyValidationResult } from "./types.js";
+
+export type AuthHeaderSource = Record<string, string | string[] | undefined>;
+
+function headerValue(headers: AuthHeaderSource, name: string): string | undefined {
+  const v = headers[name.toLowerCase()] ?? headers[name];
+  if (Array.isArray(v)) return v[0]?.trim();
+  return typeof v === "string" ? v.trim() : undefined;
+}
+
+export function extractPresentedApiKey(headers: AuthHeaderSource): string | undefined {
+  const bearer = headerValue(headers, "authorization");
+  const apiKeyHeader =
+    headerValue(headers, "x-api-key") ?? headerValue(headers, "x-clawql-api-key");
+  return (
+    apiKeyHeader ?? (bearer?.toLowerCase().startsWith("bearer ") ? bearer.slice(7).trim() : bearer)
+  );
+}
+
+export function validateVirtualKey(
+  secret: string | undefined,
+  env: NodeJS.ProcessEnv = process.env
+): KeyValidationResult {
+  if (!secret) {
+    return {
+      ok: false,
+      status: 401,
+      message: "Invalid or missing API key",
+      type: "authentication_error",
+    };
+  }
+
+  const store = loadVirtualKeyStoreSync(env);
+  const key = findKeyBySecret(store, secret);
+  if (!key) {
+    return {
+      ok: false,
+      status: 401,
+      message: "Invalid or missing API key",
+      type: "authentication_error",
+    };
+  }
+
+  if (isBudgetExceeded(key.spentUsd, key.budgetUsd)) {
+    return {
+      ok: false,
+      status: 402,
+      message: `Budget exceeded for team "${key.team}"`,
+      type: "insufficient_quota",
+    };
+  }
+
+  if (key.rateLimit && !checkRateLimit(key.id, key.rateLimit)) {
+    return {
+      ok: false,
+      status: 429,
+      message: "Rate limit exceeded",
+      type: "rate_limit_exceeded",
+    };
+  }
+
+  return {
+    ok: true,
+    context: {
+      id: key.id,
+      team: key.team,
+      budgetUsd: key.budgetUsd,
+    },
+  };
+}

--- a/packages/clawql-inference/src/observability/observed-gateway.ts
+++ b/packages/clawql-inference/src/observability/observed-gateway.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../gateway.js";
+import { estimateCostUsd } from "../keys/budget.js";
+import { recordKeySpend } from "../keys/store.js";
 import { parseModelId } from "../providers/parse-model-id.js";
 import { buildInferenceRecord } from "../store/types.js";
 import type { InferenceStore } from "../store/types.js";
@@ -8,7 +10,8 @@ import type { InferenceStore } from "../store/types.js";
 export class ObservedInferenceGateway implements InferenceGateway {
   constructor(
     private readonly inner: InferenceGateway,
-    private readonly store: InferenceStore
+    private readonly store: InferenceStore,
+    private readonly env: NodeJS.ProcessEnv = process.env
   ) {}
 
   async complete(request: InferenceRequest): Promise<InferenceResponse> {
@@ -26,14 +29,19 @@ export class ObservedInferenceGateway implements InferenceGateway {
         latencyMs: Date.now() - started,
       })
     );
+    if (request.virtualKeyId) {
+      const cost = estimateCostUsd(response.usage);
+      await recordKeySpend(request.virtualKeyId, cost, this.env);
+    }
     return response;
   }
 }
 
 export function withInferenceStore(
   gateway: InferenceGateway,
-  store: InferenceStore | null | undefined
+  store: InferenceStore | null | undefined,
+  env: NodeJS.ProcessEnv = process.env
 ): InferenceGateway {
   if (!store) return gateway;
-  return new ObservedInferenceGateway(gateway, store);
+  return new ObservedInferenceGateway(gateway, store, env);
 }

--- a/packages/clawql-inference/src/store/in-memory.ts
+++ b/packages/clawql-inference/src/store/in-memory.ts
@@ -45,7 +45,9 @@ export class InMemoryInferenceStore implements InferenceStore {
           ? record.provider
           : groupBy === "tier"
             ? (record.tier ?? "unknown")
-            : record.modelId;
+            : groupBy === "team"
+              ? (record.team ?? "unknown")
+              : record.modelId;
       const row = rows.get(key) ?? { key, calls: 0, inputTokens: 0, outputTokens: 0 };
       row.calls += 1;
       row.inputTokens += record.usage?.inputTokens ?? 0;

--- a/packages/clawql-inference/src/store/types.ts
+++ b/packages/clawql-inference/src/store/types.ts
@@ -11,6 +11,8 @@ export interface InferenceRecord {
   modelId: string;
   provider: string;
   tier?: string;
+  team?: string;
+  virtualKeyId?: string;
   messages: ChatMessage[];
   response: string;
   usage?: InferenceUsage;
@@ -31,7 +33,7 @@ export type InferenceListQuery = {
   limit?: number;
 };
 
-export type SpendGroupBy = "model" | "provider" | "tier";
+export type SpendGroupBy = "model" | "provider" | "tier" | "team";
 
 export type SpendRow = {
   key: string;
@@ -56,6 +58,8 @@ export function buildInferenceRecord(input: {
     model?: string;
     routing?: ModelEscalationDecision;
     correlationId?: string;
+    team?: string;
+    virtualKeyId?: string;
   };
   response: InferenceResponse;
   provider: string;
@@ -69,6 +73,8 @@ export function buildInferenceRecord(input: {
     modelId: input.response.model || input.request.model || `${input.provider}/${input.model}`,
     provider: input.provider,
     tier: input.request.routing?.tier ?? input.response.routing?.tier,
+    team: input.request.team,
+    virtualKeyId: input.request.virtualKeyId,
     messages: input.request.messages,
     response: input.response.content,
     usage: input.response.usage,

--- a/src/onboarding/cli.ts
+++ b/src/onboarding/cli.ts
@@ -30,6 +30,9 @@ import {
 import {
   runInferenceCacheStatusCmd,
   runInferenceFallbackShowCmd,
+  runInferenceKeysCreateCmd,
+  runInferenceKeysListCmd,
+  runInferenceKeysRevokeCmd,
   runInferenceCompleteCmd,
   runInferenceEscalationSetTierCmd,
   runInferenceEscalationShowCmd,
@@ -140,6 +143,9 @@ function parse(argv: string[]): {
     else if (a === "--target-tier") flags.targetTier = argv[++i] ?? "";
     else if (a === "--evaluate-before-promote") flags.evaluateBeforePromote = true;
     else if (a === "--output-dir") flags.outputDir = argv[++i] ?? "";
+    else if (a === "--team") flags.team = argv[++i] ?? "";
+    else if (a === "--budget-usd") flags.budgetUsd = argv[++i] ?? "";
+    else if (a === "--rate-limit") flags.rateLimit = argv[++i] ?? "";
     else if (a === "--skip-verify") flags.skipVerify = true;
     else if (a.startsWith("--image-digest=")) {
       const prev = typeof flags.imageDigest === "string" ? flags.imageDigest : "";
@@ -284,10 +290,12 @@ inference (gateway MVP):
   pipeline        enable | status | disable | run (scheduled auto-export config)
   cache           Semantic cache config (CLAWQL_INFERENCE_SEMANTIC_CACHE=1)
   fallback        Per-tier / per-model provider fallback chains
+  keys            create | list | revoke virtual API keys (per-team budgets)
   Providers: openai, anthropic, ollama via provider/model ids (e.g. ollama/phi4)
   Store: CLAWQL_INFERENCE_STORE=memory|jsonl|off (default jsonl when CLAWQL_HOME set)
   Cache: CLAWQL_INFERENCE_SEMANTIC_CACHE=1, CLAWQL_INFERENCE_CACHE_THRESHOLD=0.92
   Fallback: CLAWQL_INFERENCE_FALLBACK_ENABLED=1, CLAWQL_INFERENCE_FALLBACK_FRUGAL=a,b
+  Keys: CLAWQL_INFERENCE_KEYS_ENABLED=1 (or any active key in virtual-keys.json)
   Env: OPENAI_API_KEY, ANTHROPIC_API_KEY, OLLAMA_BASE_URL, CLAWQL_INFERENCE_PORT
 
 Docs: https://docs.clawql.com/agent-setup
@@ -519,6 +527,10 @@ async function main(): Promise<void> {
       typeof flags.minSamples === "string" && flags.minSamples
         ? Number.parseInt(flags.minSamples, 10)
         : undefined;
+    const budgetUsd =
+      typeof flags.budgetUsd === "string" && flags.budgetUsd
+        ? Number.parseFloat(flags.budgetUsd)
+        : undefined;
     const targetTier =
       typeof flags.targetTier === "string" &&
       (flags.targetTier === "frugal" ||
@@ -559,7 +571,10 @@ async function main(): Promise<void> {
       limit: Number.isFinite(limit) ? limit : undefined,
       groupBy:
         typeof flags.groupBy === "string" &&
-        (flags.groupBy === "model" || flags.groupBy === "provider" || flags.groupBy === "tier")
+        (flags.groupBy === "model" ||
+          flags.groupBy === "provider" ||
+          flags.groupBy === "tier" ||
+          flags.groupBy === "team")
           ? flags.groupBy
           : undefined,
       json: Boolean(flags.json),
@@ -587,6 +602,10 @@ async function main(): Promise<void> {
       targetTier,
       evaluateBeforePromote: Boolean(flags.evaluateBeforePromote),
       outputDir: typeof flags.outputDir === "string" ? flags.outputDir : undefined,
+      team: typeof flags.team === "string" ? flags.team : undefined,
+      budgetUsd: Number.isFinite(budgetUsd) ? budgetUsd : undefined,
+      rateLimit: typeof flags.rateLimit === "string" ? flags.rateLimit : undefined,
+      keyId: typeof flags.id === "string" ? flags.id : undefined,
     };
     if (subcmd === "serve") {
       process.exitCode = await runInferenceServeCmd(inferenceOpts);
@@ -659,8 +678,28 @@ async function main(): Promise<void> {
       process.exitCode = await runInferenceFallbackShowCmd(inferenceOpts);
       return;
     }
+    if (subcmd === "keys") {
+      const keysAction = rest[0];
+      if (keysAction === "create") {
+        process.exitCode = await runInferenceKeysCreateCmd(inferenceOpts);
+        return;
+      }
+      if (keysAction === "list") {
+        process.exitCode = await runInferenceKeysListCmd(inferenceOpts);
+        return;
+      }
+      if (keysAction === "revoke") {
+        process.exitCode = await runInferenceKeysRevokeCmd(inferenceOpts);
+        return;
+      }
+      console.error(
+        "Usage: clawql inference keys create --team <name> | list | revoke --id <vk_...>"
+      );
+      process.exitCode = 1;
+      return;
+    }
     console.error(
-      "Usage: clawql inference serve | complete | logs | trace | spend | export | finetune | escalation | pipeline | cache | fallback"
+      "Usage: clawql inference serve | complete | logs | trace | spend | export | finetune | escalation | pipeline | cache | fallback | keys"
     );
     process.exitCode = 1;
     return;

--- a/src/onboarding/cli.ts
+++ b/src/onboarding/cli.ts
@@ -295,7 +295,7 @@ inference (gateway MVP):
   Store: CLAWQL_INFERENCE_STORE=memory|jsonl|off (default jsonl when CLAWQL_HOME set)
   Cache: CLAWQL_INFERENCE_SEMANTIC_CACHE=1, CLAWQL_INFERENCE_CACHE_THRESHOLD=0.92
   Fallback: CLAWQL_INFERENCE_FALLBACK_ENABLED=1, CLAWQL_INFERENCE_FALLBACK_FRUGAL=a,b
-  Keys: CLAWQL_INFERENCE_KEYS_ENABLED=1 (or any active key in virtual-keys.json)
+  Keys: per-team virtual API keys (see clawql-inference README)
   Env: OPENAI_API_KEY, ANTHROPIC_API_KEY, OLLAMA_BASE_URL, CLAWQL_INFERENCE_PORT
 
 Docs: https://docs.clawql.com/agent-setup

--- a/src/onboarding/inference-cli.ts
+++ b/src/onboarding/inference-cli.ts
@@ -5,6 +5,9 @@
 import {
   runInferenceFallbackShow,
   runInferenceCacheStatus,
+  runInferenceKeysCreate,
+  runInferenceKeysList,
+  runInferenceKeysRevoke,
   runInferenceComplete,
   runInferenceEscalationSetTier,
   runInferenceEscalationShow,
@@ -34,7 +37,7 @@ export type InferenceCliOptions = {
   correlationId?: string;
   since?: string;
   limit?: number;
-  groupBy?: "model" | "provider" | "tier";
+  groupBy?: "model" | "provider" | "tier" | "team";
   json?: boolean;
   output?: string;
   format?: ExportFormat;
@@ -60,6 +63,10 @@ export type InferenceCliOptions = {
   targetTier?: ModelTier;
   evaluateBeforePromote?: boolean;
   outputDir?: string;
+  team?: string;
+  budgetUsd?: number;
+  rateLimit?: string;
+  keyId?: string;
 };
 
 export async function runInferenceServeCmd(opts: InferenceCliOptions): Promise<number> {
@@ -210,4 +217,21 @@ export async function runInferenceCacheStatusCmd(opts: InferenceCliOptions): Pro
 
 export async function runInferenceFallbackShowCmd(opts: InferenceCliOptions): Promise<number> {
   return runInferenceFallbackShow({ json: opts.json });
+}
+
+export async function runInferenceKeysCreateCmd(opts: InferenceCliOptions): Promise<number> {
+  return runInferenceKeysCreate({
+    team: opts.team,
+    budgetUsd: opts.budgetUsd,
+    rateLimit: opts.rateLimit,
+    json: opts.json,
+  });
+}
+
+export async function runInferenceKeysListCmd(opts: InferenceCliOptions): Promise<number> {
+  return runInferenceKeysList({ json: opts.json });
+}
+
+export async function runInferenceKeysRevokeCmd(opts: InferenceCliOptions): Promise<number> {
+  return runInferenceKeysRevoke({ id: opts.keyId, json: opts.json });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **virtual keys** for the inference gateway — per-team API keys with optional USD budgets and rate limits.

Epic [#556](https://github.com/danielsmithdevelopment/ClawQL/issues/556) priority **#4**.

## Changes

- **`keys/` module** — create/list/revoke virtual keys persisted at `$CLAWQL_HOME/Inference/virtual-keys.json`
- **HTTP auth middleware** on `/v1/*` when `CLAWQL_INFERENCE_KEYS_ENABLED=1` or active keys exist
- Clients authenticate via `Authorization: Bearer` or `x-api-key` (OpenAI-compatible)
- Budget enforcement (rough USD estimate from token usage) and in-memory rate limits (`100rpm`, `10rps`)
- `team` + `virtualKeyId` on inference records; `clawql inference spend --group-by team`
- **`clawql inference keys create | list | revoke`** CLI

## Configuration

```bash
CLAWQL_INFERENCE_KEYS_ENABLED=1
clawql inference keys create --team eng --budget-usd 500 --rate-limit 100rpm
```

## Test plan

- [x] `npm test` in `packages/clawql-inference` (56 tests)
- [x] `npm run format:check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

