### PR TITLE
feat(payments): Postgres audit store, Loki export, X402 failure events

### DIFF
--- a/docs/payments/clawql-payments.md
+++ b/docs/payments/clawql-payments.md
@@ -18,7 +18,7 @@
 | x402 Express middleware (402 + PAYMENT-REQUIRED) | ✅     | Wired into `clawql-inference` HTTP                                              |
 | Payment WORM audit (hash-chained JSONL)          | ✅     | `$CLAWQL_HOME/Payments/audit.jsonl` + `audit verify`                            |
 | Payment WORM audit (Postgres)                    | ✅     | `CLAWQL_PAYMENTS_AUDIT_STORE=postgres` for multi-node deployments               |
-| Payment audit → Loki/SIEM export                 | ✅     | Fire-and-forget push on append when `CLAWQL_LOKI_PUSH_URL` is set                 |
+| Payment audit → Loki/SIEM export                 | ✅     | Fire-and-forget push on append when `CLAWQL_LOKI_PUSH_URL` is set               |
 | `.well-known/payments.json` discovery            | 📋     | Placeholder ([#88](https://github.com/danielsmithdevelopment/ClawQL/issues/88)) |
 
 ## Architecture
@@ -366,25 +366,25 @@ Payment events append to an **append-only, hash-chained audit log** at `$CLAWQL_
 
 A hot in-process mirror still feeds the MCP `audit` ring buffer (summary fields only). **Authoritative** payment history — including full structured `payload` — lives in `audit.jsonl`.
 
-| Event                               | Trigger                        |
-| ----------------------------------- | ------------------------------ |
-| `STRIPE_INVOICE_PAID`               | Verified webhook               |
-| `STRIPE_PAYMENT_FAILED`             | Verified webhook               |
-| `STRIPE_METER_REPORTED`             | Successful meter event         |
-| `X402_PAYMENT_RECEIVED`             | Facilitator verify + reconcile |
+| Event                               | Trigger                                                                       |
+| ----------------------------------- | ----------------------------------------------------------------------------- |
+| `STRIPE_INVOICE_PAID`               | Verified webhook                                                              |
+| `STRIPE_PAYMENT_FAILED`             | Verified webhook                                                              |
+| `STRIPE_METER_REPORTED`             | Successful meter event                                                        |
+| `X402_PAYMENT_RECEIVED`             | Facilitator verify + reconcile                                                |
 | `X402_PAYMENT_FAILED`               | Invalid proof, facilitator error, or misconfiguration (not `require_payment`) |
-| `ENTITLEMENT_LIMIT_REACHED`         | Plan cap hit                   |
-| `PLAN_UPGRADED` / `PLAN_DOWNGRADED` | `clawql payments plan upgrade` |
+| `ENTITLEMENT_LIMIT_REACHED`         | Plan cap hit                                                                  |
+| `PLAN_UPGRADED` / `PLAN_DOWNGRADED` | `clawql payments plan upgrade`                                                |
 
 ### Environment
 
-| Variable                      | Default                     | Purpose                                            |
-| ----------------------------- | --------------------------- | -------------------------------------------------- |
-| `CLAWQL_PAYMENTS_AUDIT_STORE` | `jsonl` (`memory` in tests) | `jsonl` = durable file; `memory` = in-process only; `postgres` = shared DB |
-| `CLAWQL_PAYMENTS_AUDIT_FSYNC` | on                          | `fsync` after each append (set `0` to disable; jsonl only) |
-| `CLAWQL_PAYMENTS_DATABASE_URL` | —                          | Postgres connection string when `AUDIT_STORE=postgres` |
-| `CLAWQL_PAYMENTS_DB_*`        | —                           | Component vars (`HOST`, `USER`, `PASSWORD`, `NAME`, `PORT`) |
-| `CLAWQL_INFERENCE_DATABASE_URL` | —                         | Fallback Postgres URL when payments URL is unset (shared DB) |
+| Variable                        | Default                     | Purpose                                                                    |
+| ------------------------------- | --------------------------- | -------------------------------------------------------------------------- |
+| `CLAWQL_PAYMENTS_AUDIT_STORE`   | `jsonl` (`memory` in tests) | `jsonl` = durable file; `memory` = in-process only; `postgres` = shared DB |
+| `CLAWQL_PAYMENTS_AUDIT_FSYNC`   | on                          | `fsync` after each append (set `0` to disable; jsonl only)                 |
+| `CLAWQL_PAYMENTS_DATABASE_URL`  | —                           | Postgres connection string when `AUDIT_STORE=postgres`                     |
+| `CLAWQL_PAYMENTS_DB_*`          | —                           | Component vars (`HOST`, `USER`, `PASSWORD`, `NAME`, `PORT`)                |
+| `CLAWQL_INFERENCE_DATABASE_URL` | —                           | Fallback Postgres URL when payments URL is unset (shared DB)               |
 
 ### Postgres audit store (enterprise)
 

--- a/docs/payments/clawql-payments.md
+++ b/docs/payments/clawql-payments.md
@@ -17,6 +17,8 @@
 | x402 gate config + facilitator HTTP verify       | ✅     | `POST /verify` against x402.org or CDP                                          |
 | x402 Express middleware (402 + PAYMENT-REQUIRED) | ✅     | Wired into `clawql-inference` HTTP                                              |
 | Payment WORM audit (hash-chained JSONL)          | ✅     | `$CLAWQL_HOME/Payments/audit.jsonl` + `audit verify`                            |
+| Payment WORM audit (Postgres)                    | ✅     | `CLAWQL_PAYMENTS_AUDIT_STORE=postgres` for multi-node deployments               |
+| Payment audit → Loki/SIEM export                 | ✅     | Fire-and-forget push on append when `CLAWQL_LOKI_PUSH_URL` is set                 |
 | `.well-known/payments.json` discovery            | 📋     | Placeholder ([#88](https://github.com/danielsmithdevelopment/ClawQL/issues/88)) |
 
 ## Architecture
@@ -370,6 +372,7 @@ A hot in-process mirror still feeds the MCP `audit` ring buffer (summary fields 
 | `STRIPE_PAYMENT_FAILED`             | Verified webhook               |
 | `STRIPE_METER_REPORTED`             | Successful meter event         |
 | `X402_PAYMENT_RECEIVED`             | Facilitator verify + reconcile |
+| `X402_PAYMENT_FAILED`               | Invalid proof, facilitator error, or misconfiguration (not `require_payment`) |
 | `ENTITLEMENT_LIMIT_REACHED`         | Plan cap hit                   |
 | `PLAN_UPGRADED` / `PLAN_DOWNGRADED` | `clawql payments plan upgrade` |
 
@@ -377,8 +380,39 @@ A hot in-process mirror still feeds the MCP `audit` ring buffer (summary fields 
 
 | Variable                      | Default                     | Purpose                                            |
 | ----------------------------- | --------------------------- | -------------------------------------------------- |
-| `CLAWQL_PAYMENTS_AUDIT_STORE` | `jsonl` (`memory` in tests) | `jsonl` = durable file; `memory` = in-process only |
-| `CLAWQL_PAYMENTS_AUDIT_FSYNC` | on                          | `fsync` after each append (set `0` to disable)     |
+| `CLAWQL_PAYMENTS_AUDIT_STORE` | `jsonl` (`memory` in tests) | `jsonl` = durable file; `memory` = in-process only; `postgres` = shared DB |
+| `CLAWQL_PAYMENTS_AUDIT_FSYNC` | on                          | `fsync` after each append (set `0` to disable; jsonl only) |
+| `CLAWQL_PAYMENTS_DATABASE_URL` | —                          | Postgres connection string when `AUDIT_STORE=postgres` |
+| `CLAWQL_PAYMENTS_DB_*`        | —                           | Component vars (`HOST`, `USER`, `PASSWORD`, `NAME`, `PORT`) |
+| `CLAWQL_INFERENCE_DATABASE_URL` | —                         | Fallback Postgres URL when payments URL is unset (shared DB) |
+
+### Postgres audit store (enterprise)
+
+For multi-node ClawQL deployments, set:
+
+```bash
+export CLAWQL_PAYMENTS_AUDIT_STORE=postgres
+export CLAWQL_PAYMENTS_DATABASE_URL=postgres://clawql:secret@db.internal:5432/clawql
+# Or reuse the inference database:
+# export CLAWQL_INFERENCE_DATABASE_URL=postgres://...
+```
+
+Records remain **hash-chained** (`seq`, `prev_hash`, `hash`) in table `clawql_payments_audit`. Chain head metadata lives in `clawql_payments_audit_meta`. `clawql payments audit verify` validates integrity regardless of store backend.
+
+### Loki / SIEM export
+
+Each successful append can push the **full payment payload** (not just MCP ring-buffer summaries) to Grafana Loki:
+
+```bash
+export CLAWQL_LOKI_PUSH_URL=https://loki.example.com/loki/api/v1/push
+export CLAWQL_LOKI_BEARER_TOKEN=...          # optional
+export CLAWQL_LOKI_TENANT_ID=tenant-1        # optional X-Scope-OrgID
+export CLAWQL_PAYMENTS_LOKI_JOB=clawql-payments-audit  # optional stream job label
+# export CLAWQL_PAYMENTS_LOKI_PUSH=0         # disable payments push only
+# export CLAWQL_ENABLE_LOKI_PUSH=0           # disable all Loki push (MCP + payments)
+```
+
+Push is **fire-and-forget** — Loki failures log to stderr and do not fail payment processing.
 
 ### CLI
 
@@ -396,7 +430,7 @@ clawql payments spend report --group-by provider
 ```typescript
 import { verifyPaymentAuditLog } from "clawql-payments";
 
-const result = verifyPaymentAuditLog();
+const result = await verifyPaymentAuditLog();
 if (!result.ok) {
   console.error(result.issues);
 }
@@ -501,7 +535,6 @@ See also: [`packages/clawql-inference/README.md`](../../packages/clawql-inferenc
 
 | Item                                  | Tracking                                                          |
 | ------------------------------------- | ----------------------------------------------------------------- |
-| Postgres audit store (enterprise)     | optional `CLAWQL_PAYMENTS_AUDIT_STORE=postgres`                   |
 | Hosted webhook HTTP endpoint          | not CLI-only                                                      |
 | `.well-known/payments.json` discovery | [#88](https://github.com/danielsmithdevelopment/ClawQL/issues/88) |
 | MCP tool x402 enforcement in-process  | HTTP middleware + `X-Clawql-Tool` today                           |

--- a/package-lock.json
+++ b/package-lock.json
@@ -12433,6 +12433,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "clawql-core": "7.0.0",
+                "pg": "^8.21.0",
                 "stripe": "^18.5.0",
                 "zod": "^4.3.6"
             },

--- a/packages/clawql-inference/src/entitlements/check.ts
+++ b/packages/clawql-inference/src/entitlements/check.ts
@@ -58,7 +58,7 @@ export async function assertInferenceEntitlement(
   });
 
   if (!check.allowed) {
-    appendPaymentWormEntry(
+    await appendPaymentWormEntry(
       buildEntitlementLimitReachedEntry({
         tenantId: input.tenantId,
         plan: config.plan,

--- a/packages/clawql-payments/README.md
+++ b/packages/clawql-payments/README.md
@@ -11,7 +11,7 @@ clawql-payments
 ├── stripe/     # Subscriptions, invoices, webhooks, metered usage, customer portal
 ├── x402/       # Wallet setup, resource gating, proof verification, settlement reconcile
 ├── plans/      # ClawQL tier definitions, entitlements, usage tracking, limit enforcement
-├── audit/      # Payment events → WORM (ring buffer today; durable WORM writer follow-up)
+├── audit/      # Payment events → hash-chained WORM (jsonl, postgres, or memory) + optional Loki export
 └── cli/        # `clawql payments *` command implementations
 ```
 
@@ -44,7 +44,7 @@ clawql payments stripe meter report --value 1 --customer cus_xxx
 clawql payments stripe webhook verify --payload ./event.json --signature "t=...,v1=..." --process
 ````
 
-Payment audit events (`STRIPE_INVOICE_PAID`, `STRIPE_PAYMENT_FAILED`, etc.) are written when verified webhooks are processed — not at invoice creation time.
+Payment audit events (`STRIPE_INVOICE_PAID`, `STRIPE_PAYMENT_FAILED`, `X402_PAYMENT_FAILED`, etc.) are written when verified webhooks are processed or x402 enforcement fails — not at invoice creation time or when no payment proof is attached yet.
 
 ## x402 micropayments
 
@@ -89,8 +89,10 @@ Local state is stored under `$CLAWQL_HOME/Payments/` (default `~/.clawql/Payment
 - `payments.json` — tenant plan, Stripe and x402 wallet config
 - `x402-gates.json` — payment-gated resources and MCP tools
 - `usage.json` — metered usage counters per tenant/month
-- `audit.jsonl` — hash-chained payment audit log (append-only WORM)
-- `audit.meta.json` — chain head metadata
+- `audit.jsonl` — hash-chained payment audit log (append-only WORM; default store)
+- `audit.meta.json` — chain head metadata (jsonl store)
+
+Postgres store (`CLAWQL_PAYMENTS_AUDIT_STORE=postgres`) uses `clawql_payments_audit` tables instead of local files. Optional Loki export pushes full payloads when `CLAWQL_LOKI_PUSH_URL` is set.
 
 ## Status
 
@@ -98,7 +100,7 @@ Stripe SDK integration is **live** for customers, subscriptions, invoices, billi
 
 x402 facilitator HTTP verification is **live** (`POST /verify` against x402.org or CDP). Inference HTTP can enforce gates with `CLAWQL_X402_ENFORCE=1`.
 
-Payment audit is **durable** — hash-chained append-only JSONL at `$CLAWQL_HOME/Payments/audit.jsonl` with `clawql payments audit verify`.
+Payment audit is **durable** — hash-chained append-only JSONL at `$CLAWQL_HOME/Payments/audit.jsonl` (default), optional Postgres for multi-node, and optional Loki export. Use `clawql payments audit verify` to validate chain integrity.
 
 Full operator guide: [`docs/payments/clawql-payments.md`](../../docs/payments/clawql-payments.md).
 

--- a/packages/clawql-payments/package.json
+++ b/packages/clawql-payments/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "clawql-core": "7.0.0",
     "stripe": "^18.5.0",
+    "pg": "^8.21.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/clawql-payments/src/audit/events.test.ts
+++ b/packages/clawql-payments/src/audit/events.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildPaymentWormEntry, buildX402PaymentReceivedEntry } from "./events.js";
+import { buildPaymentWormEntry, buildX402PaymentFailedEntry, buildX402PaymentReceivedEntry } from "./events.js";
 
 describe("payment audit events", () => {
   it("builds x402 payment received entry", () => {
@@ -15,6 +15,20 @@ describe("payment audit events", () => {
     expect(entry.action).toBe("X402_PAYMENT_RECEIVED");
     expect(entry.payload.provider).toBe("x402");
     expect(entry.correlationId).toBe("corr-1");
+  });
+
+  it("builds x402 payment failed entry", () => {
+    const entry = buildX402PaymentFailedEntry({
+      tenantId: "tenant-1",
+      resource: "/v1/chat/completions",
+      reason: "invalid signature",
+      correlationId: "corr-fail",
+    });
+
+    expect(entry.action).toBe("X402_PAYMENT_FAILED");
+    expect(entry.payload.provider).toBe("x402");
+    expect(entry.payload.resource).toBe("/v1/chat/completions");
+    expect(entry.summary).toContain("invalid signature");
   });
 
   it("builds generic payment worm entry", () => {

--- a/packages/clawql-payments/src/audit/events.test.ts
+++ b/packages/clawql-payments/src/audit/events.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildPaymentWormEntry, buildX402PaymentFailedEntry, buildX402PaymentReceivedEntry } from "./events.js";
+import {
+  buildPaymentWormEntry,
+  buildX402PaymentFailedEntry,
+  buildX402PaymentReceivedEntry,
+} from "./events.js";
 
 describe("payment audit events", () => {
   it("builds x402 payment received entry", () => {

--- a/packages/clawql-payments/src/audit/events.ts
+++ b/packages/clawql-payments/src/audit/events.ts
@@ -87,6 +87,24 @@ export function buildX402PaymentReceivedEntry(input: {
   });
 }
 
+export function buildX402PaymentFailedEntry(input: {
+  tenantId: string;
+  resource: string;
+  reason: string;
+  correlationId?: string;
+}): PaymentWormEntry {
+  return buildPaymentWormEntry({
+    eventKind: "X402_PAYMENT_FAILED",
+    summary: `x402 payment failed for ${input.resource}: ${input.reason}`,
+    correlationId: input.correlationId,
+    payload: {
+      provider: "x402",
+      tenant_id: input.tenantId,
+      resource: input.resource,
+    },
+  });
+}
+
 export function buildEntitlementLimitReachedEntry(input: {
   tenantId: string;
   plan: string;

--- a/packages/clawql-payments/src/audit/factory.test.ts
+++ b/packages/clawql-payments/src/audit/factory.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { createPaymentAuditStore } from "./factory.js";
+
+describe("createPaymentAuditStore postgres mode", () => {
+  it("throws when postgres mode is selected without database config", () => {
+    expect(() =>
+      createPaymentAuditStore({
+        CLAWQL_PAYMENTS_AUDIT_STORE: "postgres",
+        NODE_ENV: "production",
+      })
+    ).toThrow(/CLAWQL_PAYMENTS_DATABASE_URL/);
+  });
+});

--- a/packages/clawql-payments/src/audit/factory.ts
+++ b/packages/clawql-payments/src/audit/factory.ts
@@ -1,5 +1,7 @@
 import { createJsonlPaymentAuditStore } from "./jsonl-store.js";
 import { MemoryPaymentAuditStore } from "./memory-store.js";
+import { createPostgresPaymentAuditStore } from "./postgres-store.js";
+import { resolvePaymentsPoolConfig } from "./postgres-pool.js";
 import {
   resolvePaymentAuditStoreMode,
   type PaymentAuditStore,
@@ -11,6 +13,10 @@ let defaultStoreKey: string | null = null;
 
 function storeKey(mode: PaymentAuditStoreMode, env: NodeJS.ProcessEnv): string {
   if (mode === "memory") return "memory";
+  if (mode === "postgres") {
+    const config = resolvePaymentsPoolConfig(env);
+    return `postgres:${typeof config === "string" ? config : JSON.stringify(config)}`;
+  }
   return `jsonl:${env.CLAWQL_HOME?.trim() || process.cwd()}`;
 }
 
@@ -18,6 +24,16 @@ export function createPaymentAuditStore(env: NodeJS.ProcessEnv = process.env): P
   const mode = resolvePaymentAuditStoreMode(env);
   if (mode === "memory") {
     return new MemoryPaymentAuditStore();
+  }
+  if (mode === "postgres") {
+    const store = createPostgresPaymentAuditStore(env);
+    if (!store) {
+      throw new Error(
+        "CLAWQL_PAYMENTS_AUDIT_STORE=postgres requires CLAWQL_PAYMENTS_DATABASE_URL " +
+          "(or CLAWQL_INFERENCE_DATABASE_URL / CLAWQL_PAYMENTS_DB_* component vars)"
+      );
+    }
+    return store;
   }
   return createJsonlPaymentAuditStore(env);
 }
@@ -32,9 +48,11 @@ export function getPaymentAuditStore(env: NodeJS.ProcessEnv = process.env): Paym
   return defaultStore;
 }
 
-export function resetPaymentAuditStoreForTests(env: NodeJS.ProcessEnv = process.env): void {
+export async function resetPaymentAuditStoreForTests(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<void> {
   if (defaultStore) {
-    defaultStore.reset();
+    await defaultStore.reset();
   }
   defaultStore = null;
   defaultStoreKey = null;

--- a/packages/clawql-payments/src/audit/index.ts
+++ b/packages/clawql-payments/src/audit/index.ts
@@ -4,6 +4,7 @@ export {
   buildPlanChangedEntry,
   buildStripeInvoicePaidEntry,
   buildStripeMeterReportedEntry,
+  buildX402PaymentFailedEntry,
   buildX402PaymentReceivedEntry,
   type PaymentEventKind,
   type PaymentProvider,
@@ -27,14 +28,19 @@ export {
 } from "./factory.js";
 export {
   isPaymentAuditFsyncEnabled,
+  isPaymentAuditLokiPushEnabled,
   resolvePaymentAuditStoreMode,
   type PaymentAuditStore,
   type PaymentAuditStoreMode,
 } from "./store.js";
 export { createJsonlPaymentAuditStore } from "./jsonl-store.js";
+export { createPostgresPaymentAuditStore } from "./postgres-store.js";
+export { maybePushPaymentAuditEntryToLoki } from "./loki.js";
 export {
   buildSpendReport,
   filterAuditByCorrelationId,
+  loadAuditByCorrelationId,
+  loadSpendReport,
   type SpendGroupBy,
   type SpendReport,
   type SpendReportRow,

--- a/packages/clawql-payments/src/audit/jsonl-store.ts
+++ b/packages/clawql-payments/src/audit/jsonl-store.ts
@@ -116,7 +116,7 @@ export class JsonlPaymentAuditStore implements PaymentAuditStore {
     return this.cache;
   }
 
-  append(entry: PaymentWormEntry): PaymentWormRecord {
+  async append(entry: PaymentWormEntry): Promise<PaymentWormRecord> {
     const head = resolveChainHead(this.jsonlPath, this.metaPath);
     const record = sealPaymentWormRecord({
       entry,
@@ -144,21 +144,21 @@ export class JsonlPaymentAuditStore implements PaymentAuditStore {
     return record;
   }
 
-  list(limit = 100): PaymentWormEntry[] {
-    return this.listRecords(limit).map(toPaymentWormEntry);
+  async list(limit = 100): Promise<PaymentWormEntry[]> {
+    return (await this.listRecords(limit)).map(toPaymentWormEntry);
   }
 
-  listRecords(limit = 100): PaymentWormRecord[] {
+  async listRecords(limit = 100): Promise<PaymentWormRecord[]> {
     const records = this.loadRecords();
     if (limit <= 0) return [];
     return records.slice(-limit);
   }
 
-  verify(): PaymentAuditVerifyResult {
+  async verify(): Promise<PaymentAuditVerifyResult> {
     return verifyPaymentAuditChain(this.loadRecords());
   }
 
-  reset(): void {
+  async reset(): Promise<void> {
     this.cache = [];
     try {
       writeFileSync(this.jsonlPath, "", { mode: 0o600 });

--- a/packages/clawql-payments/src/audit/loki.test.ts
+++ b/packages/clawql-payments/src/audit/loki.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildStripeInvoicePaidEntry } from "./events.js";
+import { maybePushPaymentAuditEntryToLoki } from "./loki.js";
+
+function mockResponse(ok: boolean, status = ok ? 204 : 500): Response {
+  return {
+    ok,
+    status,
+    text: async () => "",
+  } as Response;
+}
+
+describe("payment audit Loki export", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("pushes full payload to Loki when URL is configured", async () => {
+    const fetchMock = vi.fn(async () => mockResponse(true));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const entry = buildStripeInvoicePaidEntry({
+      tenantId: "acme",
+      amountUsd: 12.34,
+      correlationId: "corr-1",
+    });
+
+    maybePushPaymentAuditEntryToLoki(entry, {
+      CLAWQL_LOKI_PUSH_URL: "https://loki.example/loki/api/v1/push",
+      CLAWQL_LOKI_BEARER_TOKEN: "token-abc",
+      CLAWQL_PAYMENTS_LOKI_JOB: "payments-test",
+    });
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    const call = fetchMock.mock.calls[0] as unknown as [string, RequestInit] | undefined;
+    expect(call).toBeDefined();
+    expect(call![0]).toBe("https://loki.example/loki/api/v1/push");
+    const init = call![1];
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer token-abc");
+
+    const body = JSON.parse(String(init.body));
+    expect(body.streams[0].stream).toEqual({ job: "payments-test", service: "clawql-payments" });
+    const line = JSON.parse(body.streams[0].values[0][1]);
+    expect(line.action).toBe("STRIPE_INVOICE_PAID");
+    expect(line.payload.tenant_id).toBe("acme");
+    expect(line.correlationId).toBe("corr-1");
+  });
+
+  it("no-ops when Loki URL is unset", async () => {
+    const fetchMock = vi.fn(async () => mockResponse(true));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    maybePushPaymentAuditEntryToLoki(
+      buildStripeInvoicePaidEntry({ tenantId: "t1", amountUsd: 1 }),
+      {}
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/clawql-payments/src/audit/loki.ts
+++ b/packages/clawql-payments/src/audit/loki.ts
@@ -1,0 +1,82 @@
+import type { PaymentWormEntry } from "./events.js";
+
+function lokiPushUrl(env: NodeJS.ProcessEnv): string | undefined {
+  const u = env.CLAWQL_LOKI_PUSH_URL?.trim();
+  return u || undefined;
+}
+
+function nsTimestamp(entry: PaymentWormEntry): string {
+  const ms = Date.parse(entry.ts);
+  const t = Number.isFinite(ms) ? ms : Date.now();
+  return String(Math.floor(t * 1e6));
+}
+
+/**
+ * Push one payment audit entry to Loki. Callers should gate with
+ * {@link isPaymentAuditLokiPushEnabled} before invoking.
+ */
+export function maybePushPaymentAuditEntryToLoki(
+  entry: PaymentWormEntry,
+  env: NodeJS.ProcessEnv = process.env
+): void {
+  const url = lokiPushUrl(env);
+  if (!url) {
+    return;
+  }
+
+  const job =
+    env.CLAWQL_PAYMENTS_LOKI_JOB?.trim() || env.CLAWQL_LOKI_JOB?.trim() || "clawql-payments-audit";
+  const line = JSON.stringify({
+    ts: entry.ts,
+    category: entry.category,
+    action: entry.action,
+    summary: entry.summary,
+    payload: entry.payload,
+    ...(entry.correlationId ? { correlationId: entry.correlationId } : {}),
+  });
+
+  const body = JSON.stringify({
+    streams: [
+      {
+        stream: { job, service: "clawql-payments" },
+        values: [[nsTimestamp(entry), line]],
+      },
+    ],
+  });
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  };
+  const token = env.CLAWQL_LOKI_BEARER_TOKEN?.trim();
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  const tenant = env.CLAWQL_LOKI_TENANT_ID?.trim();
+  if (tenant) {
+    headers["X-Scope-OrgID"] = tenant;
+  }
+
+  const timeoutMs = Number.parseInt(env.CLAWQL_LOKI_PUSH_TIMEOUT_MS?.trim() ?? "5000", 10);
+  const ms = Number.isFinite(timeoutMs) ? Math.min(Math.max(timeoutMs, 500), 60_000) : 5000;
+
+  void fetch(url, {
+    method: "POST",
+    headers,
+    body,
+    signal: AbortSignal.timeout(ms),
+  })
+    .then((res) => {
+      if (!res.ok) {
+        return res.text().then((t) => {
+          throw new Error(`HTTP ${res.status}: ${t.slice(0, 200)}`);
+        });
+      }
+    })
+    .catch((err: unknown) => {
+      console.error(
+        "[clawql-payments-audit-loki] push failed:",
+        err instanceof Error ? err.message : err
+      );
+    });
+}

--- a/packages/clawql-payments/src/audit/memory-store.ts
+++ b/packages/clawql-payments/src/audit/memory-store.ts
@@ -12,7 +12,7 @@ import type { PaymentAuditStore } from "./store.js";
 export class MemoryPaymentAuditStore implements PaymentAuditStore {
   private records: PaymentWormRecord[] = [];
 
-  append(entry: PaymentWormEntry): PaymentWormRecord {
+  async append(entry: PaymentWormEntry): Promise<PaymentWormRecord> {
     const prev_hash =
       this.records.length > 0
         ? this.records[this.records.length - 1]!.hash
@@ -26,20 +26,20 @@ export class MemoryPaymentAuditStore implements PaymentAuditStore {
     return record;
   }
 
-  list(limit = 100): PaymentWormEntry[] {
-    return this.listRecords(limit).map(toPaymentWormEntry);
+  async list(limit = 100): Promise<PaymentWormEntry[]> {
+    return (await this.listRecords(limit)).map(toPaymentWormEntry);
   }
 
-  listRecords(limit = 100): PaymentWormRecord[] {
+  async listRecords(limit = 100): Promise<PaymentWormRecord[]> {
     if (limit <= 0) return [];
     return this.records.slice(-limit);
   }
 
-  verify(): PaymentAuditVerifyResult {
+  async verify(): Promise<PaymentAuditVerifyResult> {
     return verifyPaymentAuditChain(this.records);
   }
 
-  reset(): void {
+  async reset(): Promise<void> {
     this.records = [];
   }
 }

--- a/packages/clawql-payments/src/audit/postgres-migrations.ts
+++ b/packages/clawql-payments/src/audit/postgres-migrations.ts
@@ -1,0 +1,22 @@
+import type { PoolClient } from "pg";
+
+export async function runPaymentsAuditPostgresMigrations(client: PoolClient): Promise<void> {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS clawql_payments_audit (
+      seq bigint PRIMARY KEY,
+      record jsonb NOT NULL
+    )
+  `);
+  await client.query(`
+    CREATE INDEX IF NOT EXISTS clawql_payments_audit_seq_idx
+    ON clawql_payments_audit (seq DESC)
+  `);
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS clawql_payments_audit_meta (
+      id int PRIMARY KEY CHECK (id = 1),
+      seq bigint NOT NULL DEFAULT 0,
+      last_hash text NOT NULL,
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )
+  `);
+}

--- a/packages/clawql-payments/src/audit/postgres-pool.test.ts
+++ b/packages/clawql-payments/src/audit/postgres-pool.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { __testUtils } from "./postgres-pool.js";
+
+describe("resolvePaymentsPoolConfig", () => {
+  it("prefers CLAWQL_PAYMENTS_DATABASE_URL", () => {
+    expect(
+      __testUtils.resolvePaymentsPoolConfig({
+        CLAWQL_PAYMENTS_DATABASE_URL: "postgres://payments/db",
+        CLAWQL_INFERENCE_DATABASE_URL: "postgres://inference/db",
+      })
+    ).toBe("postgres://payments/db");
+  });
+
+  it("falls back to CLAWQL_INFERENCE_DATABASE_URL", () => {
+    expect(
+      __testUtils.resolvePaymentsPoolConfig({
+        CLAWQL_INFERENCE_DATABASE_URL: "postgres://shared/db",
+      })
+    ).toBe("postgres://shared/db");
+  });
+
+  it("builds config from component vars", () => {
+    expect(
+      __testUtils.resolvePaymentsPoolConfig({
+        CLAWQL_PAYMENTS_DB_HOST: "db.local",
+        CLAWQL_PAYMENTS_DB_USER: "clawql",
+        CLAWQL_PAYMENTS_DB_PASSWORD: "secret",
+        CLAWQL_PAYMENTS_DB_NAME: "payments",
+        CLAWQL_PAYMENTS_DB_PORT: "5433",
+      })
+    ).toEqual({
+      host: "db.local",
+      user: "clawql",
+      password: "secret",
+      database: "payments",
+      port: 5433,
+      max: 4,
+    });
+  });
+});

--- a/packages/clawql-payments/src/audit/postgres-pool.ts
+++ b/packages/clawql-payments/src/audit/postgres-pool.ts
@@ -1,0 +1,95 @@
+import pg from "pg";
+import { runPaymentsAuditPostgresMigrations } from "./postgres-migrations.js";
+
+let pool: pg.Pool | null = null;
+let poolKey: string | null = null;
+let migrationsDone = false;
+let shutdownHooksRegistered = false;
+
+type PaymentsPgPoolConfig = string | pg.PoolConfig | null;
+
+function parsePort(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const n = Number(raw.trim());
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  return Math.floor(n);
+}
+
+export function resolvePaymentsPoolConfig(env: NodeJS.ProcessEnv = process.env): PaymentsPgPoolConfig {
+  const url =
+    env.CLAWQL_PAYMENTS_DATABASE_URL?.trim() || env.CLAWQL_INFERENCE_DATABASE_URL?.trim();
+  if (url) return url;
+
+  const host = env.CLAWQL_PAYMENTS_DB_HOST?.trim();
+  const user = env.CLAWQL_PAYMENTS_DB_USER?.trim();
+  const password = env.CLAWQL_PAYMENTS_DB_PASSWORD ?? "";
+  const database = env.CLAWQL_PAYMENTS_DB_NAME?.trim();
+  if (!host || !user || !database) return null;
+
+  return {
+    host,
+    user,
+    password,
+    database,
+    port: parsePort(env.CLAWQL_PAYMENTS_DB_PORT),
+    max: 4,
+  };
+}
+
+function poolConfigKey(config: PaymentsPgPoolConfig): string {
+  if (!config) return "";
+  return typeof config === "string" ? config : JSON.stringify(config);
+}
+
+export function getPaymentsAuditPgPool(env: NodeJS.ProcessEnv = process.env): pg.Pool | null {
+  const config = resolvePaymentsPoolConfig(env);
+  if (!config) return null;
+
+  const key = poolConfigKey(config);
+  if (!pool || poolKey !== key) {
+    pool =
+      typeof config === "string"
+        ? new pg.Pool({ connectionString: config, max: 4 })
+        : new pg.Pool(config);
+    poolKey = key;
+    migrationsDone = false;
+  }
+  return pool;
+}
+
+export async function ensurePaymentsAuditSchema(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<void> {
+  const p = getPaymentsAuditPgPool(env);
+  if (!p || migrationsDone) return;
+  const client = await p.connect();
+  try {
+    await runPaymentsAuditPostgresMigrations(client);
+    migrationsDone = true;
+  } finally {
+    client.release();
+  }
+}
+
+export async function closePaymentsAuditPgPool(): Promise<void> {
+  migrationsDone = false;
+  poolKey = null;
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+}
+
+export function registerPaymentsAuditPoolShutdownHooks(): void {
+  if (shutdownHooksRegistered) return;
+  shutdownHooksRegistered = true;
+  const onSignal = (): void => {
+    void closePaymentsAuditPgPool().catch(() => {});
+  };
+  process.once("SIGINT", onSignal);
+  process.once("SIGTERM", onSignal);
+}
+
+export const __testUtils = {
+  resolvePaymentsPoolConfig,
+};

--- a/packages/clawql-payments/src/audit/postgres-pool.ts
+++ b/packages/clawql-payments/src/audit/postgres-pool.ts
@@ -15,9 +15,10 @@ function parsePort(raw: string | undefined): number | undefined {
   return Math.floor(n);
 }
 
-export function resolvePaymentsPoolConfig(env: NodeJS.ProcessEnv = process.env): PaymentsPgPoolConfig {
-  const url =
-    env.CLAWQL_PAYMENTS_DATABASE_URL?.trim() || env.CLAWQL_INFERENCE_DATABASE_URL?.trim();
+export function resolvePaymentsPoolConfig(
+  env: NodeJS.ProcessEnv = process.env
+): PaymentsPgPoolConfig {
+  const url = env.CLAWQL_PAYMENTS_DATABASE_URL?.trim() || env.CLAWQL_INFERENCE_DATABASE_URL?.trim();
   if (url) return url;
 
   const host = env.CLAWQL_PAYMENTS_DB_HOST?.trim();

--- a/packages/clawql-payments/src/audit/postgres-store.test.ts
+++ b/packages/clawql-payments/src/audit/postgres-store.test.ts
@@ -18,14 +18,12 @@ type MetaRow = {
 function createMockPool(): pg.Pool {
   const records: AuditRow[] = [];
   let meta: MetaRow | null = null;
-  let inTransaction = false;
 
   const client = {
     async query(sql: string, params: unknown[] = []) {
       const normalized = sql.replace(/\s+/g, " ").trim();
 
       if (normalized === "BEGIN" || normalized === "COMMIT" || normalized === "ROLLBACK") {
-        inTransaction = normalized === "BEGIN";
         return { rows: [] };
       }
 

--- a/packages/clawql-payments/src/audit/postgres-store.test.ts
+++ b/packages/clawql-payments/src/audit/postgres-store.test.ts
@@ -1,0 +1,130 @@
+import type pg from "pg";
+import { describe, expect, it, beforeEach } from "vitest";
+import { PAYMENT_AUDIT_GENESIS_HASH } from "./chain.js";
+import { buildStripeInvoicePaidEntry } from "./events.js";
+import { PostgresPaymentAuditStore } from "./postgres-store.js";
+
+type AuditRow = {
+  seq: number;
+  record: unknown;
+};
+
+type MetaRow = {
+  seq: number;
+  last_hash: string;
+  updated_at: string;
+};
+
+function createMockPool(): pg.Pool {
+  const records: AuditRow[] = [];
+  let meta: MetaRow | null = null;
+  let inTransaction = false;
+
+  const client = {
+    async query(sql: string, params: unknown[] = []) {
+      const normalized = sql.replace(/\s+/g, " ").trim();
+
+      if (normalized === "BEGIN" || normalized === "COMMIT" || normalized === "ROLLBACK") {
+        inTransaction = normalized === "BEGIN";
+        return { rows: [] };
+      }
+
+      if (normalized.startsWith("CREATE TABLE") || normalized.startsWith("CREATE INDEX")) {
+        return { rows: [] };
+      }
+
+      if (normalized.includes("FROM clawql_payments_audit_meta WHERE id = 1")) {
+        return { rows: meta ? [{ seq: String(meta.seq), last_hash: meta.last_hash }] : [] };
+      }
+
+      if (
+        normalized.includes(
+          "SELECT seq, record FROM clawql_payments_audit ORDER BY seq DESC LIMIT 1"
+        )
+      ) {
+        const last = records[records.length - 1];
+        return {
+          rows: last ? [{ seq: String(last.seq), record: last.record }] : [],
+        };
+      }
+
+      if (normalized.startsWith("INSERT INTO clawql_payments_audit (seq, record)")) {
+        const record = JSON.parse(String(params[1]));
+        records.push({ seq: Number(params[0]), record });
+        return { rows: [] };
+      }
+
+      if (normalized.startsWith("INSERT INTO clawql_payments_audit_meta")) {
+        meta = {
+          seq: Number(params[0]),
+          last_hash: String(params[1]),
+          updated_at: String(params[2]),
+        };
+        return { rows: [] };
+      }
+
+      if (normalized.includes("ORDER BY seq DESC LIMIT")) {
+        const limit = Number(params[0]);
+        const slice = records.slice(-limit).reverse();
+        return { rows: slice.map((row) => ({ record: row.record })) };
+      }
+
+      if (normalized.includes("ORDER BY seq ASC")) {
+        return { rows: records.map((row) => ({ record: row.record })) };
+      }
+
+      if (normalized.startsWith("DELETE FROM clawql_payments_audit")) {
+        records.length = 0;
+        return { rows: [] };
+      }
+
+      if (normalized.startsWith("DELETE FROM clawql_payments_audit_meta")) {
+        meta = null;
+        return { rows: [] };
+      }
+
+      throw new Error(`Unhandled mock query: ${normalized}`);
+    },
+    release() {},
+  };
+
+  return {
+    connect: async () => client,
+    query: client.query.bind(client),
+    end: async () => {},
+  } as unknown as pg.Pool;
+}
+
+describe("PostgresPaymentAuditStore", () => {
+  let pool: pg.Pool;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    pool = createMockPool();
+    env = { NODE_ENV: "test", CLAWQL_PAYMENTS_AUDIT_STORE: "postgres" };
+  });
+
+  it("appends hash-chained records and verifies chain", async () => {
+    const store = new PostgresPaymentAuditStore(pool, env);
+
+    await store.append(buildStripeInvoicePaidEntry({ tenantId: "t1", amountUsd: 10 }));
+    await store.append(buildStripeInvoicePaidEntry({ tenantId: "t2", amountUsd: 20 }));
+
+    const entries = await store.list(10);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]?.payload.tenant_id).toBe("t1");
+
+    const result = await store.verify();
+    expect(result.ok).toBe(true);
+    expect(result.records).toBe(2);
+    expect(result.head_hash).not.toBe(PAYMENT_AUDIT_GENESIS_HASH);
+  });
+
+  it("reset clears records", async () => {
+    const store = new PostgresPaymentAuditStore(pool, env);
+    await store.append(buildStripeInvoicePaidEntry({ tenantId: "t1", amountUsd: 1 }));
+    await store.reset();
+    const entries = await store.list(10);
+    expect(entries).toHaveLength(0);
+  });
+});

--- a/packages/clawql-payments/src/audit/postgres-store.ts
+++ b/packages/clawql-payments/src/audit/postgres-store.ts
@@ -1,0 +1,146 @@
+import type pg from "pg";
+import {
+  PAYMENT_AUDIT_GENESIS_HASH,
+  sealPaymentWormRecord,
+  toPaymentWormEntry,
+  verifyPaymentAuditChain,
+  type PaymentAuditVerifyResult,
+  type PaymentWormRecord,
+} from "./chain.js";
+import type { PaymentWormEntry } from "./events.js";
+import { runPaymentsAuditPostgresMigrations } from "./postgres-migrations.js";
+import { getPaymentsAuditPgPool, registerPaymentsAuditPoolShutdownHooks } from "./postgres-pool.js";
+import type { PaymentAuditStore } from "./store.js";
+
+type ChainHead = {
+  seq: number;
+  last_hash: string;
+};
+
+function hydrateRecord(raw: unknown): PaymentWormRecord {
+  return raw as PaymentWormRecord;
+}
+
+async function readChainHead(client: pg.PoolClient): Promise<ChainHead> {
+  const meta = await client.query<{ seq: string; last_hash: string }>(
+    `SELECT seq, last_hash FROM clawql_payments_audit_meta WHERE id = 1`
+  );
+  if (meta.rows.length > 0) {
+    return {
+      seq: Number(meta.rows[0]!.seq),
+      last_hash: meta.rows[0]!.last_hash,
+    };
+  }
+
+  const last = await client.query<{ seq: string; record: unknown }>(
+    `SELECT seq, record FROM clawql_payments_audit ORDER BY seq DESC LIMIT 1`
+  );
+  if (last.rows.length === 0) {
+    return { seq: 0, last_hash: PAYMENT_AUDIT_GENESIS_HASH };
+  }
+  const record = hydrateRecord(last.rows[0]!.record);
+  return { seq: Number(last.rows[0]!.seq), last_hash: record.hash };
+}
+
+async function writeChainHead(
+  client: pg.PoolClient,
+  head: ChainHead & { updated_at: string }
+): Promise<void> {
+  await client.query(
+    `INSERT INTO clawql_payments_audit_meta (id, seq, last_hash, updated_at)
+     VALUES (1, $1, $2, $3)
+     ON CONFLICT (id) DO UPDATE SET
+       seq = EXCLUDED.seq,
+       last_hash = EXCLUDED.last_hash,
+       updated_at = EXCLUDED.updated_at`,
+    [head.seq, head.last_hash, head.updated_at]
+  );
+}
+
+export class PostgresPaymentAuditStore implements PaymentAuditStore {
+  private migrationsDone = false;
+
+  constructor(
+    private readonly pool: pg.Pool,
+    private readonly env: NodeJS.ProcessEnv = process.env
+  ) {}
+
+  private async ensureSchema(): Promise<void> {
+    if (this.migrationsDone) return;
+    const client = await this.pool.connect();
+    try {
+      await runPaymentsAuditPostgresMigrations(client);
+      this.migrationsDone = true;
+    } finally {
+      client.release();
+    }
+  }
+
+  async append(entry: PaymentWormEntry): Promise<PaymentWormRecord> {
+    await this.ensureSchema();
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      const head = await readChainHead(client);
+      const record = sealPaymentWormRecord({
+        entry,
+        seq: head.seq + 1,
+        prev_hash: head.last_hash,
+      });
+      await client.query(`INSERT INTO clawql_payments_audit (seq, record) VALUES ($1, $2::jsonb)`, [
+        record.seq,
+        JSON.stringify(record),
+      ]);
+      await writeChainHead(client, {
+        seq: record.seq,
+        last_hash: record.hash,
+        updated_at: new Date().toISOString(),
+      });
+      await client.query("COMMIT");
+      return record;
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async list(limit = 100): Promise<PaymentWormEntry[]> {
+    return (await this.listRecords(limit)).map(toPaymentWormEntry);
+  }
+
+  async listRecords(limit = 100): Promise<PaymentWormRecord[]> {
+    await this.ensureSchema();
+    if (limit <= 0) return [];
+    const res = await this.pool.query<{ record: unknown }>(
+      `SELECT record FROM clawql_payments_audit ORDER BY seq DESC LIMIT $1`,
+      [limit]
+    );
+    return res.rows.map((row) => hydrateRecord(row.record)).reverse();
+  }
+
+  async verify(): Promise<PaymentAuditVerifyResult> {
+    await this.ensureSchema();
+    const res = await this.pool.query<{ record: unknown }>(
+      `SELECT record FROM clawql_payments_audit ORDER BY seq ASC`
+    );
+    const records = res.rows.map((row) => hydrateRecord(row.record));
+    return verifyPaymentAuditChain(records);
+  }
+
+  async reset(): Promise<void> {
+    await this.ensureSchema();
+    await this.pool.query(`DELETE FROM clawql_payments_audit`);
+    await this.pool.query(`DELETE FROM clawql_payments_audit_meta`);
+  }
+}
+
+export function createPostgresPaymentAuditStore(
+  env: NodeJS.ProcessEnv = process.env
+): PostgresPaymentAuditStore | null {
+  const pool = getPaymentsAuditPgPool(env);
+  if (!pool) return null;
+  registerPaymentsAuditPoolShutdownHooks();
+  return new PostgresPaymentAuditStore(pool, env);
+}

--- a/packages/clawql-payments/src/audit/reconcile.ts
+++ b/packages/clawql-payments/src/audit/reconcile.ts
@@ -1,4 +1,4 @@
-import type { PaymentProvider } from "./events.js";
+import type { PaymentProvider, PaymentWormEntry } from "./events.js";
 import { listPaymentAuditEntries } from "./worm.js";
 
 export type SpendGroupBy = "provider" | "tenant" | "plan";
@@ -18,7 +18,7 @@ export type SpendReport = {
 };
 
 export function buildSpendReport(
-  entries = listPaymentAuditEntries(10_000),
+  entries: PaymentWormEntry[],
   groupBy: SpendGroupBy = "provider"
 ): SpendReport {
   const buckets = new Map<string, SpendReportRow>();
@@ -57,9 +57,25 @@ export function buildSpendReport(
   };
 }
 
+export async function loadSpendReport(
+  groupBy: SpendGroupBy = "provider",
+  limit = 10_000
+): Promise<SpendReport> {
+  const entries = await listPaymentAuditEntries(limit);
+  return buildSpendReport(entries, groupBy);
+}
+
 export function filterAuditByCorrelationId(
   correlationId: string,
-  entries = listPaymentAuditEntries(10_000)
-) {
+  entries: PaymentWormEntry[]
+): PaymentWormEntry[] {
   return entries.filter((e) => e.correlationId === correlationId);
+}
+
+export async function loadAuditByCorrelationId(
+  correlationId: string,
+  limit = 10_000
+): Promise<PaymentWormEntry[]> {
+  const entries = await listPaymentAuditEntries(limit);
+  return filterAuditByCorrelationId(correlationId, entries);
 }

--- a/packages/clawql-payments/src/audit/store.test.ts
+++ b/packages/clawql-payments/src/audit/store.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { isPaymentAuditLokiPushEnabled } from "./store.js";
+
+describe("isPaymentAuditLokiPushEnabled", () => {
+  it("defaults on when Loki URL is set", () => {
+    expect(
+      isPaymentAuditLokiPushEnabled({
+        CLAWQL_LOKI_PUSH_URL: "https://loki.example/push",
+      })
+    ).toBe(true);
+  });
+
+  it("respects CLAWQL_PAYMENTS_LOKI_PUSH=0", () => {
+    expect(
+      isPaymentAuditLokiPushEnabled({
+        CLAWQL_LOKI_PUSH_URL: "https://loki.example/push",
+        CLAWQL_PAYMENTS_LOKI_PUSH: "0",
+      })
+    ).toBe(false);
+  });
+
+  it("respects global CLAWQL_ENABLE_LOKI_PUSH=0", () => {
+    expect(
+      isPaymentAuditLokiPushEnabled({
+        CLAWQL_LOKI_PUSH_URL: "https://loki.example/push",
+        CLAWQL_ENABLE_LOKI_PUSH: "0",
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/clawql-payments/src/audit/store.ts
+++ b/packages/clawql-payments/src/audit/store.ts
@@ -1,21 +1,21 @@
 import type { PaymentWormEntry } from "./events.js";
 import type { PaymentWormRecord, PaymentAuditVerifyResult } from "./chain.js";
 
-export type PaymentAuditStoreMode = "jsonl" | "memory";
+export type PaymentAuditStoreMode = "jsonl" | "memory" | "postgres";
 
 export type PaymentAuditStore = {
-  append(entry: PaymentWormEntry): PaymentWormRecord;
-  list(limit?: number): PaymentWormEntry[];
-  listRecords(limit?: number): PaymentWormRecord[];
-  verify(): PaymentAuditVerifyResult;
-  reset(): void;
+  append(entry: PaymentWormEntry): Promise<PaymentWormRecord>;
+  list(limit?: number): Promise<PaymentWormEntry[]>;
+  listRecords(limit?: number): Promise<PaymentWormRecord[]>;
+  verify(): Promise<PaymentAuditVerifyResult>;
+  reset(): Promise<void>;
 };
 
 export function resolvePaymentAuditStoreMode(
   env: NodeJS.ProcessEnv = process.env
 ): PaymentAuditStoreMode {
   const raw = env.CLAWQL_PAYMENTS_AUDIT_STORE?.trim().toLowerCase();
-  if (raw === "jsonl" || raw === "memory") return raw;
+  if (raw === "jsonl" || raw === "memory" || raw === "postgres") return raw;
   if (env.VITEST === "true" || env.NODE_ENV === "test") return "memory";
   return "jsonl";
 }
@@ -23,5 +23,16 @@ export function resolvePaymentAuditStoreMode(
 export function isPaymentAuditFsyncEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const raw = env.CLAWQL_PAYMENTS_AUDIT_FSYNC?.trim().toLowerCase();
   if (raw === "0" || raw === "false" || raw === "off") return false;
+  return true;
+}
+
+export function isPaymentAuditLokiPushEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const flag = env.CLAWQL_PAYMENTS_LOKI_PUSH?.trim();
+  if (flag === "0" || flag?.toLowerCase() === "false") return false;
+  if (flag === "1" || flag?.toLowerCase() === "true") return true;
+  const url = env.CLAWQL_LOKI_PUSH_URL?.trim();
+  if (!url) return false;
+  const globalFlag = env.CLAWQL_ENABLE_LOKI_PUSH?.trim();
+  if (globalFlag === "0" || globalFlag?.toLowerCase() === "false") return false;
   return true;
 }

--- a/packages/clawql-payments/src/audit/worm.test.ts
+++ b/packages/clawql-payments/src/audit/worm.test.ts
@@ -70,7 +70,10 @@ describe("durable payment audit store", () => {
   });
 
   it("buildSpendReport uses persisted payload amounts", async () => {
-    await appendPaymentWormEntry(buildStripeInvoicePaidEntry({ tenantId: "t1", amountUsd: 10 }), env);
+    await appendPaymentWormEntry(
+      buildStripeInvoicePaidEntry({ tenantId: "t1", amountUsd: 10 }),
+      env
+    );
     await appendPaymentWormEntry(
       buildX402PaymentReceivedEntry({
         tenantId: "t2",
@@ -88,8 +91,14 @@ describe("durable payment audit store", () => {
   });
 
   it("verifyPaymentAuditLog returns ok for intact chain", async () => {
-    await appendPaymentWormEntry(buildStripeInvoicePaidEntry({ tenantId: "t1", amountUsd: 1 }), env);
-    await appendPaymentWormEntry(buildStripeInvoicePaidEntry({ tenantId: "t2", amountUsd: 2 }), env);
+    await appendPaymentWormEntry(
+      buildStripeInvoicePaidEntry({ tenantId: "t1", amountUsd: 1 }),
+      env
+    );
+    await appendPaymentWormEntry(
+      buildStripeInvoicePaidEntry({ tenantId: "t2", amountUsd: 2 }),
+      env
+    );
 
     const result = await verifyPaymentAuditLog(env);
     expect(result.ok).toBe(true);

--- a/packages/clawql-payments/src/audit/worm.test.ts
+++ b/packages/clawql-payments/src/audit/worm.test.ts
@@ -17,7 +17,7 @@ describe("durable payment audit store", () => {
   let tempHome: string;
   let env: NodeJS.ProcessEnv;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     tempHome = mkdtempSync(join(tmpdir(), "clawql-payments-audit-"));
     env = {
       ...process.env,
@@ -26,16 +26,16 @@ describe("durable payment audit store", () => {
       CLAWQL_PAYMENTS_AUDIT_FSYNC: "0",
     };
     resetDefaultAuditRingBufferForTests();
-    resetPaymentAuditStoreForTests(env);
+    await resetPaymentAuditStoreForTests(env);
   });
 
-  afterEach(() => {
-    resetPaymentAuditStoreForTests(env);
+  afterEach(async () => {
+    await resetPaymentAuditStoreForTests(env);
     rmSync(tempHome, { recursive: true, force: true });
   });
 
-  it("persists full payload to audit.jsonl", () => {
-    appendPaymentWormEntry(
+  it("persists full payload to audit.jsonl", async () => {
+    await appendPaymentWormEntry(
       buildStripeInvoicePaidEntry({
         tenantId: "acme",
         amountUsd: 42.5,
@@ -45,15 +45,15 @@ describe("durable payment audit store", () => {
       env
     );
 
-    const entries = listPaymentAuditEntries(10, env);
+    const entries = await listPaymentAuditEntries(10, env);
     expect(entries).toHaveLength(1);
     expect(entries[0]?.payload.tenant_id).toBe("acme");
     expect(entries[0]?.payload.amount_usd).toBe(42.5);
     expect(entries[0]?.payload.plan).toBe("team");
   });
 
-  it("verifies hash chain after restart (new store instance)", () => {
-    appendPaymentWormEntry(
+  it("verifies hash chain after restart (new store instance)", async () => {
+    await appendPaymentWormEntry(
       buildX402PaymentReceivedEntry({
         tenantId: "default",
         amountUsdc: 0.001,
@@ -64,14 +64,14 @@ describe("durable payment audit store", () => {
     );
 
     const store = createJsonlPaymentAuditStore(env);
-    const result = store.verify();
+    const result = await store.verify();
     expect(result.ok).toBe(true);
     expect(result.records).toBe(1);
   });
 
-  it("buildSpendReport uses persisted payload amounts", () => {
-    appendPaymentWormEntry(buildStripeInvoicePaidEntry({ tenantId: "t1", amountUsd: 10 }), env);
-    appendPaymentWormEntry(
+  it("buildSpendReport uses persisted payload amounts", async () => {
+    await appendPaymentWormEntry(buildStripeInvoicePaidEntry({ tenantId: "t1", amountUsd: 10 }), env);
+    await appendPaymentWormEntry(
       buildX402PaymentReceivedEntry({
         tenantId: "t2",
         amountUsdc: 0.5,
@@ -80,18 +80,18 @@ describe("durable payment audit store", () => {
       env
     );
 
-    const report = buildSpendReport(listPaymentAuditEntries(100, env), "provider");
+    const report = buildSpendReport(await listPaymentAuditEntries(100, env), "provider");
     expect(report.totalUsd).toBe(10);
     expect(report.totalUsdc).toBe(0.5);
     expect(report.rows.some((r) => r.provider === "stripe" && r.amountUsd === 10)).toBe(true);
     expect(report.rows.some((r) => r.provider === "x402" && r.amountUsdc === 0.5)).toBe(true);
   });
 
-  it("verifyPaymentAuditLog returns ok for intact chain", () => {
-    appendPaymentWormEntry(buildStripeInvoicePaidEntry({ tenantId: "t1", amountUsd: 1 }), env);
-    appendPaymentWormEntry(buildStripeInvoicePaidEntry({ tenantId: "t2", amountUsd: 2 }), env);
+  it("verifyPaymentAuditLog returns ok for intact chain", async () => {
+    await appendPaymentWormEntry(buildStripeInvoicePaidEntry({ tenantId: "t1", amountUsd: 1 }), env);
+    await appendPaymentWormEntry(buildStripeInvoicePaidEntry({ tenantId: "t2", amountUsd: 2 }), env);
 
-    const result = verifyPaymentAuditLog(env);
+    const result = await verifyPaymentAuditLog(env);
     expect(result.ok).toBe(true);
     expect(result.records).toBe(2);
   });

--- a/packages/clawql-payments/src/audit/worm.ts
+++ b/packages/clawql-payments/src/audit/worm.ts
@@ -2,12 +2,14 @@ import { getDefaultAuditRingBuffer } from "clawql-core";
 import type { PaymentAuditVerifyResult } from "./chain.js";
 import type { PaymentWormEntry } from "./events.js";
 import { getPaymentAuditStore, resetPaymentAuditStoreForTests } from "./factory.js";
+import { maybePushPaymentAuditEntryToLoki } from "./loki.js";
+import { isPaymentAuditLokiPushEnabled } from "./store.js";
 
-export function appendPaymentWormEntry(
+export async function appendPaymentWormEntry(
   entry: PaymentWormEntry,
   env: NodeJS.ProcessEnv = process.env
-): void {
-  getPaymentAuditStore(env).append(entry);
+): Promise<void> {
+  await getPaymentAuditStore(env).append(entry);
 
   // Hot in-process mirror for MCP audit ring buffer (summary-only).
   getDefaultAuditRingBuffer().append({
@@ -17,18 +19,22 @@ export function appendPaymentWormEntry(
     summary: entry.summary,
     correlationId: entry.correlationId,
   });
+
+  if (isPaymentAuditLokiPushEnabled(env)) {
+    maybePushPaymentAuditEntryToLoki(entry, env);
+  }
 }
 
-export function listPaymentAuditEntries(
+export async function listPaymentAuditEntries(
   limit = 100,
   env: NodeJS.ProcessEnv = process.env
-): PaymentWormEntry[] {
+): Promise<PaymentWormEntry[]> {
   return getPaymentAuditStore(env).list(limit);
 }
 
-export function verifyPaymentAuditLog(
+export async function verifyPaymentAuditLog(
   env: NodeJS.ProcessEnv = process.env
-): PaymentAuditVerifyResult {
+): Promise<PaymentAuditVerifyResult> {
   return getPaymentAuditStore(env).verify();
 }
 

--- a/packages/clawql-payments/src/cli/plan.ts
+++ b/packages/clawql-payments/src/cli/plan.ts
@@ -3,7 +3,7 @@ import {
   appendPaymentWormEntry,
   buildPlanChangedEntry,
   buildSpendReport,
-  filterAuditByCorrelationId,
+  loadAuditByCorrelationId,
   listPaymentAuditEntries,
   verifyPaymentAuditLog,
   type SpendGroupBy,
@@ -71,7 +71,7 @@ export async function runPaymentsPlanUpgrade(
 
   const { config, path } = await mergePaymentsConfig({ plan: toPlan, tenantId }, env);
 
-  appendPaymentWormEntry(
+  await appendPaymentWormEntry(
     buildPlanChangedEntry({
       tenantId,
       fromPlan: current.plan,
@@ -125,7 +125,10 @@ export type PaymentsSpendReportOptions = {
 export async function runPaymentsSpendReport(
   options: PaymentsSpendReportOptions = {}
 ): Promise<number> {
-  const report = buildSpendReport(listPaymentAuditEntries(10_000), options.groupBy ?? "provider");
+  const report = buildSpendReport(
+    await listPaymentAuditEntries(10_000),
+    options.groupBy ?? "provider"
+  );
 
   if (options.json) {
     console.log(JSON.stringify(report, null, 2));
@@ -151,8 +154,8 @@ export type PaymentsAuditOptions = {
 
 export async function runPaymentsAudit(options: PaymentsAuditOptions = {}): Promise<number> {
   const entries = options.correlationId
-    ? filterAuditByCorrelationId(options.correlationId)
-    : listPaymentAuditEntries(options.limit ?? 100);
+    ? await loadAuditByCorrelationId(options.correlationId, options.limit ?? 100)
+    : await listPaymentAuditEntries(options.limit ?? 100);
 
   if (options.json) {
     console.log(JSON.stringify({ entries }, null, 2));
@@ -173,7 +176,7 @@ export async function runPaymentsAudit(options: PaymentsAuditOptions = {}): Prom
 
 export async function runPaymentsAuditVerify(options: PaymentsAuditOptions = {}): Promise<number> {
   const env = options.env ?? process.env;
-  const result = verifyPaymentAuditLog(env);
+  const result = await verifyPaymentAuditLog(env);
 
   if (options.json) {
     console.log(JSON.stringify(result, null, 2));

--- a/packages/clawql-payments/src/cli/stripe.ts
+++ b/packages/clawql-payments/src/cli/stripe.ts
@@ -340,7 +340,7 @@ export async function runPaymentsStripeMeterReport(
     env,
   });
 
-  appendPaymentWormEntry(
+  await appendPaymentWormEntry(
     buildStripeMeterReportedEntry({
       tenantId,
       value,

--- a/packages/clawql-payments/src/stripe/meter-report.test.ts
+++ b/packages/clawql-payments/src/stripe/meter-report.test.ts
@@ -15,9 +15,9 @@ vi.mock("./metered.js", () => ({
 import { reportMeteredUsage } from "./metered.js";
 
 describe("stripe meter reporting", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     resetDefaultAuditRingBufferForTests();
-    resetPaymentAuditStoreForTests();
+    await resetPaymentAuditStoreForTests();
     vi.mocked(reportMeteredUsage).mockClear();
   });
 
@@ -79,7 +79,7 @@ describe("stripe meter reporting", () => {
       })
     );
 
-    const entries = listPaymentAuditEntries(5);
+    const entries = await listPaymentAuditEntries(5);
     expect(entries.some((e) => e.action === "STRIPE_METER_REPORTED")).toBe(true);
   });
 });

--- a/packages/clawql-payments/src/stripe/meter-report.ts
+++ b/packages/clawql-payments/src/stripe/meter-report.ts
@@ -86,7 +86,7 @@ export async function reportInferenceMeterUsageIfEnabled(
     env,
   });
 
-  appendPaymentWormEntry(
+  await appendPaymentWormEntry(
     buildStripeMeterReportedEntry({
       tenantId: input.tenantId,
       value,

--- a/packages/clawql-payments/src/stripe/webhook.test.ts
+++ b/packages/clawql-payments/src/stripe/webhook.test.ts
@@ -10,9 +10,9 @@ import { StripeWebhookVerificationError } from "./errors.js";
 import { listPaymentAuditEntries, resetPaymentAuditStoreForTests } from "../audit/worm.js";
 
 describe("stripe webhook verification", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     resetDefaultAuditRingBufferForTests();
-    resetPaymentAuditStoreForTests();
+    await resetPaymentAuditStoreForTests();
   });
 
   const secret = "whsec_test_secret_for_clawql_payments";
@@ -55,7 +55,7 @@ describe("stripe webhook verification", () => {
     const event = assertStripeWebhookSignature(payload, signature, secret);
     const result = await processStripeWebhookEvent(event, { tenantId: "default" });
     expect(result.handled).toBe(true);
-    const entries = listPaymentAuditEntries(10);
+    const entries = await listPaymentAuditEntries(10);
     expect(entries.some((e) => e.action === "STRIPE_INVOICE_PAID")).toBe(true);
   });
 });

--- a/packages/clawql-payments/src/stripe/webhook.ts
+++ b/packages/clawql-payments/src/stripe/webhook.ts
@@ -78,7 +78,7 @@ export async function processStripeWebhookEvent(
     case "invoice.paid": {
       const invoice = event.data.object as Stripe.Invoice;
       const amountUsd = (invoice.amount_paid ?? 0) / 100;
-      appendPaymentWormEntry(
+      await appendPaymentWormEntry(
         buildStripeInvoicePaidEntry({
           tenantId: tenantFromEvent(event, tenantId),
           amountUsd,
@@ -90,7 +90,7 @@ export async function processStripeWebhookEvent(
     }
     case "invoice.payment_failed": {
       const invoice = event.data.object as Stripe.Invoice;
-      appendPaymentWormEntry(
+      await appendPaymentWormEntry(
         buildPaymentWormEntry({
           eventKind: "STRIPE_PAYMENT_FAILED",
           summary: `Stripe invoice payment failed for ${invoice.id}`,
@@ -107,7 +107,7 @@ export async function processStripeWebhookEvent(
     }
     case "customer.subscription.created": {
       const subscription = event.data.object as Stripe.Subscription;
-      appendPaymentWormEntry(
+      await appendPaymentWormEntry(
         buildPaymentWormEntry({
           eventKind: "STRIPE_SUBSCRIPTION_CREATED",
           summary: `Stripe subscription created ${subscription.id}`,

--- a/packages/clawql-payments/src/x402/enforce.test.ts
+++ b/packages/clawql-payments/src/x402/enforce.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetDefaultAuditRingBufferForTests } from "clawql-core";
+import { listPaymentAuditEntries, resetPaymentAuditStoreForTests } from "../audit/worm.js";
 import { createX402Gate } from "./gate.js";
 import { enforceX402Gate } from "./enforce.js";
 import { parseX402PaymentPayloadHeader } from "./headers.js";
@@ -13,7 +14,11 @@ describe("x402 gate enforcement", () => {
 
   beforeEach(async () => {
     home = await mkdtemp(join(tmpdir(), "clawql-x402-enforce-"));
-    env = { ...process.env, CLAWQL_HOME: home };
+    env = {
+      ...process.env,
+      CLAWQL_HOME: home,
+      CLAWQL_PAYMENTS_AUDIT_STORE: "memory",
+    };
     await mkdir(join(home, "Payments"), { recursive: true });
     await writeFile(
       join(home, "Payments", "payments.json"),
@@ -31,6 +36,7 @@ describe("x402 gate enforcement", () => {
       )}\n`
     );
     resetDefaultAuditRingBufferForTests();
+    await resetPaymentAuditStoreForTests(env);
   });
 
   afterEach(async () => {
@@ -51,6 +57,9 @@ describe("x402 gate enforcement", () => {
     if (result.action === "require_payment") {
       expect(result.body.accepts[0]?.amount).toBe("1000");
     }
+
+    const entries = await listPaymentAuditEntries(10, env);
+    expect(entries.some((e) => e.action === "X402_PAYMENT_FAILED")).toBe(false);
   });
 
   it("verifies payment via facilitator and allows request", async () => {
@@ -80,6 +89,53 @@ describe("x402 gate enforcement", () => {
     if (result.action === "allow") {
       expect(result.payer).toBe("0xpayer");
     }
+  });
+
+  it("records X402_PAYMENT_FAILED when facilitator rejects proof", async () => {
+    await createX402Gate({ resource: "/v1/chat/completions", price: 0.001, asset: "USDC" }, env);
+
+    const payload = {
+      x402Version: 2,
+      payload: { signature: "0xbad" },
+    };
+    const header = Buffer.from(JSON.stringify(payload)).toString("base64");
+
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ isValid: false, invalidReason: "bad sig" }),
+    }));
+
+    const result = await enforceX402Gate({
+      resource: "/v1/chat/completions",
+      requestUrl: "http://127.0.0.1:8080/v1/chat/completions",
+      headers: { "payment-signature": header },
+      correlationId: "corr-deny",
+      env,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(result.action).toBe("deny");
+    const entries = await listPaymentAuditEntries(10, env);
+    const failed = entries.find((e) => e.action === "X402_PAYMENT_FAILED");
+    expect(failed?.payload.tenant_id).toBe("tenant-a");
+    expect(failed?.payload.resource).toBe("/v1/chat/completions");
+    expect(failed?.correlationId).toBe("corr-deny");
+  });
+
+  it("records X402_PAYMENT_FAILED for invalid payment payload header", async () => {
+    await createX402Gate({ resource: "/v1/chat/completions", price: 0.001, asset: "USDC" }, env);
+
+    const result = await enforceX402Gate({
+      resource: "/v1/chat/completions",
+      requestUrl: "http://127.0.0.1:8080/v1/chat/completions",
+      headers: { "payment-signature": "not-valid-base64-json!!!" },
+      env,
+    });
+
+    expect(result.action).toBe("deny");
+    const entries = await listPaymentAuditEntries(10, env);
+    expect(entries.some((e) => e.action === "X402_PAYMENT_FAILED")).toBe(true);
   });
 
   it("parses base64 payment payload headers", () => {

--- a/packages/clawql-payments/src/x402/enforce.ts
+++ b/packages/clawql-payments/src/x402/enforce.ts
@@ -1,4 +1,6 @@
 import { loadPaymentsConfig } from "../config/store.js";
+import { appendPaymentWormEntry } from "../audit/worm.js";
+import { buildX402PaymentFailedEntry } from "../audit/events.js";
 import { loadX402RuntimeConfig } from "./config.js";
 import { findX402GateForResource } from "./gate.js";
 import { parseX402PaymentPayloadHeader, readX402PaymentHeader } from "./headers.js";
@@ -23,12 +25,33 @@ export type EnforceX402GateInput = {
   fetchImpl?: typeof fetch;
 };
 
+async function recordX402PaymentFailed(input: {
+  tenantId: string;
+  resource: string;
+  reason: string;
+  correlationId?: string;
+  env: NodeJS.ProcessEnv;
+}): Promise<void> {
+  await appendPaymentWormEntry(
+    buildX402PaymentFailedEntry({
+      tenantId: input.tenantId,
+      resource: input.resource,
+      reason: input.reason,
+      correlationId: input.correlationId,
+    }),
+    input.env
+  );
+}
+
 export async function enforceX402Gate(input: EnforceX402GateInput): Promise<X402EnforceResult> {
   const env = input.env ?? process.env;
   const gate = await findX402GateForResource(input.resource, env);
   if (!gate) {
     return { action: "allow", resource: input.resource };
   }
+
+  const paymentsConfig = await loadPaymentsConfig(env);
+  const tenantId = paymentsConfig.tenantId ?? "default";
 
   const paymentHeader = readX402PaymentHeader(input.headers);
   if (!paymentHeader) {
@@ -47,20 +70,36 @@ export async function enforceX402Gate(input: EnforceX402GateInput): Promise<X402
 
   const paymentPayload = parseX402PaymentPayloadHeader(paymentHeader);
   if (!paymentPayload) {
+    const reason = "invalid x402 payment payload in PAYMENT-SIGNATURE header";
+    await recordX402PaymentFailed({
+      tenantId,
+      resource: gate.resource,
+      reason,
+      correlationId: input.correlationId,
+      env,
+    });
     return {
       action: "deny",
       status: 402,
-      reason: "invalid x402 payment payload in PAYMENT-SIGNATURE header",
+      reason,
       resource: gate.resource,
     };
   }
 
   const config = await loadX402RuntimeConfig(env);
   if (!config.facilitatorUrl) {
+    const reason = "x402 facilitator URL is not configured";
+    await recordX402PaymentFailed({
+      tenantId,
+      resource: gate.resource,
+      reason,
+      correlationId: input.correlationId,
+      env,
+    });
     return {
       action: "deny",
       status: 402,
-      reason: "x402 facilitator URL is not configured",
+      reason,
       resource: gate.resource,
     };
   }
@@ -80,6 +119,13 @@ export async function enforceX402Gate(input: EnforceX402GateInput): Promise<X402
   });
 
   if (!verified.verified) {
+    await recordX402PaymentFailed({
+      tenantId,
+      resource: gate.resource,
+      reason: verified.reason,
+      correlationId: input.correlationId,
+      env,
+    });
     return {
       action: "deny",
       status: 402,
@@ -87,9 +133,6 @@ export async function enforceX402Gate(input: EnforceX402GateInput): Promise<X402
       resource: gate.resource,
     };
   }
-
-  const paymentsConfig = await loadPaymentsConfig(env);
-  const tenantId = paymentsConfig.tenantId ?? "default";
 
   await reconcileX402Settlement({
     tenantId,

--- a/packages/clawql-payments/src/x402/facilitator.test.ts
+++ b/packages/clawql-payments/src/x402/facilitator.test.ts
@@ -52,7 +52,7 @@ describe("x402 facilitator HTTP", () => {
     expect(result.verified).toBe(true);
     expect(result.payer).toBe("0xpayer");
     expect(fetchImpl).toHaveBeenCalledOnce();
-    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
     expect(url).toBe("https://x402.org/facilitator/verify");
     expect(init.method).toBe("POST");
   });

--- a/packages/clawql-payments/src/x402/reconcile.ts
+++ b/packages/clawql-payments/src/x402/reconcile.ts
@@ -27,7 +27,7 @@ export async function reconcileX402Settlement(input: {
     settledAt: new Date().toISOString(),
   };
 
-  appendPaymentWormEntry(
+  await appendPaymentWormEntry(
     buildX402PaymentReceivedEntry({
       tenantId: input.tenantId,
       amountUsdc: input.amountUsdc,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the optional follow-ups from the durable WORM audit work (#591):

- **Postgres audit store** — `CLAWQL_PAYMENTS_AUDIT_STORE=postgres` with hash-chained records in `clawql_payments_audit` / `clawql_payments_audit_meta`. Supports `CLAWQL_PAYMENTS_DATABASE_URL` or falls back to `CLAWQL_INFERENCE_DATABASE_URL` for shared DB deployments.
- **Loki/SIEM export** — fire-and-forget push of full payment audit payloads on append when `CLAWQL_LOKI_PUSH_URL` is configured (same auth/tenant env vars as MCP audit Loki).
- **`X402_PAYMENT_FAILED` events** — emitted on invalid proof, facilitator verify failure, and misconfiguration. Does **not** emit on `require_payment` (no proof attached yet).

The audit store interface is now async (`appendPaymentWormEntry`, `listPaymentAuditEntries`, `verifyPaymentAuditLog` return Promises) to support Postgres without blocking the event loop.

## Test plan

- [x] `npm run typecheck` in `packages/clawql-payments`
- [x] `npm test` in `packages/clawql-payments` (51 tests)
- [x] `npm run build` in `packages/clawql-payments`
- [x] New tests: Postgres store (mock pool), Loki push, X402 failure audit, pool config, factory error path
- [x] Updated docs: `docs/payments/clawql-payments.md`, `packages/clawql-payments/README.md`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

