### PR TITLE
fix(website): mobile table alignment and text architecture on inference docs

### DIFF
--- a/docs/inference/clawql-inference.md
+++ b/docs/inference/clawql-inference.md
@@ -29,37 +29,39 @@
 
 ## Architecture overview
 
-```mermaid
-flowchart TB
-  subgraph clients [Clients]
-    SDK[OpenAI SDK / curl]
-    CLI[clawql inference complete]
-    OB[Ouroboros EvolutionaryLoop]
-  end
+### Entry points
 
-  subgraph http [HTTP layer]
-    AUTH[Virtual key auth middleware]
-    OAI[OpenAI-compat router]
-  end
+| Client | Path into the gateway |
+| ------ | --------------------- |
+| **OpenAI SDK / curl** | Virtual key auth middleware → OpenAI-compat router (`/v1/chat/completions`, `/v1/models`) → gateway stack |
+| **`clawql inference complete`** | Calls the gateway stack directly (no HTTP auth layer) |
+| **Ouroboros `EvolutionaryLoop`** | Calls `ConfiguredInferenceGateway` at the innermost layer (bypasses HTTP) |
 
-  subgraph gateway [Gateway decorator stack — inner to outer]
-    CFG[ConfiguredInferenceGateway]
-    FB[FallbackChainGateway]
-    CACHE[SemanticCachedGateway]
-    ENT[EntitlementEnforcedGateway]
-    OBS[ObservedInferenceGateway]
-  end
+### Gateway decorator stack (inner → outer)
 
-  subgraph backends [Backends]
-    PLG[Provider plugins — openai / anthropic / ollama]
-    STORE[(Inference store — memory / jsonl / postgres)]
-  end
+Each `complete()` call passes **outward** through these layers before reaching a provider:
 
-  SDK --> AUTH --> OAI --> OBS
-  CLI --> OBS
-  OB --> CFG
-  OBS --> ENT --> CACHE --> FB --> CFG --> PLG
-  OBS --> STORE
+1. **`ConfiguredInferenceGateway`** — resolves `provider/model`, invokes the provider adapter
+2. **`FallbackChainGateway`** — tries alternate models on primary failure (when fallback enabled)
+3. **`SemanticCachedGateway`** — embedding-similarity cache lookup (when semantic cache enabled)
+4. **`EntitlementEnforcedGateway`** — plan limit checks via `clawql-payments` (when enforcement enabled)
+5. **`ObservedInferenceGateway`** — appends an `InferenceRecord` to the call store
+
+Call order from outside in: **Observed → Entitlement → Cache → Fallback → Configured → provider**.
+
+### Backends
+
+- **Provider plugins** — built-in OpenAI, Anthropic, Ollama; extensible via the plugin registry
+- **Inference store** — `memory`, `jsonl`, or `postgres` backend for durable call records and export
+
+### Data flow summary
+
+```
+HTTP clients → auth middleware → OpenAI router → [Observed → Entitlement → Cache → Fallback → Configured] → provider plugin
+CLI / library callers ──────────────────────────► [same decorator stack] ────────────────────────────────► provider plugin
+Ouroboros loop ─────────────────────────────────► ConfiguredInferenceGateway (innermost) ───────────────► provider plugin
+
+ObservedInferenceGateway ──writes──► Inference store (jsonl / postgres / memory)
 ```
 
 Every successful `complete()` call flows **outward through decorators** and ends in the call store. HTTP clients additionally pass through virtual-key auth before the OpenAI router invokes the same gateway.

--- a/docs/inference/clawql-inference.md
+++ b/docs/inference/clawql-inference.md
@@ -31,11 +31,11 @@
 
 ### Entry points
 
-| Client | Path into the gateway |
-| ------ | --------------------- |
-| **OpenAI SDK / curl** | Virtual key auth middleware → OpenAI-compat router (`/v1/chat/completions`, `/v1/models`) → gateway stack |
-| **`clawql inference complete`** | Calls the gateway stack directly (no HTTP auth layer) |
-| **Ouroboros `EvolutionaryLoop`** | Calls `ConfiguredInferenceGateway` at the innermost layer (bypasses HTTP) |
+| Client                           | Path into the gateway                                                                                     |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **OpenAI SDK / curl**            | Virtual key auth middleware → OpenAI-compat router (`/v1/chat/completions`, `/v1/models`) → gateway stack |
+| **`clawql inference complete`**  | Calls the gateway stack directly (no HTTP auth layer)                                                     |
+| **Ouroboros `EvolutionaryLoop`** | Calls `ConfiguredInferenceGateway` at the innermost layer (bypasses HTTP)                                 |
 
 ### Gateway decorator stack (inner → outer)
 

--- a/website/src/generated/clawql-inference-body.mdx
+++ b/website/src/generated/clawql-inference-body.mdx
@@ -29,37 +29,39 @@
 
 ## Architecture overview
 
-```mermaid
-flowchart TB
-  subgraph clients [Clients]
-    SDK[OpenAI SDK / curl]
-    CLI[clawql inference complete]
-    OB[Ouroboros EvolutionaryLoop]
-  end
+### Entry points
 
