### PR TITLE
feat(payments): live Stripe SDK + webhook signature verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11097,6 +11097,26 @@
                 "node": ">=6"
             }
         },
+        "node_modules/stripe": {
+            "version": "18.5.0",
+            "resolved": "https://registry.npmjs.org/stripe/-/stripe-18.5.0.tgz",
+            "integrity": "sha512-Hp+wFiEQtCB0LlNgcFh5uVyKznpDjzyUZ+CNVEf+I3fhlYvh7rZruIg+jOwzJRCpy0ZTPMjlzm7J2/M2N6d+DA==",
+            "license": "MIT",
+            "dependencies": {
+                "qs": "^6.11.0"
+            },
+            "engines": {
+                "node": ">=12.*"
+            },
+            "peerDependencies": {
+                "@types/node": ">=12.x.x"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/sucrase": {
             "version": "3.35.1",
             "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -12411,6 +12431,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "clawql-core": "7.0.0",
+                "stripe": "^18.5.0",
                 "zod": "^4.3.6"
             },
             "bin": {

--- a/packages/clawql-payments/README.md
+++ b/packages/clawql-payments/README.md
@@ -24,10 +24,24 @@ clawql payments plan upgrade --tier team
 clawql payments usage report --month 2026-07
 
 # Stripe (user billing)
-clawql payments stripe setup
+
+Set `STRIPE_SECRET_KEY` for live API calls. Webhook signing secret is stored locally via setup (never commit secrets).
+
+```bash
+export STRIPE_SECRET_KEY=sk_test_...
+export STRIPE_PRO_PRICE_ID=price_...
+export STRIPE_TEAM_PRICE_ID=price_...
+
+clawql payments stripe setup --webhook-secret whsec_...
 clawql payments stripe customer create --email user@acme.com
 clawql payments stripe subscription create --customer cus_xxx --plan pro
 clawql payments stripe invoice create --customer cus_xxx --amount 500
+
+# Verify webhook signatures before processing (required before going live)
+clawql payments stripe webhook verify --payload ./event.json --signature "t=...,v1=..." --process
+```
+
+Payment audit events (`STRIPE_INVOICE_PAID`, `STRIPE_PAYMENT_FAILED`, etc.) are written when verified webhooks are processed — not at invoice creation time.
 
 # x402 micropayments
 clawql payments x402 wallet setup --address 0x...
@@ -64,7 +78,9 @@ Local state is stored under `$CLAWQL_HOME/Payments/` (default `~/.clawql/Payment
 
 ## Status
 
-This package is a **foundation scaffold**. Stripe SDK integration, live x402 facilitator HTTP calls, and durable WORM persistence are follow-up work. CLI commands and plan/limit logic are wired and tested.
+Stripe SDK integration is **live** for customers, subscriptions, invoices, billing portal, meter events (Stripe Billing Meters), and webhook signature verification. Invoice payment audit events are recorded via verified `invoice.paid` webhooks only.
+
+x402 facilitator HTTP calls and durable WORM persistence remain follow-up work.
 
 ## Related
 

--- a/packages/clawql-payments/package.json
+++ b/packages/clawql-payments/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "clawql-core": "7.0.0",
+    "stripe": "^18.5.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/clawql-payments/src/cli/index.ts
+++ b/packages/clawql-payments/src/cli/index.ts
@@ -16,10 +16,12 @@ export {
   runPaymentsStripeSubscriptionCreate,
   runPaymentsStripeInvoiceCreate,
   runPaymentsStripeWebhookListen,
+  runPaymentsStripeWebhookVerify,
   type PaymentsStripeCustomerCreateOptions,
   type PaymentsStripeInvoiceCreateOptions,
   type PaymentsStripeSetupOptions,
   type PaymentsStripeSubscriptionCreateOptions,
+  type PaymentsStripeWebhookVerifyOptions,
 } from "./stripe.js";
 export {
   runPaymentsX402WalletSetup,

--- a/packages/clawql-payments/src/cli/stripe.ts
+++ b/packages/clawql-payments/src/cli/stripe.ts
@@ -1,5 +1,15 @@
-import { setupStripe, createStripeCustomer, createStripeSubscription, createStripeInvoice } from "../stripe/index.js";
-import { appendPaymentWormEntry, buildStripeInvoicePaidEntry } from "../audit/index.js";
+import { readFile } from "node:fs/promises";
+import {
+  setupStripe,
+  createStripeCustomer,
+  createStripeSubscription,
+  createStripeInvoice,
+  verifyAndProcessStripeWebhook,
+  verifyStripeWebhookSignature,
+  isStripeConfigured,
+} from "../stripe/index.js";
+import { loadPaymentsConfig } from "../config/store.js";
+import { StripeNotConfiguredError, StripeWebhookVerificationError } from "../stripe/errors.js";
 
 export type PaymentsStripeSetupOptions = {
   accountId?: string;
@@ -12,13 +22,14 @@ export type PaymentsStripeSetupOptions = {
 export async function runPaymentsStripeSetup(
   options: PaymentsStripeSetupOptions = {}
 ): Promise<number> {
+  const env = options.env ?? process.env;
   const result = await setupStripe(
     {
       accountId: options.accountId,
       publishableKey: options.publishableKey,
       webhookSecret: options.webhookSecret,
     },
-    options.env
+    env
   );
 
   if (options.json) {
@@ -28,6 +39,9 @@ export async function runPaymentsStripeSetup(
 
   console.log(`Stripe ${result.configured ? "configured" : "partially configured"} → ${result.path}`);
   if (result.accountId) console.log(`Account: ${result.accountId}`);
+  console.log(
+    `API key: ${result.apiKeyConfigured ? "STRIPE_SECRET_KEY set" : "set STRIPE_SECRET_KEY for live API calls"}`
+  );
   return 0;
 }
 
@@ -35,6 +49,7 @@ export type PaymentsStripeCustomerCreateOptions = {
   email?: string;
   name?: string;
   json?: boolean;
+  env?: NodeJS.ProcessEnv;
 };
 
 export async function runPaymentsStripeCustomerCreate(
@@ -45,24 +60,40 @@ export async function runPaymentsStripeCustomerCreate(
     return 1;
   }
 
-  const customer = await createStripeCustomer({
-    email: options.email,
-    name: options.name,
-  });
-
-  if (options.json) {
-    console.log(JSON.stringify(customer, null, 2));
-    return 0;
+  const env = options.env ?? process.env;
+  if (!isStripeConfigured(env)) {
+    console.error("STRIPE_SECRET_KEY is required for live Stripe API calls");
+    return 1;
   }
 
-  console.log(`Created Stripe customer ${customer.id} (${customer.email}) [${customer.status}]`);
-  return 0;
+  try {
+    const customer = await createStripeCustomer({
+      email: options.email,
+      name: options.name,
+      env,
+    });
+
+    if (options.json) {
+      console.log(JSON.stringify(customer, null, 2));
+      return 0;
+    }
+
+    console.log(`Created Stripe customer ${customer.id} (${customer.email})`);
+    return 0;
+  } catch (error) {
+    if (error instanceof StripeNotConfiguredError) {
+      console.error(error.message);
+      return 1;
+    }
+    throw error;
+  }
 }
 
 export type PaymentsStripeSubscriptionCreateOptions = {
   customer?: string;
   plan?: string;
   json?: boolean;
+  env?: NodeJS.ProcessEnv;
 };
 
 export async function runPaymentsStripeSubscriptionCreate(
@@ -79,27 +110,43 @@ export async function runPaymentsStripeSubscriptionCreate(
     return 1;
   }
 
-  const sub = await createStripeSubscription({
-    customerId: options.customer,
-    plan: options.plan,
-  });
-
-  if (options.json) {
-    console.log(JSON.stringify(sub, null, 2));
-    return 0;
+  const env = options.env ?? process.env;
+  if (!isStripeConfigured(env)) {
+    console.error("STRIPE_SECRET_KEY is required for live Stripe API calls");
+    return 1;
   }
 
-  console.log(`Created subscription ${sub.id} for ${sub.customerId} on ${sub.plan} [${sub.status}]`);
-  return 0;
+  try {
+    const sub = await createStripeSubscription({
+      customerId: options.customer,
+      plan: options.plan,
+      env,
+    });
+
+    if (options.json) {
+      console.log(JSON.stringify(sub, null, 2));
+      return 0;
+    }
+
+    console.log(
+      `Created subscription ${sub.id} for ${sub.customerId} on ${sub.plan} (${sub.status})`
+    );
+    return 0;
+  } catch (error) {
+    if (error instanceof StripeNotConfiguredError) {
+      console.error(error.message);
+      return 1;
+    }
+    throw error;
+  }
 }
 
 export type PaymentsStripeInvoiceCreateOptions = {
   customer?: string;
   amount?: number;
   description?: string;
-  tenantId?: string;
-  correlationId?: string;
   json?: boolean;
+  env?: NodeJS.ProcessEnv;
 };
 
 export async function runPaymentsStripeInvoiceCreate(
@@ -112,32 +159,127 @@ export async function runPaymentsStripeInvoiceCreate(
     return 1;
   }
 
-  const invoice = await createStripeInvoice({
-    customerId: options.customer,
-    amountCents: Math.round(options.amount * 100),
-    description: options.description,
-  });
-
-  appendPaymentWormEntry(
-    buildStripeInvoicePaidEntry({
-      tenantId: options.tenantId ?? "default",
-      amountUsd: options.amount,
-      correlationId: options.correlationId,
-    })
-  );
-
-  if (options.json) {
-    console.log(JSON.stringify(invoice, null, 2));
-    return 0;
+  const env = options.env ?? process.env;
+  if (!isStripeConfigured(env)) {
+    console.error("STRIPE_SECRET_KEY is required for live Stripe API calls");
+    return 1;
   }
 
-  console.log(
-    `Created invoice ${invoice.id} for ${invoice.customerId}: $${options.amount.toFixed(2)} [${invoice.status}]`
-  );
-  return 0;
+  try {
+    const invoice = await createStripeInvoice({
+      customerId: options.customer,
+      amountCents: Math.round(options.amount * 100),
+      description: options.description,
+      env,
+    });
+
+    if (options.json) {
+      console.log(JSON.stringify(invoice, null, 2));
+      return 0;
+    }
+
+    console.log(
+      `Created invoice ${invoice.id} for ${invoice.customerId}: $${options.amount.toFixed(2)} (${invoice.status})`
+    );
+    if (invoice.hostedInvoiceUrl) {
+      console.log(`Hosted invoice: ${invoice.hostedInvoiceUrl}`);
+    }
+    console.log("Payment audit events are recorded when invoice.paid webhooks arrive.");
+    return 0;
+  } catch (error) {
+    if (error instanceof StripeNotConfiguredError) {
+      console.error(error.message);
+      return 1;
+    }
+    throw error;
+  }
+}
+
+export type PaymentsStripeWebhookVerifyOptions = {
+  payloadPath?: string;
+  signature?: string;
+  webhookSecret?: string;
+  process?: boolean;
+  tenantId?: string;
+  correlationId?: string;
+  json?: boolean;
+  env?: NodeJS.ProcessEnv;
+};
+
+export async function runPaymentsStripeWebhookVerify(
+  options: PaymentsStripeWebhookVerifyOptions = {}
+): Promise<number> {
+  const env = options.env ?? process.env;
+  const config = await loadPaymentsConfig(env);
+  const secret = options.webhookSecret ?? config.stripe.webhookSecret;
+  if (!secret?.trim()) {
+    console.error(
+      "Webhook secret required — run clawql payments stripe setup --webhook-secret whsec_... or pass --webhook-secret"
+    );
+    return 1;
+  }
+  if (!options.payloadPath?.trim()) {
+    console.error(
+      "Usage: clawql payments stripe webhook verify --payload /path/to/body.json --signature t=...,v1=..."
+    );
+    return 1;
+  }
+  if (!options.signature?.trim()) {
+    console.error("Stripe-Signature header value is required (--signature)");
+    return 1;
+  }
+
+  const payload = await readFile(options.payloadPath, "utf8");
+
+  try {
+    if (options.process) {
+      const result = await verifyAndProcessStripeWebhook({
+        payload,
+        signature: options.signature,
+        secret,
+        tenantId: options.tenantId,
+        correlationId: options.correlationId,
+        env,
+      });
+      if (options.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return 0;
+      }
+      console.log(
+        `Verified and processed ${result.eventType} (${result.eventId}) handled=${result.handled}`
+      );
+      return 0;
+    }
+
+    const verified = verifyStripeWebhookSignature(payload, options.signature, secret);
+    if (!verified.ok) {
+      console.error(`Webhook verification failed: ${verified.reason}`);
+      return 1;
+    }
+
+    if (options.json) {
+      console.log(JSON.stringify({ ok: true, type: verified.event.type, id: verified.event.id }, null, 2));
+      return 0;
+    }
+
+    console.log(`Verified webhook ${verified.event.type} (${verified.event.id})`);
+    return 0;
+  } catch (error) {
+    if (error instanceof StripeWebhookVerificationError) {
+      console.error(`Webhook verification failed: ${error.message}`);
+      return 1;
+    }
+    throw error;
+  }
 }
 
 export async function runPaymentsStripeWebhookListen(): Promise<number> {
-  console.log("Stripe webhook listener not yet implemented — use stripe listen + clawql payments stripe webhook verify");
+  console.log(`Forward Stripe webhooks with the Stripe CLI, then verify/process locally:
+
+  stripe listen --forward-to http://127.0.0.1:8080/webhooks/stripe
+  clawql payments stripe webhook verify --payload ./event.json --signature "$STRIPE_SIGNATURE" --process
+
+Store the webhook signing secret via:
+  clawql payments stripe setup --webhook-secret whsec_...`);
   return 0;
 }

--- a/packages/clawql-payments/src/stripe/client.test.ts
+++ b/packages/clawql-payments/src/stripe/client.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { isStripeConfigured, resolveStripeSecretKey } from "./client.js";
+import { StripeNotConfiguredError } from "./errors.js";
+
+describe("stripe client", () => {
+  it("detects configured secret key", () => {
+    expect(isStripeConfigured({ STRIPE_SECRET_KEY: "sk_test_abc" })).toBe(true);
+    expect(isStripeConfigured({})).toBe(false);
+  });
+
+  it("throws when secret key is missing", () => {
+    expect(() => resolveStripeSecretKey({})).toThrow(StripeNotConfiguredError);
+  });
+});

--- a/packages/clawql-payments/src/stripe/client.ts
+++ b/packages/clawql-payments/src/stripe/client.ts
@@ -1,0 +1,24 @@
+import Stripe from "stripe";
+import { StripeNotConfiguredError } from "./errors.js";
+
+export function resolveStripeSecretKey(env: NodeJS.ProcessEnv = process.env): string {
+  const key = env.STRIPE_SECRET_KEY?.trim();
+  if (!key) {
+    throw new StripeNotConfiguredError();
+  }
+  return key;
+}
+
+export function isStripeConfigured(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(env.STRIPE_SECRET_KEY?.trim());
+}
+
+export function createStripeClient(env: NodeJS.ProcessEnv = process.env): Stripe {
+  return new Stripe(resolveStripeSecretKey(env));
+}
+
+export function createStripeClientOptional(env: NodeJS.ProcessEnv = process.env): Stripe | null {
+  const key = env.STRIPE_SECRET_KEY?.trim();
+  if (!key) return null;
+  return new Stripe(key);
+}

--- a/packages/clawql-payments/src/stripe/customer.ts
+++ b/packages/clawql-payments/src/stripe/customer.ts
@@ -1,148 +1,34 @@
-import { mergePaymentsConfig } from "../config/store.js";
-
-export type StripeSetupInput = {
-  accountId?: string;
-  publishableKey?: string;
-  webhookSecret?: string;
-};
-
-export type StripeSetupResult = {
-  configured: boolean;
-  path: string;
-  accountId?: string;
-};
-
-export async function setupStripe(
-  input: StripeSetupInput,
-  env: NodeJS.ProcessEnv = process.env
-): Promise<StripeSetupResult> {
-  const { config, path } = await mergePaymentsConfig(
-    {
-      stripe: {
-        accountId: input.accountId,
-        publishableKey: input.publishableKey,
-        webhookSecret: input.webhookSecret,
-      },
-    },
-    env
-  );
-
-  return {
-    configured: Boolean(config.stripe.accountId || config.stripe.publishableKey),
-    path,
-    accountId: config.stripe.accountId,
-  };
-}
+import { createStripeClient } from "./client.js";
 
 export type StripeCustomerInput = {
   email: string;
   name?: string;
+  metadata?: Record<string, string>;
+  env?: NodeJS.ProcessEnv;
 };
 
 export type StripeCustomerResult = {
   id: string;
   email: string;
-  status: "stub";
+  name?: string | null;
+  status: "live";
 };
 
-/** Stripe API integration lands in a follow-up; returns a deterministic stub id for CLI wiring. */
 export async function createStripeCustomer(
   input: StripeCustomerInput
 ): Promise<StripeCustomerResult> {
-  const slug = input.email.toLowerCase().replace(/[^a-z0-9]+/g, "_").slice(0, 24);
-  return {
-    id: `cus_stub_${slug}`,
+  const env = input.env ?? process.env;
+  const stripe = createStripeClient(env);
+  const customer = await stripe.customers.create({
     email: input.email,
-    status: "stub",
-  };
-}
+    name: input.name,
+    metadata: input.metadata,
+  });
 
-export type StripeSubscriptionInput = {
-  customerId: string;
-  plan: "pro" | "team";
-};
-
-export type StripeSubscriptionResult = {
-  id: string;
-  customerId: string;
-  plan: string;
-  status: "stub";
-};
-
-export async function createStripeSubscription(
-  input: StripeSubscriptionInput
-): Promise<StripeSubscriptionResult> {
   return {
-    id: `sub_stub_${input.customerId.replace(/^cus_/, "")}`,
-    customerId: input.customerId,
-    plan: input.plan,
-    status: "stub",
-  };
-}
-
-export type StripeInvoiceInput = {
-  customerId: string;
-  amountCents: number;
-  description?: string;
-};
-
-export type StripeInvoiceResult = {
-  id: string;
-  customerId: string;
-  amountCents: number;
-  status: "stub";
-};
-
-export async function createStripeInvoice(
-  input: StripeInvoiceInput
-): Promise<StripeInvoiceResult> {
-  return {
-    id: `inv_stub_${input.customerId.replace(/^cus_/, "")}_${input.amountCents}`,
-    customerId: input.customerId,
-    amountCents: input.amountCents,
-    status: "stub",
-  };
-}
-
-export type StripeWebhookEvent = {
-  id: string;
-  type: string;
-  payload: unknown;
-};
-
-export function verifyStripeWebhookSignature(
-  _payload: string,
-  _signature: string,
-  _secret: string
-): boolean {
-  return false;
-}
-
-export type MeteredUsageInput = {
-  subscriptionItemId: string;
-  quantity: number;
-  timestamp?: number;
-};
-
-export async function reportMeteredUsage(
-  input: MeteredUsageInput
-): Promise<{ id: string; quantity: number }> {
-  return {
-    id: `ur_stub_${input.subscriptionItemId}`,
-    quantity: input.quantity,
-  };
-}
-
-export type PortalSessionInput = {
-  customerId: string;
-  returnUrl: string;
-};
-
-export async function createCustomerPortalSession(
-  input: PortalSessionInput
-): Promise<{ url: string; customerId: string }> {
-  return {
-    url: `https://billing.stripe.com/session/stub/${input.customerId}`,
-    customerId: input.customerId,
+    id: customer.id,
+    email: customer.email ?? input.email,
+    name: customer.name,
+    status: "live",
   };
 }

--- a/packages/clawql-payments/src/stripe/errors.ts
+++ b/packages/clawql-payments/src/stripe/errors.ts
@@ -1,0 +1,13 @@
+export class StripeNotConfiguredError extends Error {
+  constructor(message = "Stripe is not configured — set STRIPE_SECRET_KEY") {
+    super(message);
+    this.name = "StripeNotConfiguredError";
+  }
+}
+
+export class StripeWebhookVerificationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StripeWebhookVerificationError";
+  }
+}

