### PR TITLE
feat(payments): MCP in-process x402 + well-known discovery

### DIFF
--- a/docs/payments/README.md
+++ b/docs/payments/README.md
@@ -16,4 +16,4 @@ ClawQL's unified billing layer — Stripe subscriptions, x402 micropayments, man
 
 - [clawql-inference](../inference/clawql-inference.md) — gateway, call store, export/finetune flywheel
 - [clawql-idp-platform](../vision/clawql-idp-platform.md) — product pricing philosophy
-- GitHub [#88](https://github.com/danielsmithdevelopment/ClawQL/issues/88) — `.well-known/payments.json` discovery (placeholder today)
+- GitHub [#88](https://github.com/danielsmithdevelopment/ClawQL/issues/88) — `.well-known/payments.json` discovery (dynamic on self-hosted HTTP; static on docs site)

--- a/docs/payments/clawql-payments.md
+++ b/docs/payments/clawql-payments.md
@@ -8,19 +8,19 @@
 
 ## What ships today
 
-| Capability                                       | Status | Notes                                                                           |
-| ------------------------------------------------ | ------ | ------------------------------------------------------------------------------- |
-| Managed plan tiers + entitlements                | ✅     | Local `usage.json` counters; limit enforcement in inference                     |
-| Stripe customers, subscriptions, invoices        | ✅     | Live SDK when `STRIPE_SECRET_KEY` is set                                        |
-| Stripe webhook signature verification            | ✅     | CLI verify/process; audit on `invoice.paid`                                     |
-| Stripe Billing Meters (`meterEvents.create`)     | ✅     | API + inference hook when `CLAWQL_PAYMENTS_REPORT_STRIPE_METER=1`               |
-| x402 gate config + facilitator HTTP verify       | ✅     | `POST /verify` against x402.org or CDP                                          |
-| x402 Express middleware (402 + PAYMENT-REQUIRED) | ✅     | Wired into `clawql-inference` HTTP                                              |
-| x402 MCP in-process enforcement                  | ✅     | `CLAWQL_X402_ENFORCE=1` on stdio / Streamable HTTP / gRPC MCP tool calls        |
-| Payment WORM audit (hash-chained JSONL)          | ✅     | `$CLAWQL_HOME/Payments/audit.jsonl` + `audit verify`                            |
-| Payment WORM audit (Postgres)                    | ✅     | `CLAWQL_PAYMENTS_AUDIT_STORE=postgres` for multi-node deployments               |
-| Payment audit → Loki/SIEM export                 | ✅     | Fire-and-forget push on append when `CLAWQL_LOKI_PUSH_URL` is set               |
-| `.well-known/payments.json` discovery            | ✅     | Dynamic on MCP + inference HTTP; static placeholder on docs site                |
+| Capability                                       | Status | Notes                                                                    |
+| ------------------------------------------------ | ------ | ------------------------------------------------------------------------ |
+| Managed plan tiers + entitlements                | ✅     | Local `usage.json` counters; limit enforcement in inference              |
+| Stripe customers, subscriptions, invoices        | ✅     | Live SDK when `STRIPE_SECRET_KEY` is set                                 |
+| Stripe webhook signature verification            | ✅     | CLI verify/process; audit on `invoice.paid`                              |
+| Stripe Billing Meters (`meterEvents.create`)     | ✅     | API + inference hook when `CLAWQL_PAYMENTS_REPORT_STRIPE_METER=1`        |
+| x402 gate config + facilitator HTTP verify       | ✅     | `POST /verify` against x402.org or CDP                                   |
+| x402 Express middleware (402 + PAYMENT-REQUIRED) | ✅     | Wired into `clawql-inference` HTTP                                       |
+| x402 MCP in-process enforcement                  | ✅     | `CLAWQL_X402_ENFORCE=1` on stdio / Streamable HTTP / gRPC MCP tool calls |
+| Payment WORM audit (hash-chained JSONL)          | ✅     | `$CLAWQL_HOME/Payments/audit.jsonl` + `audit verify`                     |
+| Payment WORM audit (Postgres)                    | ✅     | `CLAWQL_PAYMENTS_AUDIT_STORE=postgres` for multi-node deployments        |
+| Payment audit → Loki/SIEM export                 | ✅     | Fire-and-forget push on append when `CLAWQL_LOKI_PUSH_URL` is set        |
+| `.well-known/payments.json` discovery            | ✅     | Dynamic on MCP + inference HTTP; static placeholder on docs site         |
 
 ## Architecture
 
@@ -300,12 +300,12 @@ sequenceDiagram
 
 **Headers:**
 
-| Header                            | Direction      | Purpose                               |
-| --------------------------------- | -------------- | ------------------------------------- |
-| `PAYMENT-REQUIRED`                | Response (402) | Base64-encoded `PaymentRequired` JSON |
-| `PAYMENT-SIGNATURE` / `X-PAYMENT` | Request        | Client payment proof (JSON or base64) |
+| Header                            | Direction      | Purpose                                                |
+| --------------------------------- | -------------- | ------------------------------------------------------ |
+| `PAYMENT-REQUIRED`                | Response (402) | Base64-encoded `PaymentRequired` JSON                  |
+| `PAYMENT-SIGNATURE` / `X-PAYMENT` | Request        | Client payment proof (JSON or base64)                  |
 | `X-Clawql-Tool`                   | Request        | Gate MCP tools as `tool:{name}` (HTTP middleware path) |
-| `X-Correlation-Id`                | Request        | Audit correlation (optional)          |
+| `X-Correlation-Id`                | Request        | Audit correlation (optional)                           |
 
 ### MCP in-process enforcement
 
@@ -315,11 +315,11 @@ Configure gates with `clawql payments x402 gate --tool <name> --price <usdc>`.
 
 **Payment proof on MCP transports:**
 
-| Transport        | How to attach proof                                              |
-| ---------------- | ---------------------------------------------------------------- |
+| Transport        | How to attach proof                                             |
+| ---------------- | --------------------------------------------------------------- |
 | Streamable HTTP  | `PAYMENT-SIGNATURE` / `X-PAYMENT` on the HTTP request to `/mcp` |
-| gRPC MCP session | Same header names as gRPC metadata (lowercase keys)              |
-| stdio            | No request headers — use Streamable HTTP or gRPC for paid tools  |
+| gRPC MCP session | Same header names as gRPC metadata (lowercase keys)             |
+| stdio            | No request headers — use Streamable HTTP or gRPC for paid tools |
 
 When payment is required, the tool returns an MCP result with `isError: true` and JSON describing the x402 `PaymentRequired` payload (HTTP 402 semantics in tool output). Invalid proofs emit `X402_PAYMENT_FAILED` audit events (same as HTTP deny paths).
 
@@ -561,9 +561,9 @@ See also: [`packages/clawql-inference/README.md`](../../packages/clawql-inferenc
 
 ## Follow-up work
 
-| Item                         | Tracking         |
-| ---------------------------- | ---------------- |
-| Hosted webhook HTTP endpoint | not CLI-only     |
+| Item                         | Tracking     |
+| ---------------------------- | ------------ |
+| Hosted webhook HTTP endpoint | not CLI-only |
 
 ## Related
 

--- a/docs/payments/clawql-payments.md
+++ b/docs/payments/clawql-payments.md
@@ -16,10 +16,11 @@
 | Stripe Billing Meters (`meterEvents.create`)     | ✅     | API + inference hook when `CLAWQL_PAYMENTS_REPORT_STRIPE_METER=1`               |
 | x402 gate config + facilitator HTTP verify       | ✅     | `POST /verify` against x402.org or CDP                                          |
 | x402 Express middleware (402 + PAYMENT-REQUIRED) | ✅     | Wired into `clawql-inference` HTTP                                              |
+| x402 MCP in-process enforcement                  | ✅     | `CLAWQL_X402_ENFORCE=1` on stdio / Streamable HTTP / gRPC MCP tool calls        |
 | Payment WORM audit (hash-chained JSONL)          | ✅     | `$CLAWQL_HOME/Payments/audit.jsonl` + `audit verify`                            |
 | Payment WORM audit (Postgres)                    | ✅     | `CLAWQL_PAYMENTS_AUDIT_STORE=postgres` for multi-node deployments               |
 | Payment audit → Loki/SIEM export                 | ✅     | Fire-and-forget push on append when `CLAWQL_LOKI_PUSH_URL` is set               |
-| `.well-known/payments.json` discovery            | 📋     | Placeholder ([#88](https://github.com/danielsmithdevelopment/ClawQL/issues/88)) |
+| `.well-known/payments.json` discovery            | ✅     | Dynamic on MCP + inference HTTP; static placeholder on docs site                |
 
 ## Architecture
 
@@ -303,8 +304,24 @@ sequenceDiagram
 | --------------------------------- | -------------- | ------------------------------------- |
 | `PAYMENT-REQUIRED`                | Response (402) | Base64-encoded `PaymentRequired` JSON |
 | `PAYMENT-SIGNATURE` / `X-PAYMENT` | Request        | Client payment proof (JSON or base64) |
-| `X-Clawql-Tool`                   | Request        | Gate MCP tools as `tool:{name}`       |
+| `X-Clawql-Tool`                   | Request        | Gate MCP tools as `tool:{name}` (HTTP middleware path) |
 | `X-Correlation-Id`                | Request        | Audit correlation (optional)          |
+
+### MCP in-process enforcement
+
+When `CLAWQL_X402_ENFORCE=1`, **native MCP tool calls** (`tools/call` over stdio, Streamable HTTP `/mcp`, or gRPC session transport) run the same `enforceX402Gate()` path as inference HTTP middleware — before the tool handler executes.
+
+Configure gates with `clawql payments x402 gate --tool <name> --price <usdc>`.
+
+**Payment proof on MCP transports:**
+
+| Transport        | How to attach proof                                              |
+| ---------------- | ---------------------------------------------------------------- |
+| Streamable HTTP  | `PAYMENT-SIGNATURE` / `X-PAYMENT` on the HTTP request to `/mcp` |
+| gRPC MCP session | Same header names as gRPC metadata (lowercase keys)              |
+| stdio            | No request headers — use Streamable HTTP or gRPC for paid tools  |
+
+When payment is required, the tool returns an MCP result with `isError: true` and JSON describing the x402 `PaymentRequired` payload (HTTP 402 semantics in tool output). Invalid proofs emit `X402_PAYMENT_FAILED` audit events (same as HTTP deny paths).
 
 **402 response body** (x402 v2):
 
@@ -413,6 +430,17 @@ export CLAWQL_PAYMENTS_LOKI_JOB=clawql-payments-audit  # optional stream job lab
 ```
 
 Push is **fire-and-forget** — Loki failures log to stderr and do not fail payment processing.
+
+### Payment discovery (`/.well-known/payments.json`)
+
+Self-hosted ClawQL serves a **dynamic** payment discovery document at:
+
+```bash
+curl http://localhost:8080/.well-known/payments.json   # MCP HTTP (default PORT)
+curl http://localhost:8080/.well-known/payments.json   # inference HTTP (CLAWQL_INFERENCE_PORT)
+```
+
+The document lists configured x402 gates (HTTP paths and MCP tools), wallet/facilitator metadata, and Stripe plan/meter info when configured. The static docs site ships a placeholder at `website/public/.well-known/payments.json` for [issue #88](https://github.com/danielsmithdevelopment/ClawQL/issues/88).
 
 ### CLI
 
@@ -533,11 +561,9 @@ See also: [`packages/clawql-inference/README.md`](../../packages/clawql-inferenc
 
 ## Follow-up work
 
-| Item                                  | Tracking                                                          |
-| ------------------------------------- | ----------------------------------------------------------------- |
-| Hosted webhook HTTP endpoint          | not CLI-only                                                      |
-| `.well-known/payments.json` discovery | [#88](https://github.com/danielsmithdevelopment/ClawQL/issues/88) |
-| MCP tool x402 enforcement in-process  | HTTP middleware + `X-Clawql-Tool` today                           |
+| Item                         | Tracking         |
+| ---------------------------- | ---------------- |
+| Hosted webhook HTTP endpoint | not CLI-only     |
 
 ## Related
 

--- a/packages/clawql-inference/src/api/server.ts
+++ b/packages/clawql-inference/src/api/server.ts
@@ -1,5 +1,6 @@
 import express, { type Express } from "express";
 import { createX402PaymentMiddleware } from "clawql-payments/x402";
+import { attachPaymentsWellKnownRoutes } from "clawql-payments/discovery";
 import { createInferenceGateway } from "../gateway.js";
 import type { InferenceGateway } from "../gateway.js";
 import { createProviderRegistry } from "../providers/registry.js";
@@ -31,6 +32,7 @@ export function createInferenceHttpApp(options: CreateInferenceHttpAppOptions = 
       endpoints: ["/v1/chat/completions", "/v1/models"],
     });
   });
+  attachPaymentsWellKnownRoutes(app, { serverName: "ClawQL Inference" });
   app.use(createX402PaymentMiddleware({ env }));
   app.use(createVirtualKeyAuthMiddleware({ env }));
   app.use(createOpenAiCompatRouter({ gateway, registry, env }));

--- a/packages/clawql-payments/README.md
+++ b/packages/clawql-payments/README.md
@@ -98,7 +98,9 @@ Postgres store (`CLAWQL_PAYMENTS_AUDIT_STORE=postgres`) uses `clawql_payments_au
 
 Stripe SDK integration is **live** for customers, subscriptions, invoices, billing portal, meter events (Stripe Billing Meters), and webhook signature verification. Inference can report meter events when `CLAWQL_PAYMENTS_REPORT_STRIPE_METER=1`. Invoice payment audit events are recorded via verified `invoice.paid` webhooks only.
 
-x402 facilitator HTTP verification is **live** (`POST /verify` against x402.org or CDP). Inference HTTP can enforce gates with `CLAWQL_X402_ENFORCE=1`.
+x402 facilitator HTTP verification is **live** (`POST /verify` against x402.org or CDP). Inference HTTP and **native MCP tool calls** can enforce gates with `CLAWQL_X402_ENFORCE=1`.
+
+Payment discovery is served at **`/.well-known/payments.json`** on MCP and inference HTTP apps (dynamic from local gates/config).
 
 Payment audit is **durable** — hash-chained append-only JSONL at `$CLAWQL_HOME/Payments/audit.jsonl` (default), optional Postgres for multi-node, and optional Loki export. Use `clawql payments audit verify` to validate chain integrity.
 

--- a/packages/clawql-payments/package.json
+++ b/packages/clawql-payments/package.json
@@ -33,6 +33,11 @@
       "import": "./dist/audit/index.js",
       "require": "./dist/audit/index.cjs"
     },
+    "./discovery": {
+      "types": "./dist/discovery/index.d.ts",
+      "import": "./dist/discovery/index.js",
+      "require": "./dist/discovery/index.cjs"
+    },
     "./package.json": "./package.json"
   },
   "bin": {

--- a/packages/clawql-payments/src/discovery/http.ts
+++ b/packages/clawql-payments/src/discovery/http.ts
@@ -1,0 +1,47 @@
+import type { Express, Request, Response } from "express";
+import { renderPaymentsWellKnownJson, type BuildPaymentsWellKnownOptions } from "./well-known.js";
+
+export const PAYMENTS_WELL_KNOWN_PATH = "/.well-known/payments.json";
+
+export type AttachPaymentsWellKnownOptions = BuildPaymentsWellKnownOptions & {
+  /** Cache-Control max-age seconds (default 300). */
+  maxAgeSeconds?: number;
+};
+
+export async function handlePaymentsWellKnownRequest(
+  req: Request,
+  res: Response,
+  options: AttachPaymentsWellKnownOptions = {}
+): Promise<void> {
+  const origin =
+    options.origin ??
+    (req.get("x-forwarded-proto") && req.get("host")
+      ? `${req.get("x-forwarded-proto")}://${req.get("host")}`
+      : `${req.protocol}://${req.get("host") ?? "localhost"}`);
+
+  const body = await renderPaymentsWellKnownJson({
+    ...options,
+    origin,
+  });
+
+  const maxAge = options.maxAgeSeconds ?? 300;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.setHeader("Cache-Control", `public, max-age=${maxAge}`);
+  res.status(200).send(body);
+}
+
+export function attachPaymentsWellKnownRoutes(
+  app: Express,
+  options: AttachPaymentsWellKnownOptions = {}
+): void {
+  app.get(PAYMENTS_WELL_KNOWN_PATH, (req, res) => {
+    void handlePaymentsWellKnownRequest(req, res, options).catch((err: unknown) => {
+      console.error("[clawql-payments] GET /.well-known/payments.json error:", err);
+      if (!res.headersSent) {
+        res.status(500).json({
+          error: "failed to render payments discovery document",
+        });
+      }
+    });
+  });
+}

--- a/packages/clawql-payments/src/discovery/index.ts
+++ b/packages/clawql-payments/src/discovery/index.ts
@@ -1,0 +1,16 @@
+export {
+  buildPaymentsWellKnownDocument,
+  renderPaymentsWellKnownJson,
+  type BuildPaymentsWellKnownOptions,
+  type PaymentsWellKnownDocument,
+  type PaymentsWellKnownMethod,
+  type PaymentsWellKnownResource,
+  type PaymentsWellKnownStripeMethod,
+  type PaymentsWellKnownX402Method,
+} from "./well-known.js";
+export {
+  PAYMENTS_WELL_KNOWN_PATH,
+  attachPaymentsWellKnownRoutes,
+  handlePaymentsWellKnownRequest,
+  type AttachPaymentsWellKnownOptions,
+} from "./http.js";

--- a/packages/clawql-payments/src/discovery/well-known.test.ts
+++ b/packages/clawql-payments/src/discovery/well-known.test.ts
@@ -1,0 +1,68 @@
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createX402Gate } from "../x402/gate.js";
+import { buildPaymentsWellKnownDocument } from "./well-known.js";
+
+describe("buildPaymentsWellKnownDocument", () => {
+  let home: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "clawql-payments-discovery-"));
+    env = { ...process.env, CLAWQL_HOME: home };
+    await mkdir(join(home, "Payments"), { recursive: true });
+    await writeFile(
+      join(home, "Payments", "payments.json"),
+      `${JSON.stringify(
+        {
+          tenantId: "tenant-a",
+          plan: "pro",
+          x402: {
+            walletAddress: "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+            facilitatorUrl: "https://x402.org/facilitator",
+          },
+          stripe: { meterEventName: "clawql_inference_calls" },
+        },
+        null,
+        2
+      )}\n`
+    );
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("includes x402 resources from gates", async () => {
+    await createX402Gate({ tool: "knowledge_search", price: 0.0005, asset: "USDC" }, env);
+    await createX402Gate({ resource: "/v1/chat/completions", price: 0.001, asset: "USDC" }, env);
+
+    const doc = await buildPaymentsWellKnownDocument({ env, serverName: "Test" });
+    const x402 = doc.payment_methods.find((m) => m.type === "x402");
+    expect(x402?.type).toBe("x402");
+    if (x402?.type === "x402") {
+      expect(x402.resources).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ kind: "mcp_tool", id: "knowledge_search" }),
+          expect.objectContaining({ kind: "http", id: "/v1/chat/completions" }),
+        ])
+      );
+      expect(x402.pay_to).toMatch(/^0x/);
+      expect(doc.default).toBe("x402");
+    }
+  });
+
+  it("includes stripe method when secret key is configured", async () => {
+    const doc = await buildPaymentsWellKnownDocument({
+      env: { ...env, STRIPE_SECRET_KEY: "sk_test_xxx" },
+    });
+    const stripe = doc.payment_methods.find((m) => m.type === "stripe");
+    expect(stripe?.type).toBe("stripe");
+    if (stripe?.type === "stripe") {
+      expect(stripe.plans).toContain("pro");
+      expect(stripe.meter_event_name).toBe("clawql_inference_calls");
+    }
+  });
+});