-  subgraph http [HTTP layer]
-    AUTH[Virtual key auth middleware]
-    OAI[OpenAI-compat router]
-  end
+| Client                           | Path into the gateway                                                                                     |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **OpenAI SDK / curl**            | Virtual key auth middleware → OpenAI-compat router (`/v1/chat/completions`, `/v1/models`) → gateway stack |
+| **`clawql inference complete`**  | Calls the gateway stack directly (no HTTP auth layer)                                                     |
+| **Ouroboros `EvolutionaryLoop`** | Calls `ConfiguredInferenceGateway` at the innermost layer (bypasses HTTP)                                 |
 
-  subgraph gateway [Gateway decorator stack — inner to outer]
-    CFG[ConfiguredInferenceGateway]
-    FB[FallbackChainGateway]
-    CACHE[SemanticCachedGateway]
-    ENT[EntitlementEnforcedGateway]
-    OBS[ObservedInferenceGateway]
-  end
+### Gateway decorator stack (inner → outer)
 
-  subgraph backends [Backends]
-    PLG[Provider plugins — openai / anthropic / ollama]
-    STORE[(Inference store — memory / jsonl / postgres)]
-  end
+Each `complete()` call passes **outward** through these layers before reaching a provider:
 
-  SDK --> AUTH --> OAI --> OBS
-  CLI --> OBS
-  OB --> CFG
-  OBS --> ENT --> CACHE --> FB --> CFG --> PLG
-  OBS --> STORE
+1. **`ConfiguredInferenceGateway`** — resolves `provider/model`, invokes the provider adapter
+2. **`FallbackChainGateway`** — tries alternate models on primary failure (when fallback enabled)
+3. **`SemanticCachedGateway`** — embedding-similarity cache lookup (when semantic cache enabled)
+4. **`EntitlementEnforcedGateway`** — plan limit checks via `clawql-payments` (when enforcement enabled)
+5. **`ObservedInferenceGateway`** — appends an `InferenceRecord` to the call store
+
+Call order from outside in: **Observed → Entitlement → Cache → Fallback → Configured → provider**.
+
+### Backends
+
+- **Provider plugins** — built-in OpenAI, Anthropic, Ollama; extensible via the plugin registry
+- **Inference store** — `memory`, `jsonl`, or `postgres` backend for durable call records and export
+
+### Data flow summary
+
+```
+HTTP clients → auth middleware → OpenAI router → [Observed → Entitlement → Cache → Fallback → Configured] → provider plugin
+CLI / library callers ──────────────────────────► [same decorator stack] ────────────────────────────────► provider plugin
+Ouroboros loop ─────────────────────────────────► ConfiguredInferenceGateway (innermost) ───────────────► provider plugin
+
+ObservedInferenceGateway ──writes──► Inference store (jsonl / postgres / memory)
 ```
 
 Every successful `complete()` call flows **outward through decorators** and ends in the call store. HTTP clients additionally pass through virtual-key auth before the OpenAI router invokes the same gateway.

--- a/website/src/styles/tailwind.css
+++ b/website/src/styles/tailwind.css
@@ -107,11 +107,16 @@
     word-break: normal;
     white-space: normal;
     box-sizing: border-box;
-    border-bottom: 1px solid color-mix(in oklab, var(--color-zinc-900) 8%, transparent);
+    border-bottom: 1px solid
+      color-mix(in oklab, var(--color-zinc-900) 8%, transparent);
   }
 
   :is(.dark) .docs-table-scroll .docs-table :is(th, td) {
-    border-bottom-color: color-mix(in oklab, var(--color-white) 8%, transparent);
+    border-bottom-color: color-mix(
+      in oklab,
+      var(--color-white) 8%,
+      transparent
+    );
   }
 
   .docs-table-scroll .docs-table thead :is(th, td) {

--- a/website/src/styles/tailwind.css
+++ b/website/src/styles/tailwind.css
@@ -71,7 +71,7 @@
 }
 
 @layer components {
-  /* MDX tables: horizontal scroll + column widths on mobile (see mdx.tsx `table`) */
+  /* MDX tables: horizontal scroll + left-aligned columns (see mdx.tsx `table`) */
   .docs-table-scroll {
     margin-top: 2rem;
     margin-bottom: 2rem;
@@ -89,93 +89,80 @@
       padding-right: 1rem;
       scrollbar-width: thin;
     }
-
-    .docs-table-scroll::after {
-      content: '';
-      display: block;
-      height: 0;
-    }
   }
 
