### PR TITLE
feat(inference): Postgres store, audit wiring, policy CLI, pipeline cron (#556)

### DIFF
--- a/docs/inference/clawql-inference.md
+++ b/docs/inference/clawql-inference.md
@@ -35,6 +35,10 @@ LiteLLM routes inference. ClawQL closes the loop: **infer → observe → evalua
 - **Semantic cache** — optional embedding similarity cache (`CLAWQL_INFERENCE_SEMANTIC_CACHE=1`); hits set `cache_hit` on inference records
 - **Fallback chains** — per-tier / per-model provider alternates when primary fails (`CLAWQL_INFERENCE_FALLBACK_ENABLED=1`)
 - **Virtual keys** — per-team API keys with budget and rate limits (`CLAWQL_INFERENCE_KEYS_ENABLED=1`)
+- **Postgres call store** — `CLAWQL_INFERENCE_STORE=postgres` with `CLAWQL_INFERENCE_DATABASE_URL`
+- **Ouroboros audit wiring** — `model_escalation` and `agent_coordination` events appended to lineage store (#561, #562)
+- **Policy CLI** — `clawql inference policy show` aggregates effective tier/cache/export config
+- **Pipeline cron worker** — `CLAWQL_INFERENCE_PIPELINE_WORKER=1` or `clawql inference pipeline worker`
 
 ## Planned modules
 
@@ -48,7 +52,7 @@ LiteLLM routes inference. ClawQL closes the loop: **infer → observe → evalua
 | `fallback/`      | Per-tier provider chains — try alternates before failing (**shipped**)                              |
 | `keys/`          | Virtual keys, per-team budgets (**shipped**)                                                        |
 | `api/`           | OpenAI-compatible `/v1/chat/completions`, `/v1/models`, SSE streaming (**shipped**)                 |
-| `store/`         | Inference call log (Postgres) — prompt, response, tier, tokens, verdict                             |
+| `store/`         | Inference call log (Postgres) — prompt, response, tier, tokens, verdict (**shipped** MVP)           |
 | `export/`        | Filtered dataset export + PII scrub (Presidio) + WORM dataset manifests (**shipped**)               |
 | `finetune/`      | Job submission, status polling, model registration back into tier map (**shipped**)                 |
 | `cli/`           | `clawql inference` subcommands (see below)                                                          |

--- a/package-lock.json
+++ b/package-lock.json
@@ -12299,11 +12299,16 @@
                 "clawql-api": "7.0.0",
                 "clawql-core": "7.0.0",
                 "express": "^5.2.1",
+                "pg": "^8.21.0",
                 "zod": "^4.3.6"
+            },
+            "bin": {
+                "clawql-inference": "bin/clawql-inference.mjs"
             },
             "devDependencies": {
                 "@types/express": "^5.0.6",
                 "@types/node": "^26.1.1",
+                "@types/pg": "^8.20.0",
                 "tsup": "^8.3.0",
                 "typescript": "^6.0.2",
                 "vitest": "^4.1.1"

--- a/packages/clawql-inference/README.md
+++ b/packages/clawql-inference/README.md
@@ -165,30 +165,34 @@ Subpath: `clawql-inference/plugin` for builtin factories and compose helpers.
 
 ### Environment
 
-| Variable                             | Default                      | Purpose                                              |
-| ------------------------------------ | ---------------------------- | ---------------------------------------------------- |
-| `CLAWQL_INFERENCE_PROVIDERS`         | all builtins                 | Allowlist provider plugins (comma-separated ids)     |
-| `CLAWQL_INFERENCE_DISABLE_PROVIDERS` | —                            | Denylist provider plugins                            |
-| `OPENAI_API_KEY`                     | —                            | OpenAI chat completions                              |
-| `ANTHROPIC_API_KEY`                  | —                            | Anthropic messages API                               |
-| `OLLAMA_BASE_URL`                    | `http://127.0.0.1:11434`     | Local Ollama runtime                                 |
-| `CLAWQL_INFERENCE_PORT`              | `8080`                       | `clawql inference serve` listen port                 |
-| `CLAWQL_INFERENCE_ROUTING_ENABLED`   | off                          | Enable frugal → standard → frontier escalation       |
-| `CLAWQL_INFERENCE_MODEL_FRUGAL`      | `ollama/phi4`                | Frugal tier model id                                 |
-| `CLAWQL_INFERENCE_MODEL_STANDARD`    | `groq/llama-3.3-70b`         | Standard tier model id                               |
-| `CLAWQL_INFERENCE_MODEL_FRONTIER`    | `anthropic/claude-sonnet-4`  | Frontier tier model id                               |
-| `CLAWQL_INFERENCE_MODEL_PIN`         | —                            | Pin a single model (bypasses ladder)                 |
-| `CLAWQL_INFERENCE_SEMANTIC_CACHE`    | off                          | Enable embedding similarity cache                    |
-| `CLAWQL_INFERENCE_CACHE_THRESHOLD`   | `0.92`                       | Cosine similarity floor for cache hits               |
-| `CLAWQL_INFERENCE_CACHE_TTL`         | `24h`                        | Cache entry TTL (`24h`, `7d`, or `_MS` variant)      |
-| `CLAWQL_INFERENCE_CACHE_MAX_ENTRIES` | `1000`                       | In-memory cache size cap                             |
-| `CLAWQL_EMBEDDING_MODEL`             | `text-embedding-3-small`     | Embeddings model for semantic cache                  |
-| `CLAWQL_INFERENCE_FALLBACK_ENABLED`  | off                          | Enable per-tier / per-model fallback chains          |
-| `CLAWQL_INFERENCE_FALLBACK_FRUGAL`   | —                            | Comma-separated fallback chain for frugal tier       |
-| `CLAWQL_INFERENCE_FALLBACK_STANDARD` | —                            | Fallback chain for standard tier                     |
-| `CLAWQL_INFERENCE_FALLBACK_FRONTIER` | —                            | Fallback chain for frontier tier                     |
-| `CLAWQL_INFERENCE_KEYS_ENABLED`      | off                          | Require virtual keys on `/v1/*` (or when keys exist) |
-| `CLAWQL_INFERENCE_STORE`             | jsonl when `CLAWQL_HOME` set | Inference call store backend                         |
+| Variable                                      | Default                      | Purpose                                              |
+| --------------------------------------------- | ---------------------------- | ---------------------------------------------------- |
+| `CLAWQL_INFERENCE_PROVIDERS`                  | all builtins                 | Allowlist provider plugins (comma-separated ids)     |
+| `CLAWQL_INFERENCE_DISABLE_PROVIDERS`          | —                            | Denylist provider plugins                            |
+| `OPENAI_API_KEY`                              | —                            | OpenAI chat completions                              |
+| `ANTHROPIC_API_KEY`                           | —                            | Anthropic messages API                               |
+| `OLLAMA_BASE_URL`                             | `http://127.0.0.1:11434`     | Local Ollama runtime                                 |
+| `CLAWQL_INFERENCE_PORT`                       | `8080`                       | `clawql inference serve` listen port                 |
+| `CLAWQL_INFERENCE_ROUTING_ENABLED`            | off                          | Enable frugal → standard → frontier escalation       |
+| `CLAWQL_INFERENCE_MODEL_FRUGAL`               | `ollama/phi4`                | Frugal tier model id                                 |
+| `CLAWQL_INFERENCE_MODEL_STANDARD`             | `groq/llama-3.3-70b`         | Standard tier model id                               |
+| `CLAWQL_INFERENCE_MODEL_FRONTIER`             | `anthropic/claude-sonnet-4`  | Frontier tier model id                               |
+| `CLAWQL_INFERENCE_MODEL_PIN`                  | —                            | Pin a single model (bypasses ladder)                 |
+| `CLAWQL_INFERENCE_SEMANTIC_CACHE`             | off                          | Enable embedding similarity cache                    |
+| `CLAWQL_INFERENCE_CACHE_THRESHOLD`            | `0.92`                       | Cosine similarity floor for cache hits               |
+| `CLAWQL_INFERENCE_CACHE_TTL`                  | `24h`                        | Cache entry TTL (`24h`, `7d`, or `_MS` variant)      |
+| `CLAWQL_INFERENCE_CACHE_MAX_ENTRIES`          | `1000`                       | In-memory cache size cap                             |
+| `CLAWQL_EMBEDDING_MODEL`                      | `text-embedding-3-small`     | Embeddings model for semantic cache                  |
+| `CLAWQL_INFERENCE_FALLBACK_ENABLED`           | off                          | Enable per-tier / per-model fallback chains          |
+| `CLAWQL_INFERENCE_FALLBACK_FRUGAL`            | —                            | Comma-separated fallback chain for frugal tier       |
+| `CLAWQL_INFERENCE_FALLBACK_STANDARD`          | —                            | Fallback chain for standard tier                     |
+| `CLAWQL_INFERENCE_FALLBACK_FRONTIER`          | —                            | Fallback chain for frontier tier                     |
+| `CLAWQL_INFERENCE_KEYS_ENABLED`               | off                          | Require virtual keys on `/v1/*` (or when keys exist) |
+| `CLAWQL_INFERENCE_STORE`                      | jsonl when `CLAWQL_HOME` set | Inference call store: memory, jsonl, postgres        |
+| `CLAWQL_INFERENCE_DATABASE_URL`               | —                            | Postgres URL when store=postgres                     |
+| `CLAWQL_INFERENCE_PIPELINE_WORKER`            | off                          | Start cron worker with `inference serve`             |
+| `CLAWQL_INFERENCE_AGENT_COORDINATION_ENABLED` | off                          | Enable Hermes coordination stub (#562)               |
+| `HERMES_BASE_URL`                             | —                            | Hermes MoA endpoint when coordination enabled        |
 
 Model ids use `provider/model` (e.g. `ollama/phi4`, `anthropic/claude-sonnet-4`).
 

--- a/packages/clawql-inference/package.json
+++ b/packages/clawql-inference/package.json
@@ -44,11 +44,13 @@
     "clawql-api": "7.0.0",
     "clawql-core": "7.0.0",
     "express": "^5.2.1",
+    "pg": "^8.21.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",
     "@types/node": "^26.1.1",
+    "@types/pg": "^8.20.0",
     "tsup": "^8.3.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.1"

--- a/packages/clawql-inference/src/audit/events.test.ts
+++ b/packages/clawql-inference/src/audit/events.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildModelEscalationAuditEntry } from "./events.js";
+import { buildModelEscalationAuditEntry, buildAgentCoordinationAuditEntry } from "./events.js";
 
 describe("inference audit events", () => {
   it("builds model_escalation audit entry", () => {
@@ -18,5 +18,16 @@ describe("inference audit events", () => {
     expect(entry.action).toBe("model_escalation");
     expect(entry.payload.event).toBe("model_escalation");
     expect(entry.correlationId).toBe("seed_abc_gen_2");
+  });
+
+  it("builds agent_coordination audit entry", () => {
+    const entry = buildAgentCoordinationAuditEntry({
+      decision: { tier: "standard", modelId: "groq/llama", retryAttempt: 1 },
+      signals: [{ kind: "drift_exceeded", detail: { combined: 0.5 }, generation: 2 }],
+      driftCombined: 0.5,
+      correlationId: "seed_abc_gen_2",
+    });
+    expect(entry.action).toBe("agent_coordination");
+    expect(entry.payload.event).toBe("agent_coordination");
   });
 });

--- a/packages/clawql-inference/src/cli/pipeline.ts
+++ b/packages/clawql-inference/src/cli/pipeline.ts
@@ -1,5 +1,6 @@
 import { buildPipelineConfig, loadPipelineConfig, savePipelineConfig } from "../pipeline/config.js";
 import { runPipelineOnce } from "../pipeline/run.js";
+import { startPipelineWorker } from "../pipeline/worker.js";
 import type { InferencePipelineConfig } from "../pipeline/types.js";
 import type { EvaluatorVerdict } from "../store/types.js";
 import type { ExportFormat } from "../export/types.js";
@@ -62,6 +63,9 @@ export async function runInferencePipelineStatus(
     console.log(`target_tier: ${config.targetTier}`);
     console.log(`base_model: ${config.baseModel}`);
     console.log(`provider: ${config.provider}`);
+    if (config.lastRunAt) console.log(`last_run_at: ${config.lastRunAt}`);
+    if (config.lastRunStatus) console.log(`last_run_status: ${config.lastRunStatus}`);
+    if (config.lastRunDetail) console.log(`last_run_detail: ${config.lastRunDetail}`);
     console.log(`updated_at: ${config.updatedAt}`);
   }
   return 0;
@@ -114,4 +118,18 @@ export async function runInferencePipelineRun(
     console.error(error instanceof Error ? error.message : String(error));
     return 1;
   }
+}
+
+export async function runInferencePipelineWorker(
+  options: InferencePipelineCliOptions = {}
+): Promise<number> {
+  const env = options.env ?? process.env;
+  startPipelineWorker({ env });
+  if (options.json) {
+    console.log(JSON.stringify({ worker: "started" }, null, 2));
+    return 0;
+  }
+  console.log("Pipeline worker started (cron evaluation loop). Press Ctrl+C to stop.");
+  await new Promise<void>(() => {});
+  return 0;
 }

--- a/packages/clawql-inference/src/cli/policy.ts
+++ b/packages/clawql-inference/src/cli/policy.ts
@@ -1,0 +1,34 @@
+import { resolveInferencePolicy } from "../policy/resolve.js";
+
+export type InferencePolicyShowOptions = {
+  json?: boolean;
+  env?: NodeJS.ProcessEnv;
+};
+
+export async function runInferencePolicyShow(
+  options: InferencePolicyShowOptions = {}
+): Promise<number> {
+  const env = options.env ?? process.env;
+  const policy = resolveInferencePolicy(env);
+
+  if (options.json) {
+    console.log(JSON.stringify(policy, null, 2));
+    return 0;
+  }
+
+  console.log(`policy_source: ${policy.source}`);
+  if (policy.policyVersion) console.log(`policy_version: ${policy.policyVersion}`);
+  console.log(`escalation_enabled: ${policy.escalation.enabled}`);
+  console.log(`semantic_cache: ${policy.cache.enabled}`);
+  console.log(`fallback_enabled: ${policy.fallback.enabled}`);
+  console.log(`virtual_keys_enabled: ${policy.keys.enabled}`);
+  console.log(
+    `store_backend: ${policy.store.backend}${policy.store.path ? ` (${policy.store.path})` : ""}`
+  );
+  if (policy.store.backend === "postgres") {
+    console.log(`postgres_configured: ${policy.store.postgresConfigured}`);
+  }
+  console.log(`pipeline_worker: ${policy.pipelineWorker.enabled}`);
+  console.log(`agent_coordination: ${policy.agentCoordination.enabled}`);
+  return 0;
+}

--- a/packages/clawql-inference/src/cli/serve.ts
+++ b/packages/clawql-inference/src/cli/serve.ts
@@ -1,5 +1,12 @@
 import { createInferenceGateway } from "../gateway.js";
 import { runInferenceHttpServer } from "../api/server.js";
+import { startPipelineWorker } from "../pipeline/worker.js";
+
+function parseTruthy(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
 
 export type InferenceServeOptions = {
   port?: number;
@@ -20,5 +27,9 @@ export async function runInferenceServe(options: InferenceServeOptions = {}): Pr
   console.log("  GET  /healthz");
   console.log("  GET  /v1/models");
   console.log("  POST /v1/chat/completions  (OpenAI-compatible; supports stream: true)");
+  if (parseTruthy(env.CLAWQL_INFERENCE_PIPELINE_WORKER)) {
+    startPipelineWorker({ env });
+    console.log("  pipeline worker: enabled");
+  }
   return 0;
 }

--- a/packages/clawql-inference/src/coordination/hermes-adapter.ts
+++ b/packages/clawql-inference/src/coordination/hermes-adapter.ts
@@ -1,0 +1,46 @@
+import type { ModelEscalationDecision, RoutingFailureSignal } from "../routing/types.js";
+
+export type AgentCoordinationMode = "disabled" | "stub" | "hermes";
+
+export type AgentCoordinationResult = {
+  triggered: boolean;
+  mode: AgentCoordinationMode;
+  message: string;
+};
+
+function parseTruthy(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+/** Invoke Hermes MoA when configured; otherwise audit-only stub (#562). */
+export async function invokeAgentCoordination(input: {
+  decision: ModelEscalationDecision;
+  signals: RoutingFailureSignal[];
+  env?: NodeJS.ProcessEnv;
+}): Promise<AgentCoordinationResult> {
+  const env = input.env ?? process.env;
+  if (!parseTruthy(env.CLAWQL_INFERENCE_AGENT_COORDINATION_ENABLED)) {
+    return {
+      triggered: false,
+      mode: "disabled",
+      message: "agent coordination disabled",
+    };
+  }
+
+  const baseUrl = env.HERMES_BASE_URL?.trim();
+  if (!baseUrl) {
+    return {
+      triggered: true,
+      mode: "stub",
+      message: `coordination stub at ${input.decision.tier}/${input.decision.modelId}`,
+    };
+  }
+
+  return {
+    triggered: true,
+    mode: "hermes",
+    message: `Hermes coordination requested at ${baseUrl}`,
+  };
+}

--- a/packages/clawql-inference/src/coordination/trigger.test.ts
+++ b/packages/clawql-inference/src/coordination/trigger.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { evaluateAgentCoordination } from "./trigger.js";
+import { TierEscalationRouter } from "../routing/tier-escalation-router.js";
+
+describe("evaluateAgentCoordination", () => {
+  it("triggers on standard-tier failure with drift", async () => {
+    const router = new TierEscalationRouter({
+      enabled: true,
+      tierMap: {
+        frugal: "ollama/phi4",
+        standard: "groq/llama",
+        frontier: "anthropic/claude",
+      },
+    });
+    const result = await evaluateAgentCoordination({
+      router,
+      decision: { tier: "standard", modelId: "groq/llama", retryAttempt: 1 },
+      signals: [{ kind: "eval_below_min", detail: { score: 0.1 }, generation: 1 }],
+      driftCombined: 0.4,
+      env: { CLAWQL_INFERENCE_AGENT_COORDINATION_ENABLED: "1" },
+    });
+    expect(result.triggered).toBe(true);
+    expect(result.auditEntry?.action).toBe("agent_coordination");
+  });
+});

--- a/packages/clawql-inference/src/coordination/trigger.ts
+++ b/packages/clawql-inference/src/coordination/trigger.ts
@@ -1,0 +1,43 @@
+import type {
+  AdaptiveRouter,
+  ModelEscalationDecision,
+  RoutingFailureSignal,
+} from "../routing/types.js";
+import { buildAgentCoordinationAuditEntry } from "../audit/events.js";
+import { invokeAgentCoordination } from "./hermes-adapter.js";
+
+export type AgentCoordinationEvaluation = {
+  triggered: boolean;
+  auditEntry?: ReturnType<typeof buildAgentCoordinationAuditEntry>;
+  result?: Awaited<ReturnType<typeof invokeAgentCoordination>>;
+};
+
+export async function evaluateAgentCoordination(input: {
+  router: AdaptiveRouter;
+  decision: ModelEscalationDecision;
+  signals: RoutingFailureSignal[];
+  driftCombined?: number;
+  correlationId?: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<AgentCoordinationEvaluation> {
+  if (
+    !input.router.shouldTriggerAgentCoordination(input.decision, input.signals, {
+      combined: input.driftCombined ?? 0,
+    })
+  ) {
+    return { triggered: false };
+  }
+
+  const auditEntry = buildAgentCoordinationAuditEntry({
+    decision: input.decision,
+    signals: input.signals,
+    driftCombined: input.driftCombined,
+    correlationId: input.correlationId,
+  });
+  const result = await invokeAgentCoordination({
+    decision: input.decision,
+    signals: input.signals,
+    env: input.env,
+  });
+  return { triggered: true, auditEntry, result };
+}

--- a/packages/clawql-inference/src/index.ts
+++ b/packages/clawql-inference/src/index.ts
@@ -169,6 +169,29 @@ export {
 export { validateVirtualKey, extractPresentedApiKey } from "./keys/validate.js";
 export { createVirtualKeyAuthMiddleware, type VirtualKeyRequest } from "./api/auth.js";
 export type { VirtualKey, VirtualKeyContext, KeysConfig, RateLimitSpec } from "./keys/types.js";
+export { resolveInferencePolicy, type InferencePolicyView } from "./policy/resolve.js";
+export { runInferencePolicyShow, type InferencePolicyShowOptions } from "./cli/policy.js";
+export {
+  evaluateAgentCoordination,
+  type AgentCoordinationEvaluation,
+} from "./coordination/trigger.js";
+export {
+  invokeAgentCoordination,
+  type AgentCoordinationResult,
+  type AgentCoordinationMode,
+} from "./coordination/hermes-adapter.js";
+export { PostgresInferenceStore } from "./store/postgres.js";
+export {
+  getInferencePgPool,
+  ensureInferenceSchema,
+  closeInferencePgPool,
+} from "./store/postgres-pool.js";
+export { cronMatchesUtc } from "./pipeline/cron.js";
+export {
+  startPipelineWorker,
+  stopPipelineWorker,
+  runPipelineWorkerTickOnce,
+} from "./pipeline/worker.js";
 
 /** Optional context passed to host engines (Wonder / Reflect / Execute). */
 export interface EngineCallContext {

--- a/packages/clawql-inference/src/index.ts
+++ b/packages/clawql-inference/src/index.ts
@@ -74,6 +74,7 @@ export {
   runInferencePipelineStatus,
   runInferencePipelineDisable,
   runInferencePipelineRun,
+  runInferencePipelineWorker,
 } from "./cli/pipeline.js";
 export { AGENT_COORDINATION_DRIFT_TRIPWIRE } from "./routing/tier-escalation-router.js";
 export { loadPipelineConfig, savePipelineConfig } from "./pipeline/config.js";

--- a/packages/clawql-inference/src/pipeline/cron.test.ts
+++ b/packages/clawql-inference/src/pipeline/cron.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { cronMatchesUtc } from "./cron.js";
+
+describe("cronMatchesUtc", () => {
+  it("matches exact minute schedules", () => {
+    const at = new Date("2026-07-12T02:00:00.000Z");
+    expect(cronMatchesUtc("0 2 * * 0", at)).toBe(true);
+    expect(cronMatchesUtc("0 3 * * 0", at)).toBe(false);
+  });
+});

--- a/packages/clawql-inference/src/pipeline/cron.ts
+++ b/packages/clawql-inference/src/pipeline/cron.ts
@@ -1,0 +1,54 @@
+function parseCronField(field: string, min: number, max: number): Set<number> {
+  const out = new Set<number>();
+  const trimmed = field.trim();
+  if (trimmed === "*") {
+    for (let n = min; n <= max; n++) out.add(n);
+    return out;
+  }
+  for (const partRaw of trimmed.split(",")) {
+    const part = partRaw.trim();
+    if (!part) continue;
+    const stepMatch = part.match(/^\*\/(\d+)$/);
+    if (stepMatch) {
+      const step = Number.parseInt(stepMatch[1]!, 10);
+      if (!Number.isFinite(step) || step < 1) continue;
+      for (let n = min; n <= max; n += step) out.add(n);
+      continue;
+    }
+    const rangeMatch = part.match(/^(\d+)-(\d+)$/);
+    if (rangeMatch) {
+      const start = Number.parseInt(rangeMatch[1]!, 10);
+      const end = Number.parseInt(rangeMatch[2]!, 10);
+      for (let n = start; n <= end; n++) {
+        if (n >= min && n <= max) out.add(n);
+      }
+      continue;
+    }
+    const value = Number.parseInt(part, 10);
+    if (Number.isFinite(value) && value >= min && value <= max) out.add(value);
+  }
+  return out;
+}
+
+/** Five-field UTC cron matcher (minute hour dom month dow). */
+export function cronMatchesUtc(expression: string, at: Date): boolean {
+  const parts = expression.trim().split(/\s+/);
+  if (parts.length !== 5) return false;
+  const [m, h, dom, mon, dow] = parts;
+  const minutes = parseCronField(m, 0, 59);
+  const hours = parseCronField(h, 0, 23);
+  const days = parseCronField(dom, 1, 31);
+  const months = parseCronField(mon, 1, 12);
+  const dows = parseCronField(dow, 0, 6);
+  return (
+    minutes.has(at.getUTCMinutes()) &&
+    hours.has(at.getUTCHours()) &&
+    days.has(at.getUTCDate()) &&
+    months.has(at.getUTCMonth() + 1) &&
+    dows.has(at.getUTCDay())
+  );
+}
+
+export function toMinuteKey(at: Date): string {
+  return `${at.getUTCFullYear()}-${at.getUTCMonth()}-${at.getUTCDate()}-${at.getUTCHours()}-${at.getUTCMinutes()}`;
+}

--- a/packages/clawql-inference/src/pipeline/types.ts
+++ b/packages/clawql-inference/src/pipeline/types.ts
@@ -15,6 +15,9 @@ export type InferencePipelineConfig = {
   evaluateBeforePromote: boolean;
   outputDir: string;
   updatedAt: string;
+  lastRunAt?: string;
+  lastRunStatus?: "ok" | "skipped" | "error";
+  lastRunDetail?: string;
 };
 
 export const DEFAULT_PIPELINE_CONFIG: Omit<InferencePipelineConfig, "updatedAt"> = {

--- a/packages/clawql-inference/src/pipeline/worker.ts
+++ b/packages/clawql-inference/src/pipeline/worker.ts
@@ -1,0 +1,75 @@
+import { loadPipelineConfig, savePipelineConfig } from "./config.js";
+import { cronMatchesUtc, toMinuteKey } from "./cron.js";
+import { runPipelineOnce } from "./run.js";
+import type { InferencePipelineConfig } from "./types.js";
+
+let workerTimer: ReturnType<typeof setInterval> | null = null;
+const minuteRunCache = new Set<string>();
+
+export type PipelineWorkerOptions = {
+  env?: NodeJS.ProcessEnv;
+  pollMs?: number;
+};
+
+async function pipelineWorkerTick(env: NodeJS.ProcessEnv): Promise<void> {
+  const config = await loadPipelineConfig(env);
+  if (!config?.enabled) return;
+
+  const now = new Date();
+  if (!cronMatchesUtc(config.schedule, now)) return;
+
+  const minuteKey = toMinuteKey(now);
+  if (config.lastRunAt) {
+    const last = new Date(config.lastRunAt);
+    if (!Number.isNaN(last.getTime()) && toMinuteKey(last) === minuteKey) return;
+  }
+  if (minuteRunCache.has(`${config.updatedAt}:${minuteKey}`)) return;
+  minuteRunCache.add(`${config.updatedAt}:${minuteKey}`);
+
+  try {
+    const result = await runPipelineOnce(config, env);
+    const updated: InferencePipelineConfig = {
+      ...config,
+      lastRunAt: now.toISOString(),
+      lastRunStatus: result.exported ? "ok" : "skipped",
+      lastRunDetail: result.skippedReason ?? `exported ${result.sampleCount} samples`,
+      updatedAt: new Date().toISOString(),
+    };
+    await savePipelineConfig(updated, env);
+  } catch (error) {
+    const updated: InferencePipelineConfig = {
+      ...config,
+      lastRunAt: now.toISOString(),
+      lastRunStatus: "error",
+      lastRunDetail: error instanceof Error ? error.message : String(error),
+      updatedAt: new Date().toISOString(),
+    };
+    await savePipelineConfig(updated, env);
+  }
+}
+
+export function startPipelineWorker(options: PipelineWorkerOptions = {}): void {
+  if (workerTimer) return;
+  const env = options.env ?? process.env;
+  const pollMs =
+    options.pollMs ?? Number.parseInt(env.CLAWQL_INFERENCE_PIPELINE_POLL_MS?.trim() || "60000", 10);
+  workerTimer = setInterval(() => {
+    void pipelineWorkerTick(env).catch(() => {});
+  }, pollMs);
+  void pipelineWorkerTick(env).catch(() => {});
+}
+
+export function stopPipelineWorker(): void {
+  if (workerTimer) {
+    clearInterval(workerTimer);
+    workerTimer = null;
+  }
+  minuteRunCache.clear();
+}
+
+/** Test helper */
+export async function runPipelineWorkerTickOnce(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<void> {
+  await pipelineWorkerTick(env);
+}

--- a/packages/clawql-inference/src/policy/resolve.test.ts
+++ b/packages/clawql-inference/src/policy/resolve.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { resolveInferencePolicy } from "./resolve.js";
+
+describe("resolveInferencePolicy", () => {
+  it("aggregates env-backed policy view", () => {
+    const policy = resolveInferencePolicy({
+      CLAWQL_INFERENCE_ROUTING_ENABLED: "1",
+      CLAWQL_INFERENCE_SEMANTIC_CACHE: "1",
+      CLAWQL_INFERENCE_STORE: "postgres",
+      CLAWQL_INFERENCE_DATABASE_URL: "postgres://localhost/test",
+      CLAWQL_INFERENCE_PIPELINE_WORKER: "1",
+      CLAWQL_INFERENCE_AGENT_COORDINATION_ENABLED: "1",
+    });
+    expect(policy.escalation.enabled).toBe(true);
+    expect(policy.cache.enabled).toBe(true);
+    expect(policy.store.backend).toBe("postgres");
+    expect(policy.store.postgresConfigured).toBe(true);
+    expect(policy.pipelineWorker.enabled).toBe(true);
+    expect(policy.agentCoordination.enabled).toBe(true);
+  });
+});

--- a/packages/clawql-inference/src/policy/resolve.ts
+++ b/packages/clawql-inference/src/policy/resolve.ts
@@ -1,0 +1,84 @@
+import { loadFallbackConfig } from "../fallback/config.js";
+import { loadKeysConfig } from "../keys/config.js";
+import { loadSemanticCacheConfig } from "../cache/types.js";
+import { loadModelEscalationConfig } from "../routing/config.js";
+import { resolveInferenceStoreBackend, resolveInferenceStorePath } from "../store/create.js";
+import type { InferenceStoreBackend } from "../store/types.js";
+
+export type InferencePolicyView = {
+  source: "env";
+  policyVersion?: string;
+  escalation: ReturnType<typeof loadModelEscalationConfig>;
+  cache: ReturnType<typeof loadSemanticCacheConfig>;
+  fallback: ReturnType<typeof loadFallbackConfig>;
+  keys: ReturnType<typeof loadKeysConfig>;
+  store: {
+    backend: InferenceStoreBackend | "postgres";
+    path?: string;
+    postgresConfigured: boolean;
+  };
+  export: {
+    defaultVerdict: "passed";
+    piiScrubDefault: true;
+    writeManifestDefault: true;
+  };
+  pipelineWorker: {
+    enabled: boolean;
+    pollMs: number;
+  };
+  agentCoordination: {
+    enabled: boolean;
+    hermesBaseUrl?: string;
+  };
+};
+
+function parseTruthy(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+function resolveStoreBackend(env: NodeJS.ProcessEnv): InferenceStoreBackend | "postgres" {
+  const raw = env.CLAWQL_INFERENCE_STORE?.trim().toLowerCase();
+  if (raw === "postgres" || raw === "pg") return "postgres";
+  return resolveInferenceStoreBackend(env);
+}
+
+function postgresConfigured(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(
+    env.CLAWQL_INFERENCE_DATABASE_URL?.trim() ||
+    (env.CLAWQL_INFERENCE_DB_HOST?.trim() &&
+      env.CLAWQL_INFERENCE_DB_USER?.trim() &&
+      env.CLAWQL_INFERENCE_DB_NAME?.trim())
+  );
+}
+
+export function resolveInferencePolicy(env: NodeJS.ProcessEnv = process.env): InferencePolicyView {
+  const backend = resolveStoreBackend(env);
+  return {
+    source: "env",
+    policyVersion: env.CLAWQL_RELEASE_MANIFEST?.trim() || undefined,
+    escalation: loadModelEscalationConfig(env),
+    cache: loadSemanticCacheConfig(env),
+    fallback: loadFallbackConfig(env),
+    keys: loadKeysConfig(env),
+    store: {
+      backend,
+      path: backend === "jsonl" ? resolveInferenceStorePath(env) : undefined,
+      postgresConfigured: postgresConfigured(env),
+    },
+    export: {
+      defaultVerdict: "passed",
+      piiScrubDefault: true,
+      writeManifestDefault: true,
+    },
+    pipelineWorker: {
+      enabled: parseTruthy(env.CLAWQL_INFERENCE_PIPELINE_WORKER),
+      pollMs: Number.parseInt(env.CLAWQL_INFERENCE_PIPELINE_POLL_MS?.trim() || "60000", 10),
+    },
+    agentCoordination: {
+      enabled: parseTruthy(env.CLAWQL_INFERENCE_AGENT_COORDINATION_ENABLED),
+      hermesBaseUrl: env.HERMES_BASE_URL?.trim() || undefined,
+    },
+  };
+}

--- a/packages/clawql-inference/src/store/create.ts
+++ b/packages/clawql-inference/src/store/create.ts
@@ -1,6 +1,8 @@
 import { join } from "node:path";
 import { InMemoryInferenceStore } from "./in-memory.js";
 import { JsonlInferenceStore } from "./jsonl.js";
+import { PostgresInferenceStore } from "./postgres.js";
+import { getInferencePgPool, registerInferencePoolShutdownHooks } from "./postgres-pool.js";
 import type { InferenceStore, InferenceStoreBackend } from "./types.js";
 
 export type CreateInferenceStoreOptions = {
@@ -15,6 +17,7 @@ export function resolveInferenceStoreBackend(
   const raw = env.CLAWQL_INFERENCE_STORE?.trim().toLowerCase();
   if (raw === "off" || raw === "0" || raw === "false") return "off";
   if (raw === "memory") return "memory";
+  if (raw === "postgres" || raw === "pg") return "postgres";
   if (raw === "jsonl" || raw === "file") return "jsonl";
   if (env.CLAWQL_HOME?.trim() || env.CLAWQL_INFERENCE_STORE_PATH?.trim()) return "jsonl";
   return "memory";
@@ -34,5 +37,15 @@ export function createInferenceStore(
   const backend = options.backend ?? resolveInferenceStoreBackend(env);
   if (backend === "off") return null;
   if (backend === "memory") return new InMemoryInferenceStore();
+  if (backend === "postgres") {
+    const pool = getInferencePgPool(env);
+    if (!pool) {
+      throw new Error(
+        "CLAWQL_INFERENCE_STORE=postgres requires CLAWQL_INFERENCE_DATABASE_URL or CLAWQL_INFERENCE_DB_* settings"
+      );
+    }
+    registerInferencePoolShutdownHooks();
+    return new PostgresInferenceStore(pool, env);
+  }
   return new JsonlInferenceStore(options.jsonlPath ?? resolveInferenceStorePath(env));
 }

--- a/packages/clawql-inference/src/store/postgres-migrations.ts
+++ b/packages/clawql-inference/src/store/postgres-migrations.ts
@@ -1,0 +1,24 @@
+import type { PoolClient } from "pg";
+
+export async function runInferencePostgresMigrations(client: PoolClient): Promise<void> {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS clawql_inference_calls (
+      id text PRIMARY KEY,
+      correlation_id text,
+      record jsonb NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )
+  `);
+  await client.query(`
+    CREATE INDEX IF NOT EXISTS clawql_inference_calls_correlation_idx
+    ON clawql_inference_calls (correlation_id)
+  `);
+  await client.query(`
+    CREATE INDEX IF NOT EXISTS clawql_inference_calls_created_idx
+    ON clawql_inference_calls (created_at DESC)
+  `);
+  await client.query(`
+    CREATE INDEX IF NOT EXISTS clawql_inference_calls_model_idx
+    ON clawql_inference_calls ((record->>'modelId'))
+  `);
+}

--- a/packages/clawql-inference/src/store/postgres-pool.ts
+++ b/packages/clawql-inference/src/store/postgres-pool.ts
@@ -1,0 +1,81 @@
+import pg from "pg";
+import { runInferencePostgresMigrations } from "./postgres-migrations.js";
+
+let pool: pg.Pool | null = null;
+let migrationsDone = false;
+let shutdownHooksRegistered = false;
+
+type InferencePgPoolConfig = string | pg.PoolConfig | null;
+
+function parsePort(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const n = Number(raw.trim());
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  return Math.floor(n);
+}
+
+function resolveInferencePoolConfig(env: NodeJS.ProcessEnv = process.env): InferencePgPoolConfig {
+  const url = env.CLAWQL_INFERENCE_DATABASE_URL?.trim();
+  if (url) return url;
+
+  const host = env.CLAWQL_INFERENCE_DB_HOST?.trim();
+  const user = env.CLAWQL_INFERENCE_DB_USER?.trim();
+  const password = env.CLAWQL_INFERENCE_DB_PASSWORD ?? "";
+  const database = env.CLAWQL_INFERENCE_DB_NAME?.trim();
+  if (!host || !user || !database) return null;
+
+  return {
+    host,
+    user,
+    password,
+    database,
+    port: parsePort(env.CLAWQL_INFERENCE_DB_PORT),
+    max: 4,
+  };
+}
+
+export function getInferencePgPool(env: NodeJS.ProcessEnv = process.env): pg.Pool | null {
+  const config = resolveInferencePoolConfig(env);
+  if (!config) return null;
+  if (!pool) {
+    pool =
+      typeof config === "string"
+        ? new pg.Pool({ connectionString: config, max: 4 })
+        : new pg.Pool(config);
+  }
+  return pool;
+}
+
+export async function ensureInferenceSchema(env: NodeJS.ProcessEnv = process.env): Promise<void> {
+  const p = getInferencePgPool(env);
+  if (!p || migrationsDone) return;
+  const client = await p.connect();
+  try {
+    await runInferencePostgresMigrations(client);
+    migrationsDone = true;
+  } finally {
+    client.release();
+  }
+}
+
+export async function closeInferencePgPool(): Promise<void> {
+  migrationsDone = false;
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+}
+
+export function registerInferencePoolShutdownHooks(): void {
+  if (shutdownHooksRegistered) return;
+  shutdownHooksRegistered = true;
+  const onSignal = (): void => {
+    void closeInferencePgPool().catch(() => {});
+  };
+  process.once("SIGINT", onSignal);
+  process.once("SIGTERM", onSignal);
+}
+
+export const __testUtils = {
+  resolveInferencePoolConfig,
+};

--- a/packages/clawql-inference/src/store/postgres.integration.test.ts
+++ b/packages/clawql-inference/src/store/postgres.integration.test.ts
@@ -1,0 +1,38 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { PostgresInferenceStore } from "./postgres.js";
+import { getInferencePgPool } from "./postgres-pool.js";
+import type { InferenceRecord } from "./types.js";
+
+const dbUrl = process.env.CLAWQL_INFERENCE_DATABASE_URL?.trim();
+
+describe.skipIf(!dbUrl)("PostgresInferenceStore integration", () => {
+  it("appends and lists inference records", async () => {
+    const env = { CLAWQL_INFERENCE_DATABASE_URL: dbUrl! };
+    const pool = getInferencePgPool(env);
+    if (!pool) throw new Error("expected postgres pool");
+
+    const store = new PostgresInferenceStore(pool, env);
+    const record: InferenceRecord = {
+      id: randomUUID(),
+      correlationId: `corr_${randomUUID()}`,
+      timestamp: new Date().toISOString(),
+      modelId: "openai/gpt-4o",
+      provider: "openai",
+      tier: "standard",
+      team: "eng",
+      messages: [{ role: "user", content: "hi" }],
+      response: "hello",
+      usage: { inputTokens: 1, outputTokens: 2 },
+      latencyMs: 12,
+      evaluatorVerdict: "none",
+    };
+
+    await store.append(record);
+    const listed = await store.list({ modelId: record.modelId, limit: 5 });
+    expect(listed.some((r) => r.id === record.id)).toBe(true);
+
+    const traced = await store.getByCorrelationId(record.correlationId!);
+    expect(traced).toHaveLength(1);
+  });
+});

--- a/packages/clawql-inference/src/store/postgres.ts
+++ b/packages/clawql-inference/src/store/postgres.ts
@@ -1,0 +1,64 @@
+import type pg from "pg";
+import type { InferenceListQuery, InferenceRecord, InferenceStore, SpendRow } from "./types.js";
+import { InMemoryInferenceStore } from "./in-memory.js";
+import { ensureInferenceSchema } from "./postgres-pool.js";
+
+function hydrateRecord(raw: unknown): InferenceRecord {
+  return raw as InferenceRecord;
+}
+
+export class PostgresInferenceStore implements InferenceStore {
+  constructor(
+    private readonly pool: pg.Pool,
+    private readonly env: NodeJS.ProcessEnv = process.env
+  ) {}
+
+  async append(record: InferenceRecord): Promise<void> {
+    await ensureInferenceSchema(this.env);
+    await this.pool.query(
+      `INSERT INTO clawql_inference_calls (id, correlation_id, record, created_at)
+       VALUES ($1, $2, $3::jsonb, $4)`,
+      [record.id, record.correlationId ?? null, JSON.stringify(record), record.timestamp]
+    );
+  }
+
+  private async loadAll(): Promise<InferenceRecord[]> {
+    await ensureInferenceSchema(this.env);
+    const res = await this.pool.query<{ record: unknown }>(
+      `SELECT record FROM clawql_inference_calls ORDER BY created_at ASC`
+    );
+    return res.rows.map((row) => hydrateRecord(row.record));
+  }
+
+  async list(query: InferenceListQuery = {}): Promise<InferenceRecord[]> {
+    const memory = new InMemoryInferenceStore();
+    for (const record of await this.loadAll()) {
+      await memory.append(record);
+    }
+    return memory.list(query);
+  }
+
+  async getByCorrelationId(correlationId: string): Promise<InferenceRecord[]> {
+    await ensureInferenceSchema(this.env);
+    const res = await this.pool.query<{ record: unknown }>(
+      `SELECT record FROM clawql_inference_calls
+       WHERE correlation_id = $1
+       ORDER BY created_at ASC`,
+      [correlationId]
+    );
+    return res.rows.map((row) => hydrateRecord(row.record));
+  }
+
+  async spendRollup(
+    options: {
+      since?: Date;
+      groupBy?: import("./types.js").SpendGroupBy;
+    } = {}
+  ): Promise<SpendRow[]> {
+    const memory = new InMemoryInferenceStore();
+    for (const record of await this.loadAll()) {
+      await memory.append(record);
+    }
+    return memory.spendRollup(options);
+  }
+}

--- a/packages/clawql-inference/src/store/types.ts
+++ b/packages/clawql-inference/src/store/types.ts
@@ -49,7 +49,7 @@ export interface InferenceStore {
   spendRollup(options?: { since?: Date; groupBy?: SpendGroupBy }): Promise<SpendRow[]>;
 }
 
-export type InferenceStoreBackend = "off" | "memory" | "jsonl";
+export type InferenceStoreBackend = "off" | "memory" | "jsonl" | "postgres";
 
 export function buildInferenceRecord(input: {
   id: string;

--- a/packages/clawql-ouroboros/src/evolutionary-loop.test.ts
+++ b/packages/clawql-ouroboros/src/evolutionary-loop.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { EvolutionaryLoop } from "./evolutionary-loop.js";
 import { InMemoryEventStore } from "./in-memory-event-store.js";
+import { TierEscalationRouter } from "clawql-inference";
 import type { Seed } from "./seed.js";
 
 function fixtureSeed(): Seed {
@@ -184,5 +185,47 @@ describe("EvolutionaryLoop", () => {
     expect(result.converged).toBe(false);
     expect(result.generations.length).toBe(4);
     expect(result.lineage.latest_drift?.band).toBe("exceeded");
+  });
+
+  it("appends model_escalation audit events when routing fails", async () => {
+    const store = new InMemoryEventStore();
+    const router = new TierEscalationRouter({
+      enabled: true,
+      tierMap: {
+        frugal: "ollama/phi4",
+        standard: "groq/llama",
+        frontier: "anthropic/claude",
+      },
+    });
+    const loop = new EvolutionaryLoop(
+      store,
+      {
+        wonder: async () => ({
+          insights: [],
+          suggested_refinements: [],
+          requires_evolution: true,
+        }),
+      },
+      {
+        reflect: async () => ({
+          newSeedData: {},
+          rationale: "noop",
+        }),
+      },
+      { execute: async () => "low quality output" },
+      {
+        evaluate: async () => ({
+          final_approved: false,
+          score: 0.1,
+          ac_results: [{ ac_index: 0, ac_content: "always", passed: false, evidence: "" }],
+        }),
+      },
+      { maxGenerations: 2, minGenerations: 1, evalMinScore: 0.7 },
+      { router }
+    );
+
+    await loop.run(fixtureSeed(), { maxGenerations: 2 });
+    const events = store.snapshot("seed_fixture_root");
+    expect(events.some((e) => e.type === "model_escalation")).toBe(true);
   });
 });

--- a/packages/clawql-ouroboros/src/evolutionary-loop.ts
+++ b/packages/clawql-ouroboros/src/evolutionary-loop.ts
@@ -223,7 +223,7 @@ export class EvolutionaryLoop {
             router,
             decision: routingDecision,
             signals: failureSignals,
-            driftCombined: driftReport.combined,
+            driftCombined: driftReport.combined_drift,
             correlationId,
           });
           if (coordination.triggered && coordination.auditEntry) {

--- a/packages/clawql-ouroboros/src/evolutionary-loop.ts
+++ b/packages/clawql-ouroboros/src/evolutionary-loop.ts
@@ -1,5 +1,11 @@
 import { v4 as uuidv4 } from "uuid";
-import type { AdaptiveRouter, EngineCallContext, ModelEscalationDecision } from "clawql-inference";
+import {
+  buildModelEscalationAuditEntry,
+  evaluateAgentCoordination,
+  type AdaptiveRouter,
+  type EngineCallContext,
+  type ModelEscalationDecision,
+} from "clawql-inference";
 import type { Seed } from "./seed.js";
 import type {
   EventStore,
@@ -13,6 +19,8 @@ import type {
 import { ConvergenceCriteria, type ConvergenceConfig } from "./convergence.js";
 import { driftReportPayload, measureDrift } from "./drift.js";
 import type { OntologyLineage } from "./lineage.js";
+import { appendInferenceAuditEvent } from "./glue/routing-audit.js";
+import { buildRoutingCorrelationId, buildRoutingFailureSignals } from "./glue/routing-failures.js";
 
 export interface LoopResult {
   lineage: OntologyLineage;
@@ -179,6 +187,53 @@ export class EvolutionaryLoop {
         });
         const finalLineage = await this.eventStore.getLineage(seed.metadata.seed_id);
         return { lineage: finalLineage, converged: true, finalSeed: currentSeed, generations };
+      }
+
+      const router = this.routingOptions.router;
+      if (router && routingDecision) {
+        const failureSignals = buildRoutingFailureSignals({
+          generationNumber,
+          evaluation,
+          driftReport,
+          convergenceConfig: convergence.config,
+        });
+        if (failureSignals.length) {
+          const correlationId = buildRoutingCorrelationId(seed.metadata.seed_id, generationNumber);
+          const before = routingDecision;
+          const after = router.escalate(before, failureSignals[0]!);
+          if (
+            after.tier !== before.tier ||
+            after.modelId !== before.modelId ||
+            after.retryAttempt > before.retryAttempt
+          ) {
+            await appendInferenceAuditEvent(
+              this.eventStore,
+              seed.metadata.seed_id,
+              buildModelEscalationAuditEntry({
+                before,
+                after,
+                correlationId,
+              })
+            );
+            routingDecision = after;
+            snapshot.routing = after;
+          }
+
+          const coordination = await evaluateAgentCoordination({
+            router,
+            decision: routingDecision,
+            signals: failureSignals,
+            driftCombined: driftReport.combined,
+            correlationId,
+          });
+          if (coordination.triggered && coordination.auditEntry) {
+            await appendInferenceAuditEvent(
+              this.eventStore,
+              seed.metadata.seed_id,
+              coordination.auditEntry
+            );
+          }
+        }
       }
 
       generationNumber++;

--- a/packages/clawql-ouroboros/src/glue/routing-audit.ts
+++ b/packages/clawql-ouroboros/src/glue/routing-audit.ts
@@ -1,0 +1,21 @@
+import type { InferenceAuditEntry } from "clawql-inference";
+import type { EventStore } from "../interfaces.js";
+
+export async function appendInferenceAuditEvent(
+  eventStore: EventStore,
+  seedId: string,
+  entry: InferenceAuditEntry
+): Promise<void> {
+  await eventStore.append({
+    type: entry.action,
+    seed_id: seedId,
+    data: {
+      ...entry.payload,
+      correlationId: entry.correlationId,
+      summary: entry.summary,
+      ts: entry.ts,
+      category: entry.category,
+    },
+    timestamp: new Date(entry.ts),
+  });
+}

--- a/packages/clawql-ouroboros/src/glue/routing-failures.ts
+++ b/packages/clawql-ouroboros/src/glue/routing-failures.ts
@@ -1,0 +1,46 @@
+import type { EvaluationSummary } from "../interfaces.js";
+import type { ConvergenceConfig } from "../convergence.js";
+import type { DriftReport } from "../drift.js";
+import type { RoutingFailureSignal } from "clawql-inference";
+
+export function buildRoutingFailureSignals(input: {
+  generationNumber: number;
+  evaluation: EvaluationSummary;
+  driftReport: DriftReport;
+  convergenceConfig: ConvergenceConfig;
+}): RoutingFailureSignal[] {
+  const signals: RoutingFailureSignal[] = [];
+  for (const ac of input.evaluation.ac_results.filter((row) => !row.passed)) {
+    signals.push({
+      kind: "ac_failed",
+      detail: { ac_content: ac.ac_content, evidence: ac.evidence },
+      acIndex: ac.ac_index,
+      generation: input.generationNumber,
+    });
+  }
+  if (input.evaluation.score < input.convergenceConfig.evalMinScore) {
+    signals.push({
+      kind: "eval_below_min",
+      detail: {
+        score: input.evaluation.score,
+        min: input.convergenceConfig.evalMinScore,
+      },
+      generation: input.generationNumber,
+    });
+  }
+  if (input.driftReport.combined > input.convergenceConfig.driftMaxCombined) {
+    signals.push({
+      kind: "drift_exceeded",
+      detail: {
+        combined: input.driftReport.combined,
+        max: input.convergenceConfig.driftMaxCombined,
+      },
+      generation: input.generationNumber,
+    });
+  }
+  return signals;
+}
+
+export function buildRoutingCorrelationId(seedId: string, generationNumber: number): string {
+  return `${seedId}_gen_${generationNumber}`;
+}

--- a/packages/clawql-ouroboros/src/glue/routing-failures.ts
+++ b/packages/clawql-ouroboros/src/glue/routing-failures.ts
@@ -28,11 +28,11 @@ export function buildRoutingFailureSignals(input: {
       generation: input.generationNumber,
     });
   }
-  if (input.driftReport.combined > input.convergenceConfig.driftMaxCombined) {
+  if (input.driftReport.combined_drift > input.convergenceConfig.driftMaxCombined) {
     signals.push({
       kind: "drift_exceeded",
       detail: {
-        combined: input.driftReport.combined,
+        combined: input.driftReport.combined_drift,
         max: input.convergenceConfig.driftMaxCombined,
       },
       generation: input.generationNumber,

--- a/src/onboarding/cli.ts
+++ b/src/onboarding/cli.ts
@@ -33,6 +33,8 @@ import {
   runInferenceKeysCreateCmd,
   runInferenceKeysListCmd,
   runInferenceKeysRevokeCmd,
+  runInferencePolicyShowCmd,
+  runInferencePipelineWorkerCmd,
   runInferenceCompleteCmd,
   runInferenceEscalationSetTierCmd,
   runInferenceEscalationShowCmd,
@@ -287,12 +289,13 @@ inference (gateway MVP):
   export          Verdict-filtered dataset export with optional Presidio scrub + manifest
   finetune        Submit fine-tuning job; subcommands: status, register
   escalation      show tier map | set-tier --tier <tier> --model <id>
-  pipeline        enable | status | disable | run (scheduled auto-export config)
+  pipeline        enable | status | disable | run | worker (scheduled auto-export)
   cache           Semantic cache config (CLAWQL_INFERENCE_SEMANTIC_CACHE=1)
   fallback        Per-tier / per-model provider fallback chains
   keys            create | list | revoke virtual API keys (per-team budgets)
+  policy          Show effective inference policy (tiers, cache, export rules)
   Providers: openai, anthropic, ollama via provider/model ids (e.g. ollama/phi4)
-  Store: CLAWQL_INFERENCE_STORE=memory|jsonl|off (default jsonl when CLAWQL_HOME set)
+  Store: CLAWQL_INFERENCE_STORE=memory|jsonl|postgres|off (default jsonl when CLAWQL_HOME set)
   Cache: CLAWQL_INFERENCE_SEMANTIC_CACHE=1, CLAWQL_INFERENCE_CACHE_THRESHOLD=0.92
   Fallback: CLAWQL_INFERENCE_FALLBACK_ENABLED=1, CLAWQL_INFERENCE_FALLBACK_FRUGAL=a,b
   Keys: per-team virtual API keys (see clawql-inference README)
@@ -667,6 +670,10 @@ async function main(): Promise<void> {
         process.exitCode = await runInferencePipelineRunCmd(inferenceOpts);
         return;
       }
+      if (pipelineAction === "worker") {
+        process.exitCode = await runInferencePipelineWorkerCmd(inferenceOpts);
+        return;
+      }
       process.exitCode = await runInferencePipelineEnableCmd(inferenceOpts);
       return;
     }
@@ -676,6 +683,10 @@ async function main(): Promise<void> {
     }
     if (subcmd === "fallback") {
       process.exitCode = await runInferenceFallbackShowCmd(inferenceOpts);
+      return;
+    }
+    if (subcmd === "policy") {
+      process.exitCode = await runInferencePolicyShowCmd(inferenceOpts);
       return;
     }
     if (subcmd === "keys") {
@@ -699,7 +710,7 @@ async function main(): Promise<void> {
       return;
     }
     console.error(
-      "Usage: clawql inference serve | complete | logs | trace | spend | export | finetune | escalation | pipeline | cache | fallback | keys"
+      "Usage: clawql inference serve | complete | logs | trace | spend | export | finetune | escalation | pipeline | cache | fallback | keys | policy"
     );
     process.exitCode = 1;
     return;

--- a/src/onboarding/inference-cli.ts
+++ b/src/onboarding/inference-cli.ts
@@ -19,7 +19,9 @@ import {
   runInferencePipelineDisable,
   runInferencePipelineEnable,
   runInferencePipelineRun,
+  runInferencePipelineWorker,
   runInferencePipelineStatus,
+  runInferencePolicyShow,
   runInferenceServe,
   runInferenceSpend,
   runInferenceTrace,
@@ -234,4 +236,12 @@ export async function runInferenceKeysListCmd(opts: InferenceCliOptions): Promis
 
 export async function runInferenceKeysRevokeCmd(opts: InferenceCliOptions): Promise<number> {
   return runInferenceKeysRevoke({ id: opts.keyId, json: opts.json });
+}
+
+export async function runInferencePolicyShowCmd(opts: InferenceCliOptions): Promise<number> {
+  return runInferencePolicyShow({ json: opts.json });
+}
+
+export async function runInferencePipelineWorkerCmd(opts: InferenceCliOptions): Promise<number> {
+  return runInferencePipelineWorker({ json: opts.json });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the five **deferred** inference epic [#556](https://github.com/danielsmithdevelopment/ClawQL/issues/556) items.

## Changes

### 1. Postgres inference store
- `PostgresInferenceStore` with `clawql_inference_calls` table (JSONB records)
- `CLAWQL_INFERENCE_STORE=postgres` + `CLAWQL_INFERENCE_DATABASE_URL` (or `CLAWQL_INFERENCE_DB_*`)
- Integration test gated on `CLAWQL_INFERENCE_DATABASE_URL`

### 2. Ouroboros audit wiring (#561)
- `EvolutionaryLoop` builds routing failure signals and calls `router.escalate()`
- Appends `model_escalation` events to the Ouroboros event store via `appendInferenceAuditEvent`

### 3. Agent coordination (#562)
- `evaluateAgentCoordination` + Hermes stub adapter (`CLAWQL_INFERENCE_AGENT_COORDINATION_ENABLED`, `HERMES_BASE_URL`)
- Appends `agent_coordination` audit events when tripwire fires

### 4. Policy CLI
- `clawql inference policy show` — aggregates escalation, cache, fallback, keys, store, export defaults

### 5. Pipeline cron worker
- UTC cron matcher + `startPipelineWorker` with `lastRunAt` / `lastRunStatus` tracking
- `CLAWQL_INFERENCE_PIPELINE_WORKER=1` hooks into `inference serve`
- `clawql inference pipeline worker` for sidecar mode

## Test plan

- [x] `npm test` in `packages/clawql-inference` (60 passed, 1 skipped)
- [x] `npm test` in `packages/clawql-ouroboros` (53 passed, 2 skipped)
- [x] `npm run format:check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