--- a/packages/clawql-payments/src/stripe/index.ts
+++ b/packages/clawql-payments/src/stripe/index.ts
@@ -1,20 +1,38 @@
 export {
-  createCustomerPortalSession,
+  createStripeClient,
+  createStripeClientOptional,
+  isStripeConfigured,
+  resolveStripeSecretKey,
+} from "./client.js";
+export { setupStripe, type StripeSetupInput, type StripeSetupResult } from "./setup.js";
+export {
   createStripeCustomer,
-  createStripeInvoice,
-  createStripeSubscription,
-  reportMeteredUsage,
-  setupStripe,
-  verifyStripeWebhookSignature,
-  type MeteredUsageInput,
-  type PortalSessionInput,
   type StripeCustomerInput,
   type StripeCustomerResult,
-  type StripeInvoiceInput,
-  type StripeInvoiceResult,
-  type StripeSetupInput,
-  type StripeSetupResult,
+} from "./customer.js";
+export {
+  createStripeSubscription,
   type StripeSubscriptionInput,
   type StripeSubscriptionResult,
+} from "./subscription.js";
+export {
+  createStripeInvoice,
+  type StripeInvoiceInput,
+  type StripeInvoiceResult,
+} from "./invoice.js";
+export { reportMeteredUsage, type MeteredUsageInput } from "./metered.js";
+export { createCustomerPortalSession, type PortalSessionInput } from "./portal.js";
+export {
+  assertStripeWebhookSignature,
+  processStripeWebhookEvent,
+  verifyAndProcessStripeWebhook,
+  verifyStripeWebhookSignature,
+  type ProcessStripeWebhookOptions,
+  type ProcessStripeWebhookResult,
   type StripeWebhookEvent,
-} from "./customer.js";
+  type StripeWebhookVerifyResult,
+} from "./webhook.js";
+export {
+  StripeNotConfiguredError,
+  StripeWebhookVerificationError,
+} from "./errors.js";