--- a/packages/clawql-payments/src/discovery/well-known.ts
+++ b/packages/clawql-payments/src/discovery/well-known.ts
@@ -1,0 +1,144 @@
+import { CLAWQL_PLANS } from "../plans/index.js";
+import { loadPaymentsConfig } from "../config/store.js";
+import { listX402Gates } from "../x402/gate.js";
+import { loadX402RuntimeConfig } from "../x402/config.js";
+import { X402_VERSION } from "../x402/types.js";
+
+export type PaymentsWellKnownResource = {
+  kind: "http" | "mcp_tool";
+  id: string;
+  price_usdc: number;
+  asset: string;
+};
+
+export type PaymentsWellKnownMethod = {
+  type: "x402" | "stripe";
+  enabled: boolean;
+};
+
+export type PaymentsWellKnownX402Method = PaymentsWellKnownMethod & {
+  type: "x402";
+  x402_version: number;
+  scheme: string;
+  network: string;
+  asset: string;
+  asset_contract: string;
+  pay_to?: string;
+  facilitator?: string;
+  resources: PaymentsWellKnownResource[];
+};
+
+export type PaymentsWellKnownStripeMethod = PaymentsWellKnownMethod & {
+  type: "stripe";
+  billing: "subscription" | "metered";
+  plans: string[];
+  meter_event_name?: string;
+};
+
+export type PaymentsWellKnownDocument = {
+  version: string;
+  server_name: string;
+  documentation: string;
+  issue?: string;
+  payment_methods: Array<PaymentsWellKnownX402Method | PaymentsWellKnownStripeMethod>;
+  default: "x402" | "stripe" | null;
+  updated_at: string;
+};
+
+export type BuildPaymentsWellKnownOptions = {
+  env?: NodeJS.ProcessEnv;
+  serverName?: string;
+  documentationUrl?: string;
+  origin?: string;
+};
+
+function resourceFromGate(gate: {
+  resource: string;
+  tool?: string;
+  price: number;
+  asset: string;
+}): PaymentsWellKnownResource {
+  if (gate.tool?.trim()) {
+    return {
+      kind: "mcp_tool",
+      id: gate.tool.trim(),
+      price_usdc: gate.price,
+      asset: gate.asset,
+    };
+  }
+  return {
+    kind: "http",
+    id: gate.resource,
+    price_usdc: gate.price,
+    asset: gate.asset,
+  };
+}
+
+export async function buildPaymentsWellKnownDocument(
+  options: BuildPaymentsWellKnownOptions = {}
+): Promise<PaymentsWellKnownDocument> {
+  const env = options.env ?? process.env;
+  const config = await loadPaymentsConfig(env);
+  const x402Config = await loadX402RuntimeConfig(env);
+  const gates = await listX402Gates(env);
+
+  const x402Resources = gates.map(resourceFromGate);
+  const x402Enabled = x402Resources.length > 0 && Boolean(x402Config.walletAddress?.trim());
+
+  const stripeEnabled = Boolean(env.STRIPE_SECRET_KEY?.trim());
+  const paymentMethods: PaymentsWellKnownDocument["payment_methods"] = [];
+
+  if (x402Enabled || x402Resources.length > 0) {
+    paymentMethods.push({
+      type: "x402",
+      enabled: x402Enabled,
+      x402_version: X402_VERSION,
+      scheme: x402Config.scheme,
+      network: x402Config.network,
+      asset: "USDC",
+      asset_contract: x402Config.usdcAsset,
+      pay_to: x402Config.walletAddress,
+      facilitator: x402Config.facilitatorUrl,
+      resources: x402Resources,
+    });
+  }
+
+  if (stripeEnabled || config.plan) {
+    paymentMethods.push({
+      type: "stripe",
+      enabled: stripeEnabled,
+      billing: env.STRIPE_METER_EVENT_NAME?.trim() ? "metered" : "subscription",
+      plans: Object.keys(CLAWQL_PLANS),
+      meter_event_name:
+        config.stripe?.meterEventName?.trim() ||
+        env.STRIPE_METER_EVENT_NAME?.trim() ||
+        undefined,
+    });
+  }
+
+  const defaultMethod: PaymentsWellKnownDocument["default"] =
+    x402Enabled && x402Resources.length > 0
+      ? "x402"
+      : stripeEnabled
+        ? "stripe"
+        : null;
+
+  return {
+    version: "1",
+    server_name: options.serverName?.trim() || "ClawQL",
+    documentation:
+      options.documentationUrl?.trim() ||
+      "https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/clawql-payments.md",
+    issue: "https://github.com/danielsmithdevelopment/ClawQL/issues/88",
+    payment_methods: paymentMethods,
+    default: defaultMethod,
+    updated_at: new Date().toISOString(),
+  };
+}
+
+export async function renderPaymentsWellKnownJson(
+  options: BuildPaymentsWellKnownOptions = {}
+): Promise<string> {
+  const doc = await buildPaymentsWellKnownDocument(options);
+  return `${JSON.stringify(doc, null, 2)}\n`;
+}

