### PR TITLE
feat(payments): durable hash-chained WORM payment audit log

### DIFF
--- a/docs/payments/clawql-payments.md
+++ b/docs/payments/clawql-payments.md
@@ -16,7 +16,7 @@
 | Stripe Billing Meters (`meterEvents.create`)     | ✅     | API + inference hook when `CLAWQL_PAYMENTS_REPORT_STRIPE_METER=1`               |
 | x402 gate config + facilitator HTTP verify       | ✅     | `POST /verify` against x402.org or CDP                                          |
 | x402 Express middleware (402 + PAYMENT-REQUIRED) | ✅     | Wired into `clawql-inference` HTTP                                              |
-| Payment WORM audit (hash-chained JSONL)          | ✅     | `$CLAWQL_HOME/Payments/audit.jsonl` + `audit verify`                           |
+| Payment WORM audit (hash-chained JSONL)          | ✅     | `$CLAWQL_HOME/Payments/audit.jsonl` + `audit verify`                            |
 | `.well-known/payments.json` discovery            | 📋     | Placeholder ([#88](https://github.com/danielsmithdevelopment/ClawQL/issues/88)) |
 
 ## Architecture
@@ -375,10 +375,10 @@ A hot in-process mirror still feeds the MCP `audit` ring buffer (summary fields 
 
 ### Environment
 
-| Variable | Default | Purpose |
-| -------- | ------- | ------- |
+| Variable                      | Default                     | Purpose                                            |
+| ----------------------------- | --------------------------- | -------------------------------------------------- |
 | `CLAWQL_PAYMENTS_AUDIT_STORE` | `jsonl` (`memory` in tests) | `jsonl` = durable file; `memory` = in-process only |
-| `CLAWQL_PAYMENTS_AUDIT_FSYNC` | on | `fsync` after each append (set `0` to disable) |
+| `CLAWQL_PAYMENTS_AUDIT_FSYNC` | on                          | `fsync` after each append (set `0` to disable)     |
 
 ### CLI
 
@@ -499,12 +499,12 @@ See also: [`packages/clawql-inference/README.md`](../../packages/clawql-inferenc
 
 ## Follow-up work
 
-| Item | Tracking |
-| ---- | -------- |
-| Postgres audit store (enterprise) | optional `CLAWQL_PAYMENTS_AUDIT_STORE=postgres` |
-| Hosted webhook HTTP endpoint | not CLI-only |
+| Item                                  | Tracking                                                          |
+| ------------------------------------- | ----------------------------------------------------------------- |
+| Postgres audit store (enterprise)     | optional `CLAWQL_PAYMENTS_AUDIT_STORE=postgres`                   |
+| Hosted webhook HTTP endpoint          | not CLI-only                                                      |
 | `.well-known/payments.json` discovery | [#88](https://github.com/danielsmithdevelopment/ClawQL/issues/88) |
-| MCP tool x402 enforcement in-process | HTTP middleware + `X-Clawql-Tool` today |
+| MCP tool x402 enforcement in-process  | HTTP middleware + `X-Clawql-Tool` today                           |
 
 ## Related
 

--- a/docs/payments/clawql-payments.md
+++ b/docs/payments/clawql-payments.md
@@ -16,7 +16,7 @@
 | Stripe Billing Meters (`meterEvents.create`)     | ✅     | API + inference hook when `CLAWQL_PAYMENTS_REPORT_STRIPE_METER=1`               |
 | x402 gate config + facilitator HTTP verify       | ✅     | `POST /verify` against x402.org or CDP                                          |
 | x402 Express middleware (402 + PAYMENT-REQUIRED) | ✅     | Wired into `clawql-inference` HTTP                                              |
-| Payment WORM audit (ring buffer)                 | ✅     | Durable WORM writer is follow-up work                                           |
+| Payment WORM audit (hash-chained JSONL)          | ✅     | `$CLAWQL_HOME/Payments/audit.jsonl` + `audit verify`                           |
 | `.well-known/payments.json` discovery            | 📋     | Placeholder ([#88](https://github.com/danielsmithdevelopment/ClawQL/issues/88)) |
 
 ## Architecture
@@ -26,7 +26,7 @@ clawql-payments
 ├── stripe/     Subscriptions, invoices, webhooks, Billing Meters
 ├── x402/       Wallet, gates, facilitator verify/settle, middleware
 ├── plans/      Tier definitions, entitlements, usage.json counters
-├── audit/      Payment events → WORM ring buffer
+├── audit/      Hash-chained append-only JSONL + integrity verify
 └── cli/        clawql payments * implementations
 ```
 
@@ -88,6 +88,8 @@ All local state lives under `$CLAWQL_HOME/Payments/` (default `~/.clawql/Payment
 | `payments.json`   | Tenant id, plan tier, Stripe metadata, x402 wallet/facilitator            |
 | `x402-gates.json` | Payment-gated HTTP paths and MCP tool names                               |
 | `usage.json`      | Monthly counters per tenant (`inference_calls`, `documents`, `memory_mb`) |
+| `audit.jsonl`     | Append-only hash-chained payment audit log                                |
+| `audit.meta.json` | Chain head (`seq`, `last_hash`) for fast append                           |
 
 Example `payments.json`:
 
@@ -358,7 +360,9 @@ Middleware mounts **before** auth in [`packages/clawql-inference/src/api/server.
 
 ## Payment audit (WORM)
 
-Payment events append to ClawQL's WORM ring buffer (durable persistence is follow-up work):
+Payment events append to an **append-only, hash-chained audit log** at `$CLAWQL_HOME/Payments/audit.jsonl`. Each record includes `seq`, `prev_hash`, and `hash` (SHA-256 over canonical JSON) so tampering breaks the chain. By default each append **fsyncs** to disk (`CLAWQL_PAYMENTS_AUDIT_FSYNC=1`).
+
+A hot in-process mirror still feeds the MCP `audit` ring buffer (summary fields only). **Authoritative** payment history — including full structured `payload` — lives in `audit.jsonl`.
 
 | Event                               | Trigger                        |
 | ----------------------------------- | ------------------------------ |
@@ -369,9 +373,33 @@ Payment events append to ClawQL's WORM ring buffer (durable persistence is follo
 | `ENTITLEMENT_LIMIT_REACHED`         | Plan cap hit                   |
 | `PLAN_UPGRADED` / `PLAN_DOWNGRADED` | `clawql payments plan upgrade` |
 
+### Environment
+
+| Variable | Default | Purpose |
+| -------- | ------- | ------- |
+| `CLAWQL_PAYMENTS_AUDIT_STORE` | `jsonl` (`memory` in tests) | `jsonl` = durable file; `memory` = in-process only |
+| `CLAWQL_PAYMENTS_AUDIT_FSYNC` | on | `fsync` after each append (set `0` to disable) |
+
+### CLI
+
 ```bash
 clawql payments audit --correlation-id seed_abc_gen_2
+clawql payments audit verify          # validate hash chain integrity
+clawql payments audit verify --json
 clawql payments spend report --group-by provider
+```
+
+`spend report` now aggregates real `amount_usd` / `amount_usdc` values from persisted payloads (not placeholder data).
+
+### Programmatic verify
+
+```typescript
+import { verifyPaymentAuditLog } from "clawql-payments";
+
+const result = verifyPaymentAuditLog();
+if (!result.ok) {
+  console.error(result.issues);
+}
 ```
 
 ---
@@ -397,6 +425,7 @@ clawql payments x402 wallet setup | gate | gate list | verify | reconcile
 # Audit
 clawql payments spend report --group-by provider
 clawql payments audit --correlation-id xxx
+clawql payments audit verify
 ```
 
 ---
@@ -470,12 +499,12 @@ See also: [`packages/clawql-inference/README.md`](../../packages/clawql-inferenc
 
 ## Follow-up work
 
-| Item                                      | Tracking                                                          |
-| ----------------------------------------- | ----------------------------------------------------------------- |
-| Durable WORM writer (replace ring buffer) | payments README status                                            |
-| Hosted webhook HTTP endpoint              | not CLI-only                                                      |
-| `.well-known/payments.json` discovery     | [#88](https://github.com/danielsmithdevelopment/ClawQL/issues/88) |
-| MCP tool x402 enforcement in-process      | HTTP middleware + `X-Clawql-Tool` today                           |
+| Item | Tracking |
+| ---- | -------- |
+| Postgres audit store (enterprise) | optional `CLAWQL_PAYMENTS_AUDIT_STORE=postgres` |
+| Hosted webhook HTTP endpoint | not CLI-only |
+| `.well-known/payments.json` discovery | [#88](https://github.com/danielsmithdevelopment/ClawQL/issues/88) |
+| MCP tool x402 enforcement in-process | HTTP middleware + `X-Clawql-Tool` today |
 
 ## Related
 

--- a/packages/clawql-payments/README.md
+++ b/packages/clawql-payments/README.md
@@ -66,6 +66,7 @@ clawql payments x402 reconcile --date 2026-07-11
 # Unified reporting
 clawql payments spend report --group-by provider
 clawql payments audit --correlation-id xxx
+clawql payments audit verify
 ```
 
 ## Programmatic usage
@@ -88,6 +89,8 @@ Local state is stored under `$CLAWQL_HOME/Payments/` (default `~/.clawql/Payment
 - `payments.json` — tenant plan, Stripe and x402 wallet config
 - `x402-gates.json` — payment-gated resources and MCP tools
 - `usage.json` — metered usage counters per tenant/month
+- `audit.jsonl` — hash-chained payment audit log (append-only WORM)
+- `audit.meta.json` — chain head metadata
 
 ## Status
 
@@ -95,9 +98,9 @@ Stripe SDK integration is **live** for customers, subscriptions, invoices, billi
 
 x402 facilitator HTTP verification is **live** (`POST /verify` against x402.org or CDP). Inference HTTP can enforce gates with `CLAWQL_X402_ENFORCE=1`.
 
-Full operator guide: [`docs/payments/clawql-payments.md`](../../docs/payments/clawql-payments.md).
+Payment audit is **durable** — hash-chained append-only JSONL at `$CLAWQL_HOME/Payments/audit.jsonl` with `clawql payments audit verify`.
 
-Durable WORM persistence remains follow-up work.
+Full operator guide: [`docs/payments/clawql-payments.md`](../../docs/payments/clawql-payments.md).
 
 ## Related
 

--- a/packages/clawql-payments/src/audit/chain.test.ts
+++ b/packages/clawql-payments/src/audit/chain.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  PAYMENT_AUDIT_GENESIS_HASH,
+  hashPaymentAuditLink,
+  sealPaymentWormRecord,
+  verifyPaymentAuditChain,
+} from "./chain.js";
+import { buildStripeInvoicePaidEntry } from "./events.js";
+
+describe("payment audit hash chain", () => {
+  it("seals records with deterministic hash", () => {
+    const entry = buildStripeInvoicePaidEntry({
+      tenantId: "tenant-a",
+      amountUsd: 12.5,
+      plan: "pro",
+      correlationId: "corr-1",
+    });
+    entry.ts = "2026-07-12T00:00:00.000Z";
+
+    const record = sealPaymentWormRecord({
+      entry,
+      seq: 1,
+      prev_hash: PAYMENT_AUDIT_GENESIS_HASH,
+    });
+
+    expect(record.prev_hash).toBe(PAYMENT_AUDIT_GENESIS_HASH);
+    expect(record.hash).toBe(hashPaymentAuditLink(record));
+  });
+
+  it("verifyPaymentAuditChain passes for valid chain", () => {
+    const firstEntry = buildStripeInvoicePaidEntry({
+      tenantId: "tenant-a",
+      amountUsd: 1,
+    });
+    firstEntry.ts = "2026-07-12T00:00:00.000Z";
+    const secondEntry = buildStripeInvoicePaidEntry({
+      tenantId: "tenant-b",
+      amountUsd: 2,
+    });
+    secondEntry.ts = "2026-07-12T00:00:01.000Z";
+
+    const first = sealPaymentWormRecord({
+      entry: firstEntry,
+      seq: 1,
+      prev_hash: PAYMENT_AUDIT_GENESIS_HASH,
+    });
+    const second = sealPaymentWormRecord({
+      entry: secondEntry,
+      seq: 2,
+      prev_hash: first.hash,
+    });
+
+    const result = verifyPaymentAuditChain([first, second]);
+    expect(result.ok).toBe(true);
+    expect(result.records).toBe(2);
+    expect(result.head_hash).toBe(second.hash);
+  });
+
+  it("verifyPaymentAuditChain detects tampering", () => {
+    const entry = buildStripeInvoicePaidEntry({
+      tenantId: "tenant-a",
+      amountUsd: 99,
+    });
+    entry.ts = "2026-07-12T00:00:00.000Z";
+    const record = sealPaymentWormRecord({
+      entry,
+      seq: 1,
+      prev_hash: PAYMENT_AUDIT_GENESIS_HASH,
+    });
+    record.payload.amount_usd = 0.01;
+
+    const result = verifyPaymentAuditChain([record]);
+    expect(result.ok).toBe(false);
+    expect(result.issues.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/clawql-payments/src/audit/chain.ts
+++ b/packages/clawql-payments/src/audit/chain.ts
@@ -1,0 +1,107 @@
+import { createHash } from "node:crypto";
+import type { PaymentWormEntry } from "./events.js";
+
+export const PAYMENT_AUDIT_GENESIS_HASH =
+  "0000000000000000000000000000000000000000000000000000000000000000";
+
+export type PaymentWormRecord = PaymentWormEntry & {
+  seq: number;
+  prev_hash: string;
+  hash: string;
+};
+
+export type PaymentAuditChainLink = Omit<PaymentWormRecord, "hash">;
+
+export function canonicalPaymentAuditBytes(link: PaymentAuditChainLink): Buffer {
+  const body = JSON.stringify({
+    seq: link.seq,
+    prev_hash: link.prev_hash,
+    ts: link.ts,
+    category: link.category,
+    action: link.action,
+    summary: link.summary,
+    correlationId: link.correlationId ?? null,
+    payload: link.payload,
+  });
+  return Buffer.from(body, "utf8");
+}
+
+export function hashPaymentAuditLink(link: PaymentAuditChainLink): string {
+  return createHash("sha256").update(canonicalPaymentAuditBytes(link)).digest("hex");
+}
+
+export function sealPaymentWormRecord(input: {
+  entry: PaymentWormEntry;
+  seq: number;
+  prev_hash: string;
+}): PaymentWormRecord {
+  const link: PaymentAuditChainLink = {
+    ...input.entry,
+    seq: input.seq,
+    prev_hash: input.prev_hash,
+  };
+  return {
+    ...link,
+    hash: hashPaymentAuditLink(link),
+  };
+}
+
+export type PaymentAuditVerifyIssue = {
+  seq: number;
+  reason: string;
+};
+
+export type PaymentAuditVerifyResult = {
+  ok: boolean;
+  records: number;
+  head_hash: string;
+  issues: PaymentAuditVerifyIssue[];
+};
+
+export function verifyPaymentAuditChain(records: PaymentWormRecord[]): PaymentAuditVerifyResult {
+  const issues: PaymentAuditVerifyIssue[] = [];
+  let expectedSeq = 1;
+  let prevHash = PAYMENT_AUDIT_GENESIS_HASH;
+
+  for (const record of records) {
+    if (record.seq !== expectedSeq) {
+      issues.push({
+        seq: record.seq,
+        reason: `expected seq ${expectedSeq}, got ${record.seq}`,
+      });
+    }
+    if (record.prev_hash !== prevHash) {
+      issues.push({
+        seq: record.seq,
+        reason: `prev_hash mismatch at seq ${record.seq}`,
+      });
+    }
+    const recomputed = hashPaymentAuditLink(record);
+    if (record.hash !== recomputed) {
+      issues.push({
+        seq: record.seq,
+        reason: `hash mismatch at seq ${record.seq}`,
+      });
+    }
+    prevHash = record.hash;
+    expectedSeq += 1;
+  }
+
+  return {
+    ok: issues.length === 0,
+    records: records.length,
+    head_hash: records.length > 0 ? records[records.length - 1]!.hash : PAYMENT_AUDIT_GENESIS_HASH,
+    issues,
+  };
+}
+
+export function toPaymentWormEntry(record: PaymentWormRecord): PaymentWormEntry {
+  return {
+    ts: record.ts,
+    category: record.category,
+    action: record.action,
+    summary: record.summary,
+    correlationId: record.correlationId,
+    payload: record.payload,
+  };
+}

--- a/packages/clawql-payments/src/audit/events.ts
+++ b/packages/clawql-payments/src/audit/events.ts
@@ -21,7 +21,7 @@ export type PaymentWormPayload = {
   agent_id?: string;
 };
 
-/** WORM-oriented payment audit entry (maps to clawql-core ring buffer today). */
+/** Durable payment audit entry with hash-chained integrity fields on disk. */
 export type PaymentWormEntry = {
   ts: string;
   category: "payment";

--- a/packages/clawql-payments/src/audit/factory.ts
+++ b/packages/clawql-payments/src/audit/factory.ts
@@ -1,0 +1,45 @@
+import { createJsonlPaymentAuditStore } from "./jsonl-store.js";
+import { MemoryPaymentAuditStore } from "./memory-store.js";
+import {
+  resolvePaymentAuditStoreMode,
+  type PaymentAuditStore,
+  type PaymentAuditStoreMode,
+} from "./store.js";
+
+let defaultStore: PaymentAuditStore | null = null;
+let defaultStoreKey: string | null = null;
+
+function storeKey(mode: PaymentAuditStoreMode, env: NodeJS.ProcessEnv): string {
+  if (mode === "memory") return "memory";
+  return `jsonl:${env.CLAWQL_HOME?.trim() || process.cwd()}`;
+}
+
+export function createPaymentAuditStore(env: NodeJS.ProcessEnv = process.env): PaymentAuditStore {
+  const mode = resolvePaymentAuditStoreMode(env);
+  if (mode === "memory") {
+    return new MemoryPaymentAuditStore();
+  }
+  return createJsonlPaymentAuditStore(env);
+}
+
+export function getPaymentAuditStore(env: NodeJS.ProcessEnv = process.env): PaymentAuditStore {
+  const mode = resolvePaymentAuditStoreMode(env);
+  const key = storeKey(mode, env);
+  if (!defaultStore || defaultStoreKey !== key) {
+    defaultStore = createPaymentAuditStore(env);
+    defaultStoreKey = key;
+  }
+  return defaultStore;
+}
+
+export function resetPaymentAuditStoreForTests(env: NodeJS.ProcessEnv = process.env): void {
+  if (defaultStore) {
+    defaultStore.reset();
+  }
+  defaultStore = null;
+  defaultStoreKey = null;
+  if (resolvePaymentAuditStoreMode(env) === "memory") {
+    defaultStore = new MemoryPaymentAuditStore();
+    defaultStoreKey = storeKey("memory", env);
+  }
+}

--- a/packages/clawql-payments/src/audit/index.ts
+++ b/packages/clawql-payments/src/audit/index.ts
@@ -19,11 +19,7 @@ export {
   type PaymentAuditVerifyResult,
   type PaymentWormRecord,
 } from "./chain.js";
-export {
-  appendPaymentWormEntry,
-  listPaymentAuditEntries,
-  verifyPaymentAuditLog,
-} from "./worm.js";
+export { appendPaymentWormEntry, listPaymentAuditEntries, verifyPaymentAuditLog } from "./worm.js";
 export {
   createPaymentAuditStore,
   getPaymentAuditStore,

--- a/packages/clawql-payments/src/audit/index.ts
+++ b/packages/clawql-payments/src/audit/index.ts
@@ -10,7 +10,32 @@ export {
   type PaymentWormEntry,
   type PaymentWormPayload,
 } from "./events.js";
-export { appendPaymentWormEntry, listPaymentAuditEntries } from "./worm.js";
+export {
+  PAYMENT_AUDIT_GENESIS_HASH,
+  hashPaymentAuditLink,
+  sealPaymentWormRecord,
+  verifyPaymentAuditChain,
+  type PaymentAuditVerifyIssue,
+  type PaymentAuditVerifyResult,
+  type PaymentWormRecord,
+} from "./chain.js";
+export {
+  appendPaymentWormEntry,
+  listPaymentAuditEntries,
+  verifyPaymentAuditLog,
+} from "./worm.js";
+export {
+  createPaymentAuditStore,
+  getPaymentAuditStore,
+  resetPaymentAuditStoreForTests,
+} from "./factory.js";
+export {
+  isPaymentAuditFsyncEnabled,
+  resolvePaymentAuditStoreMode,
+  type PaymentAuditStore,
+  type PaymentAuditStoreMode,
+} from "./store.js";
+export { createJsonlPaymentAuditStore } from "./jsonl-store.js";
 export {
   buildSpendReport,
   filterAuditByCorrelationId,

--- a/packages/clawql-payments/src/audit/jsonl-store.ts
+++ b/packages/clawql-payments/src/audit/jsonl-store.ts
@@ -19,10 +19,7 @@ import {
   type PaymentWormRecord,
 } from "./chain.js";
 import type { PaymentWormEntry } from "./events.js";
-import {
-  resolvePaymentAuditJsonlPath,
-  resolvePaymentAuditMetaPath,
-} from "../config/paths.js";
+import { resolvePaymentAuditJsonlPath, resolvePaymentAuditMetaPath } from "../config/paths.js";
 import type { PaymentAuditStore } from "./store.js";
 import { isPaymentAuditFsyncEnabled } from "./store.js";
 
@@ -89,10 +86,7 @@ function loadRecordsFromJsonl(jsonlPath: string): PaymentWormRecord[] {
   }
 }
 
-function resolveChainHead(
-  jsonlPath: string,
-  metaPath: string
-): { seq: number; last_hash: string } {
+function resolveChainHead(jsonlPath: string, metaPath: string): { seq: number; last_hash: string } {
   const meta = readMetaFile(metaPath);
   if (meta) {
     return { seq: meta.seq, last_hash: meta.last_hash };
@@ -179,7 +173,9 @@ export class JsonlPaymentAuditStore implements PaymentAuditStore {
   }
 }
 
-export function createJsonlPaymentAuditStore(env: NodeJS.ProcessEnv = process.env): JsonlPaymentAuditStore {
+export function createJsonlPaymentAuditStore(
+  env: NodeJS.ProcessEnv = process.env
+): JsonlPaymentAuditStore {
   return new JsonlPaymentAuditStore(
     resolvePaymentAuditJsonlPath(env),
     resolvePaymentAuditMetaPath(env),

--- a/packages/clawql-payments/src/audit/jsonl-store.ts
+++ b/packages/clawql-payments/src/audit/jsonl-store.ts
@@ -1,0 +1,188 @@
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import {
+  PAYMENT_AUDIT_GENESIS_HASH,
+  sealPaymentWormRecord,
+  toPaymentWormEntry,
+  verifyPaymentAuditChain,
+  type PaymentAuditVerifyResult,
+  type PaymentWormRecord,
+} from "./chain.js";
+import type { PaymentWormEntry } from "./events.js";
+import {
+  resolvePaymentAuditJsonlPath,
+  resolvePaymentAuditMetaPath,
+} from "../config/paths.js";
+import type { PaymentAuditStore } from "./store.js";
+import { isPaymentAuditFsyncEnabled } from "./store.js";
+
+type PaymentAuditMeta = {
+  seq: number;
+  last_hash: string;
+  updated_at: string;
+};
+
+function parseJsonlRecords(raw: string): PaymentWormRecord[] {
+  return raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as PaymentWormRecord);
+}
+
+function readMetaFile(metaPath: string): PaymentAuditMeta | null {
+  try {
+    return JSON.parse(readFileSync(metaPath, "utf8")) as PaymentAuditMeta;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function writeMetaFile(metaPath: string, meta: PaymentAuditMeta, fsync: boolean): void {
+  mkdirSync(dirname(metaPath), { recursive: true, mode: 0o700 });
+  const tempPath = `${metaPath}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify(meta, null, 2)}\n`, { mode: 0o600 });
+  if (fsync) {
+    const fd = openSync(tempPath, "r+");
+    try {
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+  }
+  renameSync(tempPath, metaPath);
+}
+
+function appendLineSync(filePath: string, line: string, fsync: boolean): void {
+  mkdirSync(dirname(filePath), { recursive: true, mode: 0o700 });
+  if (!existsSync(filePath)) {
+    writeFileSync(filePath, "", { mode: 0o600 });
+  }
+  const fd = openSync(filePath, "a");
+  try {
+    writeSync(fd, line);
+    if (fsync) {
+      fsyncSync(fd);
+    }
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function loadRecordsFromJsonl(jsonlPath: string): PaymentWormRecord[] {
+  try {
+    return parseJsonlRecords(readFileSync(jsonlPath, "utf8"));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+function resolveChainHead(
+  jsonlPath: string,
+  metaPath: string
+): { seq: number; last_hash: string } {
+  const meta = readMetaFile(metaPath);
+  if (meta) {
+    return { seq: meta.seq, last_hash: meta.last_hash };
+  }
+
+  const records = loadRecordsFromJsonl(jsonlPath);
+  if (records.length === 0) {
+    return { seq: 0, last_hash: PAYMENT_AUDIT_GENESIS_HASH };
+  }
+  const last = records[records.length - 1]!;
+  return { seq: last.seq, last_hash: last.hash };
+}
+
+export class JsonlPaymentAuditStore implements PaymentAuditStore {
+  private cache: PaymentWormRecord[] | null = null;
+
+  constructor(
+    private readonly jsonlPath: string,
+    private readonly metaPath: string,
+    private readonly fsync: boolean
+  ) {}
+
+  private loadRecords(): PaymentWormRecord[] {
+    if (!this.cache) {
+      this.cache = loadRecordsFromJsonl(this.jsonlPath);
+    }
+    return this.cache;
+  }
+
+  append(entry: PaymentWormEntry): PaymentWormRecord {
+    const head = resolveChainHead(this.jsonlPath, this.metaPath);
+    const record = sealPaymentWormRecord({
+      entry,
+      seq: head.seq + 1,
+      prev_hash: head.last_hash,
+    });
+
+    appendLineSync(this.jsonlPath, `${JSON.stringify(record)}\n`, this.fsync);
+    writeMetaFile(
+      this.metaPath,
+      {
+        seq: record.seq,
+        last_hash: record.hash,
+        updated_at: new Date().toISOString(),
+      },
+      this.fsync
+    );
+
+    if (this.cache) {
+      this.cache.push(record);
+    } else {
+      this.cache = loadRecordsFromJsonl(this.jsonlPath);
+    }
+
+    return record;
+  }
+
+  list(limit = 100): PaymentWormEntry[] {
+    return this.listRecords(limit).map(toPaymentWormEntry);
+  }
+
+  listRecords(limit = 100): PaymentWormRecord[] {
+    const records = this.loadRecords();
+    if (limit <= 0) return [];
+    return records.slice(-limit);
+  }
+
+  verify(): PaymentAuditVerifyResult {
+    return verifyPaymentAuditChain(this.loadRecords());
+  }
+
+  reset(): void {
+    this.cache = [];
+    try {
+      writeFileSync(this.jsonlPath, "", { mode: 0o600 });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    try {
+      writeFileSync(this.metaPath, "", { mode: 0o600 });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+}
+
+export function createJsonlPaymentAuditStore(env: NodeJS.ProcessEnv = process.env): JsonlPaymentAuditStore {
+  return new JsonlPaymentAuditStore(
+    resolvePaymentAuditJsonlPath(env),
+    resolvePaymentAuditMetaPath(env),
+    isPaymentAuditFsyncEnabled(env)
+  );
+}

--- a/packages/clawql-payments/src/audit/memory-store.ts
+++ b/packages/clawql-payments/src/audit/memory-store.ts
@@ -14,7 +14,9 @@ export class MemoryPaymentAuditStore implements PaymentAuditStore {
 
   append(entry: PaymentWormEntry): PaymentWormRecord {
     const prev_hash =
-      this.records.length > 0 ? this.records[this.records.length - 1]!.hash : PAYMENT_AUDIT_GENESIS_HASH;
+      this.records.length > 0
+        ? this.records[this.records.length - 1]!.hash
+        : PAYMENT_AUDIT_GENESIS_HASH;
     const record = sealPaymentWormRecord({
       entry,
       seq: this.records.length + 1,

--- a/packages/clawql-payments/src/audit/memory-store.ts
+++ b/packages/clawql-payments/src/audit/memory-store.ts
@@ -1,0 +1,43 @@
+import {
+  PAYMENT_AUDIT_GENESIS_HASH,
+  sealPaymentWormRecord,
+  toPaymentWormEntry,
+  verifyPaymentAuditChain,
+  type PaymentAuditVerifyResult,
+  type PaymentWormRecord,
+} from "./chain.js";
+import type { PaymentWormEntry } from "./events.js";
+import type { PaymentAuditStore } from "./store.js";
+
+export class MemoryPaymentAuditStore implements PaymentAuditStore {
+  private records: PaymentWormRecord[] = [];
+
+  append(entry: PaymentWormEntry): PaymentWormRecord {
+    const prev_hash =
+      this.records.length > 0 ? this.records[this.records.length - 1]!.hash : PAYMENT_AUDIT_GENESIS_HASH;
+    const record = sealPaymentWormRecord({
+      entry,
+      seq: this.records.length + 1,
+      prev_hash,
+    });
+    this.records.push(record);
+    return record;
+  }
+
+  list(limit = 100): PaymentWormEntry[] {
+    return this.listRecords(limit).map(toPaymentWormEntry);
+  }
+
+  listRecords(limit = 100): PaymentWormRecord[] {
+    if (limit <= 0) return [];
+    return this.records.slice(-limit);
+  }
+
+  verify(): PaymentAuditVerifyResult {
+    return verifyPaymentAuditChain(this.records);
+  }
+
+  reset(): void {
+    this.records = [];
+  }
+}

--- a/packages/clawql-payments/src/audit/store.ts
+++ b/packages/clawql-payments/src/audit/store.ts
@@ -1,0 +1,27 @@
+import type { PaymentWormEntry } from "./events.js";
+import type { PaymentWormRecord, PaymentAuditVerifyResult } from "./chain.js";
+
+export type PaymentAuditStoreMode = "jsonl" | "memory";
+
+export type PaymentAuditStore = {
+  append(entry: PaymentWormEntry): PaymentWormRecord;
+  list(limit?: number): PaymentWormEntry[];
+  listRecords(limit?: number): PaymentWormRecord[];
+  verify(): PaymentAuditVerifyResult;
+  reset(): void;
+};
+
+export function resolvePaymentAuditStoreMode(
+  env: NodeJS.ProcessEnv = process.env
+): PaymentAuditStoreMode {
+  const raw = env.CLAWQL_PAYMENTS_AUDIT_STORE?.trim().toLowerCase();
+  if (raw === "jsonl" || raw === "memory") return raw;
+  if (env.VITEST === "true" || env.NODE_ENV === "test") return "memory";
+  return "jsonl";
+}
+
+export function isPaymentAuditFsyncEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.CLAWQL_PAYMENTS_AUDIT_FSYNC?.trim().toLowerCase();
+  if (raw === "0" || raw === "false" || raw === "off") return false;
+  return true;
+}

--- a/packages/clawql-payments/src/audit/worm.test.ts
+++ b/packages/clawql-payments/src/audit/worm.test.ts
@@ -70,10 +70,7 @@ describe("durable payment audit store", () => {
   });
 
   it("buildSpendReport uses persisted payload amounts", () => {
-    appendPaymentWormEntry(
-      buildStripeInvoicePaidEntry({ tenantId: "t1", amountUsd: 10 }),
-      env
-    );
+    appendPaymentWormEntry(buildStripeInvoicePaidEntry({ tenantId: "t1", amountUsd: 10 }), env);
     appendPaymentWormEntry(
       buildX402PaymentReceivedEntry({
         tenantId: "t2",
@@ -91,14 +88,8 @@ describe("durable payment audit store", () => {
   });
 
   it("verifyPaymentAuditLog returns ok for intact chain", () => {
-    appendPaymentWormEntry(
-      buildStripeInvoicePaidEntry({ tenantId: "t1", amountUsd: 1 }),
-      env
-    );
-    appendPaymentWormEntry(
-      buildStripeInvoicePaidEntry({ tenantId: "t2", amountUsd: 2 }),
-      env
-    );
+    appendPaymentWormEntry(buildStripeInvoicePaidEntry({ tenantId: "t1", amountUsd: 1 }), env);
+    appendPaymentWormEntry(buildStripeInvoicePaidEntry({ tenantId: "t2", amountUsd: 2 }), env);
 
     const result = verifyPaymentAuditLog(env);
     expect(result.ok).toBe(true);

--- a/packages/clawql-payments/src/audit/worm.test.ts
+++ b/packages/clawql-payments/src/audit/worm.test.ts
@@ -1,0 +1,107 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resetDefaultAuditRingBufferForTests } from "clawql-core";
+import { buildStripeInvoicePaidEntry, buildX402PaymentReceivedEntry } from "./events.js";
+import { createJsonlPaymentAuditStore } from "./jsonl-store.js";
+import {
+  appendPaymentWormEntry,
+  listPaymentAuditEntries,
+  resetPaymentAuditStoreForTests,
+  verifyPaymentAuditLog,
+} from "./worm.js";
+import { buildSpendReport } from "./reconcile.js";
+
+describe("durable payment audit store", () => {
+  let tempHome: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), "clawql-payments-audit-"));
+    env = {
+      ...process.env,
+      CLAWQL_HOME: tempHome,
+      CLAWQL_PAYMENTS_AUDIT_STORE: "jsonl",
+      CLAWQL_PAYMENTS_AUDIT_FSYNC: "0",
+    };
+    resetDefaultAuditRingBufferForTests();
+    resetPaymentAuditStoreForTests(env);
+  });
+
+  afterEach(() => {
+    resetPaymentAuditStoreForTests(env);
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it("persists full payload to audit.jsonl", () => {
+    appendPaymentWormEntry(
+      buildStripeInvoicePaidEntry({
+        tenantId: "acme",
+        amountUsd: 42.5,
+        plan: "team",
+        correlationId: "inv_123",
+      }),
+      env
+    );
+
+    const entries = listPaymentAuditEntries(10, env);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.payload.tenant_id).toBe("acme");
+    expect(entries[0]?.payload.amount_usd).toBe(42.5);
+    expect(entries[0]?.payload.plan).toBe("team");
+  });
+
+  it("verifies hash chain after restart (new store instance)", () => {
+    appendPaymentWormEntry(
+      buildX402PaymentReceivedEntry({
+        tenantId: "default",
+        amountUsdc: 0.001,
+        resource: "/v1/chat/completions",
+        correlationId: "pay-1",
+      }),
+      env
+    );
+
+    const store = createJsonlPaymentAuditStore(env);
+    const result = store.verify();
+    expect(result.ok).toBe(true);
+    expect(result.records).toBe(1);
+  });
+
+  it("buildSpendReport uses persisted payload amounts", () => {
+    appendPaymentWormEntry(
+      buildStripeInvoicePaidEntry({ tenantId: "t1", amountUsd: 10 }),
+      env
+    );
+    appendPaymentWormEntry(
+      buildX402PaymentReceivedEntry({
+        tenantId: "t2",
+        amountUsdc: 0.5,
+        resource: "tool:search",
+      }),
+      env
+    );
+
+    const report = buildSpendReport(listPaymentAuditEntries(100, env), "provider");
+    expect(report.totalUsd).toBe(10);
+    expect(report.totalUsdc).toBe(0.5);
+    expect(report.rows.some((r) => r.provider === "stripe" && r.amountUsd === 10)).toBe(true);
+    expect(report.rows.some((r) => r.provider === "x402" && r.amountUsdc === 0.5)).toBe(true);
+  });
+
+  it("verifyPaymentAuditLog returns ok for intact chain", () => {
+    appendPaymentWormEntry(
+      buildStripeInvoicePaidEntry({ tenantId: "t1", amountUsd: 1 }),
+      env
+    );
+    appendPaymentWormEntry(
+      buildStripeInvoicePaidEntry({ tenantId: "t2", amountUsd: 2 }),
+      env
+    );
+
+    const result = verifyPaymentAuditLog(env);
+    expect(result.ok).toBe(true);
+    expect(result.records).toBe(2);
+  });
+});

--- a/packages/clawql-payments/src/audit/worm.ts
+++ b/packages/clawql-payments/src/audit/worm.ts
@@ -1,7 +1,15 @@
 import { getDefaultAuditRingBuffer } from "clawql-core";
+import type { PaymentAuditVerifyResult } from "./chain.js";
 import type { PaymentWormEntry } from "./events.js";
+import { getPaymentAuditStore, resetPaymentAuditStoreForTests } from "./factory.js";
 
-export function appendPaymentWormEntry(entry: PaymentWormEntry): void {
+export function appendPaymentWormEntry(
+  entry: PaymentWormEntry,
+  env: NodeJS.ProcessEnv = process.env
+): void {
+  getPaymentAuditStore(env).append(entry);
+
+  // Hot in-process mirror for MCP audit ring buffer (summary-only).
   getDefaultAuditRingBuffer().append({
     ts: entry.ts,
     category: entry.category,
@@ -11,19 +19,17 @@ export function appendPaymentWormEntry(entry: PaymentWormEntry): void {
   });
 }
 
-export function listPaymentAuditEntries(limit = 100): PaymentWormEntry[] {
-  const { entries } = getDefaultAuditRingBuffer().list(limit);
-  return entries
-    .filter((e) => e.category === "payment")
-    .map((e) => ({
-      ts: e.ts,
-      category: "payment" as const,
-      action: e.action as PaymentWormEntry["action"],
-      summary: e.summary,
-      correlationId: e.correlationId,
-      payload: {
-        provider: "stripe" as const,
-        tenant_id: "unknown",
-      },
-    }));
+export function listPaymentAuditEntries(
+  limit = 100,
+  env: NodeJS.ProcessEnv = process.env
+): PaymentWormEntry[] {
+  return getPaymentAuditStore(env).list(limit);
 }
+
+export function verifyPaymentAuditLog(
+  env: NodeJS.ProcessEnv = process.env
+): PaymentAuditVerifyResult {
+  return getPaymentAuditStore(env).verify();
+}
+
+export { resetPaymentAuditStoreForTests };

--- a/packages/clawql-payments/src/cli/index.ts
+++ b/packages/clawql-payments/src/cli/index.ts
@@ -4,6 +4,7 @@ export {
   runPaymentsUsageReport,
   runPaymentsSpendReport,
   runPaymentsAudit,
+  runPaymentsAuditVerify,
   type PaymentsAuditOptions,
   type PaymentsPlanShowOptions,
   type PaymentsPlanUpgradeOptions,

--- a/packages/clawql-payments/src/cli/plan.ts
+++ b/packages/clawql-payments/src/cli/plan.ts
@@ -171,9 +171,7 @@ export async function runPaymentsAudit(options: PaymentsAuditOptions = {}): Prom
   return 0;
 }
 
-export async function runPaymentsAuditVerify(
-  options: PaymentsAuditOptions = {}
-): Promise<number> {
+export async function runPaymentsAuditVerify(options: PaymentsAuditOptions = {}): Promise<number> {
   const env = options.env ?? process.env;
   const result = verifyPaymentAuditLog(env);
 

--- a/packages/clawql-payments/src/cli/plan.ts
+++ b/packages/clawql-payments/src/cli/plan.ts
@@ -5,6 +5,7 @@ import {
   buildSpendReport,
   filterAuditByCorrelationId,
   listPaymentAuditEntries,
+  verifyPaymentAuditLog,
   type SpendGroupBy,
 } from "../audit/index.js";
 import {
@@ -145,6 +146,7 @@ export type PaymentsAuditOptions = {
   correlationId?: string;
   limit?: number;
   json?: boolean;
+  env?: NodeJS.ProcessEnv;
 };
 
 export async function runPaymentsAudit(options: PaymentsAuditOptions = {}): Promise<number> {
@@ -167,4 +169,32 @@ export async function runPaymentsAudit(options: PaymentsAuditOptions = {}): Prom
     console.log(`${entry.ts} ${entry.action}${corr}: ${entry.summary}`);
   }
   return 0;
+}
+
+export async function runPaymentsAuditVerify(
+  options: PaymentsAuditOptions = {}
+): Promise<number> {
+  const env = options.env ?? process.env;
+  const result = verifyPaymentAuditLog(env);
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return result.ok ? 0 : 1;
+  }
+
+  if (result.ok) {
+    console.log(
+      `Payment audit chain OK — ${result.records} record(s), head=${result.head_hash.slice(0, 16)}…`
+    );
+    return 0;
+  }
+
+  console.error(`Payment audit chain FAILED — ${result.issues.length} issue(s)`);
+  for (const issue of result.issues.slice(0, 20)) {
+    console.error(`  seq ${issue.seq}: ${issue.reason}`);
+  }
+  if (result.issues.length > 20) {
+    console.error(`  … and ${result.issues.length - 20} more`);
+  }
+  return 1;
 }

--- a/packages/clawql-payments/src/config/paths.ts
+++ b/packages/clawql-payments/src/config/paths.ts
@@ -19,3 +19,11 @@ export function resolveX402GatesPath(env: NodeJS.ProcessEnv = process.env): stri
 export function resolveUsagePath(env: NodeJS.ProcessEnv = process.env): string {
   return join(resolvePaymentsDir(env), "usage.json");
 }
+
+export function resolvePaymentAuditJsonlPath(env: NodeJS.ProcessEnv = process.env): string {
+  return join(resolvePaymentsDir(env), "audit.jsonl");
+}
+
+export function resolvePaymentAuditMetaPath(env: NodeJS.ProcessEnv = process.env): string {
+  return join(resolvePaymentsDir(env), "audit.meta.json");
+}

--- a/packages/clawql-payments/src/index.ts
+++ b/packages/clawql-payments/src/index.ts
@@ -11,4 +11,6 @@ export {
   resolvePaymentsDir,
   resolveUsagePath,
   resolveX402GatesPath,
+  resolvePaymentAuditJsonlPath,
+  resolvePaymentAuditMetaPath,
 } from "./config/paths.js";

--- a/packages/clawql-payments/src/stripe/meter-report.test.ts
+++ b/packages/clawql-payments/src/stripe/meter-report.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { resetDefaultAuditRingBufferForTests } from "clawql-core";
-import { listPaymentAuditEntries } from "../audit/worm.js";
+import { listPaymentAuditEntries, resetPaymentAuditStoreForTests } from "../audit/worm.js";
 import {
   buildInferenceMeterIdentifier,
   isStripeMeterReportingActive,
@@ -17,6 +17,7 @@ import { reportMeteredUsage } from "./metered.js";
 describe("stripe meter reporting", () => {
   beforeEach(() => {
     resetDefaultAuditRingBufferForTests();
+    resetPaymentAuditStoreForTests();
     vi.mocked(reportMeteredUsage).mockClear();
   });
 

--- a/packages/clawql-payments/src/stripe/webhook.test.ts
+++ b/packages/clawql-payments/src/stripe/webhook.test.ts
@@ -1,5 +1,5 @@
 import Stripe from "stripe";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, beforeEach } from "vitest";
 import { resetDefaultAuditRingBufferForTests } from "clawql-core";
 import {
   assertStripeWebhookSignature,
@@ -7,9 +7,14 @@ import {
   verifyStripeWebhookSignature,
 } from "./webhook.js";
 import { StripeWebhookVerificationError } from "./errors.js";
-import { listPaymentAuditEntries } from "../audit/worm.js";
+import { listPaymentAuditEntries, resetPaymentAuditStoreForTests } from "../audit/worm.js";
 
 describe("stripe webhook verification", () => {
+  beforeEach(() => {
+    resetDefaultAuditRingBufferForTests();
+    resetPaymentAuditStoreForTests();
+  });
+
   const secret = "whsec_test_secret_for_clawql_payments";
   const payload = JSON.stringify({
     id: "evt_test_webhook",
@@ -46,7 +51,6 @@ describe("stripe webhook verification", () => {
   });
 
   it("processes invoice.paid into payment audit trail", async () => {
-    resetDefaultAuditRingBufferForTests();
     const signature = Stripe.webhooks.generateTestHeaderString({ payload, secret });
     const event = assertStripeWebhookSignature(payload, signature, secret);
     const result = await processStripeWebhookEvent(event, { tenantId: "default" });

--- a/src/onboarding/cli.ts
+++ b/src/onboarding/cli.ts
@@ -54,6 +54,7 @@ import {
 } from "./inference-cli.js";
 import {
   runPaymentsAuditCmd,
+  runPaymentsAuditVerifyCmd,
   runPaymentsPlanShowCmd,
   runPaymentsPlanUpgradeCmd,
   runPaymentsSpendReportCmd,
@@ -830,6 +831,10 @@ async function main(): Promise<void> {
       return;
     }
     if (subcmd === "audit") {
+      if (rest[0] === "verify") {
+        process.exitCode = await runPaymentsAuditVerifyCmd(paymentsOpts);
+        return;
+      }
       process.exitCode = await runPaymentsAuditCmd(paymentsOpts);
       return;
     }

--- a/src/onboarding/payments-cli.ts
+++ b/src/onboarding/payments-cli.ts
@@ -4,6 +4,7 @@
 
 import {
   runPaymentsAudit,
+  runPaymentsAuditVerify,
   runPaymentsPlanShow,
   runPaymentsPlanUpgrade,
   runPaymentsSpendReport,
@@ -82,6 +83,12 @@ export async function runPaymentsAuditCmd(options: PaymentsCliOptions = {}): Pro
     limit: options.limit,
     json: options.json,
   });
+}
+
+export async function runPaymentsAuditVerifyCmd(
+  options: PaymentsCliOptions = {}
+): Promise<number> {
+  return runPaymentsAuditVerify({ json: options.json });
 }
 
 export async function runPaymentsStripeSetupCmd(options: PaymentsCliOptions = {}): Promise<number> {

--- a/src/onboarding/payments-cli.ts
+++ b/src/onboarding/payments-cli.ts
@@ -85,9 +85,7 @@ export async function runPaymentsAuditCmd(options: PaymentsCliOptions = {}): Pro
   });
 }
 
-export async function runPaymentsAuditVerifyCmd(
-  options: PaymentsCliOptions = {}
-): Promise<number> {
+export async function runPaymentsAuditVerifyCmd(options: PaymentsCliOptions = {}): Promise<number> {
   return runPaymentsAuditVerify({ json: options.json });
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements a **bulletproof, durable payment audit log** for `clawql-payments` — replacing ring-buffer-only storage with hash-chained append-only JSONL.

### Durable WORM writer

- **Append-only log:** `$CLAWQL_HOME/Payments/audit.jsonl` (mode `0600`)
- **Hash chain:** each record has `seq`, `prev_hash`, `hash` (SHA-256 over canonical JSON)
- **Chain head:** `audit.meta.json` for fast append without full-file scan
- **fsync by default:** `CLAWQL_PAYMENTS_AUDIT_FSYNC=1` (disable with `0`)
- **Full payload persistence:** fixes `buildSpendReport` / tenant grouping (no more placeholder `tenant_id: unknown`)

### CLI & API

```bash
clawql payments audit verify
clawql payments audit verify --json
```

```typescript
import { verifyPaymentAuditLog } from "clawql-payments";
```

### Env vars

| Variable | Default | Purpose |
| -------- | ------- | ------- |
| `CLAWQL_PAYMENTS_AUDIT_STORE` | `jsonl` (`memory` in tests) | Storage backend |
| `CLAWQL_PAYMENTS_AUDIT_FSYNC` | on | fsync after each append |

Ring buffer still receives summary-only mirror for MCP `audit` tool compatibility.

### Tests

37 passing in `clawql-payments` — chain verification, JSONL persistence across store restart, spend report with real payloads.

## Docs

Updated [`docs/payments/clawql-payments.md`](docs/payments/clawql-payments.md) Payment audit section.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