--- a/packages/clawql-payments/src/stripe/invoice.ts
+++ b/packages/clawql-payments/src/stripe/invoice.ts
@@ -1,0 +1,56 @@
+import { createStripeClient } from "./client.js";
+
+export type StripeInvoiceInput = {
+  customerId: string;
+  amountCents: number;
+  description?: string;
+  currency?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+export type StripeInvoiceResult = {
+  id: string;
+  customerId: string;
+  amountCents: number;
+  status: string;
+  hostedInvoiceUrl?: string | null;
+};
+
+export async function createStripeInvoice(
+  input: StripeInvoiceInput
+): Promise<StripeInvoiceResult> {
+  const env = input.env ?? process.env;
+  const stripe = createStripeClient(env);
+  const currency = input.currency ?? "usd";
+
+  await stripe.invoiceItems.create({
+    customer: input.customerId,
+    amount: input.amountCents,
+    currency,
+    description: input.description,
+  });
+
+  const invoice = await stripe.invoices.create({
+    customer: input.customerId,
+    auto_advance: true,
+    collection_method: "send_invoice",
+    days_until_due: 30,
+  });
+
+  if (!invoice.id) {
+    throw new Error("Stripe invoice create did not return an id");
+  }
+
+  const finalized =
+    invoice.status === "draft"
+      ? await stripe.invoices.finalizeInvoice(invoice.id)
+      : invoice;
+
+  return {
+    id: finalized.id ?? invoice.id,
+    customerId: input.customerId,
+    amountCents: input.amountCents,
+    status: finalized.status ?? "open",
+    hostedInvoiceUrl: finalized.hosted_invoice_url,
+  };
+}

--- a/packages/clawql-payments/src/stripe/metered.ts
+++ b/packages/clawql-payments/src/stripe/metered.ts
@@ -1,0 +1,31 @@
+import { createStripeClient } from "./client.js";
+
+export type MeteredUsageInput = {
+  eventName: string;
+  stripeCustomerId: string;
+  value: number;
+  identifier?: string;
+  timestamp?: number;
+  env?: NodeJS.ProcessEnv;
+};
+
+export async function reportMeteredUsage(
+  input: MeteredUsageInput
+): Promise<{ id: string; value: number }> {
+  const env = input.env ?? process.env;
+  const stripe = createStripeClient(env);
+  const event = await stripe.billing.meterEvents.create({
+    event_name: input.eventName,
+    payload: {
+      stripe_customer_id: input.stripeCustomerId,
+      value: String(input.value),
+    },
+    identifier: input.identifier,
+    timestamp: input.timestamp,
+  });
+
+  return {
+    id: event.identifier,
+    value: input.value,
+  };
+}

--- a/packages/clawql-payments/src/stripe/portal.ts
+++ b/packages/clawql-payments/src/stripe/portal.ts
@@ -1,0 +1,23 @@
+import { createStripeClient } from "./client.js";
+
+export type PortalSessionInput = {
+  customerId: string;
+  returnUrl: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+export async function createCustomerPortalSession(
+  input: PortalSessionInput
+): Promise<{ url: string; customerId: string }> {
+  const env = input.env ?? process.env;
+  const stripe = createStripeClient(env);
+  const session = await stripe.billingPortal.sessions.create({
+    customer: input.customerId,
+    return_url: input.returnUrl,
+  });
+
+  return {
+    url: session.url,
+    customerId: input.customerId,
+  };
+}

--- a/packages/clawql-payments/src/stripe/setup.ts
+++ b/packages/clawql-payments/src/stripe/setup.ts
@@ -1,0 +1,43 @@
+import { mergePaymentsConfig } from "../config/store.js";
+import { isStripeConfigured } from "./client.js";
+
+export type StripeSetupInput = {
+  accountId?: string;
+  publishableKey?: string;
+  webhookSecret?: string;
+};
+
+export type StripeSetupResult = {
+  configured: boolean;
+  apiKeyConfigured: boolean;
+  path: string;
+  accountId?: string;
+};
+
+export async function setupStripe(
+  input: StripeSetupInput,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<StripeSetupResult> {
+  const { config, path } = await mergePaymentsConfig(
+    {
+      stripe: {
+        accountId: input.accountId,
+        publishableKey: input.publishableKey,
+        webhookSecret: input.webhookSecret,
+      },
+    },
+    env
+  );
+
+  return {
+    configured: Boolean(
+      isStripeConfigured(env) ||
+        config.stripe.accountId ||
+        config.stripe.publishableKey ||
+        config.stripe.webhookSecret
+    ),
+    apiKeyConfigured: isStripeConfigured(env),
+    path,
+    accountId: config.stripe.accountId,
+  };
+}

--- a/packages/clawql-payments/src/stripe/subscription.ts
+++ b/packages/clawql-payments/src/stripe/subscription.ts
@@ -1,0 +1,53 @@
+import { getPlanDefinition, type ClawqlPlanId } from "../plans/tiers.js";
+import { createStripeClient } from "./client.js";
+import { StripeNotConfiguredError } from "./errors.js";
+
+export type StripeSubscriptionInput = {
+  customerId: string;
+  plan: "pro" | "team";
+  env?: NodeJS.ProcessEnv;
+};
+
+export type StripeSubscriptionResult = {
+  id: string;
+  customerId: string;
+  plan: string;
+  priceId: string;
+  status: string;
+};
+
+function resolvePriceId(plan: ClawqlPlanId, env: NodeJS.ProcessEnv): string {
+  const priceId = getPlanDefinition(plan).stripe_price_id;
+  if (!priceId) {
+    throw new StripeNotConfiguredError(
+      `Stripe price id not configured for plan "${plan}" — set STRIPE_${plan.toUpperCase()}_PRICE_ID`
+    );
+  }
+  return priceId;
+}
+
+export async function createStripeSubscription(
+  input: StripeSubscriptionInput
+): Promise<StripeSubscriptionResult> {
+  const env = input.env ?? process.env;
+  const stripe = createStripeClient(env);
+  const priceId = resolvePriceId(input.plan, env);
+
+  const subscription = await stripe.subscriptions.create({
+    customer: input.customerId,
+    items: [{ price: priceId }],
+    payment_behavior: "default_incomplete",
+    expand: ["latest_invoice.payment_intent"],
+  });
+
+  return {
+    id: subscription.id,
+    customerId:
+      typeof subscription.customer === "string"
+        ? subscription.customer
+        : subscription.customer.id,
+    plan: input.plan,
+    priceId,
+    status: subscription.status,
+  };
+}

--- a/packages/clawql-payments/src/stripe/webhook.test.ts
+++ b/packages/clawql-payments/src/stripe/webhook.test.ts
@@ -1,0 +1,57 @@
+import Stripe from "stripe";
+import { describe, expect, it } from "vitest";
+import { resetDefaultAuditRingBufferForTests } from "clawql-core";
+import {
+  assertStripeWebhookSignature,
+  processStripeWebhookEvent,
+  verifyStripeWebhookSignature,
+} from "./webhook.js";
+import { StripeWebhookVerificationError } from "./errors.js";
+import { listPaymentAuditEntries } from "../audit/worm.js";
+
+describe("stripe webhook verification", () => {
+  const secret = "whsec_test_secret_for_clawql_payments";
+  const payload = JSON.stringify({
+    id: "evt_test_webhook",
+    object: "event",
+    type: "invoice.paid",
+    data: {
+      object: {
+        id: "in_test",
+        object: "invoice",
+        amount_paid: 5000,
+        metadata: { tenant_id: "tenant-a" },
+      },
+    },
+  });
+
+  it("verifies a valid Stripe-Signature", () => {
+    const signature = Stripe.webhooks.generateTestHeaderString({ payload, secret });
+    const result = verifyStripeWebhookSignature(payload, signature, secret);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.event.type).toBe("invoice.paid");
+    }
+  });
+
+  it("rejects an invalid signature", () => {
+    const result = verifyStripeWebhookSignature(payload, "t=0,v1=invalid", secret);
+    expect(result.ok).toBe(false);
+  });
+
+  it("assertStripeWebhookSignature throws on invalid signature", () => {
+    expect(() => assertStripeWebhookSignature(payload, "bad", secret)).toThrow(
+      StripeWebhookVerificationError
+    );
+  });
+
+  it("processes invoice.paid into payment audit trail", async () => {
+    resetDefaultAuditRingBufferForTests();
+    const signature = Stripe.webhooks.generateTestHeaderString({ payload, secret });
+    const event = assertStripeWebhookSignature(payload, signature, secret);
+    const result = await processStripeWebhookEvent(event, { tenantId: "default" });
+    expect(result.handled).toBe(true);
+    const entries = listPaymentAuditEntries(10);
+    expect(entries.some((e) => e.action === "STRIPE_INVOICE_PAID")).toBe(true);
+  });
+});

--- a/packages/clawql-payments/src/stripe/webhook.ts
+++ b/packages/clawql-payments/src/stripe/webhook.ts
@@ -1,0 +1,157 @@
+import Stripe from "stripe";
+import {
+  appendPaymentWormEntry,
+  buildPaymentWormEntry,
+  buildStripeInvoicePaidEntry,
+} from "../audit/index.js";
+import { loadPaymentsConfig } from "../config/store.js";
+import { StripeWebhookVerificationError } from "./errors.js";
+
+export type StripeWebhookEvent = {
+  id: string;
+  type: string;
+  payload: Stripe.Event;
+};
+
+export type StripeWebhookVerifyResult =
+  | { ok: true; event: Stripe.Event }
+  | { ok: false; reason: string };
+
+export function verifyStripeWebhookSignature(
+  payload: string | Buffer,
+  signature: string,
+  secret: string
+): StripeWebhookVerifyResult {
+  if (!secret.trim()) {
+    return { ok: false, reason: "webhook secret is required" };
+  }
+  if (!signature.trim()) {
+    return { ok: false, reason: "Stripe-Signature header is required" };
+  }
+
+  try {
+    const event = Stripe.webhooks.constructEvent(payload, signature, secret);
+    return { ok: true, event };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, reason: message };
+  }
+}
+
+export function assertStripeWebhookSignature(
+  payload: string | Buffer,
+  signature: string,
+  secret: string
+): Stripe.Event {
+  const result = verifyStripeWebhookSignature(payload, signature, secret);
+  if (!result.ok) {
+    throw new StripeWebhookVerificationError(result.reason);
+  }
+  return result.event;
+}
+
+export type ProcessStripeWebhookOptions = {
+  tenantId?: string;
+  correlationId?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+export type ProcessStripeWebhookResult = {
+  handled: boolean;
+  eventType: string;
+  eventId: string;
+};
+
+function tenantFromEvent(
+  event: Stripe.Event,
+  fallbackTenantId: string
+): string {
+  const object = event.data.object as { metadata?: Record<string, string> };
+  return object.metadata?.tenant_id?.trim() || fallbackTenantId;
+}
+
+export async function processStripeWebhookEvent(
+  event: Stripe.Event,
+  options: ProcessStripeWebhookOptions = {}
+): Promise<ProcessStripeWebhookResult> {
+  const env = options.env ?? process.env;
+  const config = await loadPaymentsConfig(env);
+  const tenantId = options.tenantId ?? config.tenantId ?? "default";
+
+  switch (event.type) {
+    case "invoice.paid": {
+      const invoice = event.data.object as Stripe.Invoice;
+      const amountUsd = (invoice.amount_paid ?? 0) / 100;
+      appendPaymentWormEntry(
+        buildStripeInvoicePaidEntry({
+          tenantId: tenantFromEvent(event, tenantId),
+          amountUsd,
+          plan: config.plan,
+          correlationId: options.correlationId ?? event.id,
+        })
+      );
+      break;
+    }
+    case "invoice.payment_failed": {
+      const invoice = event.data.object as Stripe.Invoice;
+      appendPaymentWormEntry(
+        buildPaymentWormEntry({
+          eventKind: "STRIPE_PAYMENT_FAILED",
+          summary: `Stripe invoice payment failed for ${invoice.id}`,
+          correlationId: options.correlationId ?? event.id,
+          payload: {
+            provider: "stripe",
+            amount_usd: (invoice.amount_due ?? 0) / 100,
+            tenant_id: tenantFromEvent(event, tenantId),
+            plan: config.plan,
+          },
+        })
+      );
+      break;
+    }
+    case "customer.subscription.created": {
+      const subscription = event.data.object as Stripe.Subscription;
+      appendPaymentWormEntry(
+        buildPaymentWormEntry({
+          eventKind: "STRIPE_SUBSCRIPTION_CREATED",
+          summary: `Stripe subscription created ${subscription.id}`,
+          correlationId: options.correlationId ?? event.id,
+          payload: {
+            provider: "stripe",
+            tenant_id: tenantFromEvent(event, tenantId),
+            plan: config.plan,
+          },
+        })
+      );
+      break;
+    }
+    default:
+      return {
+        handled: false,
+        eventType: event.type,
+        eventId: event.id,
+      };
+  }
+
+  return {
+    handled: true,
+    eventType: event.type,
+    eventId: event.id,
+  };
+}
+
+export async function verifyAndProcessStripeWebhook(input: {
+  payload: string | Buffer;
+  signature: string;
+  secret: string;
+  tenantId?: string;
+  correlationId?: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<ProcessStripeWebhookResult> {
+  const event = assertStripeWebhookSignature(input.payload, input.signature, input.secret);
+  return processStripeWebhookEvent(event, {
+    tenantId: input.tenantId,
+    correlationId: input.correlationId,
+    env: input.env,
+  });
+}

--- a/src/onboarding/cli.ts
+++ b/src/onboarding/cli.ts
@@ -60,6 +60,7 @@ import {
   runPaymentsStripeSetupCmd,
   runPaymentsStripeSubscriptionCreateCmd,
   runPaymentsStripeWebhookListenCmd,
+  runPaymentsStripeWebhookVerifyCmd,
   runPaymentsUsageReportCmd,
   runPaymentsX402GateCmd,
   runPaymentsX402GateListCmd,
@@ -182,6 +183,8 @@ function parse(argv: string[]): {
     else if (a === "--account-id") flags.accountId = argv[++i] ?? "";
     else if (a === "--publishable-key") flags.publishableKey = argv[++i] ?? "";
     else if (a === "--webhook-secret") flags.webhookSecret = argv[++i] ?? "";
+    else if (a === "--payload") flags.payloadPath = argv[++i] ?? "";
+    else if (a === "--process") flags.process = true;
     else if (a === "--facilitator-url") flags.facilitatorUrl = argv[++i] ?? "";
     else if (a === "--tenant-id") flags.tenantId = argv[++i] ?? "";
     else if (a === "--skip-verify") flags.skipVerify = true;
@@ -252,7 +255,7 @@ Usage:
   clawql inference pipeline enable [--schedule "0 2 * * 0"] [--min-samples 500] | status | disable | run
   clawql inference finetune status --job-id <id> | register --job-id <id> --tier frugal --alias <model>
   clawql payments plan show | upgrade --tier team | usage report [--month YYYY-MM]
-  clawql payments stripe setup | customer create --email user@acme.com | subscription create | invoice create
+  clawql payments stripe setup | customer create --email user@acme.com | subscription create | invoice create | webhook verify
   clawql payments x402 wallet setup --address 0x... | gate --tool knowledge_search --price 0.001 | verify | reconcile
   clawql payments spend report [--group-by provider|tenant|plan] | audit [--correlation-id ID]
   clawql claude | codex | cursor | opencode [-- harness args...]
@@ -796,6 +799,8 @@ async function main(): Promise<void> {
       webhookSecret: typeof flags.webhookSecret === "string" ? flags.webhookSecret : undefined,
       facilitatorUrl:
         typeof flags.facilitatorUrl === "string" ? flags.facilitatorUrl : undefined,
+      payloadPath: typeof flags.payloadPath === "string" ? flags.payloadPath : undefined,
+      process: Boolean(flags.process),
     };
 
     if (subcmd === "plan") {
@@ -841,8 +846,12 @@ async function main(): Promise<void> {
         process.exitCode = await runPaymentsStripeWebhookListenCmd();
         return;
       }
+      if (stripeAction === "webhook" && rest[1] === "verify") {
+        process.exitCode = await runPaymentsStripeWebhookVerifyCmd(paymentsOpts);
+        return;
+      }
       console.error(
-        "Usage: clawql payments stripe setup | customer create | subscription create | invoice create | webhook listen"
+        "Usage: clawql payments stripe setup | customer create | subscription create | invoice create | webhook listen | webhook verify"
       );
       process.exitCode = 1;
       return;

--- a/src/onboarding/payments-cli.ts
+++ b/src/onboarding/payments-cli.ts
@@ -12,6 +12,7 @@ import {
   runPaymentsStripeSetup,
   runPaymentsStripeSubscriptionCreate,
   runPaymentsStripeWebhookListen,
+  runPaymentsStripeWebhookVerify,
   runPaymentsUsageReport,
   runPaymentsX402Gate,
   runPaymentsX402GateList,
@@ -47,6 +48,8 @@ export type PaymentsCliOptions = {
   publishableKey?: string;
   webhookSecret?: string;
   facilitatorUrl?: string;
+  payloadPath?: string;
+  process?: boolean;
 };
 
 export async function runPaymentsPlanShowCmd(
@@ -122,14 +125,26 @@ export async function runPaymentsStripeInvoiceCreateCmd(
   return runPaymentsStripeInvoiceCreate({
     customer: options.customer,
     amount: options.amount,
-    tenantId: options.tenantId,
-    correlationId: options.correlationId,
     json: options.json,
   });
 }
 
 export async function runPaymentsStripeWebhookListenCmd(): Promise<number> {
   return runPaymentsStripeWebhookListen();
+}
+
+export async function runPaymentsStripeWebhookVerifyCmd(
+  options: PaymentsCliOptions = {}
+): Promise<number> {
+  return runPaymentsStripeWebhookVerify({
+    payloadPath: options.payloadPath,
+    signature: options.signature,
+    webhookSecret: options.webhookSecret,
+    process: options.process,
+    tenantId: options.tenantId,
+    correlationId: options.correlationId,
+    json: options.json,
+  });
 }
 
 export async function runPaymentsX402WalletSetupCmd(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces Stripe stubs with live Stripe SDK integration and mandatory webhook signature verification before payment events enter the audit trail.

**Depends on:** #583 (payments scaffold) → #584 (inference limits)

## Stripe SDK (`stripe@^18`)

Split monolithic stub into proper modules:

| Module | Function |
|--------|----------|
| `client.ts` | `STRIPE_SECRET_KEY` resolution, Stripe client factory |
| `customer.ts` | Live `customers.create` |
| `subscription.ts` | `subscriptions.create` with `STRIPE_PRO/TEAM_PRICE_ID` |
| `invoice.ts` | Invoice item + create + finalize |
| `portal.ts` | Billing portal sessions |
| `metered.ts` | Stripe Billing Meters (`billing.meterEvents.create`) |
| `webhook.ts` | `constructEvent` verification + event processing |

## Webhook security

- **`verifyStripeWebhookSignature`** — uses `Stripe.webhooks.constructEvent`; rejects missing/invalid signatures
- **`verifyAndProcessStripeWebhook`** — verify then process in one call
- **`processStripeWebhookEvent`** — writes audit entries for:
  - `invoice.paid` → `STRIPE_INVOICE_PAID`
  - `invoice.payment_failed` → `STRIPE_PAYMENT_FAILED`
  - `customer.subscription.created` → `STRIPE_SUBSCRIPTION_CREATED`

Invoice creation no longer writes audit events prematurely — revenue events only arrive via verified webhooks.

## CLI

```bash
export STRIPE_SECRET_KEY=sk_test_...
clawql payments stripe setup --webhook-secret whsec_...
clawql payments stripe customer create --email user@acme.com
clawql payments stripe webhook verify --payload ./event.json --signature "t=...,v1=..." --process
```

## Tests

6 new tests (client config, webhook verify/process). 17 total in `clawql-payments`.

## Next in sequence

1. ~~Stripe SDK + webhook verification~~ (this PR)
2. x402 facilitator HTTP calls
3. Metered usage → Stripe billing (wire inference/IDP usage to meter events)
4. Durable WORM writer
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