--- a/packages/clawql-payments/src/discovery/well-known.ts
+++ b/packages/clawql-payments/src/discovery/well-known.ts
@@ -110,18 +110,12 @@ export async function buildPaymentsWellKnownDocument(
       billing: env.STRIPE_METER_EVENT_NAME?.trim() ? "metered" : "subscription",
       plans: Object.keys(CLAWQL_PLANS),
       meter_event_name:
-        config.stripe?.meterEventName?.trim() ||
-        env.STRIPE_METER_EVENT_NAME?.trim() ||
-        undefined,
+        config.stripe?.meterEventName?.trim() || env.STRIPE_METER_EVENT_NAME?.trim() || undefined,
     });
   }
 
   const defaultMethod: PaymentsWellKnownDocument["default"] =
-    x402Enabled && x402Resources.length > 0
-      ? "x402"
-      : stripeEnabled
-        ? "stripe"
-        : null;
+    x402Enabled && x402Resources.length > 0 ? "x402" : stripeEnabled ? "stripe" : null;
 
   return {
     version: "1",

--- a/packages/clawql-payments/src/index.ts
+++ b/packages/clawql-payments/src/index.ts
@@ -2,6 +2,7 @@ export * from "./plans/index.js";
 export * from "./stripe/index.js";
 export * from "./x402/index.js";
 export * from "./audit/index.js";
+export * from "./discovery/index.js";
 export * from "./cli/index.js";
 export { loadPaymentsConfig, mergePaymentsConfig, savePaymentsConfig } from "./config/store.js";
 export type { PaymentsConfig } from "./config/store.js";

--- a/packages/clawql-payments/src/x402/index.ts
+++ b/packages/clawql-payments/src/x402/index.ts
@@ -51,6 +51,24 @@ export {
   type EnforceX402GateInput,
 } from "./enforce.js";
 export {
+  runMcpX402BeforeCallTool,
+  mcpToolResourceName,
+  type RunMcpX402BeforeCallToolOptions,
+} from "./mcp-enforce.js";
+export {
+  getMcpX402Context,
+  runWithMcpX402Context,
+  headersFromExpressRequest,
+  headersFromPlainRecord,
+  type McpX402RequestContext,
+} from "./mcp-context.js";
+export {
+  X402McpPaymentDeniedError,
+  X402McpPaymentRequiredError,
+  isX402McpPaymentError,
+  type X402McpToolResult,
+} from "./mcp-errors.js";
+export {
   createX402PaymentMiddleware,
   type CreateX402PaymentMiddlewareOptions,
   type X402PaymentRequest,

--- a/packages/clawql-payments/src/x402/mcp-context.ts
+++ b/packages/clawql-payments/src/x402/mcp-context.ts
@@ -19,9 +19,12 @@ export function getMcpX402Context(): McpX402RequestContext | undefined {
   return mcpX402Storage.getStore();
 }
 
-export function headersFromExpressRequest(
-  req: { headers: Record<string, string | string[] | undefined>; protocol?: string; get?: (name: string) => string | undefined; originalUrl?: string }
-): McpX402RequestContext {
+export function headersFromExpressRequest(req: {
+  headers: Record<string, string | string[] | undefined>;
+  protocol?: string;
+  get?: (name: string) => string | undefined;
+  originalUrl?: string;
+}): McpX402RequestContext {
   const host = req.get?.("host") ?? "localhost";
   const protocol = req.protocol ?? "http";
   const path = req.originalUrl ?? "/mcp";

--- a/packages/clawql-payments/src/x402/mcp-context.ts
+++ b/packages/clawql-payments/src/x402/mcp-context.ts
@@ -1,0 +1,54 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type McpX402RequestContext = {
+  headers: Record<string, string | string[] | undefined>;
+  requestUrl?: string;
+  correlationId?: string;
+};
+
+const mcpX402Storage = new AsyncLocalStorage<McpX402RequestContext>();
+
+export function runWithMcpX402Context<T>(
+  context: McpX402RequestContext,
+  fn: () => T | Promise<T>
+): Promise<T> {
+  return Promise.resolve(mcpX402Storage.run(context, fn));
+}
+
+export function getMcpX402Context(): McpX402RequestContext | undefined {
+  return mcpX402Storage.getStore();
+}
+
+export function headersFromExpressRequest(
+  req: { headers: Record<string, string | string[] | undefined>; protocol?: string; get?: (name: string) => string | undefined; originalUrl?: string }
+): McpX402RequestContext {
+  const host = req.get?.("host") ?? "localhost";
+  const protocol = req.protocol ?? "http";
+  const path = req.originalUrl ?? "/mcp";
+  return {
+    headers: req.headers,
+    requestUrl: `${protocol}://${host}${path}`,
+    correlationId:
+      (typeof req.headers["x-correlation-id"] === "string"
+        ? req.headers["x-correlation-id"]
+        : undefined) ??
+      (typeof req.headers["x-clawql-correlation-id"] === "string"
+        ? req.headers["x-clawql-correlation-id"]
+        : undefined),
+  };
+}
+
+export function headersFromPlainRecord(
+  headers: Record<string, string | string[] | undefined>,
+  requestUrl?: string
+): McpX402RequestContext {
+  return {
+    headers,
+    requestUrl,
+    correlationId:
+      (typeof headers["x-correlation-id"] === "string" ? headers["x-correlation-id"] : undefined) ??
+      (typeof headers["x-clawql-correlation-id"] === "string"
+        ? headers["x-clawql-correlation-id"]
+        : undefined),
+  };
+}

--- a/packages/clawql-payments/src/x402/mcp-enforce.test.ts
+++ b/packages/clawql-payments/src/x402/mcp-enforce.test.ts
@@ -1,0 +1,116 @@
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetPaymentAuditStoreForTests } from "../audit/worm.js";
+import { createX402Gate } from "./gate.js";
+import {
+  runMcpX402BeforeCallTool,
+  runWithMcpX402Context,
+  X402McpPaymentDeniedError,
+  X402McpPaymentRequiredError,
+} from "./index.js";
+
+describe("runMcpX402BeforeCallTool", () => {
+  let home: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "clawql-x402-mcp-"));
+    env = {
+      ...process.env,
+      CLAWQL_HOME: home,
+      CLAWQL_PAYMENTS_AUDIT_STORE: "memory",
+      CLAWQL_X402_ENFORCE: "1",
+    };
+    await mkdir(join(home, "Payments"), { recursive: true });
+    await writeFile(
+      join(home, "Payments", "payments.json"),
+      `${JSON.stringify(
+        {
+          tenantId: "tenant-a",
+          plan: "pro",
+          x402: {
+            walletAddress: "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+            facilitatorUrl: "https://x402.org/facilitator",
+          },
+        },
+        null,
+        2
+      )}\n`
+    );
+    await resetPaymentAuditStoreForTests(env);
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("allows ungated tools", async () => {
+    await expect(
+      runMcpX402BeforeCallTool({ toolName: "search", env })
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws payment required for gated tool without proof", async () => {
+    await createX402Gate({ tool: "knowledge_search", price: 0.0005, asset: "USDC" }, env);
+
+    await expect(
+      runMcpX402BeforeCallTool({ toolName: "knowledge_search", env })
+    ).rejects.toBeInstanceOf(X402McpPaymentRequiredError);
+  });
+
+  it("allows gated tool when facilitator verifies proof from MCP context headers", async () => {
+    await createX402Gate({ tool: "knowledge_search", price: 0.0005, asset: "USDC" }, env);
+
+    const payload = { x402Version: 2, payload: { signature: "0xabc" } };
+    const header = Buffer.from(JSON.stringify(payload)).toString("base64");
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ isValid: true, payer: "0xpayer" }),
+    }));
+
+    await runWithMcpX402Context(
+      {
+        headers: { "payment-signature": header },
+        requestUrl: "mcp://tool/knowledge_search",
+        correlationId: "corr-mcp",
+      },
+      async () => {
+        await expect(
+          runMcpX402BeforeCallTool({
+            toolName: "knowledge_search",
+            env,
+            fetchImpl: fetchImpl as unknown as typeof fetch,
+          })
+        ).resolves.toBeUndefined();
+      }
+    );
+  });
+
+  it("throws payment denied when facilitator rejects proof", async () => {
+    await createX402Gate({ tool: "knowledge_search", price: 0.0005, asset: "USDC" }, env);
+
+    const payload = { x402Version: 2, payload: { signature: "0xbad" } };
+    const header = Buffer.from(JSON.stringify(payload)).toString("base64");
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ isValid: false, invalidReason: "bad sig" }),
+    }));
+
+    await runWithMcpX402Context(
+      { headers: { "payment-signature": header }, requestUrl: "mcp://tool/knowledge_search" },
+      async () => {
+        await expect(
+          runMcpX402BeforeCallTool({
+            toolName: "knowledge_search",
+            env,
+            fetchImpl: fetchImpl as unknown as typeof fetch,
+          })
+        ).rejects.toBeInstanceOf(X402McpPaymentDeniedError);
+      }
+    );
+  });
+});