-  .prose .docs-table {
+  /* Tables live inside `not-prose` scroll wrappers — do not scope under `.prose` */
+  .docs-table-scroll .docs-table {
     width: max-content;
-    min-width: 100%;
     table-layout: auto;
     border-collapse: collapse;
+    border-spacing: 0;
   }
 
-  .prose .docs-table :is(th, td) {
-    overflow-wrap: break-word;
-    word-break: normal;
+  .docs-table-scroll .docs-table :is(th, td) {
+    text-align: left;
     vertical-align: top;
-    padding: 0.5rem 0.75rem;
+    padding: 0.5rem 0.875rem;
+    overflow-wrap: anywhere;
+    word-break: normal;
+    white-space: normal;
+    box-sizing: border-box;
+    border-bottom: 1px solid color-mix(in oklab, var(--color-zinc-900) 8%, transparent);
   }
 
-  .prose .docs-table code {
-    white-space: nowrap;
-    word-break: keep-all;
+  :is(.dark) .docs-table-scroll .docs-table :is(th, td) {
+    border-bottom-color: color-mix(in oklab, var(--color-white) 8%, transparent);
+  }
+
+  .docs-table-scroll .docs-table thead :is(th, td) {
+    font-weight: 600;
+    border-bottom-width: 2px;
+  }
+
+  .docs-table-scroll .docs-table code {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   /* Column layouts (data-cols set at build time in mdx.tsx `table`) */
-  .prose .docs-table[data-cols='2'] {
-    min-width: 20rem;
-  }
-
-  .prose .docs-table[data-cols='2'] :is(th, td):nth-child(1) {
-    min-width: 6.5rem;
-    max-width: 11rem;
-  }
-
-  .prose .docs-table[data-cols='2'] :is(th, td):nth-child(2) {
-    min-width: 12rem;
-  }
-
-  .prose .docs-table[data-cols='3'] {
-    min-width: 32rem;
-  }
-
-  .prose .docs-table[data-cols='3'] :is(th, td) {
-    min-width: 9rem;
-  }
-
-  .prose .docs-table[data-cols='4'] {
-    min-width: 40rem;
-  }
-
-  .prose .docs-table[data-cols='4'] :is(th, td) {
-    min-width: 8.5rem;
-  }
-
-  .prose .docs-table[data-cols='5'] {
-    min-width: 48rem;
-  }
-
-  .prose .docs-table[data-cols='5'] :is(th, td) {
-    min-width: 8rem;
-  }
-
-  .prose .docs-table[data-cols='6'] {
-    min-width: 56rem;
-  }
-
-  .prose .docs-table[data-cols='6'] :is(th, td) {
-    min-width: 7.5rem;
-  }
-
-  .prose .docs-table[data-cols='7'] {
-    min-width: 64rem;
-  }
-
-  .prose .docs-table[data-cols='7'] :is(th, td) {
+  .docs-table-scroll .docs-table[data-cols='2'] :is(th, td):nth-child(1) {
     min-width: 7rem;
   }
 
-  /* Wide matrices (plugin registry, etc.) */
-  .prose .docs-table[data-cols='8'] {
-    min-width: 72rem;
+  .docs-table-scroll .docs-table[data-cols='2'] :is(th, td):nth-child(2) {
+    min-width: 14rem;
   }
 
-  .prose .docs-table[data-cols='8'] :is(th, td) {
+  .docs-table-scroll .docs-table[data-cols='3'] :is(th, td):nth-child(1) {
+    min-width: 6rem;
+  }
+
+  .docs-table-scroll .docs-table[data-cols='3'] :is(th, td):nth-child(2) {
+    min-width: 10rem;
+  }
+
+  .docs-table-scroll .docs-table[data-cols='3'] :is(th, td):nth-child(3) {
+    min-width: 10rem;
+  }
+
+  .docs-table-scroll .docs-table[data-cols='4'] :is(th, td) {
+    min-width: 9rem;
+  }
+
+  .docs-table-scroll .docs-table[data-cols='5'] :is(th, td) {
+    min-width: 8rem;
+  }
+
+  .docs-table-scroll .docs-table[data-cols='6'] :is(th, td) {
+    min-width: 7.5rem;
+  }
+
+  .docs-table-scroll .docs-table[data-cols='7'] :is(th, td) {
+    min-width: 7rem;
+  }
+
+  .docs-table-scroll .docs-table[data-cols='8'] :is(th, td) {
     min-width: 6.5rem;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Mobile table layout on the inference docs (and other synced pages) still had overlapping columns and centered headers. Screenshots showed header text misaligned with cell content and columns bleeding into each other.

**Root cause:** Table CSS used `.prose .docs-table` selectors, but the MDX `table` component wraps tables in a `not-prose` scroll container — so none of the responsive table rules were applying.

The architecture Mermaid diagram also fails to render reliably on mobile (client-only lazy load), leaving a blank pulse placeholder.

## Fix

### Tables
- Scope styles to `.docs-table-scroll .docs-table` so they actually apply
- Left-align `th` and `td`; add subtle row borders for readability
- Remove `min-width: 100%` and per-column `max-width` that squashed columns on narrow screens
- Allow `code` in cells to wrap instead of forcing `nowrap` overlap
- Per-column `min-width` rules for 2–8 column tables; horizontal scroll when needed

### Architecture section
- Replace the Mermaid flowchart with text: entry-point table, numbered decorator stack, backends list, and ASCII data-flow summary

## Verification

- `npm run build` in `website/` succeeds
- Synced `clawql-inference-body.mdx` regenerated without mermaid fence
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

