### PR TITLE
fix(website): site-wide mobile table layout and MDX consistency

### DIFF
--- a/packages/clawql-payments/src/plans/usage.ts
+++ b/packages/clawql-payments/src/plans/usage.ts
@@ -25,5 +25,3 @@ export function createUsageStore(env: NodeJS.ProcessEnv = process.env): UsageSto
       ),
   };
 }
-
-import type { ClawqlPlanId } from "./tiers.js";

--- a/packages/clawql-payments/src/plugin/payments-layer.ts
+++ b/packages/clawql-payments/src/plugin/payments-layer.ts
@@ -9,7 +9,6 @@ import {
   paymentsServicesLiveLayer,
   type PaymentsServices,
 } from "../runtime/payments-effect-runtime.js";
-import { PaymentAuditService } from "./payment-audit-service.js";
 import { createPaymentsX402ProxyPlugin } from "./payments-x402-proxy-plugin.js";
 
 export type PaymentsLayerError =

--- a/website/scripts/lib/rewrite-doc-links.mjs
+++ b/website/scripts/lib/rewrite-doc-links.mjs
@@ -155,10 +155,15 @@ export function wrapper({ children }) {
 `
 
 /** @param {string} body */
+export function appendPassthroughWrapper(body) {
+  if (body.includes('export function wrapper')) {
+    return body
+  }
+  return `${body}${MDX_BODY_WRAPPER_EXPORT}`
+}
+
+/** @param {string} body */
 export function prepareMdxBody(body, sourceDocPathFromRepoRoot) {
   const rewritten = rewriteDocLinks(body, sourceDocPathFromRepoRoot)
-  if (rewritten.includes('export function wrapper')) {
-    return rewritten
-  }
-  return `${rewritten}${MDX_BODY_WRAPPER_EXPORT}`
+  return appendPassthroughWrapper(rewritten)
 }

--- a/website/scripts/sync-clawql-defense-in-depth-doc.mjs
+++ b/website/scripts/sync-clawql-defense-in-depth-doc.mjs
@@ -13,6 +13,8 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { appendPassthroughWrapper } from './lib/rewrite-doc-links.mjs'
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const websiteRoot = path.resolve(__dirname, '..')
 const dstDir = path.join(websiteRoot, 'src/generated')
@@ -106,7 +108,7 @@ if (!src || !fs.existsSync(src)) {
 
 fs.writeFileSync(
   dst,
-  rewriteLinksForSite(fs.readFileSync(src, 'utf8')),
+  appendPassthroughWrapper(rewriteLinksForSite(fs.readFileSync(src, 'utf8'))),
   'utf8',
 )
 

--- a/website/scripts/sync-clawql-hybrid-decentralized-doc.mjs
+++ b/website/scripts/sync-clawql-hybrid-decentralized-doc.mjs
@@ -12,6 +12,8 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { appendPassthroughWrapper } from './lib/rewrite-doc-links.mjs'
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const websiteRoot = path.resolve(__dirname, '..')
 const dstDir = path.join(websiteRoot, 'src/generated')
@@ -94,7 +96,9 @@ if (!src || !fs.existsSync(src)) {
   process.exit(1)
 }
 
-const body = rewriteLinksForSite(fs.readFileSync(src, 'utf8'))
+const body = appendPassthroughWrapper(
+  rewriteLinksForSite(fs.readFileSync(src, 'utf8')),
+)
 fs.writeFileSync(dst, body)
 execSync(
   'npx prettier --write src/generated/clawql-hybrid-decentralized-body.mdx',

--- a/website/scripts/sync-clawql-plugin-pages.mjs
+++ b/website/scripts/sync-clawql-plugin-pages.mjs
@@ -14,6 +14,8 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { appendPassthroughWrapper } from './lib/rewrite-doc-links.mjs'
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const websiteRoot = path.resolve(__dirname, '..')
 const dstRoot = path.join(websiteRoot, 'src/generated/clawql-plugins')
@@ -140,7 +142,7 @@ for (const file of names) {
   plugins.push({
     slug,
     fm: { title, description, status, package: pkg, order: String(order), prev, next },
-    body: rewriteLinksForSite(body.trimStart()),
+    body: appendPassthroughWrapper(rewriteLinksForSite(body.trimStart())),
   })
 }
 

--- a/website/scripts/sync-clawql-token-efficiency-doc.mjs
+++ b/website/scripts/sync-clawql-token-efficiency-doc.mjs
@@ -10,6 +10,8 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { appendPassthroughWrapper } from './lib/rewrite-doc-links.mjs'
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const websiteRoot = path.resolve(__dirname, '..')
 const dstDir = path.join(websiteRoot, 'src/generated')
@@ -90,7 +92,11 @@ if (!src || !fs.existsSync(src)) {
   process.exit(1)
 }
 
-fs.writeFileSync(dst, rewriteLinksForSite(fs.readFileSync(src, 'utf8')), 'utf8')
+fs.writeFileSync(
+  dst,
+  appendPassthroughWrapper(rewriteLinksForSite(fs.readFileSync(src, 'utf8'))),
+  'utf8',
+)
 execSync('npx prettier --write src/generated/clawql-token-efficiency-body.mdx', {
   cwd: websiteRoot,
   stdio: 'inherit',

--- a/website/scripts/sync-daos-build-plan-doc.mjs
+++ b/website/scripts/sync-daos-build-plan-doc.mjs
@@ -9,6 +9,8 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { appendPassthroughWrapper } from './lib/rewrite-doc-links.mjs'
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const websiteRoot = path.resolve(__dirname, '..')
 const dstDir = path.join(websiteRoot, 'src/generated')
@@ -102,7 +104,11 @@ if (!src || !fs.existsSync(src)) {
   process.exit(1)
 }
 
-fs.writeFileSync(dst, rewriteLinksForSite(fs.readFileSync(src, 'utf8')), 'utf8')
+fs.writeFileSync(
+  dst,
+  appendPassthroughWrapper(rewriteLinksForSite(fs.readFileSync(src, 'utf8'))),
+  'utf8',
+)
 execSync('npx prettier --write src/generated/daos-build-plan-body.mdx', {
   cwd: websiteRoot,
   stdio: 'inherit',

--- a/website/scripts/sync-daos-coordination-layer-spec-doc.mjs
+++ b/website/scripts/sync-daos-coordination-layer-spec-doc.mjs
@@ -10,6 +10,8 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { appendPassthroughWrapper } from './lib/rewrite-doc-links.mjs'
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const websiteRoot = path.resolve(__dirname, '..')
 const dstDir = path.join(websiteRoot, 'src/generated')
@@ -107,7 +109,11 @@ if (!src || !fs.existsSync(src)) {
   process.exit(1)
 }
 
-fs.writeFileSync(dst, rewriteLinksForSite(fs.readFileSync(src, 'utf8')), 'utf8')
+fs.writeFileSync(
+  dst,
+  appendPassthroughWrapper(rewriteLinksForSite(fs.readFileSync(src, 'utf8'))),
+  'utf8',
+)
 execSync('npx prettier --write src/generated/daos-coordination-layer-spec-body.mdx', {
   cwd: websiteRoot,
   stdio: 'inherit',

--- a/website/scripts/sync-daos-unified-architecture-spec-doc.mjs
+++ b/website/scripts/sync-daos-unified-architecture-spec-doc.mjs
@@ -9,6 +9,8 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { appendPassthroughWrapper } from './lib/rewrite-doc-links.mjs'
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const websiteRoot = path.resolve(__dirname, '..')
 const dstDir = path.join(websiteRoot, 'src/generated')
@@ -106,7 +108,11 @@ if (!src || !fs.existsSync(src)) {
   process.exit(1)
 }
 
-fs.writeFileSync(dst, rewriteLinksForSite(fs.readFileSync(src, 'utf8')), 'utf8')
+fs.writeFileSync(
+  dst,
+  appendPassthroughWrapper(rewriteLinksForSite(fs.readFileSync(src, 'utf8'))),
+  'utf8',
+)
 execSync(
   'npx prettier --write src/generated/daos-unified-architecture-spec-body.mdx',
   { cwd: websiteRoot, stdio: 'inherit' },

--- a/website/scripts/sync-security-training-modules.mjs
+++ b/website/scripts/sync-security-training-modules.mjs
@@ -14,6 +14,8 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { appendPassthroughWrapper } from './lib/rewrite-doc-links.mjs'
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const websiteRoot = path.resolve(__dirname, '..')
 const dstRoot = path.join(websiteRoot, 'src/generated/security-training')
@@ -170,7 +172,7 @@ for (const file of names) {
     file,
     slug,
     fm: { title, description, part, total_parts: totalParts, prev, next },
-    body: rewriteLinksForSite(body.trimStart()),
+    body: appendPassthroughWrapper(rewriteLinksForSite(body.trimStart())),
   })
 }
 

--- a/website/src/generated/clawql-defense-in-depth-body.mdx
+++ b/website/src/generated/clawql-defense-in-depth-body.mdx
@@ -413,3 +413,7 @@ helm upgrade --install clawql-full-stack ./clawql-full-stack \
 
 _For the full security curriculum (reasoning, red-team test cases, configuration specifics), see the [Security best practices curriculum](/security/best-practices)._
 _For MCP proxy JWT/ATR details: [`mcp-proxy-jwt-atr.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/security/mcp-proxy-jwt-atr.md)._
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/clawql-hybrid-decentralized-body.mdx
+++ b/website/src/generated/clawql-hybrid-decentralized-body.mdx
@@ -223,3 +223,7 @@ Nothing here requires an all-or-nothing migration.
 The only required step is publishing your first release. Everything else is optional hardening that you adopt when it solves a problem you actually have.
 
 _For package boundaries and Layer 0 in the platform architecture, see [Modularization v2.1](/vision/modularization). For platform vision and roadmap, see [Vision & Roadmap](/vision/roadmap)._
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/clawql-plugins/bodies/automation.mdx
+++ b/website/src/generated/clawql-plugins/bodies/automation.mdx
@@ -26,3 +26,7 @@ Registers optional automation and GitOps MCP tools. Each tool is gated independe
 - [Schedule & notify workflows](/learn/schedule-notify-workflows)
 - [Workflow tool (repo)](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/mcp/workflow-tool.md)
 - [Argo CD tool (repo)](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/mcp/argocd-tool.md)
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/clawql-plugins/bodies/bundled-providers.mdx
+++ b/website/src/generated/clawql-plugins/bodies/bundled-providers.mdx
@@ -52,3 +52,7 @@ Single-spec mode (`CLAWQL_SPEC_PATH`, `CLAWQL_PROVIDER=cloudflare`, …) bypasse
 - [Bundled specs](/bundled-specs)
 - [Spec configuration](/spec-configuration)
 - [providers/README.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/providers/README.md)
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/clawql-plugins/bodies/core.mdx
+++ b/website/src/generated/clawql-plugins/bodies/core.mdx
@@ -28,3 +28,7 @@ Core behavior is driven by **spec selection** (which APIs are in the merge) and 
 - [Search & execute walkthrough](/learn/search-and-execute-mcp)
 - [Audit & observability](/learn/audit-tool-and-observability)
 - [Session cache](/cache)
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/clawql-plugins/bodies/documents.mdx
+++ b/website/src/generated/clawql-plugins/bodies/documents.mdx
@@ -37,3 +37,7 @@ Explicit **`CLAWQL_BUNDLED_PROVIDERS=paperless,tika,...`** can still list IDP ve
 - [Onyx knowledge search](/learn/knowledge-search-onyx)
 - [Document pipeline](/learn/document-pipeline)
 - [IDP pipeline (repo)](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/providers/idp-pipeline.md)
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/clawql-plugins/bodies/hitl-label-studio.mdx
+++ b/website/src/generated/clawql-plugins/bodies/hitl-label-studio.mdx
@@ -27,3 +27,7 @@ Full architecture, security, RBAC, Helm, and OpenClaw integration:
 | Tool                            | Purpose                       |
 | ------------------------------- | ----------------------------- |
 | **`hitl_enqueue_label_studio`** | Import tasks for human review |
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/clawql-plugins/bodies/inference-providers.mdx
+++ b/website/src/generated/clawql-plugins/bodies/inference-providers.mdx
@@ -67,3 +67,7 @@ Publish third-party packages as `clawql-*-inference-provider` (or in-repo under 
 - [clawql-inference gateway](/inference/clawql-inference)
 - [Third-party plugins](/plugins/third-party)
 - [Plugin registry](/reference/plugins)
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/clawql-plugins/bodies/memory.mdx
+++ b/website/src/generated/clawql-plugins/bodies/memory.mdx
@@ -41,3 +41,7 @@ Optional hybrid vector index: see [memory-db-hybrid-implementation.md](https://g
 - [Phase 1 platform guide — PageIndex](/getting-started/phase-1-platform-guide#2-pageindex-clawql-pageindex)
 - [Vault memory between chats](/learn/vault-memory-between-chats)
 - [MCP tools § memory](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/mcp/mcp-tools.md)
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/clawql-plugins/bodies/ouroboros.mdx
+++ b/website/src/generated/clawql-plugins/bodies/ouroboros.mdx
@@ -28,3 +28,7 @@ Eval webhook integration: **`CLAWQL_ENABLE_LANGFUSE_EVAL=1`** (requires Ouroboro
 - [Ouroboros library](/ouroboros)
 - [Ouroboros tools walkthrough](/learn/ouroboros-tools)
 - [clawql-ouroboros.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/ouroboros/clawql-ouroboros.md)
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/clawql-plugins/bodies/panguard-proxy.mdx
+++ b/website/src/generated/clawql-plugins/bodies/panguard-proxy.mdx
@@ -30,3 +30,7 @@ The Panguard proxy plugin is the synchronous **`beforeCallTool`** chokepoint for
 - [Defense in depth (site)](/security/defense-in-depth)
 - [MCP proxy JWT ATR (repo)](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/security/mcp-proxy-jwt-atr.md)
 - [Plugin registry](/reference/plugins)
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/clawql-plugins/bodies/sandbox.mdx
+++ b/website/src/generated/clawql-plugins/bodies/sandbox.mdx
@@ -51,3 +51,7 @@ Helm: `enableSandbox: true` plus optional `sandboxKata` / `sandboxDocker` blocks
 - [Local agent sandbox](/getting-started/local-agent-sandbox)
 - [Sandbox exec walkthrough](/learn/sandbox-exec)
 - [MCP tools § sandbox_exec](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/mcp/mcp-tools.md#sandbox_exec)
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/clawql-plugins/bodies/third-party.mdx
+++ b/website/src/generated/clawql-plugins/bodies/third-party.mdx
@@ -21,3 +21,7 @@ ClawQL is moving toward a **plugin registry** model where horizontal features sh
 - [Plugin model & registry](/reference/plugins)
 - [Contributor technical specification](/contributing/technical-specification)
 - [Modularization v2.1](/vision/modularization)
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/clawql-token-efficiency-body.mdx
+++ b/website/src/generated/clawql-token-efficiency-body.mdx
@@ -199,3 +199,7 @@ Token estimates throughout use a roughly 4-characters-per-token approximation, c
 ---
 
 _For the search/execute workflow, see [`docs/mcp/mcp-tools.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/mcp/mcp-tools.md). For platform context, see the [Vision & Roadmap document](/vision/roadmap)._
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/daos-build-plan-body.mdx
+++ b/website/src/generated/daos-build-plan-body.mdx
@@ -260,3 +260,7 @@ export interface WORMEntry {
 ---
 
 **Consolidated specification approved as of June 28, 2026. Implementation begins on P0 components immediately. Pi runtime integration is a first-class requirement at every priority level.**
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/daos-coordination-layer-spec-body.mdx
+++ b/website/src/generated/daos-coordination-layer-spec-body.mdx
@@ -785,3 +785,7 @@ The transport layer guarantees durable, ordered, safely gated communication over
 The strategic layer measures collective reasoning quality using two complementary signals: NSV as a cheap scalar tripwire for overall clustering, and SGDOP as a directional diagnostic identifying specifically which axis of embedding space the swarm has failed to explore — derived from the same matrix-conditioning logic that gives GPS dilution-of-precision its meaning, not borrowed as a label. Per-turn reputation attribution is baseline-corrected against both an independent success rate and a calibrated similarity floor, protecting dissenters from group-failure penalties. Diversity Dividends extend this into a persistent incentive layer, rewarding agents whose consistent blind-spot coverage over multiple rounds aligns individual utility with global swarm stability.
 
 Two boundaries are named explicitly. Agent positions are plaintext to the Coordinator by design — TLS protects transit, not computation — and a genuinely zero-trust version would require CKKS or a two-party protocol, both deliberately out of scope. The Evaluator gates final candidates, not reasoning trajectories; deterministic process verification at the step level remains unestablished for open-ended swarm reasoning. These are not temporary limitations awaiting a fix; they are the honest boundaries of what this architecture currently delivers.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/daos-unified-architecture-spec-body.mdx
+++ b/website/src/generated/daos-unified-architecture-spec-body.mdx
@@ -792,3 +792,7 @@ The strategic framing in this document describes the full design intent of the c
 ---
 
 **ClawQL is infrastructure for trustworthy, long-lived, multi-agent systems.**
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/agent-gateway-hardening-dns-rebinding.mdx
+++ b/website/src/generated/security-training/bodies/agent-gateway-hardening-dns-rebinding.mdx
@@ -183,3 +183,7 @@ Key Takeaways (Memorize These!)
 - Every gateway configuration change must be followed by a port audit — silent drift is the operational risk.
 
 The gateway is now hardened end-to-end. It can only be reached in the exact ways we explicitly allow, and the most dangerous browser-based bypass is structurally impossible. This completes the perimeter around the single highest-value component in the entire platform.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/agent-identity-lifecycle-provisioning.mdx
+++ b/website/src/generated/security-training/bodies/agent-identity-lifecycle-provisioning.mdx
@@ -175,3 +175,7 @@ Key Takeaways (Memorize These!)
 - Under compromise: forensic preservation before revocation, always — rushed cleanup that destroys evidence trades short-term containment for long-term blindness.
 
 You now have a complete lifecycle for agents that treats them with the same rigor we apply to human identities. Agents are created deliberately, governed tightly, observed continuously, and decommissioned safely — with evidence preserved when it matters most. This closes the beginning-to-end gap that every other module depends on.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/authentication-session-management-scoped-tokens.mdx
+++ b/website/src/generated/security-training/bodies/authentication-session-management-scoped-tokens.mdx
@@ -208,3 +208,7 @@ Key Takeaways (Memorize These!)
 - Device pairing for local access and OIDC workload identity for CI are the two second-factor patterns that cover all access scenarios without requiring static credentials.
 
 You now have an authentication and session management system designed specifically for autonomous agents. Long-lived tokens are gone. Every action is individually authenticated, scoped, replay-protected, and permanently audited. Credential theft is no longer a meaningful attack.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/automated-response-incident-recovery-picerl.mdx
+++ b/website/src/generated/security-training/bodies/automated-response-incident-recovery-picerl.mdx
@@ -137,3 +137,7 @@ Key Takeaways (Memorize These!)
 - A post-incident review that doesn’t result in a new rule, a runbook update, or a control change is not a post-incident review — it is a post-incident report.
 
 You now have automated response that acts faster than any attacker and a structured incident lifecycle that turns every event into measurable improvement. Detection-to-response is no longer a vulnerability — it is a controlled, forensic-grade process. This completes the operational security layer that makes the entire platform resilient in the face of real incidents.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/clawhub-skill-vetting-safe-installation.mdx
+++ b/website/src/generated/security-training/bodies/clawhub-skill-vetting-safe-installation.mdx
@@ -175,3 +175,7 @@ Key Takeaways (Memorize These!)
 - Quarantine mode gives a safe in-production trial without granting full capability prematurely.
 
 You now have a complete, repeatable process that turns third-party skills from an uncontrolled risk into a vetted, observable, and revocable capability. Skills are no longer a blind spot — they are a controlled, auditable part of your agentic platform.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/cluster-admission-control-signing-policy.mdx
+++ b/website/src/generated/security-training/bodies/cluster-admission-control-signing-policy.mdx
@@ -157,3 +157,7 @@ Key Takeaways (Memorize These!)
 You now have a cluster that refuses to run anything untrusted or unsafe — no matter how it was submitted.
 
 This is defense-in-depth at its best: the registry gives us trusted images, and the cluster enforces that trust at the final gate.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/compliance-regulatory-mapping.mdx
+++ b/website/src/generated/security-training/bodies/compliance-regulatory-mapping.mdx
@@ -149,3 +149,7 @@ Key Takeaways (Memorize These!)
 - Audit readiness as a continuous state (quarterly evidence packages, WORM retention, Merkle chain) is cheaper than audit preparation as a periodic scramble.
 
 You now have a compliance mapping that turns every technical control into auditable evidence across GDPR, HIPAA, SOC 2 Type II, and the EU AI Act. Regulatory requirements are no longer an afterthought — they are satisfied by the same infrastructure that keeps the platform secure. This completes the governance layer that makes the entire platform audit-ready by design.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/container-image-security-pinning-distroless-golden-images.mdx
+++ b/website/src/generated/security-training/bodies/container-image-security-pinning-distroless-golden-images.mdx
@@ -221,3 +221,7 @@ Next Steps & Hands-On Challenge
 3. Add Trivy + OSV-Scanner to your CI and watch the first scan results come in.
 
 You’ve just taken the single biggest step toward supply-chain security for your agentic platform.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/data-classification-pii-redaction-residency.mdx
+++ b/website/src/generated/security-training/bodies/data-classification-pii-redaction-residency.mdx
@@ -121,3 +121,7 @@ Key Takeaways (Memorize These!)
 - Residency controls must be enforced at the infrastructure layer, not just documented in policy — Panguard + bucket policies are the enforcement mechanism.
 
 You now have data classification as a built-in platform property. Sensitive information is tagged once at ingestion, redacted automatically at every boundary, and only accessible to agents that are explicitly allowed to see it. Residency and anonymisation complete the picture, turning data handling from an accidental risk into a controlled, auditable, and regulation-friendly system.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/development-deployment-security.mdx
+++ b/website/src/generated/security-training/bodies/development-deployment-security.mdx
@@ -113,3 +113,7 @@ Key Takeaways (Memorize These!)
 - Staging must enforce the same security controls as production; a staging environment that is more permissive is not a staging environment, it is a gap.
 
 You now have a development and deployment pipeline where security is the path of least resistance. The workstation is hardened, leakage is prevented, and production deployments are secure by default and fully automated. This closes the loop between developer intent and production reality — the entire platform is only as secure as the code and configuration that reaches it.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/disaster-recovery-business-continuity.mdx
+++ b/website/src/generated/security-training/bodies/disaster-recovery-business-continuity.mdx
@@ -141,3 +141,7 @@ Key Takeaways (Memorize These!)
 - The session recovery decision tree must be documented and automated; human judgement under disaster conditions is inconsistent.
 
 You now have a tested, measurable disaster recovery plan that keeps agents operational even when entire regions disappear. The platform can survive infrastructure failure with minimal data loss and minimal downtime. This completes the business continuity layer that makes the entire security stack production-ready for the real world.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/egress-filtering-dns-dlp.mdx
+++ b/website/src/generated/security-training/bodies/egress-filtering-dns-dlp.mdx
@@ -187,3 +187,7 @@ Key Takeaways (Memorize These!)
 - Baseline before enabling blocking thresholds — alert fatigue from miscalibrated egress volume alerts is itself a security risk.
 
 You now have a complete egress control stack that makes data exfiltration structurally difficult and instantly detectable. Even if an attacker achieves code execution or prompt injection, the data cannot easily leave the platform. This is the final barrier that turns potential breaches into contained incidents.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/gpu-resource-protection-isolation.mdx
+++ b/website/src/generated/security-training/bodies/gpu-resource-protection-isolation.mdx
@@ -124,3 +124,7 @@ Key Takeaways (Memorize These!)
 - GPU monitoring is a security control as much as an operational one — unexpected GPU consumers are a signal of workload escape or resource theft.
 
 You now have least privilege enforced at the GPU hardware level. Residual data leakage is prevented, resource exhaustion is bounded, and every GPU access is monitored. The compute layer that powers your agents is now as securely isolated as every other component in the platform.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/human-operator-security-admin-controls.mdx
+++ b/website/src/generated/security-training/bodies/human-operator-security-admin-controls.mdx
@@ -186,3 +186,7 @@ Key Takeaways (Memorize These!)
 You have now completed the full 30-module security curriculum. Every layer — from supply chain to human operators — is secured with defense-in-depth, zero-trust principles, and continuous verification. The platform is ready for production use in the most demanding environments.
 
 Thank you for completing the course. You now possess a complete, production-grade security architecture for agentic AI platforms.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/input-validation-protocol-hardening.mdx
+++ b/website/src/generated/security-training/bodies/input-validation-protocol-hardening.mdx
@@ -154,3 +154,7 @@ Key Takeaways (Memorize These!)
 - Tool definition integrity is the attack surface that most operators don’t know exists — sign the tools manifest and monitor for mid-session changes.
 
 You now have a hardened input boundary that ensures every piece of data reaching Panguard and the model is clean, normalized, size-bounded, and free of injection tricks. The enforcement layer in Module 12 can now do its job on trustworthy input. This completes the upstream defenses that make the entire runtime stack reliable.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/least-privilege-scoped-kubernetes-identities.mdx
+++ b/website/src/generated/security-training/bodies/least-privilege-scoped-kubernetes-identities.mdx
@@ -195,3 +195,7 @@ Key Takeaways (Memorize These!)
 - RBAC is only as good as its ongoing auditing — permissions that were appropriate at launch accumulate over time.
 
 You now have the identity and permission model that ensures a compromised pod can only do the exact minimum it was designed to do. This is the foundation that makes every other control in the curriculum effective. Least privilege is no longer a checkbox — it is the default operating mode of your entire platform.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/mcp-runtime-enforcement-panguard-atr.mdx
+++ b/website/src/generated/security-training/bodies/mcp-runtime-enforcement-panguard-atr.mdx
@@ -187,3 +187,7 @@ Key Takeaways (Memorize These!)
 - Prompt guard libraries add behavioral depth but cannot substitute for structural enforcement at the gateway layer.
 
 You now have a runtime enforcement engine that makes malicious tool execution structurally impossible. Even if the model is fully compromised or the prompt is perfectly injected, the agent cannot perform actions it is not explicitly allowed to do. This is the enforcement layer that turns the rest of the security stack into a complete, working system.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/memory-context-poisoning-prevention.mdx
+++ b/website/src/generated/security-training/bodies/memory-context-poisoning-prevention.mdx
@@ -141,3 +141,7 @@ Key Takeaways (Memorize These!)
 - WORM storage is the final backstop — no administrative action can destroy the memory history during the retention period.
 
 You now have long-term memory that is redacted at source, cryptographically immutable, GDPR-compliant, and poisoning-resistant. A poisoned entry cannot be written, cannot be modified after the fact, and cannot be silently retrieved later. This closes the last major persistent attack surface in the agentic platform.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/model-weight-integrity-verification.mdx
+++ b/website/src/generated/security-training/bodies/model-weight-integrity-verification.mdx
@@ -67,3 +67,7 @@ For externally-sourced weights (Module 26's multi-provider weight management), t
 - Detecting a backdoor introduced during training by examining the resulting weights is an open research problem with no general solution — do not represent behavioral monitoring as solving this
 - Behavioral evaluation and output monitoring are real, useful controls for capability regression and production drift — they are not backdoor detectors, and should not be the basis for a claim that backdoored weights will be caught
 - Backdoor risk is addressed by securing the training pipeline itself, not by inspecting its output — apply the same supply chain rigor to training infrastructure as to weight storage
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/multi-agent-trust-orchestrator-security.mdx
+++ b/website/src/generated/security-training/bodies/multi-agent-trust-orchestrator-security.mdx
@@ -158,3 +158,7 @@ Key Takeaways (Memorize These!)
 - Pipeline-level cumulative risk scoring is the control that catches slow-moving attacks that evade per-node rate limits.
 
 You now have a complete trust architecture for multi-agent pipelines. Orchestrators and subagents can no longer trust each other by default. Every instruction and every result is cryptographically verifiable, and the blast radius of any single node is strictly limited. This brings the same zero-trust discipline we built for single agents to the full multi-agent world.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/owasp-agentic-top-10-mitigations.mdx
+++ b/website/src/generated/security-training/bodies/owasp-agentic-top-10-mitigations.mdx
@@ -143,3 +143,7 @@ Key Takeaways (Memorize These!)
 - Module 24’s test cases provide the evidence that the mapping is operational rather than theoretical.
 
 You now have a direct, auditable mapping from the industry’s most important agentic risk framework to the exact controls running in your platform. This turns the OWASP Agentic Top 10 from a list of worries into a verified set of mitigations — and gives you the language and evidence you need for audits, leadership updates, and continuous improvement.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/quarterly-security-review-checklist.mdx
+++ b/website/src/generated/security-training/bodies/quarterly-security-review-checklist.mdx
@@ -151,3 +151,7 @@ Key Takeaways (Memorize These!)
 - The metric review is where alert tuning decisions are made — a rule with zero fires in 90 days either isn’t being triggered or isn’t working, and the quarterly review is where that question is asked.
 
 You now have a repeatable, evidence-driven quarterly process that keeps the entire security posture healthy and auditable. This is the governance layer that ensures everything we built in Modules 1–24 continues to work as intended, quarter after quarter, year after year. The platform does not drift into insecurity — it is actively kept secure.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/red-teaming-adversarial-testing.mdx
+++ b/website/src/generated/security-training/bodies/red-teaming-adversarial-testing.mdx
@@ -214,3 +214,7 @@ Key Takeaways (Memorize These!)
 - External pen test scope must include the MCP-specific attack surface — a standard web-application scope will miss the most critical vectors.
 
 You now have a continuous adversarial testing program that keeps every control honest. The gap between “deployed” and “effective” is closed. This verification layer ensures that the entire defense-in-depth stack remains effective as the platform evolves, new skills are added, and new attack techniques emerge. This is what turns our security architecture from a static set of rules into a living, proven system.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/sandboxing-kata-gvisor-seatbelt.mdx
+++ b/website/src/generated/security-training/bodies/sandboxing-kata-gvisor-seatbelt.mdx
@@ -201,3 +201,7 @@ Key Takeaways (Memorize These!)
 - The choice of sandbox runtime is a threat-model decision based on the workload’s trust level and performance requirements, not a one-size-fits-all answer.
 
 You now have a true security boundary between agent code and the host kernel. Even if an attacker achieves arbitrary code execution inside an agent, they are still trapped inside the sandbox. This is the final layer that makes the entire platform resilient to kernel-level escapes.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/secrets-at-rest-vault-hsm-audit.mdx
+++ b/website/src/generated/security-training/bodies/secrets-at-rest-vault-hsm-audit.mdx
@@ -133,3 +133,7 @@ Key Takeaways (Memorize These!)
 - The gateway-as-exchange-point pattern ensures agents never hold Vault tokens — a compromised agent cannot directly access Vault.
 
 You now have a secrets architecture where credentials are created on demand, live for minutes, and every access is permanently and verifiably recorded. Static secrets are gone. The last major class of long-term credential risk has been closed.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/secure-multi-tenancy-isolation.mdx
+++ b/website/src/generated/security-training/bodies/secure-multi-tenancy-isolation.mdx
@@ -150,3 +150,7 @@ Key Takeaways (Memorize These!)
 - Audit log segregation encrypted with the tenant’s public key gives tenants evidence ownership without requiring platform operator access.
 
 You now have secure multi-tenancy that is architecturally enforced rather than policy-dependent. Cross-tenant leakage is structurally impossible, resource exhaustion is bounded, and audit logs remain clean and tenant-owned. This completes the foundation needed to run multiple tenants safely on the same platform.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/security-monitoring-observability-siem.mdx
+++ b/website/src/generated/security-training/bodies/security-monitoring-observability-siem.mdx
@@ -197,3 +197,7 @@ Key Takeaways (Memorize These!)
 - Alert fatigue is a security failure with the same practical outcome as having no alerts — precision measurement and tiered routing are not optional.
 
 You now have observability that is designed for agentic platforms: high-signal, low-noise, tamper-evident, and cardinality-safe. When something goes wrong, the right people know within minutes, with full forensic context already available in the WORM trail. This turns detection from a hope into a reliable, measurable capability.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/third-party-model-api-security.mdx
+++ b/website/src/generated/security-training/bodies/third-party-model-api-security.mdx
@@ -61,3 +61,7 @@
 - Provider data retention and training-use policies must be verified per API product and re-verified on a defined schedule, not assumed from general reputation
 - Classification-gated content must never reach an external provider unless that provider's verified policy and configuration support the content's classification level
 - Multi-provider routing must carry classification checks through every fallback path — a verified policy for one provider does not transfer to another
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/threat-modelling-stride-agentic-ai.mdx
+++ b/website/src/generated/security-training/bodies/threat-modelling-stride-agentic-ai.mdx
@@ -181,3 +181,7 @@ Key Takeaways (Memorize These!)
 - Residual risk must be explicitly accepted and documented — undocumented residual risk is the same as unmitigated risk from a governance perspective.
 
 You now have a living, agentic-specific threat model that stays current as the platform evolves. It is no longer a dusty document on a shelf — it is an active security control that drives architecture decisions, red-team exercises, and quarterly reviews. This is the strategic layer that ensures all the tactical controls in Modules 1–21 are aimed at the right threats.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/vulnerability-management-patch-cryptography.mdx
+++ b/website/src/generated/security-training/bodies/vulnerability-management-patch-cryptography.mdx
@@ -194,3 +194,7 @@ Key Takeaways (Memorize These!)
 - Cryptographic agility must be planned before the algorithm is deprecated — a migration under pressure produces outages.
 
 You now have a mature vulnerability management program that keeps the platform current without ever sacrificing supply-chain integrity or operational stability. Pinning and patching work together, cryptographic migrations are planned and painless, and every CVE is handled with speed appropriate to its actual risk. This is the operational discipline that keeps the entire security stack fresh and effective for the long term.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/where-to-start-prioritization-new-deployment.mdx
+++ b/website/src/generated/security-training/bodies/where-to-start-prioritization-new-deployment.mdx
@@ -40,3 +40,7 @@ Once the first five are operational and verified, the next priorities — before
 A deployment that implements the first five completely and correctly, and nothing else, is meaningfully more secure than a deployment that implements all thirty modules at 20% completeness each. Partial implementations of structural controls — an ATR system that's enforced for some tools but not others, redaction that runs on most write paths but not all of them, an egress allowlist with a few too-broad entries left in "temporarily" — provide a false sense of coverage that is often worse than no coverage at all, because the gaps are invisible until they're exploited.
 
 Build the five completely. Verify them. Then expand scope, and let the expanding scope tell you which subsequent modules become load-bearing — rather than trying to anticipate all of them at once.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/generated/security-training/bodies/zero-trust-network-mtls-istio-rbac.mdx
+++ b/website/src/generated/security-training/bodies/zero-trust-network-mtls-istio-rbac.mdx
@@ -182,3 +182,7 @@ Key Takeaways (Memorize These!)
 - Zero trust is an ongoing operational posture, not a one-time configuration — every new service must be added to the trust fabric.
 
 You now have a network where compromise of one pod does not grant free movement across the cluster. Every hop is authenticated, authorized, and observed. This is the structural foundation that makes the rest of the security stack effective.
+
+export function wrapper({ children }) {
+  return children
+}

--- a/website/src/styles/tailwind.css
+++ b/website/src/styles/tailwind.css
@@ -103,12 +103,17 @@
     text-align: left;
     vertical-align: top;
     padding: 0.5rem 0.875rem;
+    min-width: 5.5rem;
     overflow-wrap: anywhere;
     word-break: normal;
     white-space: normal;
     box-sizing: border-box;
     border-bottom: 1px solid
       color-mix(in oklab, var(--color-zinc-900) 8%, transparent);
+  }
+
+  .docs-table-scroll .docs-table thead :is(th, td) {
+    text-align: left;
   }
 
   :is(.dark) .docs-table-scroll .docs-table :is(th, td) {

--- a/website/tests/table-layout.spec.ts
+++ b/website/tests/table-layout.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test, type Locator, type Page } from '@playwright/test'
+
+const MOBILE_VIEWPORT = { width: 390, height: 844 }
+
+/** Assert header cells in a table do not overlap horizontally. */
+async function expectTableHeadersAligned(table: Locator) {
+  const headers = table.locator('thead th')
+  const count = await headers.count()
+  test.skip(count < 2, 'Table has fewer than two columns')
+
+  for (let i = 0; i < count - 1; i++) {
+    const left = await headers.nth(i).boundingBox()
+    const right = await headers.nth(i + 1).boundingBox()
+    expect(left, `header ${i} missing box`).not.toBeNull()
+    expect(right, `header ${i + 1} missing box`).not.toBeNull()
+    if (left && right) {
+      expect(left.x + left.width).toBeLessThanOrEqual(right.x + 1)
+    }
+  }
+}
+
+async function expectDocsTablePresent(page: Page) {
+  const table = page.locator('.docs-table').first()
+  await expect(table).toBeVisible()
+  await expectTableHeadersAligned(table)
+}
+
+test.describe('mobile table layout', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize(MOBILE_VIEWPORT)
+  })
+
+  const tableHeavyRoutes = [
+    { path: '/inference/clawql-inference', name: 'inference' },
+    { path: '/architecture/token-efficiency', name: 'token efficiency' },
+    { path: '/security/defense-in-depth', name: 'defense in depth' },
+    { path: '/reference/plugins', name: 'plugin registry' },
+    { path: '/plugins/bundled-providers', name: 'bundled providers plugin' },
+    { path: '/vision/ecosystem', name: 'vision ecosystem' },
+    { path: '/deployment/operations-guide', name: 'deployment operations' },
+    { path: '/tools', name: 'tools reference' },
+    { path: '/bundled-specs', name: 'bundled specs' },
+    { path: '/learn/document-pipeline', name: 'document pipeline' },
+    {
+      path: '/case-studies/cloudflare-docs-mcp',
+      name: 'cloudflare case study',
+    },
+  ]
+
+  for (const { path, name } of tableHeavyRoutes) {
+    test(`${name} tables are left-aligned without column overlap`, async ({
+      page,
+    }) => {
+      await page.goto(path)
+      await expectDocsTablePresent(page)
+    })
+  }
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audited table formatting across the docs site. The PR #595 fix (scoping CSS to `.docs-table-scroll .docs-table`) already applies **site-wide** — every GFM table in MDX goes through the shared `table` component in `mdx.tsx`, including:

- 64 `page.mdx` routes
- Synced `*-body.mdx` pages (inference, vision, deployment, etc.)
- Plugin bodies (`/plugins/*`)
- Security training modules (`/security/best-practices/*`)

## Additional hardening

1. **Table CSS** — base `min-width` on all cells; explicit `text-align: left` on `thead` headers
2. **Sync script consistency** — `appendPassthroughWrapper()` exported and wired into 8 sync scripts that previously omitted the passthrough `wrapper` export (token-efficiency, defense-in-depth, hybrid-decentralized, DAOS specs, plugins, security training)
3. **Regression tests** — new Playwright suite (`tests/table-layout.spec.ts`) verifies mobile column alignment (no header overlap) on 11 table-heavy routes

## Routes covered by tests

- `/inference/clawql-inference`
- `/architecture/token-efficiency`
- `/security/defense-in-depth`
- `/reference/plugins`
- `/plugins/bundled-providers`
- `/vision/ecosystem`
- `/deployment/operations-guide`
- `/tools`
- `/bundled-specs`
- `/learn/document-pipeline`
- `/case-studies/cloudflare-docs-mcp`

## Verification

- `npm run build` succeeds
- All 11 mobile table layout Playwright tests pass locally
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