--- a/packages/clawql-payments/src/x402/mcp-enforce.test.ts
+++ b/packages/clawql-payments/src/x402/mcp-enforce.test.ts
@@ -47,9 +47,7 @@ describe("runMcpX402BeforeCallTool", () => {
   });
 
   it("allows ungated tools", async () => {
-    await expect(
-      runMcpX402BeforeCallTool({ toolName: "search", env })
-    ).resolves.toBeUndefined();
+    await expect(runMcpX402BeforeCallTool({ toolName: "search", env })).resolves.toBeUndefined();
   });
 
   it("throws payment required for gated tool without proof", async () => {

--- a/packages/clawql-payments/src/x402/mcp-enforce.ts
+++ b/packages/clawql-payments/src/x402/mcp-enforce.ts
@@ -34,9 +34,7 @@ export async function runMcpX402BeforeCallTool(
 
   const ctx = getMcpX402Context();
   const headers = ctx?.headers ?? {};
-  const requestUrl =
-    ctx?.requestUrl ??
-    `mcp://tool/${encodeURIComponent(options.toolName)}`;
+  const requestUrl = ctx?.requestUrl ?? `mcp://tool/${encodeURIComponent(options.toolName)}`;
 
   const result = await enforceX402Gate({
     resource,

--- a/packages/clawql-payments/src/x402/mcp-enforce.ts
+++ b/packages/clawql-payments/src/x402/mcp-enforce.ts
@@ -1,0 +1,59 @@
+import { findX402GateForResource } from "./gate.js";
+import { enforceX402Gate } from "./enforce.js";
+import { isX402EnforcementActive } from "./config.js";
+import { getMcpX402Context } from "./mcp-context.js";
+import { X402McpPaymentDeniedError, X402McpPaymentRequiredError } from "./mcp-errors.js";
+
+export function mcpToolResourceName(toolName: string): string {
+  return `tool:${toolName.trim()}`;
+}
+
+export type RunMcpX402BeforeCallToolOptions = {
+  toolName: string;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+};
+
+/**
+ * In-process x402 gate for MCP `tools/call`. Uses payment proof from
+ * {@link getMcpX402Context} (Streamable HTTP / gRPC headers) when set.
+ */
+export async function runMcpX402BeforeCallTool(
+  options: RunMcpX402BeforeCallToolOptions
+): Promise<void> {
+  const env = options.env ?? process.env;
+  if (!isX402EnforcementActive(env)) {
+    return;
+  }
+
+  const resource = mcpToolResourceName(options.toolName);
+  const gate = await findX402GateForResource(resource, env);
+  if (!gate) {
+    return;
+  }
+
+  const ctx = getMcpX402Context();
+  const headers = ctx?.headers ?? {};
+  const requestUrl =
+    ctx?.requestUrl ??
+    `mcp://tool/${encodeURIComponent(options.toolName)}`;
+
+  const result = await enforceX402Gate({
+    resource,
+    requestUrl,
+    headers,
+    correlationId: ctx?.correlationId,
+    env,
+    fetchImpl: options.fetchImpl,
+  });
+
+  if (result.action === "allow") {
+    return;
+  }
+
+  if (result.action === "require_payment") {
+    throw new X402McpPaymentRequiredError(result.body);
+  }
+
+  throw new X402McpPaymentDeniedError(result.reason, result.resource);
+}

--- a/packages/clawql-payments/src/x402/mcp-errors.ts
+++ b/packages/clawql-payments/src/x402/mcp-errors.ts
@@ -1,0 +1,84 @@
+import type { X402PaymentRequired } from "./types.js";
+
+export type X402McpToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  isError: true;
+  _meta?: Record<string, unknown>;
+};
+
+export class X402McpPaymentRequiredError extends Error {
+  readonly name = "X402McpPaymentRequiredError";
+
+  constructor(public readonly body: X402PaymentRequired) {
+    super("x402 payment required");
+  }
+
+  toToolResult(): X402McpToolResult {
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              error: "payment_required",
+              httpStatus: 402,
+              x402: this.body,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+      isError: true,
+      _meta: {
+        "clawql/x402": this.body,
+        "clawql/httpStatus": 402,
+      },
+    };
+  }
+}
+
+export class X402McpPaymentDeniedError extends Error {
+  readonly name = "X402McpPaymentDeniedError";
+
+  constructor(
+    public readonly reason: string,
+    public readonly resource: string
+  ) {
+    super(reason);
+  }
+
+  toToolResult(): X402McpToolResult {
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              error: "payment_denied",
+              httpStatus: 402,
+              reason: this.reason,
+              resource: this.resource,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+      isError: true,
+      _meta: {
+        "clawql/httpStatus": 402,
+        "clawql/x402Reason": this.reason,
+        "clawql/x402Resource": this.resource,
+      },
+    };
+  }
+}
+
+export function isX402McpPaymentError(
+  err: unknown
+): err is X402McpPaymentRequiredError | X402McpPaymentDeniedError {
+  return (
+    err instanceof X402McpPaymentRequiredError || err instanceof X402McpPaymentDeniedError
+  );
+}

--- a/packages/clawql-payments/src/x402/mcp-errors.ts
+++ b/packages/clawql-payments/src/x402/mcp-errors.ts
@@ -78,7 +78,5 @@ export class X402McpPaymentDeniedError extends Error {
 export function isX402McpPaymentError(
   err: unknown
 ): err is X402McpPaymentRequiredError | X402McpPaymentDeniedError {
-  return (
-    err instanceof X402McpPaymentRequiredError || err instanceof X402McpPaymentDeniedError
-  );
+  return err instanceof X402McpPaymentRequiredError || err instanceof X402McpPaymentDeniedError;
 }

--- a/packages/clawql-payments/tsup.config.ts
+++ b/packages/clawql-payments/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     "x402/index": "src/x402/index.ts",
     "plans/index": "src/plans/index.ts",
     "audit/index": "src/audit/index.ts",
+    "discovery/index": "src/discovery/index.ts",
   },
   format: ["esm", "cjs"],
   dts: true,

--- a/packages/mcp-grpc-transport/src/index.ts
+++ b/packages/mcp-grpc-transport/src/index.ts
@@ -7,11 +7,12 @@
 export {
   GrpcMcpSessionTransport,
   maybeStartGrpcMcpServer,
+  setMcpMessageContextHook,
   defaultGrpcServerMessageSizeBytes,
   PROTOBUF_MCP_SERVICE_FQN,
   MCP_TRANSPORT_SESSION_SERVICE_FQN,
 } from "./server.js";
-export type { GrpcMcpServerOptions, StartedGrpcServer } from "./server.js";
+export type { GrpcMcpServerOptions, McpMessageContextHook, StartedGrpcServer } from "./server.js";
 export {
   callToolServerStreamingGrpc,
   lastNonEmptyCallToolText,

--- a/packages/mcp-grpc-transport/src/server.ts
+++ b/packages/mcp-grpc-transport/src/server.ts
@@ -27,6 +27,17 @@ import { McpProtobufBridge } from "./mcp-protobuf-bridge.js";
 import { TaskCancellationRegistry } from "./mcp-protobuf-tasks.js";
 import { patchProtoLoaderPackageDefinitionForReflection } from "./proto-loader-reflection-patch.js";
 
+export type McpMessageContextHook = (
+  extra: MessageExtraInfo
+) => <T>(fn: () => T | Promise<T>) => Promise<T>;
+
+let mcpMessageContextHook: McpMessageContextHook | undefined;
+
+/** Optional hook to bind transport metadata (e.g. x402 payment headers) around each MCP message. */
+export function setMcpMessageContextHook(hook: McpMessageContextHook | undefined): void {
+  mcpMessageContextHook = hook;
+}
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 const wellKnownProtoRoot = dirname(require.resolve("google-proto-files/package.json"));
@@ -255,7 +266,19 @@ export class GrpcMcpSessionTransport implements Transport {
           related_request_id: msg.related_request_id ?? undefined,
           resumption_token: msg.resumption_token ?? undefined,
         });
-        this.onmessage?.(message, extra);
+        void (async () => {
+          const deliver = (): void => {
+            this.onmessage?.(message, extra);
+          };
+          if (mcpMessageContextHook) {
+            await mcpMessageContextHook(extra)(deliver);
+          } else {
+            deliver();
+          }
+        })().catch((e) => {
+          const err = e instanceof Error ? e : new Error(String(e));
+          this.onerror?.(err);
+        });
       } catch (e) {
         const err = e instanceof Error ? e : new Error(String(e));
         this.onerror?.(err);

--- a/src/mcp-tool-wrap.test.ts
+++ b/src/mcp-tool-wrap.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-  X402McpPaymentRequiredError,
-  runMcpX402BeforeCallTool,
-} from "clawql-payments/x402";
+import { X402McpPaymentRequiredError, runMcpX402BeforeCallTool } from "clawql-payments/x402";
 import { wrapRegisteredMcpToolHandler } from "./mcp-tool-wrap.js";
 
 vi.mock("clawql-payments/x402", async (importOriginal) => {

--- a/src/mcp-tool-wrap.test.ts
+++ b/src/mcp-tool-wrap.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  X402McpPaymentRequiredError,
+  runMcpX402BeforeCallTool,
+} from "clawql-payments/x402";
+import { wrapRegisteredMcpToolHandler } from "./mcp-tool-wrap.js";
+
+vi.mock("clawql-payments/x402", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("clawql-payments/x402")>();
+  return {
+    ...actual,
+    runMcpX402BeforeCallTool: vi.fn(async () => undefined),
+    isX402McpPaymentError: actual.isX402McpPaymentError,
+  };
+});
+
+describe("wrapRegisteredMcpToolHandler", () => {
+  it("returns x402 payment required tool result instead of throwing", async () => {
+    const body = {
+      x402Version: 2,
+      resource: { url: "mcp://tool/search" },
+      accepts: [],
+    };
+    vi.mocked(runMcpX402BeforeCallTool).mockRejectedValueOnce(
+      new X402McpPaymentRequiredError(body)
+    );
+
+    const wrapped = wrapRegisteredMcpToolHandler("search", async () => ({
+      content: [{ type: "text" as const, text: "ok" }],
+    }));
+
+    const result = await wrapped({ query: "x", limit: 1 });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("payment_required");
+  });
+});

--- a/src/mcp-tool-wrap.ts
+++ b/src/mcp-tool-wrap.ts
@@ -1,0 +1,26 @@
+import {
+  isX402McpPaymentError,
+  runMcpX402BeforeCallTool,
+} from "clawql-payments/x402";
+import { wrapMcpToolHandler } from "./otel-tracing.js";
+
+/**
+ * Wrap MCP tool handlers with optional x402 enforcement (when `CLAWQL_X402_ENFORCE=1`)
+ * and OpenTelemetry spans.
+ */
+export function wrapRegisteredMcpToolHandler<TArgs extends unknown[], TResult>(
+  toolName: string,
+  handler: (...args: TArgs) => Promise<TResult>
+): (...args: TArgs) => Promise<TResult> {
+  return wrapMcpToolHandler(toolName, async (...args: TArgs): Promise<TResult> => {
+    try {
+      await runMcpX402BeforeCallTool({ toolName });
+    } catch (err: unknown) {
+      if (isX402McpPaymentError(err)) {
+        return err.toToolResult() as TResult;
+      }
+      throw err;
+    }
+    return handler(...args);
+  });
+}

--- a/src/mcp-tool-wrap.ts
+++ b/src/mcp-tool-wrap.ts
@@ -1,7 +1,4 @@
-import {
-  isX402McpPaymentError,
-  runMcpX402BeforeCallTool,
-} from "clawql-payments/x402";
+import { isX402McpPaymentError, runMcpX402BeforeCallTool } from "clawql-payments/x402";
 import { wrapMcpToolHandler } from "./otel-tracing.js";
 
 /**

--- a/src/mcp-x402-transport.ts
+++ b/src/mcp-x402-transport.ts
@@ -1,7 +1,4 @@
-import {
-  headersFromPlainRecord,
-  runWithMcpX402Context,
-} from "clawql-payments/x402";
+import { headersFromPlainRecord, runWithMcpX402Context } from "clawql-payments/x402";
 import { setMcpMessageContextHook } from "mcp-grpc-transport";
 
 let registered = false;

--- a/src/mcp-x402-transport.ts
+++ b/src/mcp-x402-transport.ts
@@ -3,6 +3,12 @@ import { setMcpMessageContextHook } from "mcp-grpc-transport";
 
 let registered = false;
 
+function headerString(value: string | string[] | undefined): string | undefined {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value[0];
+  return undefined;
+}
+
 /** Propagate gRPC / HTTP MCP request headers into x402 AsyncLocalStorage for tool calls. */
 export function registerMcpX402TransportHooks(): void {
   if (registered) return;
@@ -10,7 +16,10 @@ export function registerMcpX402TransportHooks(): void {
 
   setMcpMessageContextHook((extra) => async (fn) => {
     const headers = extra.requestInfo?.headers ?? {};
-    return runWithMcpX402Context(headersFromPlainRecord(headers, headers["x-grpc-host"]), fn);
+    return runWithMcpX402Context(
+      headersFromPlainRecord(headers, headerString(headers["x-grpc-host"])),
+      fn
+    );
   });
 }
 

--- a/src/mcp-x402-transport.ts
+++ b/src/mcp-x402-transport.ts
@@ -1,0 +1,20 @@
+import {
+  headersFromPlainRecord,
+  runWithMcpX402Context,
+} from "clawql-payments/x402";
+import { setMcpMessageContextHook } from "mcp-grpc-transport";
+
+let registered = false;
+
+/** Propagate gRPC / HTTP MCP request headers into x402 AsyncLocalStorage for tool calls. */
+export function registerMcpX402TransportHooks(): void {
+  if (registered) return;
+  registered = true;
+
+  setMcpMessageContextHook((extra) => async (fn) => {
+    const headers = extra.requestInfo?.headers ?? {};
+    return runWithMcpX402Context(headersFromPlainRecord(headers, headers["x-grpc-host"]), fn);
+  });
+}
+
+export { runWithMcpX402Context, headersFromExpressRequest } from "clawql-payments/x402";

--- a/src/server-http.ts
+++ b/src/server-http.ts
@@ -36,6 +36,12 @@ import { handleConeshareWebhookRequest } from "./coneshare-webhook.js";
 import { handleLangfuseEvalWebhookRequest } from "./langfuse-eval-webhook.js";
 import { createWebhookRateLimiter } from "./webhook-rate-limit.js";
 import { resolveAtrClaimsFromHeaders } from "clawql-auth";
+import { attachPaymentsWellKnownRoutes } from "clawql-payments/discovery";
+import {
+  headersFromExpressRequest,
+  registerMcpX402TransportHooks,
+  runWithMcpX402Context,
+} from "./mcp-x402-transport.js";
 
 const PORT = Number.parseInt(process.env.PORT ?? process.env.MCP_PORT ?? "8080", 10);
 const DEFAULT_MCP_PATH = "/mcp";
@@ -138,6 +144,7 @@ export type CreateMcpHttpAppOptions = {
  */
 export async function createMcpHttpApp(options: CreateMcpHttpAppOptions = {}): Promise<Express> {
   configureHitlTransportDeps();
+  registerMcpX402TransportHooks();
   if (!options.skipSpecPreload) {
     await loadSpec();
     await preloadSchemaFieldCacheFromDisk();
@@ -152,6 +159,8 @@ export async function createMcpHttpApp(options: CreateMcpHttpAppOptions = {}): P
   });
 
   app.use(applyCorsIfConfigured);
+
+  attachPaymentsWellKnownRoutes(app, { serverName: "ClawQL MCP" });
 
   /** Gateway auth (Phase 1 `clawql-auth`): enforced on MCP routes when `CLAWQL_AUTH_MODE=apiKey`. */
   function applyGatewayAuth(
@@ -317,7 +326,9 @@ export async function createMcpHttpApp(options: CreateMcpHttpAppOptions = {}): P
         jsonRpcError(res, "Bad Request: transport could not be resolved.");
         return;
       }
-      await transport.handleRequest(req, res, req.body);
+      await runWithMcpX402Context(headersFromExpressRequest(req), () =>
+        transport!.handleRequest(req, res, req.body)
+      );
     } catch (err: unknown) {
       console.error("[clawql-mcp-http] POST /mcp error:", err);
       if (!res.headersSent) {
@@ -341,7 +352,9 @@ export async function createMcpHttpApp(options: CreateMcpHttpAppOptions = {}): P
       jsonRpcError(res, "Bad Request: invalid mcp-session-id.");
       return;
     }
-    await transport.handleRequest(req, res);
+    await runWithMcpX402Context(headersFromExpressRequest(req), () =>
+      transport.handleRequest(req, res)
+    );
   });
 
   app.delete(mcpPath, applyGatewayAuth, async (req, res) => {
@@ -355,7 +368,9 @@ export async function createMcpHttpApp(options: CreateMcpHttpAppOptions = {}): P
       jsonRpcError(res, "Bad Request: invalid mcp-session-id.");
       return;
     }
-    await transport.handleRequest(req, res);
+    await runWithMcpX402Context(headersFromExpressRequest(req), () =>
+      transport.handleRequest(req, res)
+    );
   });
 
   return app;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -175,8 +175,16 @@ export function registerTools(server: McpServer) {
 
   // Non-negotiable Core tools: register immediately after search/execute so optional branches
   // below cannot throw and skip cache/audit (#89 #75).
-  server.tool("cache", cacheToolSchema, wrapRegisteredMcpToolHandler("cache", handleCacheToolInput));
-  server.tool("audit", auditToolSchema, wrapRegisteredMcpToolHandler("audit", handleAuditToolInput));
+  server.tool(
+    "cache",
+    cacheToolSchema,
+    wrapRegisteredMcpToolHandler("cache", handleCacheToolInput)
+  );
+  server.tool(
+    "audit",
+    auditToolSchema,
+    wrapRegisteredMcpToolHandler("audit", handleAuditToolInput)
+  );
 
   registerPluginMcpTools(server);
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -42,7 +42,7 @@ import {
   SLACK_NOTIFY_OPERATION_ID,
 } from "clawql-automation/plugin";
 import { configureDocumentsPluginDeps } from "clawql-documents/plugin";
-import { wrapMcpToolHandler } from "./otel-tracing.js";
+import { wrapRegisteredMcpToolHandler } from "./mcp-tool-wrap.js";
 import { configureHomeSyncHooks } from "./configure-home-sync.js";
 import { handleMemorySyncToolInput, memorySyncToolSchema } from "./home-sync/memory-sync.js";
 
@@ -113,7 +113,7 @@ function registerPluginMcpTools(server: McpServer): void {
     server.tool(
       tool.name,
       tool.schema,
-      wrapMcpToolHandler(tool.name, (args) =>
+      wrapRegisteredMcpToolHandler(tool.name, (args) =>
         tool.handler(args).then((result) => ({
           content: result.content.map((c) => ({ type: "text" as const, text: c.text })),
         }))
@@ -141,7 +141,7 @@ export function registerTools(server: McpServer) {
         .default(5)
         .describe("Max number of matching operations to return."),
     },
-    wrapMcpToolHandler("search", handleClawqlSearchToolInput)
+    wrapRegisteredMcpToolHandler("search", handleClawqlSearchToolInput)
   );
 
   server.tool(
@@ -170,13 +170,13 @@ export function registerTools(server: McpServer) {
             "Omit to get a sensible default. E.g. ['name', 'uri', 'latestReadyRevision']"
         ),
     },
-    wrapMcpToolHandler("execute", handleClawqlExecuteToolInput)
+    wrapRegisteredMcpToolHandler("execute", handleClawqlExecuteToolInput)
   );
 
   // Non-negotiable Core tools: register immediately after search/execute so optional branches
   // below cannot throw and skip cache/audit (#89 #75).
-  server.tool("cache", cacheToolSchema, wrapMcpToolHandler("cache", handleCacheToolInput));
-  server.tool("audit", auditToolSchema, wrapMcpToolHandler("audit", handleAuditToolInput));
+  server.tool("cache", cacheToolSchema, wrapRegisteredMcpToolHandler("cache", handleCacheToolInput));
+  server.tool("audit", auditToolSchema, wrapRegisteredMcpToolHandler("audit", handleAuditToolInput));
 
   registerPluginMcpTools(server);
 
@@ -184,7 +184,7 @@ export function registerTools(server: McpServer) {
     server.tool(
       "memory_sync",
       memorySyncToolSchema,
-      wrapMcpToolHandler("memory_sync", handleMemorySyncToolInput)
+      wrapRegisteredMcpToolHandler("memory_sync", handleMemorySyncToolInput)
     );
   }
 }

--- a/website/public/.well-known/payments.json
+++ b/website/public/.well-known/payments.json
@@ -1,9 +1,26 @@
 {
-  "version": "1-draft",
+  "version": "1",
   "server_name": "ClawQL MCP",
-  "documentation": "https://github.com/danielsmithdevelopment/ClawQL",
-  "payment_methods": [],
+  "documentation": "https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/clawql-payments.md",
+  "payment_methods": [
+    {
+      "type": "x402",
+      "enabled": false,
+      "x402_version": 2,
+      "scheme": "exact",
+      "network": "eip155:84532",
+      "asset": "USDC",
+      "asset_contract": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      "resources": [],
+      "note": "Static docs-site placeholder. Self-hosted ClawQL serves a dynamic document at GET /.well-known/payments.json when payments are configured."
+    },
+    {
+      "type": "stripe",
+      "enabled": false,
+      "billing": "subscription",
+      "plans": ["free", "pro", "team", "enterprise"]
+    }
+  ],
   "default": null,
-  "note": "Placeholder for payment-rail discovery (x402, optional card rails). Implementation tracked in GitHub issue #88.",
   "issue": "https://github.com/danielsmithdevelopment/ClawQL/issues/88"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the two payment follow-ups discussed after #593:

### MCP in-process x402 enforcement

When `CLAWQL_X402_ENFORCE=1`, native MCP `tools/call` now runs `enforceX402Gate()` **before** tool handlers execute (stdio / Streamable HTTP `/mcp` / gRPC session transport).

- Payment proof via `PAYMENT-SIGNATURE` / `X-PAYMENT` on Streamable HTTP requests (and gRPC metadata)
- Gated tools return MCP `isError` results with x402 `PaymentRequired` JSON instead of opaque failures
- Invalid proofs continue to emit `X402_PAYMENT_FAILED` audit events

### `/.well-known/payments.json` discovery

- Dynamic document built from `x402-gates.json`, wallet/facilitator config, and Stripe plan/meter metadata
- Served on MCP HTTP and inference HTTP via `attachPaymentsWellKnownRoutes()`
- Docs site placeholder updated to schema `version: "1"` (static; self-hosted serves live data)

## Test plan

- [x] `npm run typecheck` + `npm test` in `packages/clawql-payments` (57 tests)
- [x] `npx vitest run src/mcp-tool-wrap.test.ts`
- [x] `npm run lint` (root)
- [x] `npm run build` in `packages/clawql-payments`

## Operator notes

```bash
export CLAWQL_X402_ENFORCE=1
clawql payments x402 gate --tool knowledge_search --price 0.0005
curl http://localhost:8080/.well-known/payments.json
```

Paid MCP tools over stdio have no request headers — use Streamable HTTP or gRPC for payment proof attachment.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

