### PR TITLE
feat(payments): wire inference usage to Stripe Billing Meters

### DIFF
--- a/packages/clawql-inference/src/api/openai-compat.ts
+++ b/packages/clawql-inference/src/api/openai-compat.ts
@@ -12,9 +12,10 @@ import {
   assertInferenceEntitlement,
   EntitlementLimitError,
   isInferenceEntitlementEnforcementActive,
-  recordInferenceUsage,
+  recordInferenceBilling,
   resolveInferenceTenantId,
 } from "../entitlements/enforced-gateway.js";
+import { isStripeMeterReportingActive } from "clawql-payments";
 
 type OpenAiChatCompletionRequest = {
   model?: string;
@@ -104,6 +105,8 @@ export function createOpenAiCompatRouter(options: CreateOpenAiCompatRouterOption
           if (adapter?.streamComplete) {
             const tenantId = await resolveInferenceTenantId({ team: keyContext?.team }, env);
             const enforcementActive = isInferenceEntitlementEnforcementActive(env);
+            const billingActive =
+              enforcementActive || isStripeMeterReportingActive(env);
             if (enforcementActive) {
               await assertInferenceEntitlement({
                 tenantId,
@@ -118,8 +121,8 @@ export function createOpenAiCompatRouter(options: CreateOpenAiCompatRouterOption
               correlationId,
               chunks: adapter.streamComplete(resolved.model, messages, completeOptions),
             });
-            if (enforcementActive) {
-              await recordInferenceUsage({ tenantId, env });
+            if (billingActive) {
+              await recordInferenceBilling({ tenantId, correlationId, env });
             }
             return;
           }

--- a/packages/clawql-inference/src/api/openai-compat.ts
+++ b/packages/clawql-inference/src/api/openai-compat.ts
@@ -105,8 +105,7 @@ export function createOpenAiCompatRouter(options: CreateOpenAiCompatRouterOption
           if (adapter?.streamComplete) {
             const tenantId = await resolveInferenceTenantId({ team: keyContext?.team }, env);
             const enforcementActive = isInferenceEntitlementEnforcementActive(env);
-            const billingActive =
-              enforcementActive || isStripeMeterReportingActive(env);
+            const billingActive = enforcementActive || isStripeMeterReportingActive(env);
             if (enforcementActive) {
               await assertInferenceEntitlement({
                 tenantId,

--- a/packages/clawql-inference/src/entitlements/check.ts
+++ b/packages/clawql-inference/src/entitlements/check.ts
@@ -5,6 +5,7 @@ import {
   createUsageStore,
   entitlementsFromPlan,
   loadPaymentsConfig,
+  reportInferenceMeterUsageIfEnabled,
 } from "clawql-payments";
 import { EntitlementLimitError } from "./errors.js";
 
@@ -72,6 +73,7 @@ export async function assertInferenceEntitlement(
 export type RecordInferenceUsageInput = {
   tenantId: string;
   amount?: number;
+  correlationId?: string;
   env?: NodeJS.ProcessEnv;
 };
 
@@ -84,4 +86,17 @@ export async function recordInferenceUsage(input: RecordInferenceUsageInput): Pr
     input.amount ?? 1,
     config.plan
   );
+}
+
+export async function recordInferenceBilling(input: RecordInferenceUsageInput): Promise<void> {
+  const env = input.env ?? process.env;
+  if (isInferenceEntitlementEnforcementActive(env)) {
+    await recordInferenceUsage(input);
+  }
+  await reportInferenceMeterUsageIfEnabled({
+    tenantId: input.tenantId,
+    value: input.amount ?? 1,
+    correlationId: input.correlationId,
+    env,
+  });
 }

--- a/packages/clawql-inference/src/entitlements/enforced-gateway.ts
+++ b/packages/clawql-inference/src/entitlements/enforced-gateway.ts
@@ -2,9 +2,10 @@ import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../g
 import {
   assertInferenceEntitlement,
   isInferenceEntitlementEnforcementActive,
-  recordInferenceUsage,
+  recordInferenceBilling,
   resolveInferenceTenantId,
 } from "./check.js";
+import { isStripeMeterReportingActive } from "clawql-payments";
 
 export class EntitlementEnforcedGateway implements InferenceGateway {
   constructor(
@@ -13,23 +14,25 @@ export class EntitlementEnforcedGateway implements InferenceGateway {
   ) {}
 
   async complete(request: InferenceRequest): Promise<InferenceResponse> {
-    if (!isInferenceEntitlementEnforcementActive(this.env)) {
-      return this.inner.complete(request);
-    }
-
     const tenantId = await resolveInferenceTenantId(
       { team: request.team, tenantId: request.tenantId },
       this.env
     );
 
-    await assertInferenceEntitlement({
+    if (isInferenceEntitlementEnforcementActive(this.env)) {
+      await assertInferenceEntitlement({
+        tenantId,
+        correlationId: request.correlationId,
+        env: this.env,
+      });
+    }
+
+    const response = await this.inner.complete(request);
+    await recordInferenceBilling({
       tenantId,
       correlationId: request.correlationId,
       env: this.env,
     });
-
-    const response = await this.inner.complete(request);
-    await recordInferenceUsage({ tenantId, env: this.env });
     return response;
   }
 }
@@ -38,7 +41,12 @@ export function withEntitlementEnforcement(
   gateway: InferenceGateway,
   env: NodeJS.ProcessEnv = process.env
 ): InferenceGateway {
-  if (!isInferenceEntitlementEnforcementActive(env)) return gateway;
+  if (
+    !isInferenceEntitlementEnforcementActive(env) &&
+    !isStripeMeterReportingActive(env)
+  ) {
+    return gateway;
+  }
   return new EntitlementEnforcedGateway(gateway, env);
 }
 
@@ -47,5 +55,6 @@ export {
   assertInferenceEntitlement,
   isInferenceEntitlementEnforcementActive,
   recordInferenceUsage,
+  recordInferenceBilling,
   resolveInferenceTenantId,
 } from "./check.js";

--- a/packages/clawql-inference/src/entitlements/enforced-gateway.ts
+++ b/packages/clawql-inference/src/entitlements/enforced-gateway.ts
@@ -41,10 +41,7 @@ export function withEntitlementEnforcement(
   gateway: InferenceGateway,
   env: NodeJS.ProcessEnv = process.env
 ): InferenceGateway {
-  if (
-    !isInferenceEntitlementEnforcementActive(env) &&
-    !isStripeMeterReportingActive(env)
-  ) {
+  if (!isInferenceEntitlementEnforcementActive(env) && !isStripeMeterReportingActive(env)) {
     return gateway;
   }
   return new EntitlementEnforcedGateway(gateway, env);

--- a/packages/clawql-payments/src/audit/events.ts
+++ b/packages/clawql-payments/src/audit/events.ts
@@ -2,6 +2,7 @@ export type PaymentEventKind =
   | "STRIPE_SUBSCRIPTION_CREATED"
   | "STRIPE_INVOICE_PAID"
   | "STRIPE_PAYMENT_FAILED"
+  | "STRIPE_METER_REPORTED"
   | "X402_PAYMENT_RECEIVED"
   | "X402_PAYMENT_FAILED"
   | "ENTITLEMENT_LIMIT_REACHED"
@@ -120,6 +121,25 @@ export function buildPlanChangedEntry(input: {
       provider: "stripe",
       tenant_id: input.tenantId,
       plan: input.toPlan,
+    },
+  });
+}
+
+export function buildStripeMeterReportedEntry(input: {
+  tenantId: string;
+  value: number;
+  eventName: string;
+  stripeCustomerId: string;
+  correlationId?: string;
+}): PaymentWormEntry {
+  return buildPaymentWormEntry({
+    eventKind: "STRIPE_METER_REPORTED",
+    summary: `Stripe meter ${input.eventName} +${input.value} for tenant ${input.tenantId}`,
+    correlationId: input.correlationId,
+    payload: {
+      provider: "stripe",
+      tenant_id: input.tenantId,
+      resource: input.eventName,
     },
   });
 }

--- a/packages/clawql-payments/src/audit/index.ts
+++ b/packages/clawql-payments/src/audit/index.ts
@@ -3,6 +3,7 @@ export {
   buildPaymentWormEntry,
   buildPlanChangedEntry,
   buildStripeInvoicePaidEntry,
+  buildStripeMeterReportedEntry,
   buildX402PaymentReceivedEntry,
   type PaymentEventKind,
   type PaymentProvider,

--- a/packages/clawql-payments/src/cli/index.ts
+++ b/packages/clawql-payments/src/cli/index.ts
@@ -17,11 +17,13 @@ export {
   runPaymentsStripeInvoiceCreate,
   runPaymentsStripeWebhookListen,
   runPaymentsStripeWebhookVerify,
+  runPaymentsStripeMeterReport,
   type PaymentsStripeCustomerCreateOptions,
   type PaymentsStripeInvoiceCreateOptions,
   type PaymentsStripeSetupOptions,
   type PaymentsStripeSubscriptionCreateOptions,
   type PaymentsStripeWebhookVerifyOptions,
+  type PaymentsStripeMeterReportOptions,
 } from "./stripe.js";
 export {
   runPaymentsX402WalletSetup,

--- a/packages/clawql-payments/src/cli/stripe.ts
+++ b/packages/clawql-payments/src/cli/stripe.ts
@@ -86,7 +86,9 @@ export async function runPaymentsStripeCustomerCreate(
       return 0;
     }
 
-    console.log(`Created Stripe customer ${customer.id} (${customer.email}) → saved to payments.json`);
+    console.log(
+      `Created Stripe customer ${customer.id} (${customer.email}) → saved to payments.json`
+    );
     return 0;
   } catch (error) {
     if (error instanceof StripeNotConfiguredError) {
@@ -314,9 +316,7 @@ export async function runPaymentsStripeMeterReport(
 
   const config = await loadPaymentsConfig(env);
   const customerId =
-    options.customer?.trim() ||
-    config.stripe.customerId?.trim() ||
-    env.STRIPE_CUSTOMER_ID?.trim();
+    options.customer?.trim() || config.stripe.customerId?.trim() || env.STRIPE_CUSTOMER_ID?.trim();
   const eventName =
     options.eventName?.trim() ||
     config.stripe.meterEventName?.trim() ||

--- a/packages/clawql-payments/src/cli/stripe.ts
+++ b/packages/clawql-payments/src/cli/stripe.ts
@@ -7,8 +7,10 @@ import {
   verifyAndProcessStripeWebhook,
   verifyStripeWebhookSignature,
   isStripeConfigured,
+  reportMeteredUsage,
 } from "../stripe/index.js";
-import { loadPaymentsConfig } from "../config/store.js";
+import { appendPaymentWormEntry, buildStripeMeterReportedEntry } from "../audit/index.js";
+import { loadPaymentsConfig, mergePaymentsConfig } from "../config/store.js";
 import { StripeNotConfiguredError, StripeWebhookVerificationError } from "../stripe/errors.js";
 
 export type PaymentsStripeSetupOptions = {
@@ -77,12 +79,14 @@ export async function runPaymentsStripeCustomerCreate(
       env,
     });
 
+    await mergePaymentsConfig({ stripe: { customerId: customer.id } }, env);
+
     if (options.json) {
       console.log(JSON.stringify(customer, null, 2));
       return 0;
     }
 
-    console.log(`Created Stripe customer ${customer.id} (${customer.email})`);
+    console.log(`Created Stripe customer ${customer.id} (${customer.email}) → saved to payments.json`);
     return 0;
   } catch (error) {
     if (error instanceof StripeNotConfiguredError) {
@@ -285,5 +289,74 @@ export async function runPaymentsStripeWebhookListen(): Promise<number> {
 
 Store the webhook signing secret via:
   clawql payments stripe setup --webhook-secret whsec_...`);
+  return 0;
+}
+
+export type PaymentsStripeMeterReportOptions = {
+  value?: number;
+  customer?: string;
+  eventName?: string;
+  identifier?: string;
+  tenantId?: string;
+  correlationId?: string;
+  json?: boolean;
+  env?: NodeJS.ProcessEnv;
+};
+
+export async function runPaymentsStripeMeterReport(
+  options: PaymentsStripeMeterReportOptions = {}
+): Promise<number> {
+  const env = options.env ?? process.env;
+  if (!isStripeConfigured(env)) {
+    console.error("STRIPE_SECRET_KEY is required for live Stripe API calls");
+    return 1;
+  }
+
+  const config = await loadPaymentsConfig(env);
+  const customerId =
+    options.customer?.trim() ||
+    config.stripe.customerId?.trim() ||
+    env.STRIPE_CUSTOMER_ID?.trim();
+  const eventName =
+    options.eventName?.trim() ||
+    config.stripe.meterEventName?.trim() ||
+    env.STRIPE_METER_EVENT_NAME?.trim();
+
+  if (!customerId || !eventName) {
+    console.error(
+      "Usage: clawql payments stripe meter report --value 1 --customer cus_xxx --event-name clawql_inference_calls"
+    );
+    return 1;
+  }
+
+  const value = options.value ?? 1;
+  const tenantId = options.tenantId?.trim() || config.tenantId?.trim() || "default";
+
+  const result = await reportMeteredUsage({
+    eventName,
+    stripeCustomerId: customerId,
+    value,
+    identifier: options.identifier,
+    env,
+  });
+
+  appendPaymentWormEntry(
+    buildStripeMeterReportedEntry({
+      tenantId,
+      value,
+      eventName,
+      stripeCustomerId: customerId,
+      correlationId: options.correlationId,
+    })
+  );
+
+  if (options.json) {
+    console.log(JSON.stringify({ tenantId, ...result, eventName, customerId }, null, 2));
+    return 0;
+  }
+
+  console.log(
+    `Reported Stripe meter ${eventName} +${value} for ${customerId} (id=${result.id}, tenant=${tenantId})`
+  );
   return 0;
 }

--- a/packages/clawql-payments/src/config/store.ts
+++ b/packages/clawql-payments/src/config/store.ts
@@ -11,6 +11,8 @@ export const PaymentsConfigSchema = z.object({
       accountId: z.string().optional(),
       publishableKey: z.string().optional(),
       webhookSecret: z.string().optional(),
+      customerId: z.string().optional(),
+      meterEventName: z.string().optional(),
     })
     .default({}),
   x402: z

--- a/packages/clawql-payments/src/stripe/index.ts
+++ b/packages/clawql-payments/src/stripe/index.ts
@@ -21,6 +21,15 @@ export {
   type StripeInvoiceResult,
 } from "./invoice.js";
 export { reportMeteredUsage, type MeteredUsageInput } from "./metered.js";
+export {
+  buildInferenceMeterIdentifier,
+  isStripeMeterReportingActive,
+  reportInferenceMeterUsageIfEnabled,
+  resolveStripeMeterConfig,
+  type ReportInferenceMeterUsageInput,
+  type ReportInferenceMeterUsageResult,
+  type StripeMeterConfig,
+} from "./meter-report.js";
 export { createCustomerPortalSession, type PortalSessionInput } from "./portal.js";
 export {
   assertStripeWebhookSignature,

--- a/packages/clawql-payments/src/stripe/meter-report.test.ts
+++ b/packages/clawql-payments/src/stripe/meter-report.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { resetDefaultAuditRingBufferForTests } from "clawql-core";
+import { listPaymentAuditEntries } from "../audit/worm.js";
+import {
+  buildInferenceMeterIdentifier,
+  isStripeMeterReportingActive,
+  reportInferenceMeterUsageIfEnabled,
+  resolveStripeMeterConfig,
+} from "./meter-report.js";
+
+vi.mock("./metered.js", () => ({
+  reportMeteredUsage: vi.fn(async () => ({ id: "meter_evt_test", value: 1 })),
+}));
+
+import { reportMeteredUsage } from "./metered.js";
+
+describe("stripe meter reporting", () => {
+  beforeEach(() => {
+    resetDefaultAuditRingBufferForTests();
+    vi.mocked(reportMeteredUsage).mockClear();
+  });
+
+  it("isStripeMeterReportingActive respects env flag", () => {
+    expect(isStripeMeterReportingActive({ CLAWQL_PAYMENTS_REPORT_STRIPE_METER: "1" })).toBe(true);
+    expect(isStripeMeterReportingActive({})).toBe(false);
+  });
+
+  it("buildInferenceMeterIdentifier uses correlation id when present", () => {
+    expect(
+      buildInferenceMeterIdentifier({ tenantId: "acme", correlationId: "corr-1" })
+    ).toBe("inference:acme:corr-1");
+  });
+
+  it("resolveStripeMeterConfig merges payments.json and env", async () => {
+    const env = {
+      STRIPE_SECRET_KEY: "sk_test_xxx",
+      STRIPE_CUSTOMER_ID: "cus_env",
+      STRIPE_METER_EVENT_NAME: "env_meter",
+      CLAWQL_HOME: "/tmp/clawql-meter-test-empty",
+    } as NodeJS.ProcessEnv;
+
+    const config = await resolveStripeMeterConfig(env);
+    expect(config).toEqual({ customerId: "cus_env", eventName: "env_meter" });
+  });
+
+  it("reportInferenceMeterUsageIfEnabled skips when disabled", async () => {
+    const result = await reportInferenceMeterUsageIfEnabled({
+      tenantId: "default",
+      env: { STRIPE_SECRET_KEY: "sk_test" },
+    });
+    expect(result.reported).toBe(false);
+    expect(vi.mocked(reportMeteredUsage)).not.toHaveBeenCalled();
+  });
+
+  it("reportInferenceMeterUsageIfEnabled emits meter event and audit entry", async () => {
+    const result = await reportInferenceMeterUsageIfEnabled({
+      tenantId: "tenant-a",
+      correlationId: "corr-99",
+      env: {
+        STRIPE_SECRET_KEY: "sk_test_xxx",
+        STRIPE_CUSTOMER_ID: "cus_abc",
+        STRIPE_METER_EVENT_NAME: "clawql_inference_calls",
+        CLAWQL_PAYMENTS_REPORT_STRIPE_METER: "1",
+      },
+    });
+
+    expect(result.reported).toBe(true);
+    if (result.reported) {
+      expect(result.eventId).toBe("meter_evt_test");
+    }
+
+    expect(vi.mocked(reportMeteredUsage)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventName: "clawql_inference_calls",
+        stripeCustomerId: "cus_abc",
+        value: 1,
+        identifier: "inference:tenant-a:corr-99",
+      })
+    );
+
+    const entries = listPaymentAuditEntries(5);
+    expect(entries.some((e) => e.action === "STRIPE_METER_REPORTED")).toBe(true);
+  });
+});

--- a/packages/clawql-payments/src/stripe/meter-report.test.ts
+++ b/packages/clawql-payments/src/stripe/meter-report.test.ts
@@ -26,9 +26,9 @@ describe("stripe meter reporting", () => {
   });
 
   it("buildInferenceMeterIdentifier uses correlation id when present", () => {
-    expect(
-      buildInferenceMeterIdentifier({ tenantId: "acme", correlationId: "corr-1" })
-    ).toBe("inference:acme:corr-1");
+    expect(buildInferenceMeterIdentifier({ tenantId: "acme", correlationId: "corr-1" })).toBe(
+      "inference:acme:corr-1"
+    );
   });
 
   it("resolveStripeMeterConfig merges payments.json and env", async () => {

--- a/packages/clawql-payments/src/stripe/meter-report.ts
+++ b/packages/clawql-payments/src/stripe/meter-report.ts
@@ -52,8 +52,7 @@ export type ReportInferenceMeterUsageInput = {
 };
 
 export type ReportInferenceMeterUsageResult =
-  | { reported: true; eventId: string; value: number }
-  | { reported: false; reason: string };
+  { reported: true; eventId: string; value: number } | { reported: false; reason: string };
 
 export async function reportInferenceMeterUsageIfEnabled(
   input: ReportInferenceMeterUsageInput

--- a/packages/clawql-payments/src/stripe/meter-report.ts
+++ b/packages/clawql-payments/src/stripe/meter-report.ts
@@ -1,0 +1,101 @@
+import { appendPaymentWormEntry, buildStripeMeterReportedEntry } from "../audit/index.js";
+import { loadPaymentsConfig } from "../config/store.js";
+import { isStripeConfigured } from "./client.js";
+import { reportMeteredUsage } from "./metered.js";
+
+export type StripeMeterConfig = {
+  customerId: string;
+  eventName: string;
+};
+
+function parseTruthy(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+export function isStripeMeterReportingActive(env: NodeJS.ProcessEnv = process.env): boolean {
+  return parseTruthy(env.CLAWQL_PAYMENTS_REPORT_STRIPE_METER);
+}
+
+export async function resolveStripeMeterConfig(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<StripeMeterConfig | null> {
+  if (!isStripeConfigured(env)) return null;
+
+  const config = await loadPaymentsConfig(env);
+  const customerId =
+    config.stripe.customerId?.trim() || env.STRIPE_CUSTOMER_ID?.trim() || undefined;
+  const eventName =
+    config.stripe.meterEventName?.trim() || env.STRIPE_METER_EVENT_NAME?.trim() || undefined;
+
+  if (!customerId || !eventName) return null;
+  return { customerId, eventName };
+}
+
+export function buildInferenceMeterIdentifier(input: {
+  tenantId: string;
+  correlationId?: string;
+}): string {
+  if (input.correlationId?.trim()) {
+    return `inference:${input.tenantId}:${input.correlationId.trim()}`;
+  }
+  return `inference:${input.tenantId}:${Date.now()}`;
+}
+
+export type ReportInferenceMeterUsageInput = {
+  tenantId: string;
+  value?: number;
+  correlationId?: string;
+  identifier?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+export type ReportInferenceMeterUsageResult =
+  | { reported: true; eventId: string; value: number }
+  | { reported: false; reason: string };
+
+export async function reportInferenceMeterUsageIfEnabled(
+  input: ReportInferenceMeterUsageInput
+): Promise<ReportInferenceMeterUsageResult> {
+  const env = input.env ?? process.env;
+  if (!isStripeMeterReportingActive(env)) {
+    return { reported: false, reason: "stripe meter reporting is disabled" };
+  }
+
+  const meterConfig = await resolveStripeMeterConfig(env);
+  if (!meterConfig) {
+    return {
+      reported: false,
+      reason: "stripe customer id or meter event name is not configured",
+    };
+  }
+
+  const value = input.value ?? 1;
+  const identifier =
+    input.identifier ??
+    buildInferenceMeterIdentifier({
+      tenantId: input.tenantId,
+      correlationId: input.correlationId,
+    });
+
+  const result = await reportMeteredUsage({
+    eventName: meterConfig.eventName,
+    stripeCustomerId: meterConfig.customerId,
+    value,
+    identifier,
+    env,
+  });
+
+  appendPaymentWormEntry(
+    buildStripeMeterReportedEntry({
+      tenantId: input.tenantId,
+      value,
+      eventName: meterConfig.eventName,
+      stripeCustomerId: meterConfig.customerId,
+      correlationId: input.correlationId,
+    })
+  );
+
+  return { reported: true, eventId: result.id, value: result.value };
+}

--- a/src/onboarding/cli.ts
+++ b/src/onboarding/cli.ts
@@ -63,6 +63,7 @@ import {
   runPaymentsStripeSubscriptionCreateCmd,
   runPaymentsStripeWebhookListenCmd,
   runPaymentsStripeWebhookVerifyCmd,
+  runPaymentsStripeMeterReportCmd,
   runPaymentsUsageReportCmd,
   runPaymentsX402GateCmd,
   runPaymentsX402GateListCmd,
@@ -770,6 +771,8 @@ async function main(): Promise<void> {
         : undefined;
     const price =
       typeof flags.price === "string" && flags.price ? Number.parseFloat(flags.price) : undefined;
+    const value =
+      typeof flags.value === "string" && flags.value ? Number.parseFloat(flags.value) : undefined;
     const limit =
       typeof flags.limit === "string" && flags.limit ? Number.parseInt(flags.limit, 10) : undefined;
     const paymentsOpts: PaymentsCliOptions = {
@@ -804,6 +807,9 @@ async function main(): Promise<void> {
       facilitatorUrl: typeof flags.facilitatorUrl === "string" ? flags.facilitatorUrl : undefined,
       payloadPath: typeof flags.payloadPath === "string" ? flags.payloadPath : undefined,
       process: Boolean(flags.process),
+      eventName: typeof flags.eventName === "string" ? flags.eventName : undefined,
+      identifier: typeof flags.identifier === "string" ? flags.identifier : undefined,
+      value: Number.isFinite(value) ? value : undefined,
     };
 
     if (subcmd === "plan") {
@@ -853,8 +859,12 @@ async function main(): Promise<void> {
         process.exitCode = await runPaymentsStripeWebhookVerifyCmd(paymentsOpts);
         return;
       }
+      if (stripeAction === "meter" && rest[1] === "report") {
+        process.exitCode = await runPaymentsStripeMeterReportCmd(paymentsOpts);
+        return;
+      }
       console.error(
-        "Usage: clawql payments stripe setup | customer create | subscription create | invoice create | webhook listen | webhook verify"
+        "Usage: clawql payments stripe setup | customer create | subscription create | invoice create | meter report | webhook listen | webhook verify"
       );
       process.exitCode = 1;
       return;

--- a/src/onboarding/payments-cli.ts
+++ b/src/onboarding/payments-cli.ts
@@ -13,6 +13,7 @@ import {
   runPaymentsStripeSubscriptionCreate,
   runPaymentsStripeWebhookListen,
   runPaymentsStripeWebhookVerify,
+  runPaymentsStripeMeterReport,
   runPaymentsUsageReport,
   runPaymentsX402Gate,
   runPaymentsX402GateList,
@@ -50,6 +51,9 @@ export type PaymentsCliOptions = {
   facilitatorUrl?: string;
   payloadPath?: string;
   process?: boolean;
+  eventName?: string;
+  identifier?: string;
+  value?: number;
 };
 
 export async function runPaymentsPlanShowCmd(options: PaymentsCliOptions = {}): Promise<number> {
@@ -131,6 +135,20 @@ export async function runPaymentsStripeWebhookVerifyCmd(
     signature: options.signature,
     webhookSecret: options.webhookSecret,
     process: options.process,
+    tenantId: options.tenantId,
+    correlationId: options.correlationId,
+    json: options.json,
+  });
+}
+
+export async function runPaymentsStripeMeterReportCmd(
+  options: PaymentsCliOptions = {}
+): Promise<number> {
+  return runPaymentsStripeMeterReport({
+    value: options.value,
+    customer: options.customer,
+    eventName: options.eventName,
+    identifier: options.identifier,
     tenantId: options.tenantId,
     correlationId: options.correlationId,
     json: options.json,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wires inference usage to **Stripe Billing Meters** via `billing.meterEvents.create`.

- **`reportInferenceMeterUsageIfEnabled()`** — emits meter events when `CLAWQL_PAYMENTS_REPORT_STRIPE_METER=1`
- **Inference hook** — `recordInferenceBilling()` in gateway + streaming HTTP path (works with or without plan enforcement)
- **Config** — `payments.json` → `stripe.customerId`, `stripe.meterEventName`; customer create persists customer id
- **CLI** — `clawql payments stripe meter report --value 1 --customer cus_xxx`
- **Audit** — `STRIPE_METER_REPORTED` WORM events
- **Tests** — 5 new unit tests in `meter-report.test.ts`

## Enable

```bash
export CLAWQL_PAYMENTS_REPORT_STRIPE_METER=1
export STRIPE_METER_EVENT_NAME=clawql_inference_calls
export STRIPE_CUSTOMER_ID=cus_xxx   # or via payments.json after customer create

# Optional: also enforce local plan caps
export CLAWQL_PAYMENTS_ENFORCE_INFERENCE=1

clawql inference serve --port 8080
```

## Docs

Full operator guide: [`docs/payments/clawql-payments.md`](docs/payments/clawql-payments.md) (lands with #587).

## Follow-up

- Durable WORM writer for production compliance
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

