### PR TITLE
feat(payments): Effect services for Stripe webhook, meter, and billing

### DIFF
--- a/docs/payments/clawql-payments.md
+++ b/docs/payments/clawql-payments.md
@@ -328,8 +328,12 @@ Effect entrypoints: `paymentsServicesLiveLayer()` merges all services; `runPayme
 | `UsageStoreService`        | Monthly usage counters                                            |
 | `EntitlementService`       | Plan limit checks (`EntitlementLimitError`)                       |
 | `PaymentsDiscoveryService` | `/.well-known/payments.json` builder                              |
+| `StripeClientService`      | Stripe SDK client lifecycle                                       |
+| `StripeWebhookService`     | Webhook verify + WORM-audited event handling                      |
+| `StripeMeterService`       | Meter events + inference usage reporting                          |
+| `StripeBillingService`     | Setup, customer, subscription, invoice, portal                    |
 
-Public async exports (`loadPaymentsConfig`, `enforceX402Gate`, `appendPaymentWormEntry`, …) delegate to `runPaymentsEffect`. **Stripe billing** modules remain async wrappers (next migration increment).
+Public async exports (`loadPaymentsConfig`, `enforceX402Gate`, `appendPaymentWormEntry`, …) delegate to `runPaymentsEffect`. **Stripe** modules now use Effect services (`StripeClientService`, `StripeWebhookService`, `StripeMeterService`, `StripeBillingService`) with tagged errors (`StripeSignatureError`, `StripeApiError`, …); legacy `Error` subclasses remain at async boundaries for CLI compatibility.
 
 Configure gates with `clawql payments x402 gate --tool <name> --price <usdc>`.
 

--- a/packages/clawql-payments/src/plans/usage.ts
+++ b/packages/clawql-payments/src/plans/usage.ts
@@ -25,5 +25,3 @@ export function createUsageStore(env: NodeJS.ProcessEnv = process.env): UsageSto
       ),
   };
 }
-
-import type { ClawqlPlanId } from "./tiers.js";

--- a/packages/clawql-payments/src/plugin/index.ts
+++ b/packages/clawql-payments/src/plugin/index.ts
@@ -40,3 +40,22 @@ export {
   PaymentsDiscoveryService,
   paymentsDiscoveryLiveLayer,
 } from "../discovery/payments-discovery-service.js";
+export {
+  StripeClientService,
+  stripeClientLiveLayer,
+  isStripeConfigured,
+} from "../stripe/stripe-client-service.js";
+export {
+  StripeWebhookService,
+  stripeWebhookLiveLayer,
+} from "../stripe/stripe-webhook-service.js";
+export { StripeMeterService, stripeMeterLiveLayer } from "../stripe/stripe-meter-service.js";
+export {
+  StripeBillingService,
+  stripeBillingLiveLayer,
+} from "../stripe/stripe-billing-service.js";
+export {
+  StripeNotConfigured,
+  StripeSignatureError,
+  StripeApiError,
+} from "../stripe/stripe-errors.js";

--- a/packages/clawql-payments/src/plugin/index.ts
+++ b/packages/clawql-payments/src/plugin/index.ts
@@ -45,15 +45,9 @@ export {
   stripeClientLiveLayer,
   isStripeConfigured,
 } from "../stripe/stripe-client-service.js";
-export {
-  StripeWebhookService,
-  stripeWebhookLiveLayer,
-} from "../stripe/stripe-webhook-service.js";
+export { StripeWebhookService, stripeWebhookLiveLayer } from "../stripe/stripe-webhook-service.js";
 export { StripeMeterService, stripeMeterLiveLayer } from "../stripe/stripe-meter-service.js";
-export {
-  StripeBillingService,
-  stripeBillingLiveLayer,
-} from "../stripe/stripe-billing-service.js";
+export { StripeBillingService, stripeBillingLiveLayer } from "../stripe/stripe-billing-service.js";
 export {
   StripeNotConfigured,
   StripeSignatureError,

--- a/packages/clawql-payments/src/plugin/payments-layer.ts
+++ b/packages/clawql-payments/src/plugin/payments-layer.ts
@@ -9,7 +9,6 @@ import {
   paymentsServicesLiveLayer,
   type PaymentsServices,
 } from "../runtime/payments-effect-runtime.js";
-import { PaymentAuditService } from "./payment-audit-service.js";
 import { createPaymentsX402ProxyPlugin } from "./payments-x402-proxy-plugin.js";
 
 export type PaymentsLayerError =

--- a/packages/clawql-payments/src/runtime/payments-effect-runtime.ts
+++ b/packages/clawql-payments/src/runtime/payments-effect-runtime.ts
@@ -4,6 +4,10 @@ import { paymentsDiscoveryLiveLayer } from "../discovery/payments-discovery-serv
 import { entitlementLiveLayer } from "../plans/entitlement-service.js";
 import { usageStoreLiveLayer } from "../plans/usage-store-service.js";
 import { paymentAuditLiveLayer } from "../plugin/payment-audit-service.js";
+import { stripeBillingLiveLayer } from "../stripe/stripe-billing-service.js";
+import { stripeClientLiveLayer } from "../stripe/stripe-client-service.js";
+import { stripeMeterLiveLayer } from "../stripe/stripe-meter-service.js";
+import { stripeWebhookLiveLayer } from "../stripe/stripe-webhook-service.js";
 import { x402EnforcementLiveLayer } from "../x402/x402-enforcement-service.js";
 import { x402FacilitatorLiveLayer } from "../x402/x402-facilitator-service.js";
 import { x402GateLiveLayer } from "../x402/x402-gate-service.js";
@@ -18,7 +22,11 @@ export type PaymentsServices =
   | import("../x402/x402-enforcement-service.js").X402EnforcementService
   | import("../plans/usage-store-service.js").UsageStoreService
   | import("../plans/entitlement-service.js").EntitlementService
-  | import("../discovery/payments-discovery-service.js").PaymentsDiscoveryService;
+  | import("../discovery/payments-discovery-service.js").PaymentsDiscoveryService
+  | import("../stripe/stripe-client-service.js").StripeClientService
+  | import("../stripe/stripe-webhook-service.js").StripeWebhookService
+  | import("../stripe/stripe-meter-service.js").StripeMeterService
+  | import("../stripe/stripe-billing-service.js").StripeBillingService;
 
 const layerCache = new Map<string, Layer.Layer<PaymentsServices>>();
 
@@ -36,6 +44,7 @@ export function paymentsServicesLiveLayer(
   const usage = usageStoreLiveLayer(env);
   const entitlement = entitlementLiveLayer();
   const facilitator = x402FacilitatorLiveLayer(env);
+  const stripeClient = stripeClientLiveLayer(env);
 
   const runtimeConfig = x402RuntimeConfigLiveLayer(env).pipe(Layer.provide(config));
   const enforcement = x402EnforcementLiveLayer().pipe(
@@ -43,6 +52,13 @@ export function paymentsServicesLiveLayer(
   );
   const discovery = paymentsDiscoveryLiveLayer(env).pipe(
     Layer.provide(Layer.mergeAll(config, runtimeConfig, gate))
+  );
+  const stripeWebhook = stripeWebhookLiveLayer().pipe(Layer.provide(Layer.mergeAll(config, audit)));
+  const stripeMeter = stripeMeterLiveLayer(env).pipe(
+    Layer.provide(Layer.mergeAll(stripeClient, config, audit))
+  );
+  const stripeBilling = stripeBillingLiveLayer(env).pipe(
+    Layer.provide(Layer.mergeAll(stripeClient, config))
   );
 
   const layer = Layer.mergeAll(
@@ -54,7 +70,11 @@ export function paymentsServicesLiveLayer(
     facilitator,
     runtimeConfig,
     enforcement,
-    discovery
+    discovery,
+    stripeClient,
+    stripeWebhook,
+    stripeMeter,
+    stripeBilling
   );
   layerCache.set(key, layer);
   return layer;

--- a/packages/clawql-payments/src/stripe/client.ts
+++ b/packages/clawql-payments/src/stripe/client.ts
@@ -9,9 +9,11 @@ export function resolveStripeSecretKey(env: NodeJS.ProcessEnv = process.env): st
   return key;
 }
 
-export function isStripeConfigured(env: NodeJS.ProcessEnv = process.env): boolean {
-  return Boolean(env.STRIPE_SECRET_KEY?.trim());
-}
+export {
+  isStripeConfigured,
+  StripeClientService,
+  stripeClientLiveLayer,
+} from "./stripe-client-service.js";
 
 export function createStripeClient(env: NodeJS.ProcessEnv = process.env): Stripe {
   return new Stripe(resolveStripeSecretKey(env));

--- a/packages/clawql-payments/src/stripe/customer.ts
+++ b/packages/clawql-payments/src/stripe/customer.ts
@@ -1,34 +1,21 @@
-import { createStripeClient } from "./client.js";
+import { Effect } from "effect";
+import { runPaymentsEffect } from "../runtime/payments-effect-runtime.js";
+import {
+  StripeBillingService,
+  type StripeCustomerInput,
+  type StripeCustomerResult,
+} from "./stripe-billing-service.js";
 
-export type StripeCustomerInput = {
-  email: string;
-  name?: string;
-  metadata?: Record<string, string>;
-  env?: NodeJS.ProcessEnv;
-};
-
-export type StripeCustomerResult = {
-  id: string;
-  email: string;
-  name?: string | null;
-  status: "live";
-};
+export type { StripeCustomerInput, StripeCustomerResult };
 
 export async function createStripeCustomer(
   input: StripeCustomerInput
 ): Promise<StripeCustomerResult> {
-  const env = input.env ?? process.env;
-  const stripe = createStripeClient(env);
-  const customer = await stripe.customers.create({
-    email: input.email,
-    name: input.name,
-    metadata: input.metadata,
-  });
-
-  return {
-    id: customer.id,
-    email: customer.email ?? input.email,
-    name: customer.name,
-    status: "live",
-  };
+  return runPaymentsEffect(
+    Effect.gen(function* () {
+      const billing = yield* StripeBillingService;
+      return yield* billing.createCustomer(input);
+    }),
+    input.env
+  );
 }

--- a/packages/clawql-payments/src/stripe/invoice.ts
+++ b/packages/clawql-payments/src/stripe/invoice.ts
@@ -1,52 +1,19 @@
-import { createStripeClient } from "./client.js";
+import { Effect } from "effect";
+import { runPaymentsEffect } from "../runtime/payments-effect-runtime.js";
+import {
+  StripeBillingService,
+  type StripeInvoiceInput,
+  type StripeInvoiceResult,
+} from "./stripe-billing-service.js";
 
-export type StripeInvoiceInput = {
-  customerId: string;
-  amountCents: number;
-  description?: string;
-  currency?: string;
-  env?: NodeJS.ProcessEnv;
-};
-
-export type StripeInvoiceResult = {
-  id: string;
-  customerId: string;
-  amountCents: number;
-  status: string;
-  hostedInvoiceUrl?: string | null;
-};
+export type { StripeInvoiceInput, StripeInvoiceResult };
 
 export async function createStripeInvoice(input: StripeInvoiceInput): Promise<StripeInvoiceResult> {
-  const env = input.env ?? process.env;
-  const stripe = createStripeClient(env);
-  const currency = input.currency ?? "usd";
-
-  await stripe.invoiceItems.create({
-    customer: input.customerId,
-    amount: input.amountCents,
-    currency,
-    description: input.description,
-  });
-
-  const invoice = await stripe.invoices.create({
-    customer: input.customerId,
-    auto_advance: true,
-    collection_method: "send_invoice",
-    days_until_due: 30,
-  });
-
-  if (!invoice.id) {
-    throw new Error("Stripe invoice create did not return an id");
-  }
-
-  const finalized =
-    invoice.status === "draft" ? await stripe.invoices.finalizeInvoice(invoice.id) : invoice;
-
-  return {
-    id: finalized.id ?? invoice.id,
-    customerId: input.customerId,
-    amountCents: input.amountCents,
-    status: finalized.status ?? "open",
-    hostedInvoiceUrl: finalized.hosted_invoice_url,
-  };
+  return runPaymentsEffect(
+    Effect.gen(function* () {
+      const billing = yield* StripeBillingService;
+      return yield* billing.createInvoice(input);
+    }),
+    input.env
+  );
 }

--- a/packages/clawql-payments/src/stripe/meter-report.test.ts
+++ b/packages/clawql-payments/src/stripe/meter-report.test.ts
@@ -1,6 +1,13 @@
+import Stripe from "stripe";
+import { Effect, Layer } from "effect";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { resetDefaultAuditRingBufferForTests } from "clawql-core";
+import { paymentsConfigLiveLayer } from "../config/payments-config-service.js";
 import { listPaymentAuditEntries, resetPaymentAuditStoreForTests } from "../audit/worm.js";
+import { paymentAuditLiveLayer } from "../plugin/payment-audit-service.js";
+import { resetPaymentsEffectRuntimeForTests } from "../runtime/payments-effect-runtime.js";
+import { StripeClientService } from "./stripe-client-service.js";
+import { StripeMeterService, stripeMeterLiveLayer } from "./stripe-meter-service.js";
 import {
   buildInferenceMeterIdentifier,
   isStripeMeterReportingActive,
@@ -8,17 +15,12 @@ import {
   resolveStripeMeterConfig,
 } from "./meter-report.js";
 
-vi.mock("./metered.js", () => ({
-  reportMeteredUsage: vi.fn(async () => ({ id: "meter_evt_test", value: 1 })),
-}));
-
-import { reportMeteredUsage } from "./metered.js";
-
 describe("stripe meter reporting", () => {
   beforeEach(async () => {
     resetDefaultAuditRingBufferForTests();
     await resetPaymentAuditStoreForTests();
-    vi.mocked(reportMeteredUsage).mockClear();
+    resetPaymentsEffectRuntimeForTests();
+    vi.restoreAllMocks();
   });
 
   it("isStripeMeterReportingActive respects env flag", () => {
@@ -50,36 +52,65 @@ describe("stripe meter reporting", () => {
       env: { STRIPE_SECRET_KEY: "sk_test" },
     });
     expect(result.reported).toBe(false);
-    expect(vi.mocked(reportMeteredUsage)).not.toHaveBeenCalled();
   });
 
   it("reportInferenceMeterUsageIfEnabled emits meter event and audit entry", async () => {
-    const result = await reportInferenceMeterUsageIfEnabled({
-      tenantId: "tenant-a",
-      correlationId: "corr-99",
-      env: {
-        STRIPE_SECRET_KEY: "sk_test_xxx",
-        STRIPE_CUSTOMER_ID: "cus_abc",
-        STRIPE_METER_EVENT_NAME: "clawql_inference_calls",
-        CLAWQL_PAYMENTS_REPORT_STRIPE_METER: "1",
-      },
+    const meterCreate = vi.fn(async () => ({ identifier: "meter_evt_test" }));
+    const env = {
+      STRIPE_SECRET_KEY: "sk_test_xxx",
+      STRIPE_CUSTOMER_ID: "cus_abc",
+      STRIPE_METER_EVENT_NAME: "clawql_inference_calls",
+      CLAWQL_PAYMENTS_REPORT_STRIPE_METER: "1",
+      CLAWQL_PAYMENTS_AUDIT_STORE: "memory",
+    } as NodeJS.ProcessEnv;
+
+    const stubStripe = {
+      billing: { meterEvents: { create: meterCreate } },
+    } as unknown as Stripe;
+
+    const stubClientLayer = Layer.succeed(
+      StripeClientService,
+      StripeClientService.of({
+        isConfigured: () => true,
+        getClient: () => Effect.succeed(stubStripe),
+        getClientOptional: () => stubStripe,
+      })
+    );
+
+    const layer = stripeMeterLiveLayer(env).pipe(
+      Layer.provide(
+        Layer.mergeAll(stubClientLayer, paymentsConfigLiveLayer(env), paymentAuditLiveLayer(env))
+      )
+    );
+
+    const program = Effect.gen(function* () {
+      const meter = yield* StripeMeterService;
+      return yield* meter.reportInferenceUsageIfEnabled({
+        tenantId: "tenant-a",
+        correlationId: "corr-99",
+        env,
+      });
     });
+
+    const result = await Effect.runPromise(program.pipe(Effect.provide(layer)));
 
     expect(result.reported).toBe(true);
     if (result.reported) {
       expect(result.eventId).toBe("meter_evt_test");
     }
 
-    expect(vi.mocked(reportMeteredUsage)).toHaveBeenCalledWith(
+    expect(meterCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        eventName: "clawql_inference_calls",
-        stripeCustomerId: "cus_abc",
-        value: 1,
+        event_name: "clawql_inference_calls",
+        payload: expect.objectContaining({
+          stripe_customer_id: "cus_abc",
+          value: "1",
+        }),
         identifier: "inference:tenant-a:corr-99",
       })
     );
 
-    const entries = await listPaymentAuditEntries(5);
+    const entries = await listPaymentAuditEntries(5, env);
     expect(entries.some((e) => e.action === "STRIPE_METER_REPORTED")).toBe(true);
   });
 });

--- a/packages/clawql-payments/src/stripe/meter-report.ts
+++ b/packages/clawql-payments/src/stripe/meter-report.ts
@@ -1,100 +1,42 @@
-import { appendPaymentWormEntry, buildStripeMeterReportedEntry } from "../audit/index.js";
-import { loadPaymentsConfig } from "../config/store.js";
-import { isStripeConfigured } from "./client.js";
-import { reportMeteredUsage } from "./metered.js";
+import { Effect } from "effect";
+import { runPaymentsEffect } from "../runtime/payments-effect-runtime.js";
+import {
+  StripeMeterService,
+  buildInferenceMeterIdentifier,
+  isStripeMeterReportingActive,
+  type ReportInferenceMeterUsageInput,
+  type ReportInferenceMeterUsageResult,
+  type StripeMeterConfig,
+} from "./stripe-meter-service.js";
 
-export type StripeMeterConfig = {
-  customerId: string;
-  eventName: string;
+export {
+  buildInferenceMeterIdentifier,
+  isStripeMeterReportingActive,
+  type ReportInferenceMeterUsageInput,
+  type ReportInferenceMeterUsageResult,
+  type StripeMeterConfig,
 };
-
-function parseTruthy(value: string | undefined): boolean {
-  if (value === undefined) return false;
-  const normalized = value.trim().toLowerCase();
-  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
-}
-
-export function isStripeMeterReportingActive(env: NodeJS.ProcessEnv = process.env): boolean {
-  return parseTruthy(env.CLAWQL_PAYMENTS_REPORT_STRIPE_METER);
-}
 
 export async function resolveStripeMeterConfig(
   env: NodeJS.ProcessEnv = process.env
 ): Promise<StripeMeterConfig | null> {
-  if (!isStripeConfigured(env)) return null;
-
-  const config = await loadPaymentsConfig(env);
-  const customerId =
-    config.stripe.customerId?.trim() || env.STRIPE_CUSTOMER_ID?.trim() || undefined;
-  const eventName =
-    config.stripe.meterEventName?.trim() || env.STRIPE_METER_EVENT_NAME?.trim() || undefined;
-
-  if (!customerId || !eventName) return null;
-  return { customerId, eventName };
+  return runPaymentsEffect(
+    Effect.gen(function* () {
+      const meter = yield* StripeMeterService;
+      return yield* meter.resolveMeterConfig(env);
+    }),
+    env
+  );
 }
-
-export function buildInferenceMeterIdentifier(input: {
-  tenantId: string;
-  correlationId?: string;
-}): string {
-  if (input.correlationId?.trim()) {
-    return `inference:${input.tenantId}:${input.correlationId.trim()}`;
-  }
-  return `inference:${input.tenantId}:${Date.now()}`;
-}
-
-export type ReportInferenceMeterUsageInput = {
-  tenantId: string;
-  value?: number;
-  correlationId?: string;
-  identifier?: string;
-  env?: NodeJS.ProcessEnv;
-};
-
-export type ReportInferenceMeterUsageResult =
-  { reported: true; eventId: string; value: number } | { reported: false; reason: string };
 
 export async function reportInferenceMeterUsageIfEnabled(
   input: ReportInferenceMeterUsageInput
 ): Promise<ReportInferenceMeterUsageResult> {
-  const env = input.env ?? process.env;
-  if (!isStripeMeterReportingActive(env)) {
-    return { reported: false, reason: "stripe meter reporting is disabled" };
-  }
-
-  const meterConfig = await resolveStripeMeterConfig(env);
-  if (!meterConfig) {
-    return {
-      reported: false,
-      reason: "stripe customer id or meter event name is not configured",
-    };
-  }
-
-  const value = input.value ?? 1;
-  const identifier =
-    input.identifier ??
-    buildInferenceMeterIdentifier({
-      tenantId: input.tenantId,
-      correlationId: input.correlationId,
-    });
-
-  const result = await reportMeteredUsage({
-    eventName: meterConfig.eventName,
-    stripeCustomerId: meterConfig.customerId,
-    value,
-    identifier,
-    env,
-  });
-
-  await appendPaymentWormEntry(
-    buildStripeMeterReportedEntry({
-      tenantId: input.tenantId,
-      value,
-      eventName: meterConfig.eventName,
-      stripeCustomerId: meterConfig.customerId,
-      correlationId: input.correlationId,
-    })
+  return runPaymentsEffect(
+    Effect.gen(function* () {
+      const meter = yield* StripeMeterService;
+      return yield* meter.reportInferenceUsageIfEnabled(input);
+    }),
+    input.env
   );
-
-  return { reported: true, eventId: result.id, value: result.value };
 }

--- a/packages/clawql-payments/src/stripe/metered.ts
+++ b/packages/clawql-payments/src/stripe/metered.ts
@@ -1,31 +1,17 @@
-import { createStripeClient } from "./client.js";
+import { Effect } from "effect";
+import { runPaymentsEffect } from "../runtime/payments-effect-runtime.js";
+import { StripeMeterService, type MeteredUsageInput } from "./stripe-meter-service.js";
 
-export type MeteredUsageInput = {
-  eventName: string;
-  stripeCustomerId: string;
-  value: number;
-  identifier?: string;
-  timestamp?: number;
-  env?: NodeJS.ProcessEnv;
-};
+export type { MeteredUsageInput };
 
 export async function reportMeteredUsage(
   input: MeteredUsageInput
 ): Promise<{ id: string; value: number }> {
-  const env = input.env ?? process.env;
-  const stripe = createStripeClient(env);
-  const event = await stripe.billing.meterEvents.create({
-    event_name: input.eventName,
-    payload: {
-      stripe_customer_id: input.stripeCustomerId,
-      value: String(input.value),
-    },
-    identifier: input.identifier,
-    timestamp: input.timestamp,
-  });
-
-  return {
-    id: event.identifier,
-    value: input.value,
-  };
+  return runPaymentsEffect(
+    Effect.gen(function* () {
+      const meter = yield* StripeMeterService;
+      return yield* meter.reportMeteredUsage(input);
+    }),
+    input.env
+  );
 }

--- a/packages/clawql-payments/src/stripe/portal.ts
+++ b/packages/clawql-payments/src/stripe/portal.ts
@@ -1,9 +1,6 @@
 import { Effect } from "effect";
 import { runPaymentsEffect } from "../runtime/payments-effect-runtime.js";
-import {
-  StripeBillingService,
-  type PortalSessionInput,
-} from "./stripe-billing-service.js";
+import { StripeBillingService, type PortalSessionInput } from "./stripe-billing-service.js";
 
 export type { PortalSessionInput };
 

--- a/packages/clawql-payments/src/stripe/portal.ts
+++ b/packages/clawql-payments/src/stripe/portal.ts
@@ -1,23 +1,20 @@
-import { createStripeClient } from "./client.js";
+import { Effect } from "effect";
+import { runPaymentsEffect } from "../runtime/payments-effect-runtime.js";
+import {
+  StripeBillingService,
+  type PortalSessionInput,
+} from "./stripe-billing-service.js";
 
-export type PortalSessionInput = {
-  customerId: string;
-  returnUrl: string;
-  env?: NodeJS.ProcessEnv;
-};
+export type { PortalSessionInput };
 
 export async function createCustomerPortalSession(
   input: PortalSessionInput
 ): Promise<{ url: string; customerId: string }> {
-  const env = input.env ?? process.env;
-  const stripe = createStripeClient(env);
-  const session = await stripe.billingPortal.sessions.create({
-    customer: input.customerId,
-    return_url: input.returnUrl,
-  });
-
-  return {
-    url: session.url,
-    customerId: input.customerId,
-  };
+  return runPaymentsEffect(
+    Effect.gen(function* () {
+      const billing = yield* StripeBillingService;
+      return yield* billing.createPortalSession(input);
+    }),
+    input.env
+  );
 }

--- a/packages/clawql-payments/src/stripe/setup.ts
+++ b/packages/clawql-payments/src/stripe/setup.ts
@@ -1,43 +1,22 @@
-import { mergePaymentsConfig } from "../config/store.js";
-import { isStripeConfigured } from "./client.js";
+import { Effect } from "effect";
+import { runPaymentsEffect } from "../runtime/payments-effect-runtime.js";
+import {
+  StripeBillingService,
+  type StripeSetupInput,
+  type StripeSetupResult,
+} from "./stripe-billing-service.js";
 
-export type StripeSetupInput = {
-  accountId?: string;
-  publishableKey?: string;
-  webhookSecret?: string;
-};
-
-export type StripeSetupResult = {
-  configured: boolean;
-  apiKeyConfigured: boolean;
-  path: string;
-  accountId?: string;
-};
+export type { StripeSetupInput, StripeSetupResult };
 
 export async function setupStripe(
   input: StripeSetupInput,
   env: NodeJS.ProcessEnv = process.env
 ): Promise<StripeSetupResult> {
-  const { config, path } = await mergePaymentsConfig(
-    {
-      stripe: {
-        accountId: input.accountId,
-        publishableKey: input.publishableKey,
-        webhookSecret: input.webhookSecret,
-      },
-    },
+  return runPaymentsEffect(
+    Effect.gen(function* () {
+      const billing = yield* StripeBillingService;
+      return yield* billing.setup(input, env);
+    }),
     env
   );
-
-  return {
-    configured: Boolean(
-      isStripeConfigured(env) ||
-      config.stripe.accountId ||
-      config.stripe.publishableKey ||
-      config.stripe.webhookSecret
-    ),
-    apiKeyConfigured: isStripeConfigured(env),
-    path,
-    accountId: config.stripe.accountId,
-  };
 }

--- a/packages/clawql-payments/src/stripe/stripe-billing-service.ts
+++ b/packages/clawql-payments/src/stripe/stripe-billing-service.ts
@@ -106,11 +106,7 @@ export class StripeBillingService extends Context.Tag("clawql/StripeBillingServi
 
 export function stripeBillingLiveLayer(
   env: NodeJS.ProcessEnv = process.env
-): Layer.Layer<
-  StripeBillingService,
-  never,
-  StripeClientService | PaymentsConfigService
-> {
+): Layer.Layer<StripeBillingService, never, StripeClientService | PaymentsConfigService> {
   return Layer.effect(
     StripeBillingService,
     Effect.gen(function* () {
@@ -129,9 +125,9 @@ export function stripeBillingLiveLayer(
           return {
             configured: Boolean(
               isStripeConfigured(runEnv) ||
-                config.stripe.accountId ||
-                config.stripe.publishableKey ||
-                config.stripe.webhookSecret
+              config.stripe.accountId ||
+              config.stripe.publishableKey ||
+              config.stripe.webhookSecret
             ),
             apiKeyConfigured: isStripeConfigured(runEnv),
             path,

--- a/packages/clawql-payments/src/stripe/stripe-billing-service.ts
+++ b/packages/clawql-payments/src/stripe/stripe-billing-service.ts
@@ -1,0 +1,245 @@
+import { Context, Effect, Layer } from "effect";
+import { getPlanDefinition, type ClawqlPlanId } from "../plans/tiers.js";
+import { PaymentsConfigService } from "../config/payments-config-service.js";
+import type { ConfigError } from "../errors/payment-errors.js";
+import { isStripeConfigured } from "./stripe-client-service.js";
+import { StripeApiError, StripeNotConfigured } from "./stripe-errors.js";
+import { StripeClientService, stripeTryPromise } from "./stripe-client-service.js";
+
+export type StripeSetupInput = {
+  accountId?: string;
+  publishableKey?: string;
+  webhookSecret?: string;
+};
+
+export type StripeSetupResult = {
+  configured: boolean;
+  apiKeyConfigured: boolean;
+  path: string;
+  accountId?: string;
+};
+
+export type StripeCustomerInput = {
+  email: string;
+  name?: string;
+  metadata?: Record<string, string>;
+  env?: NodeJS.ProcessEnv;
+};
+
+export type StripeCustomerResult = {
+  id: string;
+  email: string;
+  name?: string | null;
+  status: "live";
+};
+
+export type StripeSubscriptionInput = {
+  customerId: string;
+  plan: "pro" | "team";
+  env?: NodeJS.ProcessEnv;
+};
+
+export type StripeSubscriptionResult = {
+  id: string;
+  customerId: string;
+  plan: string;
+  priceId: string;
+  status: string;
+};
+
+export type StripeInvoiceInput = {
+  customerId: string;
+  amountCents: number;
+  description?: string;
+  currency?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+export type StripeInvoiceResult = {
+  id: string;
+  customerId: string;
+  amountCents: number;
+  status: string;
+  hostedInvoiceUrl?: string | null;
+};
+
+export type PortalSessionInput = {
+  customerId: string;
+  returnUrl: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+function resolvePriceId(plan: ClawqlPlanId): Effect.Effect<string, StripeNotConfigured> {
+  const priceId = getPlanDefinition(plan).stripe_price_id;
+  if (!priceId) {
+    return Effect.fail(
+      new StripeNotConfigured({
+        reason: `Stripe price id not configured for plan "${plan}" — set STRIPE_${plan.toUpperCase()}_PRICE_ID`,
+      })
+    );
+  }
+  return Effect.succeed(priceId);
+}
+
+/** Effect service for Stripe billing setup and CRUD helpers. */
+export class StripeBillingService extends Context.Tag("clawql/StripeBillingService")<
+  StripeBillingService,
+  {
+    readonly setup: (
+      input: StripeSetupInput,
+      env?: NodeJS.ProcessEnv
+    ) => Effect.Effect<StripeSetupResult, ConfigError>;
+    readonly createCustomer: (
+      input: StripeCustomerInput
+    ) => Effect.Effect<StripeCustomerResult, StripeApiError | StripeNotConfigured>;
+    readonly createSubscription: (
+      input: StripeSubscriptionInput
+    ) => Effect.Effect<StripeSubscriptionResult, StripeApiError | StripeNotConfigured>;
+    readonly createInvoice: (
+      input: StripeInvoiceInput
+    ) => Effect.Effect<StripeInvoiceResult, StripeApiError | StripeNotConfigured>;
+    readonly createPortalSession: (
+      input: PortalSessionInput
+    ) => Effect.Effect<{ url: string; customerId: string }, StripeApiError | StripeNotConfigured>;
+  }
+>() {}
+
+export function stripeBillingLiveLayer(
+  env: NodeJS.ProcessEnv = process.env
+): Layer.Layer<
+  StripeBillingService,
+  never,
+  StripeClientService | PaymentsConfigService
+> {
+  return Layer.effect(
+    StripeBillingService,
+    Effect.gen(function* () {
+      const stripeClient = yield* StripeClientService;
+      const configService = yield* PaymentsConfigService;
+
+      const setup = (input: StripeSetupInput, runEnv: NodeJS.ProcessEnv = env) =>
+        Effect.gen(function* () {
+          const { config, path } = yield* configService.merge({
+            stripe: {
+              accountId: input.accountId,
+              publishableKey: input.publishableKey,
+              webhookSecret: input.webhookSecret,
+            },
+          });
+          return {
+            configured: Boolean(
+              isStripeConfigured(runEnv) ||
+                config.stripe.accountId ||
+                config.stripe.publishableKey ||
+                config.stripe.webhookSecret
+            ),
+            apiKeyConfigured: isStripeConfigured(runEnv),
+            path,
+            accountId: config.stripe.accountId,
+          };
+        });
+
+      const createCustomer = (input: StripeCustomerInput) =>
+        Effect.gen(function* () {
+          const client = yield* stripeClient.getClient();
+          const customer = yield* stripeTryPromise("stripe customer create failed", () =>
+            client.customers.create({
+              email: input.email,
+              name: input.name,
+              metadata: input.metadata,
+            })
+          );
+          return {
+            id: customer.id,
+            email: customer.email ?? input.email,
+            name: customer.name,
+            status: "live" as const,
+          };
+        });
+
+      const createSubscription = (input: StripeSubscriptionInput) =>
+        Effect.gen(function* () {
+          const client = yield* stripeClient.getClient();
+          const priceId = yield* resolvePriceId(input.plan);
+          const subscription = yield* stripeTryPromise("stripe subscription create failed", () =>
+            client.subscriptions.create({
+              customer: input.customerId,
+              items: [{ price: priceId }],
+              payment_behavior: "default_incomplete",
+              expand: ["latest_invoice.payment_intent"],
+            })
+          );
+          return {
+            id: subscription.id,
+            customerId:
+              typeof subscription.customer === "string"
+                ? subscription.customer
+                : subscription.customer.id,
+            plan: input.plan,
+            priceId,
+            status: subscription.status,
+          };
+        });
+
+      const createInvoice = (input: StripeInvoiceInput) =>
+        Effect.gen(function* () {
+          const client = yield* stripeClient.getClient();
+          const currency = input.currency ?? "usd";
+          yield* stripeTryPromise("stripe invoice item create failed", () =>
+            client.invoiceItems.create({
+              customer: input.customerId,
+              amount: input.amountCents,
+              currency,
+              description: input.description,
+            })
+          );
+          const invoice = yield* stripeTryPromise("stripe invoice create failed", () =>
+            client.invoices.create({
+              customer: input.customerId,
+              auto_advance: true,
+              collection_method: "send_invoice",
+              days_until_due: 30,
+            })
+          );
+          if (!invoice.id) {
+            return yield* Effect.fail(
+              new StripeApiError({ reason: "Stripe invoice create did not return an id" })
+            );
+          }
+          const finalized =
+            invoice.status === "draft"
+              ? yield* stripeTryPromise("stripe invoice finalize failed", () =>
+                  client.invoices.finalizeInvoice(invoice.id!)
+                )
+              : invoice;
+          return {
+            id: finalized.id ?? invoice.id,
+            customerId: input.customerId,
+            amountCents: input.amountCents,
+            status: finalized.status ?? "open",
+            hostedInvoiceUrl: finalized.hosted_invoice_url,
+          };
+        });
+
+      const createPortalSession = (input: PortalSessionInput) =>
+        Effect.gen(function* () {
+          const client = yield* stripeClient.getClient();
+          const session = yield* stripeTryPromise("stripe portal session create failed", () =>
+            client.billingPortal.sessions.create({
+              customer: input.customerId,
+              return_url: input.returnUrl,
+            })
+          );
+          return { url: session.url, customerId: input.customerId };
+        });
+
+      return StripeBillingService.of({
+        setup,
+        createCustomer,
+        createSubscription,
+        createInvoice,
+        createPortalSession,
+      });
+    })
+  );
+}

--- a/packages/clawql-payments/src/stripe/stripe-client-service.ts
+++ b/packages/clawql-payments/src/stripe/stripe-client-service.ts
@@ -1,0 +1,64 @@
+import Stripe from "stripe";
+import { Context, Effect, Layer } from "effect";
+import { StripeApiError, StripeNotConfigured } from "./stripe-errors.js";
+
+function resolveStripeSecretKey(env: NodeJS.ProcessEnv): string | undefined {
+  return env.STRIPE_SECRET_KEY?.trim() || undefined;
+}
+
+/** Effect service for Stripe SDK client lifecycle. */
+export class StripeClientService extends Context.Tag("clawql/StripeClientService")<
+  StripeClientService,
+  {
+    readonly isConfigured: () => boolean;
+    readonly getClient: () => Effect.Effect<Stripe, StripeNotConfigured>;
+    readonly getClientOptional: () => Stripe | null;
+  }
+>() {}
+
+export function isStripeConfigured(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(resolveStripeSecretKey(env));
+}
+
+export function stripeClientLiveLayer(
+  env: NodeJS.ProcessEnv = process.env
+): Layer.Layer<StripeClientService> {
+  let cached: Stripe | null = null;
+
+  return Layer.succeed(
+    StripeClientService,
+    StripeClientService.of({
+      isConfigured: () => isStripeConfigured(env),
+      getClient: () => {
+        const key = resolveStripeSecretKey(env);
+        if (!key) {
+          return Effect.fail(
+            new StripeNotConfigured({
+              reason: "Stripe is not configured — set STRIPE_SECRET_KEY",
+            })
+          );
+        }
+        if (!cached) {
+          cached = new Stripe(key);
+        }
+        return Effect.succeed(cached);
+      },
+      getClientOptional: () => {
+        const key = resolveStripeSecretKey(env);
+        if (!key) return null;
+        if (!cached) cached = new Stripe(key);
+        return cached;
+      },
+    })
+  );
+}
+
+export function stripeTryPromise<A>(
+  reason: string,
+  fn: () => Promise<A>
+): Effect.Effect<A, StripeApiError> {
+  return Effect.tryPromise({
+    try: fn,
+    catch: (cause) => new StripeApiError({ reason, cause }),
+  });
+}

--- a/packages/clawql-payments/src/stripe/stripe-errors.ts
+++ b/packages/clawql-payments/src/stripe/stripe-errors.ts
@@ -1,0 +1,14 @@
+import { Data } from "effect";
+
+export class StripeNotConfigured extends Data.TaggedError("StripeNotConfigured")<{
+  readonly reason?: string;
+}> {}
+
+export class StripeSignatureError extends Data.TaggedError("StripeSignatureError")<{
+  readonly reason: string;
+}> {}
+
+export class StripeApiError extends Data.TaggedError("StripeApiError")<{
+  readonly reason: string;
+  readonly cause?: unknown;
+}> {}

--- a/packages/clawql-payments/src/stripe/stripe-meter-service.ts
+++ b/packages/clawql-payments/src/stripe/stripe-meter-service.ts
@@ -1,0 +1,171 @@
+import { Context, Effect, Layer } from "effect";
+import { PaymentsConfigService } from "../config/payments-config-service.js";
+import { buildStripeMeterReportedEntry } from "../audit/events.js";
+import type { ConfigError } from "../errors/payment-errors.js";
+import type { PaymentError } from "../errors/payment-errors.js";
+import { PaymentAuditService } from "../plugin/payment-audit-service.js";
+import { StripeApiError, StripeNotConfigured } from "./stripe-errors.js";
+import { StripeClientService, isStripeConfigured, stripeTryPromise } from "./stripe-client-service.js";
+
+export type StripeMeterConfig = {
+  customerId: string;
+  eventName: string;
+};
+
+export type MeteredUsageInput = {
+  eventName: string;
+  stripeCustomerId: string;
+  value: number;
+  identifier?: string;
+  timestamp?: number;
+  env?: NodeJS.ProcessEnv;
+};
+
+export type ReportInferenceMeterUsageInput = {
+  tenantId: string;
+  value?: number;
+  correlationId?: string;
+  identifier?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+export type ReportInferenceMeterUsageResult =
+  | { reported: true; eventId: string; value: number }
+  | { reported: false; reason: string };
+
+function parseTruthy(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+export function isStripeMeterReportingActive(env: NodeJS.ProcessEnv = process.env): boolean {
+  return parseTruthy(env.CLAWQL_PAYMENTS_REPORT_STRIPE_METER);
+}
+
+export function buildInferenceMeterIdentifier(input: {
+  tenantId: string;
+  correlationId?: string;
+}): string {
+  if (input.correlationId?.trim()) {
+    return `inference:${input.tenantId}:${input.correlationId.trim()}`;
+  }
+  return `inference:${input.tenantId}:${Date.now()}`;
+}
+
+/** Effect service for Stripe meter events and inference usage reporting. */
+export class StripeMeterService extends Context.Tag("clawql/StripeMeterService")<
+  StripeMeterService,
+  {
+    readonly resolveMeterConfig: (
+      env?: NodeJS.ProcessEnv
+    ) => Effect.Effect<StripeMeterConfig | null, ConfigError>;
+    readonly reportMeteredUsage: (
+      input: MeteredUsageInput
+    ) => Effect.Effect<{ id: string; value: number }, StripeApiError | StripeNotConfigured>;
+    readonly reportInferenceUsageIfEnabled: (
+      input: ReportInferenceMeterUsageInput
+    ) => Effect.Effect<
+      ReportInferenceMeterUsageResult,
+      ConfigError | PaymentError | StripeApiError | StripeNotConfigured
+    >;
+  }
+>() {}
+
+export function stripeMeterLiveLayer(
+  env: NodeJS.ProcessEnv = process.env
+): Layer.Layer<
+  StripeMeterService,
+  never,
+  StripeClientService | PaymentsConfigService | PaymentAuditService
+> {
+  return Layer.effect(
+    StripeMeterService,
+    Effect.gen(function* () {
+      const stripeClient = yield* StripeClientService;
+      const configService = yield* PaymentsConfigService;
+      const audit = yield* PaymentAuditService;
+
+      const resolveMeterConfig = (runEnv: NodeJS.ProcessEnv = env) =>
+        Effect.gen(function* () {
+          if (!isStripeConfigured(runEnv)) return null;
+          const config = yield* configService.load();
+          const customerId =
+            config.stripe.customerId?.trim() || runEnv.STRIPE_CUSTOMER_ID?.trim() || undefined;
+          const eventName =
+            config.stripe.meterEventName?.trim() ||
+            runEnv.STRIPE_METER_EVENT_NAME?.trim() ||
+            undefined;
+          if (!customerId || !eventName) return null;
+          return { customerId, eventName };
+        });
+
+      const reportMeteredUsage = (input: MeteredUsageInput) =>
+        Effect.gen(function* () {
+          const client = yield* stripeClient.getClient();
+          const event = yield* stripeTryPromise("stripe meter event create failed", () =>
+            client.billing.meterEvents.create({
+              event_name: input.eventName,
+              payload: {
+                stripe_customer_id: input.stripeCustomerId,
+                value: String(input.value),
+              },
+              identifier: input.identifier,
+              timestamp: input.timestamp,
+            })
+          );
+          return { id: event.identifier, value: input.value };
+        });
+
+      const reportInferenceUsageIfEnabled = (input: ReportInferenceMeterUsageInput) =>
+        Effect.gen(function* () {
+          const runEnv = input.env ?? env;
+          if (!isStripeMeterReportingActive(runEnv)) {
+            return { reported: false as const, reason: "stripe meter reporting is disabled" };
+          }
+
+          const meterConfig = yield* resolveMeterConfig(runEnv);
+          if (!meterConfig) {
+            return {
+              reported: false as const,
+              reason: "stripe customer id or meter event name is not configured",
+            };
+          }
+
+          const value = input.value ?? 1;
+          const identifier =
+            input.identifier ??
+            buildInferenceMeterIdentifier({
+              tenantId: input.tenantId,
+              correlationId: input.correlationId,
+            });
+
+          const result = yield* reportMeteredUsage({
+            eventName: meterConfig.eventName,
+            stripeCustomerId: meterConfig.customerId,
+            value,
+            identifier,
+            env: runEnv,
+          });
+
+          yield* audit.appendEntry(
+            buildStripeMeterReportedEntry({
+              tenantId: input.tenantId,
+              value,
+              eventName: meterConfig.eventName,
+              stripeCustomerId: meterConfig.customerId,
+              correlationId: input.correlationId,
+            })
+          );
+
+          return { reported: true as const, eventId: result.id, value: result.value };
+        });
+
+      return StripeMeterService.of({
+        resolveMeterConfig,
+        reportMeteredUsage,
+        reportInferenceUsageIfEnabled,
+      });
+    })
+  );
+}

--- a/packages/clawql-payments/src/stripe/stripe-meter-service.ts
+++ b/packages/clawql-payments/src/stripe/stripe-meter-service.ts
@@ -5,7 +5,11 @@ import type { ConfigError } from "../errors/payment-errors.js";
 import type { PaymentError } from "../errors/payment-errors.js";
 import { PaymentAuditService } from "../plugin/payment-audit-service.js";
 import { StripeApiError, StripeNotConfigured } from "./stripe-errors.js";
-import { StripeClientService, isStripeConfigured, stripeTryPromise } from "./stripe-client-service.js";
+import {
+  StripeClientService,
+  isStripeConfigured,
+  stripeTryPromise,
+} from "./stripe-client-service.js";
 
 export type StripeMeterConfig = {
   customerId: string;
@@ -30,8 +34,7 @@ export type ReportInferenceMeterUsageInput = {
 };
 
 export type ReportInferenceMeterUsageResult =
-  | { reported: true; eventId: string; value: number }
-  | { reported: false; reason: string };
+  { reported: true; eventId: string; value: number } | { reported: false; reason: string };
 
 function parseTruthy(value: string | undefined): boolean {
   if (value === undefined) return false;

--- a/packages/clawql-payments/src/stripe/stripe-webhook-service.ts
+++ b/packages/clawql-payments/src/stripe/stripe-webhook-service.ts
@@ -1,0 +1,194 @@
+import Stripe from "stripe";
+import { Context, Effect, Layer } from "effect";
+import { PaymentsConfigService } from "../config/payments-config-service.js";
+import {
+  buildPaymentWormEntry,
+  buildStripeInvoicePaidEntry,
+} from "../audit/events.js";
+import { PaymentAuditService } from "../plugin/payment-audit-service.js";
+import type { ConfigError } from "../errors/payment-errors.js";
+import type { PaymentError } from "../errors/payment-errors.js";
+import { StripeSignatureError } from "./stripe-errors.js";
+
+export type StripeWebhookVerifyResult =
+  | { ok: true; event: Stripe.Event }
+  | { ok: false; reason: string };
+
+export type ProcessStripeWebhookOptions = {
+  tenantId?: string;
+  correlationId?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+export type ProcessStripeWebhookResult = {
+  handled: boolean;
+  eventType: string;
+  eventId: string;
+};
+
+function tenantFromEvent(event: Stripe.Event, fallbackTenantId: string): string {
+  const object = event.data.object as { metadata?: Record<string, string> };
+  return object.metadata?.tenant_id?.trim() || fallbackTenantId;
+}
+
+export function verifyStripeWebhookSignature(
+  payload: string | Buffer,
+  signature: string,
+  secret: string
+): StripeWebhookVerifyResult {
+  if (!secret.trim()) {
+    return { ok: false, reason: "webhook secret is required" };
+  }
+  if (!signature.trim()) {
+    return { ok: false, reason: "Stripe-Signature header is required" };
+  }
+
+  try {
+    const event = Stripe.webhooks.constructEvent(payload, signature, secret);
+    return { ok: true, event };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, reason: message };
+  }
+}
+
+/** Effect service for Stripe webhook verification and WORM-audited event handling. */
+export class StripeWebhookService extends Context.Tag("clawql/StripeWebhookService")<
+  StripeWebhookService,
+  {
+    readonly verifySignature: (
+      payload: string | Buffer,
+      signature: string,
+      secret: string
+    ) => Effect.Effect<Stripe.Event, StripeSignatureError>;
+    readonly processEvent: (
+      event: Stripe.Event,
+      options?: ProcessStripeWebhookOptions
+    ) => Effect.Effect<ProcessStripeWebhookResult, ConfigError | PaymentError>;
+    readonly verifyAndProcess: (input: {
+      payload: string | Buffer;
+      signature: string;
+      secret: string;
+      tenantId?: string;
+      correlationId?: string;
+      env?: NodeJS.ProcessEnv;
+    }) => Effect.Effect<
+      ProcessStripeWebhookResult,
+      StripeSignatureError | ConfigError | PaymentError
+    >;
+  }
+>() {}
+
+export function stripeWebhookLiveLayer(): Layer.Layer<
+  StripeWebhookService,
+  never,
+  PaymentsConfigService | PaymentAuditService
+> {
+  return Layer.effect(
+    StripeWebhookService,
+    Effect.gen(function* () {
+      const configService = yield* PaymentsConfigService;
+      const audit = yield* PaymentAuditService;
+
+      const verifySignature = (payload: string | Buffer, signature: string, secret: string) =>
+        Effect.sync(() => verifyStripeWebhookSignature(payload, signature, secret)).pipe(
+          Effect.flatMap((result) =>
+            result.ok
+              ? Effect.succeed(result.event)
+              : Effect.fail(new StripeSignatureError({ reason: result.reason }))
+          )
+        );
+
+      const processEvent = (event: Stripe.Event, options: ProcessStripeWebhookOptions = {}) =>
+        Effect.gen(function* () {
+          const env = options.env ?? process.env;
+          const config = yield* configService.load();
+          const tenantId = options.tenantId ?? config.tenantId ?? "default";
+
+          switch (event.type) {
+            case "invoice.paid": {
+              const invoice = event.data.object as Stripe.Invoice;
+              const amountUsd = (invoice.amount_paid ?? 0) / 100;
+              yield* audit.appendEntry(
+                buildStripeInvoicePaidEntry({
+                  tenantId: tenantFromEvent(event, tenantId),
+                  amountUsd,
+                  plan: config.plan,
+                  correlationId: options.correlationId ?? event.id,
+                })
+              );
+              break;
+            }
+            case "invoice.payment_failed": {
+              const invoice = event.data.object as Stripe.Invoice;
+              yield* audit.appendEntry(
+                buildPaymentWormEntry({
+                  eventKind: "STRIPE_PAYMENT_FAILED",
+                  summary: `Stripe invoice payment failed for ${invoice.id}`,
+                  correlationId: options.correlationId ?? event.id,
+                  payload: {
+                    provider: "stripe",
+                    amount_usd: (invoice.amount_due ?? 0) / 100,
+                    tenant_id: tenantFromEvent(event, tenantId),
+                    plan: config.plan,
+                  },
+                })
+              );
+              break;
+            }
+            case "customer.subscription.created": {
+              const subscription = event.data.object as Stripe.Subscription;
+              yield* audit.appendEntry(
+                buildPaymentWormEntry({
+                  eventKind: "STRIPE_SUBSCRIPTION_CREATED",
+                  summary: `Stripe subscription created ${subscription.id}`,
+                  correlationId: options.correlationId ?? event.id,
+                  payload: {
+                    provider: "stripe",
+                    tenant_id: tenantFromEvent(event, tenantId),
+                    plan: config.plan,
+                  },
+                })
+              );
+              break;
+            }
+            default:
+              return {
+                handled: false,
+                eventType: event.type,
+                eventId: event.id,
+              };
+          }
+
+          return {
+            handled: true,
+            eventType: event.type,
+            eventId: event.id,
+          };
+        });
+
+      const verifyAndProcess = (input: {
+        payload: string | Buffer;
+        signature: string;
+        secret: string;
+        tenantId?: string;
+        correlationId?: string;
+        env?: NodeJS.ProcessEnv;
+      }) =>
+        Effect.gen(function* () {
+          const event = yield* verifySignature(input.payload, input.signature, input.secret);
+          return yield* processEvent(event, {
+            tenantId: input.tenantId,
+            correlationId: input.correlationId,
+            env: input.env,
+          });
+        });
+
+      return StripeWebhookService.of({
+        verifySignature,
+        processEvent,
+        verifyAndProcess,
+      });
+    })
+  );
+}

--- a/packages/clawql-payments/src/stripe/stripe-webhook-service.ts
+++ b/packages/clawql-payments/src/stripe/stripe-webhook-service.ts
@@ -97,7 +97,6 @@ export function stripeWebhookLiveLayer(): Layer.Layer<
 
       const processEvent = (event: Stripe.Event, options: ProcessStripeWebhookOptions = {}) =>
         Effect.gen(function* () {
-          const env = options.env ?? process.env;
           const config = yield* configService.load();
           const tenantId = options.tenantId ?? config.tenantId ?? "default";
 

--- a/packages/clawql-payments/src/stripe/stripe-webhook-service.ts
+++ b/packages/clawql-payments/src/stripe/stripe-webhook-service.ts
@@ -1,18 +1,14 @@
 import Stripe from "stripe";
 import { Context, Effect, Layer } from "effect";
 import { PaymentsConfigService } from "../config/payments-config-service.js";
-import {
-  buildPaymentWormEntry,
-  buildStripeInvoicePaidEntry,
-} from "../audit/events.js";
+import { buildPaymentWormEntry, buildStripeInvoicePaidEntry } from "../audit/events.js";
 import { PaymentAuditService } from "../plugin/payment-audit-service.js";
 import type { ConfigError } from "../errors/payment-errors.js";
 import type { PaymentError } from "../errors/payment-errors.js";
 import { StripeSignatureError } from "./stripe-errors.js";
 
 export type StripeWebhookVerifyResult =
-  | { ok: true; event: Stripe.Event }
-  | { ok: false; reason: string };
+  { ok: true; event: Stripe.Event } | { ok: false; reason: string };
 
 export type ProcessStripeWebhookOptions = {
   tenantId?: string;

--- a/packages/clawql-payments/src/stripe/subscription.ts
+++ b/packages/clawql-payments/src/stripe/subscription.ts
@@ -1,51 +1,21 @@
-import { getPlanDefinition, type ClawqlPlanId } from "../plans/tiers.js";
-import { createStripeClient } from "./client.js";
-import { StripeNotConfiguredError } from "./errors.js";
+import { Effect } from "effect";
+import { runPaymentsEffect } from "../runtime/payments-effect-runtime.js";
+import {
+  StripeBillingService,
+  type StripeSubscriptionInput,
+  type StripeSubscriptionResult,
+} from "./stripe-billing-service.js";
 
-export type StripeSubscriptionInput = {
-  customerId: string;
-  plan: "pro" | "team";
-  env?: NodeJS.ProcessEnv;
-};
-
-export type StripeSubscriptionResult = {
-  id: string;
-  customerId: string;
-  plan: string;
-  priceId: string;
-  status: string;
-};
-
-function resolvePriceId(plan: ClawqlPlanId, _env: NodeJS.ProcessEnv): string {
-  const priceId = getPlanDefinition(plan).stripe_price_id;
-  if (!priceId) {
-    throw new StripeNotConfiguredError(
-      `Stripe price id not configured for plan "${plan}" — set STRIPE_${plan.toUpperCase()}_PRICE_ID`
-    );
-  }
-  return priceId;
-}
+export type { StripeSubscriptionInput, StripeSubscriptionResult };
 
 export async function createStripeSubscription(
   input: StripeSubscriptionInput
 ): Promise<StripeSubscriptionResult> {
-  const env = input.env ?? process.env;
-  const stripe = createStripeClient(env);
-  const priceId = resolvePriceId(input.plan, env);
-
-  const subscription = await stripe.subscriptions.create({
-    customer: input.customerId,
-    items: [{ price: priceId }],
-    payment_behavior: "default_incomplete",
-    expand: ["latest_invoice.payment_intent"],
-  });
-
-  return {
-    id: subscription.id,
-    customerId:
-      typeof subscription.customer === "string" ? subscription.customer : subscription.customer.id,
-    plan: input.plan,
-    priceId,
-    status: subscription.status,
-  };
+  return runPaymentsEffect(
+    Effect.gen(function* () {
+      const billing = yield* StripeBillingService;
+      return yield* billing.createSubscription(input);
+    }),
+    input.env
+  );
 }

--- a/packages/clawql-payments/src/stripe/webhook.test.ts
+++ b/packages/clawql-payments/src/stripe/webhook.test.ts
@@ -76,11 +76,7 @@ describe("stripe webhook verification", () => {
       Effect.gen(function* () {
         const webhook = yield* StripeWebhookService;
         return yield* webhook.verifySignature(payload, signature, secret);
-      }).pipe(
-        Effect.provide(
-          paymentsServicesLiveLayer({ CLAWQL_PAYMENTS_AUDIT_STORE: "memory" })
-        )
-      )
+      }).pipe(Effect.provide(paymentsServicesLiveLayer({ CLAWQL_PAYMENTS_AUDIT_STORE: "memory" })))
     );
     expect(event.type).toBe("invoice.paid");
     expect(verifyFromService(payload, signature, secret).ok).toBe(true);

--- a/packages/clawql-payments/src/stripe/webhook.test.ts
+++ b/packages/clawql-payments/src/stripe/webhook.test.ts
@@ -1,4 +1,5 @@
 import Stripe from "stripe";
+import { Effect } from "effect";
 import { describe, expect, it, beforeEach } from "vitest";
 import { resetDefaultAuditRingBufferForTests } from "clawql-core";
 import {
@@ -8,11 +9,18 @@ import {
 } from "./webhook.js";
 import { StripeWebhookVerificationError } from "./errors.js";
 import { listPaymentAuditEntries, resetPaymentAuditStoreForTests } from "../audit/worm.js";
+import { resetPaymentsEffectRuntimeForTests } from "../runtime/payments-effect-runtime.js";
+import {
+  StripeWebhookService,
+  verifyStripeWebhookSignature as verifyFromService,
+} from "./stripe-webhook-service.js";
+import { paymentsServicesLiveLayer } from "../runtime/payments-effect-runtime.js";
 
 describe("stripe webhook verification", () => {
   beforeEach(async () => {
     resetDefaultAuditRingBufferForTests();
     await resetPaymentAuditStoreForTests();
+    resetPaymentsEffectRuntimeForTests();
   });
 
   const secret = "whsec_test_secret_for_clawql_payments";
@@ -53,9 +61,28 @@ describe("stripe webhook verification", () => {
   it("processes invoice.paid into payment audit trail", async () => {
     const signature = Stripe.webhooks.generateTestHeaderString({ payload, secret });
     const event = assertStripeWebhookSignature(payload, signature, secret);
-    const result = await processStripeWebhookEvent(event, { tenantId: "default" });
+    const result = await processStripeWebhookEvent(event, {
+      tenantId: "default",
+      env: { CLAWQL_PAYMENTS_AUDIT_STORE: "memory" },
+    });
     expect(result.handled).toBe(true);
     const entries = await listPaymentAuditEntries(10);
     expect(entries.some((e) => e.action === "STRIPE_INVOICE_PAID")).toBe(true);
+  });
+
+  it("StripeWebhookService verifySignature returns Effect for valid payload", async () => {
+    const signature = Stripe.webhooks.generateTestHeaderString({ payload, secret });
+    const event = await Effect.runPromise(
+      Effect.gen(function* () {
+        const webhook = yield* StripeWebhookService;
+        return yield* webhook.verifySignature(payload, signature, secret);
+      }).pipe(
+        Effect.provide(
+          paymentsServicesLiveLayer({ CLAWQL_PAYMENTS_AUDIT_STORE: "memory" })
+        )
+      )
+    );
+    expect(event.type).toBe("invoice.paid");
+    expect(verifyFromService(payload, signature, secret).ok).toBe(true);
   });
 });

--- a/packages/clawql-payments/src/stripe/webhook.ts
+++ b/packages/clawql-payments/src/stripe/webhook.ts
@@ -16,11 +16,7 @@ export type StripeWebhookEvent = {
   payload: Stripe.Event;
 };
 
-export type {
-  ProcessStripeWebhookOptions,
-  ProcessStripeWebhookResult,
-  StripeWebhookVerifyResult,
-};
+export type { ProcessStripeWebhookOptions, ProcessStripeWebhookResult, StripeWebhookVerifyResult };
 
 export { verifyStripeWebhookSignature };
 

--- a/packages/clawql-payments/src/stripe/webhook.ts
+++ b/packages/clawql-payments/src/stripe/webhook.ts
@@ -1,11 +1,14 @@
+import { Effect } from "effect";
 import Stripe from "stripe";
-import {
-  appendPaymentWormEntry,
-  buildPaymentWormEntry,
-  buildStripeInvoicePaidEntry,
-} from "../audit/index.js";
-import { loadPaymentsConfig } from "../config/store.js";
+import { runPaymentsEffect } from "../runtime/payments-effect-runtime.js";
 import { StripeWebhookVerificationError } from "./errors.js";
+import {
+  StripeWebhookService,
+  verifyStripeWebhookSignature,
+  type ProcessStripeWebhookOptions,
+  type ProcessStripeWebhookResult,
+  type StripeWebhookVerifyResult,
+} from "./stripe-webhook-service.js";
 
 export type StripeWebhookEvent = {
   id: string;
@@ -13,29 +16,13 @@ export type StripeWebhookEvent = {
   payload: Stripe.Event;
 };
 
-export type StripeWebhookVerifyResult =
-  { ok: true; event: Stripe.Event } | { ok: false; reason: string };
+export type {
+  ProcessStripeWebhookOptions,
+  ProcessStripeWebhookResult,
+  StripeWebhookVerifyResult,
+};
 
-export function verifyStripeWebhookSignature(
-  payload: string | Buffer,
-  signature: string,
-  secret: string
-): StripeWebhookVerifyResult {
-  if (!secret.trim()) {
-    return { ok: false, reason: "webhook secret is required" };
-  }
-  if (!signature.trim()) {
-    return { ok: false, reason: "Stripe-Signature header is required" };
-  }
-
-  try {
-    const event = Stripe.webhooks.constructEvent(payload, signature, secret);
-    return { ok: true, event };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return { ok: false, reason: message };
-  }
-}
+export { verifyStripeWebhookSignature };
 
 export function assertStripeWebhookSignature(
   payload: string | Buffer,
@@ -49,91 +36,17 @@ export function assertStripeWebhookSignature(
   return result.event;
 }
 
-export type ProcessStripeWebhookOptions = {
-  tenantId?: string;
-  correlationId?: string;
-  env?: NodeJS.ProcessEnv;
-};
-
-export type ProcessStripeWebhookResult = {
-  handled: boolean;
-  eventType: string;
-  eventId: string;
-};
-
-function tenantFromEvent(event: Stripe.Event, fallbackTenantId: string): string {
-  const object = event.data.object as { metadata?: Record<string, string> };
-  return object.metadata?.tenant_id?.trim() || fallbackTenantId;
-}
-
 export async function processStripeWebhookEvent(
   event: Stripe.Event,
   options: ProcessStripeWebhookOptions = {}
 ): Promise<ProcessStripeWebhookResult> {
-  const env = options.env ?? process.env;
-  const config = await loadPaymentsConfig(env);
-  const tenantId = options.tenantId ?? config.tenantId ?? "default";
-
-  switch (event.type) {
-    case "invoice.paid": {
-      const invoice = event.data.object as Stripe.Invoice;
-      const amountUsd = (invoice.amount_paid ?? 0) / 100;
-      await appendPaymentWormEntry(
-        buildStripeInvoicePaidEntry({
-          tenantId: tenantFromEvent(event, tenantId),
-          amountUsd,
-          plan: config.plan,
-          correlationId: options.correlationId ?? event.id,
-        })
-      );
-      break;
-    }
-    case "invoice.payment_failed": {
-      const invoice = event.data.object as Stripe.Invoice;
-      await appendPaymentWormEntry(
-        buildPaymentWormEntry({
-          eventKind: "STRIPE_PAYMENT_FAILED",
-          summary: `Stripe invoice payment failed for ${invoice.id}`,
-          correlationId: options.correlationId ?? event.id,
-          payload: {
-            provider: "stripe",
-            amount_usd: (invoice.amount_due ?? 0) / 100,
-            tenant_id: tenantFromEvent(event, tenantId),
-            plan: config.plan,
-          },
-        })
-      );
-      break;
-    }
-    case "customer.subscription.created": {
-      const subscription = event.data.object as Stripe.Subscription;
-      await appendPaymentWormEntry(
-        buildPaymentWormEntry({
-          eventKind: "STRIPE_SUBSCRIPTION_CREATED",
-          summary: `Stripe subscription created ${subscription.id}`,
-          correlationId: options.correlationId ?? event.id,
-          payload: {
-            provider: "stripe",
-            tenant_id: tenantFromEvent(event, tenantId),
-            plan: config.plan,
-          },
-        })
-      );
-      break;
-    }
-    default:
-      return {
-        handled: false,
-        eventType: event.type,
-        eventId: event.id,
-      };
-  }
-
-  return {
-    handled: true,
-    eventType: event.type,
-    eventId: event.id,
-  };
+  return runPaymentsEffect(
+    Effect.gen(function* () {
+      const webhook = yield* StripeWebhookService;
+      return yield* webhook.processEvent(event, options);
+    }),
+    options.env
+  );
 }
 
 export async function verifyAndProcessStripeWebhook(input: {
@@ -144,10 +57,11 @@ export async function verifyAndProcessStripeWebhook(input: {
   correlationId?: string;
   env?: NodeJS.ProcessEnv;
 }): Promise<ProcessStripeWebhookResult> {
-  const event = assertStripeWebhookSignature(input.payload, input.signature, input.secret);
-  return processStripeWebhookEvent(event, {
-    tenantId: input.tenantId,
-    correlationId: input.correlationId,
-    env: input.env,
-  });
+  return runPaymentsEffect(
+    Effect.gen(function* () {
+      const webhook = yield* StripeWebhookService;
+      return yield* webhook.verifyAndProcess(input);
+    }),
+    input.env
+  );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the **Stripe Effect migration** for `clawql-payments`, following the webhook-first pattern from the monorepo Effect strategy (typed failure modes, Layer DI, boundary-only async exports).

Follows merged #597 (x402 + core payments Effect services).

### New Effect services

| Service | Responsibility |
|---------|----------------|
| `StripeClientService` | SDK client lifecycle (`getClient`, `isConfigured`) |
| `StripeWebhookService` | Signature verify + WORM-audited `invoice.paid` / `payment_failed` / `subscription.created` |
| `StripeMeterService` | Meter events + inference usage reporting |
| `StripeBillingService` | Setup, customer, subscription, invoice, portal |

### Tagged errors

- `StripeNotConfigured`, `StripeSignatureError`, `StripeApiError`
- Legacy `StripeNotConfiguredError` / `StripeWebhookVerificationError` preserved at async boundaries for CLI/tests

### Architecture

- All Stripe async exports delegate to `runPaymentsEffect` + `paymentsServicesLiveLayer()`
- Webhook handler is native `Effect.gen` over `PaymentAuditService` + `PaymentsConfigService`
- Test layers demonstrate injectable Stripe client (meter-report test)

### Next steps (per full-monorepo Effect plan)

1. `clawql-core` shared base layers (WORM, config, audit tags)
2. `clawql-inference` — PAL router, fallback chains, `Effect.Stream` for SSE
3. Optional `@effect/schema` at boundaries (keep Zod elsewhere for now)

## Tests

- 66/66 `clawql-payments` tests passing
- Full monorepo build green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

