### PR TITLE
feat(inference): Effect fallback chain executor

### DIFF
--- a/docs/inference/clawql-inference.md
+++ b/docs/inference/clawql-inference.md
@@ -229,6 +229,8 @@ export CLAWQL_INFERENCE_FALLBACK_STANDARD=groq/llama-3.3-70b,anthropic/claude-ha
 
 Chains also persist at `$CLAWQL_HOME/Inference/fallback-chains.json` (`byTier` / `byModel`). Responses include `fallback.attempted` and `fallback.succeeded`.
 
+`FallbackChainGateway` keeps the public `InferenceGateway` API (`Promise`-based `complete()`). Internally, retry logic runs through Effect services (`InferenceGatewayService`, `FallbackChainService`) with `runFallbackEffect()` at the async boundary—matching the boundary-only Effect pattern used in `clawql-payments`.
+
 ```bash
 clawql inference fallback
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -12324,6 +12324,7 @@
                 "clawql-api": "7.0.0",
                 "clawql-core": "7.0.0",
                 "clawql-payments": "7.0.0",
+                "effect": "^3.21.4",
                 "express": "^5.2.1",
                 "pg": "^8.21.0",
                 "zod": "^4.3.6"

--- a/packages/clawql-inference/package.json
+++ b/packages/clawql-inference/package.json
@@ -44,6 +44,7 @@
     "clawql-api": "7.0.0",
     "clawql-core": "7.0.0",
     "clawql-payments": "7.0.0",
+    "effect": "^3.21.4",
     "express": "^5.2.1",
     "pg": "^8.21.0",
     "zod": "^4.3.6"

--- a/packages/clawql-inference/src/fallback/effect/fallback-chain-service.test.ts
+++ b/packages/clawql-inference/src/fallback/effect/fallback-chain-service.test.ts
@@ -1,0 +1,120 @@
+import { Cause, Effect, Layer } from "effect";
+import { describe, expect, it } from "vitest";
+import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../../gateway.js";
+import { FallbackExhaustedError } from "./fallback-errors.js";
+import { FallbackChainService, fallbackChainLiveLayer } from "./fallback-chain-service.js";
+import { InferenceGatewayService } from "./inference-gateway-service.js";
+
+class StubGateway implements InferenceGateway {
+  constructor(private readonly outcomes: Record<string, InferenceResponse | Error>) {}
+
+  async complete(request: InferenceRequest): Promise<InferenceResponse> {
+    const model = request.model ?? "unknown";
+    const outcome = this.outcomes[model];
+    if (!outcome) throw new Error(`no stub for ${model}`);
+    if (outcome instanceof Error) throw outcome;
+    return outcome;
+  }
+}
+
+function stubGatewayLayer(inner: InferenceGateway) {
+  return Layer.succeed(
+    InferenceGatewayService,
+    InferenceGatewayService.of({
+      complete: (request) =>
+        Effect.tryPromise({
+          try: () => inner.complete(request),
+          catch: (cause) => cause,
+        }),
+    })
+  );
+}
+
+describe("FallbackChainService", () => {
+  it("tries fallbacks in order after primary failure", async () => {
+    const inner = new StubGateway({
+      "openai/gpt-4o": new Error("rate limited"),
+      "anthropic/claude-sonnet-4": { content: "backup", model: "anthropic/claude-sonnet-4" },
+    });
+
+    const layer = fallbackChainLiveLayer({
+      enabled: true,
+      chains: {
+        byModel: {
+          "openai/gpt-4o": ["openai/gpt-4o", "anthropic/claude-sonnet-4"],
+        },
+        byTier: {},
+      },
+    }).pipe(Layer.provide(stubGatewayLayer(inner)));
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fallback = yield* FallbackChainService;
+        return yield* fallback.completeWithFallback({
+          model: "openai/gpt-4o",
+          messages: [{ role: "user", content: "hi" }],
+        });
+      }).pipe(Effect.provide(layer))
+    );
+
+    expect(result.content).toBe("backup");
+    expect(result.fallback?.succeeded).toBe("anthropic/claude-sonnet-4");
+    expect(result.fallback?.attempted).toEqual(["openai/gpt-4o", "anthropic/claude-sonnet-4"]);
+  });
+
+  it("fails with FallbackExhaustedError when all models fail", async () => {
+    const inner = new StubGateway({
+      "openai/gpt-4o": new Error("rate limited"),
+      "anthropic/claude-sonnet-4": new Error("also down"),
+    });
+
+    const layer = fallbackChainLiveLayer({
+      enabled: true,
+      chains: {
+        byModel: {
+          "openai/gpt-4o": ["openai/gpt-4o", "anthropic/claude-sonnet-4"],
+        },
+        byTier: {},
+      },
+    }).pipe(Layer.provide(stubGatewayLayer(inner)));
+
+    const exit = await Effect.runPromiseExit(
+      Effect.gen(function* () {
+        const fallback = yield* FallbackChainService;
+        return yield* fallback.completeWithFallback({
+          model: "openai/gpt-4o",
+          messages: [{ role: "user", content: "hi" }],
+        });
+      }).pipe(Effect.provide(layer))
+    );
+
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      const err = Cause.squash(exit.cause);
+      expect(err).toBeInstanceOf(FallbackExhaustedError);
+    }
+  });
+
+  it("passes through when disabled", async () => {
+    const inner = new StubGateway({
+      m: { content: "ok", model: "m" },
+    });
+
+    const layer = fallbackChainLiveLayer({
+      enabled: false,
+      chains: { byTier: {}, byModel: {} },
+    }).pipe(Layer.provide(stubGatewayLayer(inner)));
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fallback = yield* FallbackChainService;
+        return yield* fallback.completeWithFallback({
+          model: "m",
+          messages: [{ role: "user", content: "x" }],
+        });
+      }).pipe(Effect.provide(layer))
+    );
+
+    expect(result.content).toBe("ok");
+  });
+});

--- a/packages/clawql-inference/src/fallback/effect/fallback-chain-service.ts
+++ b/packages/clawql-inference/src/fallback/effect/fallback-chain-service.ts
@@ -1,0 +1,71 @@
+import { Context, Effect, Either, Layer } from "effect";
+import type { InferenceRequest, InferenceResponse } from "../../gateway.js";
+import { resolveFallbackChain } from "../resolve.js";
+import type { FallbackConfig } from "../types.js";
+import { FallbackExhaustedError } from "./fallback-errors.js";
+import { InferenceGatewayService } from "./inference-gateway-service.js";
+
+/** Effect service for ordered model fallback within a single `complete()` call. */
+export class FallbackChainService extends Context.Tag("clawql/FallbackChainService")<
+  FallbackChainService,
+  {
+    readonly completeWithFallback: (
+      request: InferenceRequest
+    ) => Effect.Effect<InferenceResponse, FallbackExhaustedError | unknown>;
+  }
+>() {}
+
+export function fallbackChainLiveLayer(
+  config: FallbackConfig
+): Layer.Layer<FallbackChainService, never, InferenceGatewayService> {
+  return Layer.effect(
+    FallbackChainService,
+    Effect.gen(function* () {
+      const gateway = yield* InferenceGatewayService;
+
+      const completeWithFallback = (request: InferenceRequest) =>
+        Effect.gen(function* () {
+          if (!config.enabled) {
+            return yield* gateway.complete(request);
+          }
+
+          const chain = resolveFallbackChain(request, config.chains);
+          if (chain.length <= 1) {
+            return yield* gateway.complete(request);
+          }
+
+          const attempted: string[] = [];
+          let lastError: unknown;
+
+          for (const modelId of chain) {
+            attempted.push(modelId);
+            const result = yield* gateway
+              .complete({ ...request, model: modelId })
+              .pipe(Effect.either);
+
+            if (Either.isRight(result)) {
+              const primary = request.model ?? request.routing?.modelId ?? modelId;
+              if (modelId === primary) {
+                return result.right;
+              }
+              return {
+                ...result.right,
+                model: result.right.model || modelId,
+                fallback: { attempted: [...attempted], succeeded: modelId },
+              };
+            }
+            lastError = result.left;
+          }
+
+          return yield* Effect.fail(
+            new FallbackExhaustedError({
+              attempted,
+              cause: lastError,
+            })
+          );
+        });
+
+      return FallbackChainService.of({ completeWithFallback });
+    })
+  );
+}

--- a/packages/clawql-inference/src/fallback/effect/fallback-errors.ts
+++ b/packages/clawql-inference/src/fallback/effect/fallback-errors.ts
@@ -1,0 +1,7 @@
+import { Data } from "effect";
+
+/** All models in a fallback chain failed. */
+export class FallbackExhaustedError extends Data.TaggedError("FallbackExhaustedError")<{
+  readonly attempted: readonly string[];
+  readonly cause: unknown;
+}> {}

--- a/packages/clawql-inference/src/fallback/effect/fallback-layer.ts
+++ b/packages/clawql-inference/src/fallback/effect/fallback-layer.ts
@@ -3,10 +3,7 @@ import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../.
 import type { FallbackConfig } from "../types.js";
 import { FallbackExhaustedError } from "./fallback-errors.js";
 import { FallbackChainService, fallbackChainLiveLayer } from "./fallback-chain-service.js";
-import {
-  InferenceGatewayService,
-  inferenceGatewayLiveLayer,
-} from "./inference-gateway-service.js";
+import { InferenceGatewayService, inferenceGatewayLiveLayer } from "./inference-gateway-service.js";
 
 export type FallbackServices = FallbackChainService;
 

--- a/packages/clawql-inference/src/fallback/effect/fallback-layer.ts
+++ b/packages/clawql-inference/src/fallback/effect/fallback-layer.ts
@@ -3,7 +3,7 @@ import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../.
 import type { FallbackConfig } from "../types.js";
 import { FallbackExhaustedError } from "./fallback-errors.js";
 import { FallbackChainService, fallbackChainLiveLayer } from "./fallback-chain-service.js";
-import { InferenceGatewayService, inferenceGatewayLiveLayer } from "./inference-gateway-service.js";
+import { inferenceGatewayLiveLayer } from "./inference-gateway-service.js";
 
 export type FallbackServices = FallbackChainService;
 

--- a/packages/clawql-inference/src/fallback/effect/fallback-layer.ts
+++ b/packages/clawql-inference/src/fallback/effect/fallback-layer.ts
@@ -1,0 +1,56 @@
+import { Cause, Effect, Exit, Layer } from "effect";
+import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../../gateway.js";
+import type { FallbackConfig } from "../types.js";
+import { FallbackExhaustedError } from "./fallback-errors.js";
+import { FallbackChainService, fallbackChainLiveLayer } from "./fallback-chain-service.js";
+import {
+  InferenceGatewayService,
+  inferenceGatewayLiveLayer,
+} from "./inference-gateway-service.js";
+
+export type FallbackServices = FallbackChainService;
+
+export function makeFallbackLayer(
+  inner: InferenceGateway,
+  config: FallbackConfig
+): Layer.Layer<FallbackChainService> {
+  return fallbackChainLiveLayer(config).pipe(Layer.provide(inferenceGatewayLiveLayer(inner)));
+}
+
+function squashFallbackFailure(cause: Cause.Cause<unknown>): never {
+  const err = Cause.squash(cause);
+  if (err instanceof FallbackExhaustedError) {
+    if (err.cause instanceof Error) {
+      throw err.cause;
+    }
+    throw new Error(
+      `All fallback models failed (${err.attempted.join(" → ")}): ${String(err.cause)}`
+    );
+  }
+  throw err;
+}
+
+/** Run a fallback Effect program with gateway + config layers. */
+export async function runFallbackEffect<A>(
+  program: Effect.Effect<A, unknown, FallbackServices>,
+  inner: InferenceGateway,
+  config: FallbackConfig
+): Promise<A> {
+  const exit = await Effect.runPromiseExit(
+    program.pipe(Effect.provide(makeFallbackLayer(inner, config)))
+  );
+  if (Exit.isSuccess(exit)) {
+    return exit.value;
+  }
+  squashFallbackFailure(exit.cause);
+}
+
+/** Complete with fallback chain via Effect services (used by {@link FallbackChainGateway}). */
+export function completeWithFallbackProgram(
+  request: InferenceRequest
+): Effect.Effect<InferenceResponse, unknown, FallbackChainService> {
+  return Effect.gen(function* () {
+    const fallback = yield* FallbackChainService;
+    return yield* fallback.completeWithFallback(request);
+  });
+}

--- a/packages/clawql-inference/src/fallback/effect/index.ts
+++ b/packages/clawql-inference/src/fallback/effect/index.ts
@@ -1,0 +1,15 @@
+export { FallbackExhaustedError } from "./fallback-errors.js";
+export {
+  FallbackChainService,
+  fallbackChainLiveLayer,
+} from "./fallback-chain-service.js";
+export {
+  InferenceGatewayService,
+  inferenceGatewayLiveLayer,
+} from "./inference-gateway-service.js";
+export {
+  completeWithFallbackProgram,
+  makeFallbackLayer,
+  runFallbackEffect,
+  type FallbackServices,
+} from "./fallback-layer.js";

--- a/packages/clawql-inference/src/fallback/effect/index.ts
+++ b/packages/clawql-inference/src/fallback/effect/index.ts
@@ -1,12 +1,6 @@
 export { FallbackExhaustedError } from "./fallback-errors.js";
-export {
-  FallbackChainService,
-  fallbackChainLiveLayer,
-} from "./fallback-chain-service.js";
-export {
-  InferenceGatewayService,
-  inferenceGatewayLiveLayer,
-} from "./inference-gateway-service.js";
+export { FallbackChainService, fallbackChainLiveLayer } from "./fallback-chain-service.js";
+export { InferenceGatewayService, inferenceGatewayLiveLayer } from "./inference-gateway-service.js";
 export {
   completeWithFallbackProgram,
   makeFallbackLayer,

--- a/packages/clawql-inference/src/fallback/effect/inference-gateway-service.ts
+++ b/packages/clawql-inference/src/fallback/effect/inference-gateway-service.ts
@@ -5,9 +5,7 @@ import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../.
 export class InferenceGatewayService extends Context.Tag("clawql/InferenceGatewayService")<
   InferenceGatewayService,
   {
-    readonly complete: (
-      request: InferenceRequest
-    ) => Effect.Effect<InferenceResponse, unknown>;
+    readonly complete: (request: InferenceRequest) => Effect.Effect<InferenceResponse, unknown>;
   }
 >() {}
 

--- a/packages/clawql-inference/src/fallback/effect/inference-gateway-service.ts
+++ b/packages/clawql-inference/src/fallback/effect/inference-gateway-service.ts
@@ -1,0 +1,27 @@
+import { Context, Effect, Layer } from "effect";
+import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../../gateway.js";
+
+/** Effect wrapper for an inner {@link InferenceGateway} (fallback chain attempts). */
+export class InferenceGatewayService extends Context.Tag("clawql/InferenceGatewayService")<
+  InferenceGatewayService,
+  {
+    readonly complete: (
+      request: InferenceRequest
+    ) => Effect.Effect<InferenceResponse, unknown>;
+  }
+>() {}
+
+export function inferenceGatewayLiveLayer(
+  inner: InferenceGateway
+): Layer.Layer<InferenceGatewayService> {
+  return Layer.succeed(
+    InferenceGatewayService,
+    InferenceGatewayService.of({
+      complete: (request) =>
+        Effect.tryPromise({
+          try: () => inner.complete(request),
+          catch: (cause) => cause,
+        }),
+    })
+  );
+}

--- a/packages/clawql-inference/src/fallback/fallback-gateway.ts
+++ b/packages/clawql-inference/src/fallback/fallback-gateway.ts
@@ -9,11 +9,7 @@ export class FallbackChainGateway implements InferenceGateway {
   ) {}
 
   async complete(request: InferenceRequest): Promise<InferenceResponse> {
-    return runFallbackEffect(
-      completeWithFallbackProgram(request),
-      this.inner,
-      this.config
-    );
+    return runFallbackEffect(completeWithFallbackProgram(request), this.inner, this.config);
   }
 }
 

--- a/packages/clawql-inference/src/fallback/fallback-gateway.ts
+++ b/packages/clawql-inference/src/fallback/fallback-gateway.ts
@@ -1,6 +1,6 @@
 import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../gateway.js";
 import type { FallbackConfig } from "./types.js";
-import { resolveFallbackChain } from "./resolve.js";
+import { completeWithFallbackProgram, runFallbackEffect } from "./effect/fallback-layer.js";
 
 export class FallbackChainGateway implements InferenceGateway {
   constructor(
@@ -9,38 +9,11 @@ export class FallbackChainGateway implements InferenceGateway {
   ) {}
 
   async complete(request: InferenceRequest): Promise<InferenceResponse> {
-    if (!this.config.enabled) {
-      return this.inner.complete(request);
-    }
-
-    const chain = resolveFallbackChain(request, this.config.chains);
-    if (chain.length <= 1) {
-      return this.inner.complete(request);
-    }
-
-    const attempted: string[] = [];
-    let lastError: unknown;
-
-    for (const modelId of chain) {
-      attempted.push(modelId);
-      try {
-        const response = await this.inner.complete({ ...request, model: modelId });
-        const primary = request.model ?? request.routing?.modelId ?? modelId;
-        if (modelId === primary) {
-          return response;
-        }
-        return {
-          ...response,
-          model: response.model || modelId,
-          fallback: { attempted, succeeded: modelId },
-        };
-      } catch (error) {
-        lastError = error;
-      }
-    }
-
-    if (lastError instanceof Error) throw lastError;
-    throw new Error(`All fallback models failed (${attempted.join(" → ")}): ${String(lastError)}`);
+    return runFallbackEffect(
+      completeWithFallbackProgram(request),
+      this.inner,
+      this.config
+    );
   }
 }
 

--- a/packages/clawql-inference/src/index.ts
+++ b/packages/clawql-inference/src/index.ts
@@ -161,6 +161,17 @@ export {
 } from "./fallback/config.js";
 export { resolveFallbackChain, normalizeFallbackChain } from "./fallback/resolve.js";
 export type { FallbackAttempt, FallbackChainMap, FallbackConfig } from "./fallback/types.js";
+export {
+  FallbackExhaustedError,
+  FallbackChainService,
+  InferenceGatewayService,
+  completeWithFallbackProgram,
+  fallbackChainLiveLayer,
+  inferenceGatewayLiveLayer,
+  makeFallbackLayer,
+  runFallbackEffect,
+  type FallbackServices,
+} from "./fallback/effect/index.js";
 export { runInferenceFallbackShow, type InferenceFallbackShowOptions } from "./cli/fallback.js";
 export {
   runInferenceKeysCreate,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First slice of the `clawql-inference` Effect-TS migration: the **fallback chain executor** (`FallbackChainGateway`).

Public API is unchanged — `complete()` remains `Promise`-based. Internals now run through Effect services with Layer DI, matching the boundary-only pattern established in `clawql-payments` (#597).

## Changes

- Add `effect` dependency to `clawql-inference`
- **`InferenceGatewayService`** — wraps inner gateway `complete()` as `Effect`
- **`FallbackChainService`** — ordered retry loop via `Effect.gen` + `Either`
- **`FallbackExhaustedError`** — tagged error; maps to prior throw behavior at async boundary
- **`runFallbackEffect` / `makeFallbackLayer`** — Layer composition + `Cause.squash` failure handling
- Refactor `fallback-gateway.ts` to thin async wrapper
- Export Effect modules from package index for tests/advanced callers
- Brief doc note in `docs/inference/clawql-inference.md`

## Testing

- `npm run build -w clawql-inference` ✅
- `npm test -w clawql-inference` — 69 passed, 1 skipped ✅
- New unit tests for `FallbackChainService` (success, exhaustion, disabled pass-through)
- Existing `FallbackChainGateway` integration tests unchanged

## Migration plan context

Per agreed order: **payments (done/in progress) → inference fallback chains (this PR) → semantic cache → entitlements → PAL router → SSE streaming**.

## Related

- #597 (payments Effect MCP proxy — merged)
- #599 (Stripe Effect services — parallel track)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

