### PR TITLE
feat(inference): Effect entitlement enforcement gateway

### DIFF
--- a/docs/inference/clawql-inference.md
+++ b/docs/inference/clawql-inference.md
@@ -272,6 +272,8 @@ When plan enforcement is enabled, the gateway checks limits before each completi
 
 Limit breaches throw `EntitlementLimitError` (HTTP 402-shaped OpenAI error) and append a WORM payment audit entry.
 
+`EntitlementEnforcedGateway` keeps the public `InferenceGateway` API (`Promise`-based `complete()`). Internally, entitlement checks and billing run through Effect services wired to `clawql-payments` (`EntitlementEnforcementService`, `EntitlementService`, `UsageStoreService`, `StripeMeterService`) with `runEntitlementEffect()` at the async boundary.
+
 **Middleware order** in `createInferenceHttpApp()`: x402 payment middleware → virtual key auth → OpenAI-compat router.
 
 **Do not conflate** plan usage (`usage.json`), inference call-store tokens (`clawql inference spend`), and virtual-key USD budgets — see [Three usage systems](../payments/clawql-payments.md#three-usage-systems-do-not-conflate).

--- a/packages/clawql-inference/src/entitlements/check.ts
+++ b/packages/clawql-inference/src/entitlements/check.ts
@@ -11,7 +11,11 @@ import {
 
 export { isInferenceEntitlementEnforcementActive } from "./flags.js";
 
-export type { InferenceTenantContext, AssertInferenceEntitlementInput, RecordInferenceBillingInput };
+export type {
+  InferenceTenantContext,
+  AssertInferenceEntitlementInput,
+  RecordInferenceBillingInput,
+};
 
 export async function resolveInferenceTenantId(
   context: InferenceTenantContext = {},

--- a/packages/clawql-inference/src/entitlements/check.ts
+++ b/packages/clawql-inference/src/entitlements/check.ts
@@ -1,73 +1,37 @@
+import { runPaymentsEffect } from "clawql-payments/plugin";
 import {
-  appendPaymentWormEntry,
-  buildEntitlementLimitReachedEntry,
-  checkEntitlementLimit,
-  createUsageStore,
-  entitlementsFromPlan,
-  loadPaymentsConfig,
-  reportInferenceMeterUsageIfEnabled,
-} from "clawql-payments";
-import { EntitlementLimitError } from "./errors.js";
+  assertInferenceEntitlementEffect,
+  recordInferenceBillingEffect,
+  recordInferenceUsageEffect,
+  resolveInferenceTenantIdEffect,
+  type AssertInferenceEntitlementInput,
+  type InferenceTenantContext,
+  type RecordInferenceBillingInput,
+} from "./effect/entitlement-programs.js";
 
-function parseTruthy(value: string | undefined): boolean {
-  if (value === undefined) return false;
-  const normalized = value.trim().toLowerCase();
-  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
-}
+export { isInferenceEntitlementEnforcementActive } from "./flags.js";
 
-export function isInferenceEntitlementEnforcementActive(
-  env: NodeJS.ProcessEnv = process.env
-): boolean {
-  return parseTruthy(env.CLAWQL_PAYMENTS_ENFORCE_INFERENCE);
-}
-
-export type InferenceTenantContext = {
-  team?: string;
-  tenantId?: string;
-};
+export type { InferenceTenantContext, AssertInferenceEntitlementInput, RecordInferenceBillingInput };
 
 export async function resolveInferenceTenantId(
   context: InferenceTenantContext = {},
   env: NodeJS.ProcessEnv = process.env
 ): Promise<string> {
-  if (context.tenantId?.trim()) return context.tenantId.trim();
-  if (context.team?.trim()) return context.team.trim();
-  const config = await loadPaymentsConfig(env);
-  return config.tenantId?.trim() || "default";
+  return runPaymentsEffect(resolveInferenceTenantIdEffect(context), env);
 }
 
-export type AssertInferenceEntitlementInput = {
-  tenantId: string;
-  requested?: number;
-  correlationId?: string;
-  env?: NodeJS.ProcessEnv;
-};
-
 export async function assertInferenceEntitlement(
-  input: AssertInferenceEntitlementInput
+  input: AssertInferenceEntitlementInput & { env?: NodeJS.ProcessEnv }
 ): Promise<void> {
   const env = input.env ?? process.env;
-  const config = await loadPaymentsConfig(env);
-  const entitlements = entitlementsFromPlan(config.plan);
-  const usage = await createUsageStore(env).getUsage(input.tenantId);
-  const check = checkEntitlementLimit({
-    entitlements,
-    usage,
-    resource: "inference_calls",
-    requested: input.requested ?? 1,
-  });
-
-  if (!check.allowed) {
-    await appendPaymentWormEntry(
-      buildEntitlementLimitReachedEntry({
-        tenantId: input.tenantId,
-        plan: config.plan,
-        resource: "inference_calls",
-        correlationId: input.correlationId,
-      })
-    );
-    throw new EntitlementLimitError(check.reason);
-  }
+  await runPaymentsEffect(
+    assertInferenceEntitlementEffect({
+      tenantId: input.tenantId,
+      requested: input.requested,
+      correlationId: input.correlationId,
+    }),
+    env
+  );
 }
 
 export type RecordInferenceUsageInput = {
@@ -79,24 +43,18 @@ export type RecordInferenceUsageInput = {
 
 export async function recordInferenceUsage(input: RecordInferenceUsageInput): Promise<void> {
   const env = input.env ?? process.env;
-  const config = await loadPaymentsConfig(env);
-  await createUsageStore(env).increment(
-    input.tenantId,
-    "inference_calls",
-    input.amount ?? 1,
-    config.plan
-  );
+  await runPaymentsEffect(recordInferenceUsageEffect({ ...input, env }), env);
 }
 
 export async function recordInferenceBilling(input: RecordInferenceUsageInput): Promise<void> {
   const env = input.env ?? process.env;
-  if (isInferenceEntitlementEnforcementActive(env)) {
-    await recordInferenceUsage(input);
-  }
-  await reportInferenceMeterUsageIfEnabled({
-    tenantId: input.tenantId,
-    value: input.amount ?? 1,
-    correlationId: input.correlationId,
-    env,
-  });
+  await runPaymentsEffect(
+    recordInferenceBillingEffect({
+      tenantId: input.tenantId,
+      amount: input.amount,
+      correlationId: input.correlationId,
+      env,
+    }),
+    env
+  );
 }

--- a/packages/clawql-inference/src/entitlements/effect/entitlement-enforcement-service.test.ts
+++ b/packages/clawql-inference/src/entitlements/effect/entitlement-enforcement-service.test.ts
@@ -67,9 +67,7 @@ describe("EntitlementEnforcementService", () => {
 
   function makeLayer(inner: InferenceGateway) {
     return entitlementEnforcementLiveLayer(env).pipe(
-      Layer.provide(
-        Layer.mergeAll(stubGatewayLayer(inner), paymentsServicesLiveLayer(env))
-      )
+      Layer.provide(Layer.mergeAll(stubGatewayLayer(inner), paymentsServicesLiveLayer(env)))
     );
   }
 

--- a/packages/clawql-inference/src/entitlements/effect/entitlement-enforcement-service.test.ts
+++ b/packages/clawql-inference/src/entitlements/effect/entitlement-enforcement-service.test.ts
@@ -1,0 +1,140 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect, Layer } from "effect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resetPaymentsEffectRuntimeForTests } from "clawql-payments/plugin";
+import { createUsageStore } from "clawql-payments";
+import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../../gateway.js";
+import { InferenceGatewayService } from "../../fallback/effect/inference-gateway-service.js";
+import { EntitlementLimitError } from "../errors.js";
+import {
+  EntitlementEnforcementService,
+  entitlementEnforcementLiveLayer,
+} from "./entitlement-enforcement-service.js";
+import { paymentsServicesLiveLayer } from "clawql-payments/plugin";
+
+class StubGateway implements InferenceGateway {
+  readonly calls: InferenceRequest[] = [];
+
+  async complete(request: InferenceRequest): Promise<InferenceResponse> {
+    this.calls.push(request);
+    return {
+      content: "ok",
+      model: request.model ?? "stub/model",
+      correlationId: request.correlationId,
+    };
+  }
+}
+
+function stubGatewayLayer(inner: InferenceGateway) {
+  return Layer.succeed(
+    InferenceGatewayService,
+    InferenceGatewayService.of({
+      complete: (request) =>
+        Effect.tryPromise({
+          try: () => inner.complete(request),
+          catch: (cause) => cause,
+        }),
+    })
+  );
+}
+
+describe("EntitlementEnforcementService", () => {
+  let home: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    resetPaymentsEffectRuntimeForTests();
+    home = await mkdtemp(join(tmpdir(), "clawql-inference-entitlements-effect-"));
+    env = {
+      ...process.env,
+      CLAWQL_HOME: home,
+      CLAWQL_PAYMENTS_ENFORCE_INFERENCE: "1",
+    };
+    await mkdir(join(home, "Payments"), { recursive: true });
+    await writeFile(
+      join(home, "Payments", "payments.json"),
+      `${JSON.stringify({ plan: "free", tenantId: "default" }, null, 2)}\n`
+    );
+  });
+
+  afterEach(async () => {
+    resetPaymentsEffectRuntimeForTests();
+    await rm(home, { recursive: true, force: true });
+  });
+
+  function makeLayer(inner: InferenceGateway) {
+    return entitlementEnforcementLiveLayer(env).pipe(
+      Layer.provide(
+        Layer.mergeAll(stubGatewayLayer(inner), paymentsServicesLiveLayer(env))
+      )
+    );
+  }
+
+  it("allows completions under the monthly inference limit", async () => {
+    const inner = new StubGateway();
+    const layer = makeLayer(inner);
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const enforcement = yield* EntitlementEnforcementService;
+        return yield* enforcement.completeWithEnforcement({
+          model: "openai/gpt-4o",
+          messages: [{ role: "user", content: "hi" }],
+        });
+      }).pipe(Effect.provide(layer))
+    );
+
+    expect(result.content).toBe("ok");
+    expect(inner.calls).toHaveLength(1);
+  });
+
+  it("blocks completions when the monthly inference limit is reached", async () => {
+    const usageStore = createUsageStore(env);
+    for (let i = 0; i < 100; i++) {
+      await usageStore.increment("default", "inference_calls", 1, "free");
+    }
+
+    const inner = new StubGateway();
+    const layer = makeLayer(inner);
+
+    const exit = await Effect.runPromiseExit(
+      Effect.gen(function* () {
+        const enforcement = yield* EntitlementEnforcementService;
+        return yield* enforcement.completeWithEnforcement({
+          model: "openai/gpt-4o",
+          messages: [{ role: "user", content: "blocked" }],
+        });
+      }).pipe(Effect.provide(layer))
+    );
+
+    expect(exit._tag).toBe("Failure");
+    expect(inner.calls).toHaveLength(0);
+    if (exit._tag === "Failure") {
+      const { Cause } = await import("effect");
+      const err = Cause.squash(exit.cause);
+      expect(err).toBeInstanceOf(EntitlementLimitError);
+    }
+  });
+
+  it("uses virtual key team as tenant id for usage", async () => {
+    const inner = new StubGateway();
+    const layer = makeLayer(inner);
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const enforcement = yield* EntitlementEnforcementService;
+        return yield* enforcement.completeWithEnforcement({
+          model: "openai/gpt-4o",
+          messages: [{ role: "user", content: "team scoped" }],
+          team: "acme",
+        });
+      }).pipe(Effect.provide(layer))
+    );
+
+    const usage = await createUsageStore(env).getUsage("acme");
+    expect(usage.inferenceCalls).toBe(1);
+  });
+});

--- a/packages/clawql-inference/src/entitlements/effect/entitlement-enforcement-service.ts
+++ b/packages/clawql-inference/src/entitlements/effect/entitlement-enforcement-service.ts
@@ -1,0 +1,102 @@
+import { Context, Effect, Layer } from "effect";
+import {
+  EntitlementService,
+  PaymentAuditService,
+  PaymentsConfigService,
+  StripeMeterService,
+  UsageStoreService,
+  type PaymentsServices,
+} from "clawql-payments/plugin";
+import {
+  buildEntitlementLimitReachedEntry,
+  entitlementsFromPlan,
+} from "clawql-payments";
+import type { InferenceRequest, InferenceResponse } from "../../gateway.js";
+import { InferenceGatewayService } from "../../fallback/effect/inference-gateway-service.js";
+import { isInferenceEntitlementEnforcementActive } from "../flags.js";
+import { EntitlementLimitError } from "../errors.js";
+import { isStripeMeterReportingActive } from "clawql-payments";
+
+/** Effect service for plan entitlement checks around gateway completion. */
+export class EntitlementEnforcementService extends Context.Tag(
+  "clawql/EntitlementEnforcementService"
+)<
+  EntitlementEnforcementService,
+  {
+    readonly completeWithEnforcement: (
+      request: InferenceRequest
+    ) => Effect.Effect<InferenceResponse, unknown>;
+  }
+>() {}
+
+export function entitlementEnforcementLiveLayer(
+  env: NodeJS.ProcessEnv
+): Layer.Layer<
+  EntitlementEnforcementService,
+  never,
+  InferenceGatewayService | PaymentsServices
+> {
+  return Layer.effect(
+    EntitlementEnforcementService,
+    Effect.gen(function* () {
+      const gateway = yield* InferenceGatewayService;
+      const configService = yield* PaymentsConfigService;
+      const usageStore = yield* UsageStoreService;
+      const entitlement = yield* EntitlementService;
+      const audit = yield* PaymentAuditService;
+      const meter = yield* StripeMeterService;
+
+      const completeWithEnforcement = (request: InferenceRequest) =>
+        Effect.gen(function* () {
+          let tenantId = request.tenantId?.trim();
+          if (!tenantId && request.team?.trim()) tenantId = request.team.trim();
+          if (!tenantId) {
+            const config = yield* configService.load();
+            tenantId = config.tenantId?.trim() || "default";
+          }
+
+          if (isInferenceEntitlementEnforcementActive(env)) {
+            const config = yield* configService.load();
+            const entitlements = entitlementsFromPlan(config.plan);
+            const usage = yield* usageStore.getUsage(tenantId);
+            const check = yield* entitlement.checkLimit({
+              entitlements,
+              usage,
+              resource: "inference_calls",
+              requested: 1,
+            });
+            if (!check.allowed) {
+              yield* audit.appendEntry(
+                buildEntitlementLimitReachedEntry({
+                  tenantId,
+                  plan: config.plan,
+                  resource: "inference_calls",
+                  correlationId: request.correlationId,
+                })
+              );
+              return yield* Effect.fail(new EntitlementLimitError(check.reason));
+            }
+          }
+
+          const response = yield* gateway.complete(request);
+
+          if (isInferenceEntitlementEnforcementActive(env)) {
+            const config = yield* configService.load();
+            yield* usageStore.increment(tenantId, "inference_calls", 1, config.plan);
+          }
+          if (isStripeMeterReportingActive(env)) {
+            yield* meter.reportInferenceUsageIfEnabled({
+              tenantId,
+              value: 1,
+              correlationId: request.correlationId,
+              env,
+            });
+          }
+
+          return response;
+        });
+
+      return EntitlementEnforcementService.of({ completeWithEnforcement });
+    })
+  );
+}

--- a/packages/clawql-inference/src/entitlements/effect/entitlement-enforcement-service.ts
+++ b/packages/clawql-inference/src/entitlements/effect/entitlement-enforcement-service.ts
@@ -7,10 +7,7 @@ import {
   UsageStoreService,
   type PaymentsServices,
 } from "clawql-payments/plugin";
-import {
-  buildEntitlementLimitReachedEntry,
-  entitlementsFromPlan,
-} from "clawql-payments";
+import { buildEntitlementLimitReachedEntry, entitlementsFromPlan } from "clawql-payments";
 import type { InferenceRequest, InferenceResponse } from "../../gateway.js";
 import { InferenceGatewayService } from "../../fallback/effect/inference-gateway-service.js";
 import { isInferenceEntitlementEnforcementActive } from "../flags.js";
@@ -31,11 +28,7 @@ export class EntitlementEnforcementService extends Context.Tag(
 
 export function entitlementEnforcementLiveLayer(
   env: NodeJS.ProcessEnv
-): Layer.Layer<
-  EntitlementEnforcementService,
-  never,
-  InferenceGatewayService | PaymentsServices
-> {
+): Layer.Layer<EntitlementEnforcementService, never, InferenceGatewayService | PaymentsServices> {
   return Layer.effect(
     EntitlementEnforcementService,
     Effect.gen(function* () {

--- a/packages/clawql-inference/src/entitlements/effect/entitlement-layer.ts
+++ b/packages/clawql-inference/src/entitlements/effect/entitlement-layer.ts
@@ -1,7 +1,5 @@
 import { Cause, Effect, Exit, Layer } from "effect";
-import {
-  paymentsServicesLiveLayer,
-} from "clawql-payments/plugin";
+import { paymentsServicesLiveLayer } from "clawql-payments/plugin";
 import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../../gateway.js";
 import { inferenceGatewayLiveLayer } from "../../fallback/effect/inference-gateway-service.js";
 import { EntitlementLimitError } from "../errors.js";
@@ -17,9 +15,7 @@ export function makeEntitlementLayer(
   env: NodeJS.ProcessEnv
 ): Layer.Layer<EntitlementEnforcementService> {
   return entitlementEnforcementLiveLayer(env).pipe(
-    Layer.provide(
-      Layer.mergeAll(inferenceGatewayLiveLayer(inner), paymentsServicesLiveLayer(env))
-    )
+    Layer.provide(Layer.mergeAll(inferenceGatewayLiveLayer(inner), paymentsServicesLiveLayer(env)))
   );
 }
 

--- a/packages/clawql-inference/src/entitlements/effect/entitlement-layer.ts
+++ b/packages/clawql-inference/src/entitlements/effect/entitlement-layer.ts
@@ -1,0 +1,57 @@
+import { Cause, Effect, Exit, Layer } from "effect";
+import {
+  paymentsServicesLiveLayer,
+} from "clawql-payments/plugin";
+import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../../gateway.js";
+import { inferenceGatewayLiveLayer } from "../../fallback/effect/inference-gateway-service.js";
+import { EntitlementLimitError } from "../errors.js";
+import {
+  EntitlementEnforcementService,
+  entitlementEnforcementLiveLayer,
+} from "./entitlement-enforcement-service.js";
+
+export type EntitlementServices = EntitlementEnforcementService;
+
+export function makeEntitlementLayer(
+  inner: InferenceGateway,
+  env: NodeJS.ProcessEnv
+): Layer.Layer<EntitlementEnforcementService> {
+  return entitlementEnforcementLiveLayer(env).pipe(
+    Layer.provide(
+      Layer.mergeAll(inferenceGatewayLiveLayer(inner), paymentsServicesLiveLayer(env))
+    )
+  );
+}
+
+function squashEntitlementFailure(cause: Cause.Cause<unknown>): never {
+  const err = Cause.squash(cause);
+  if (err instanceof EntitlementLimitError) {
+    throw err;
+  }
+  throw err;
+}
+
+/** Run an entitlement Effect program with gateway + payments layers. */
+export async function runEntitlementEffect<A>(
+  program: Effect.Effect<A, unknown, EntitlementServices>,
+  inner: InferenceGateway,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<A> {
+  const exit = await Effect.runPromiseExit(
+    program.pipe(Effect.provide(makeEntitlementLayer(inner, env)))
+  );
+  if (Exit.isSuccess(exit)) {
+    return exit.value;
+  }
+  squashEntitlementFailure(exit.cause);
+}
+
+/** Complete with entitlement enforcement via Effect services. */
+export function completeWithEnforcementProgram(
+  request: InferenceRequest
+): Effect.Effect<InferenceResponse, unknown, EntitlementEnforcementService> {
+  return Effect.gen(function* () {
+    const enforcement = yield* EntitlementEnforcementService;
+    return yield* enforcement.completeWithEnforcement(request);
+  });
+}

--- a/packages/clawql-inference/src/entitlements/effect/entitlement-programs.ts
+++ b/packages/clawql-inference/src/entitlements/effect/entitlement-programs.ts
@@ -89,12 +89,7 @@ export function recordInferenceUsageEffect(
     const configService = yield* PaymentsConfigService;
     const config = yield* configService.load();
     const usageStore = yield* UsageStoreService;
-    yield* usageStore.increment(
-      input.tenantId,
-      "inference_calls",
-      input.amount ?? 1,
-      config.plan
-    );
+    yield* usageStore.increment(input.tenantId, "inference_calls", input.amount ?? 1, config.plan);
   });
 }
 

--- a/packages/clawql-inference/src/entitlements/effect/entitlement-programs.ts
+++ b/packages/clawql-inference/src/entitlements/effect/entitlement-programs.ts
@@ -1,0 +1,127 @@
+import {
+  buildEntitlementLimitReachedEntry,
+  entitlementsFromPlan,
+  isStripeMeterReportingActive,
+} from "clawql-payments";
+import {
+  EntitlementService,
+  PaymentAuditService,
+  PaymentsConfigService,
+  StripeMeterService,
+  UsageStoreService,
+  type PaymentsServices,
+} from "clawql-payments/plugin";
+import { Effect } from "effect";
+import { isInferenceEntitlementEnforcementActive } from "../flags.js";
+import { EntitlementLimitError } from "../errors.js";
+
+export type InferenceTenantContext = {
+  team?: string;
+  tenantId?: string;
+};
+
+/** Resolve billing tenant from request context or payments config. */
+export function resolveInferenceTenantIdEffect(
+  context: InferenceTenantContext = {}
+): Effect.Effect<string, unknown, PaymentsConfigService> {
+  return Effect.gen(function* () {
+    if (context.tenantId?.trim()) return context.tenantId.trim();
+    if (context.team?.trim()) return context.team.trim();
+    const configService = yield* PaymentsConfigService;
+    const config = yield* configService.load();
+    return config.tenantId?.trim() || "default";
+  });
+}
+
+export type AssertInferenceEntitlementInput = {
+  tenantId: string;
+  requested?: number;
+  correlationId?: string;
+};
+
+/** Assert monthly inference entitlement; audit and fail when over limit. */
+export function assertInferenceEntitlementEffect(
+  input: AssertInferenceEntitlementInput
+): Effect.Effect<void, unknown, PaymentsServices> {
+  return Effect.gen(function* () {
+    const configService = yield* PaymentsConfigService;
+    const config = yield* configService.load();
+    const entitlements = entitlementsFromPlan(config.plan);
+    const usageStore = yield* UsageStoreService;
+    const usage = yield* usageStore.getUsage(input.tenantId);
+    const entitlement = yield* EntitlementService;
+    const check = yield* entitlement.checkLimit({
+      entitlements,
+      usage,
+      resource: "inference_calls",
+      requested: input.requested ?? 1,
+    });
+
+    if (!check.allowed) {
+      const audit = yield* PaymentAuditService;
+      yield* audit.appendEntry(
+        buildEntitlementLimitReachedEntry({
+          tenantId: input.tenantId,
+          plan: config.plan,
+          resource: "inference_calls",
+          correlationId: input.correlationId,
+        })
+      );
+      return yield* Effect.fail(new EntitlementLimitError(check.reason));
+    }
+  });
+}
+
+export type RecordInferenceBillingInput = {
+  tenantId: string;
+  amount?: number;
+  correlationId?: string;
+  env: NodeJS.ProcessEnv;
+};
+
+/** Increment inference usage counter for the current month. */
+export function recordInferenceUsageEffect(
+  input: Omit<RecordInferenceBillingInput, "env"> & { env?: NodeJS.ProcessEnv }
+): Effect.Effect<void, unknown, PaymentsServices> {
+  return Effect.gen(function* () {
+    const env = input.env ?? process.env;
+    if (!isInferenceEntitlementEnforcementActive(env)) return;
+    const configService = yield* PaymentsConfigService;
+    const config = yield* configService.load();
+    const usageStore = yield* UsageStoreService;
+    yield* usageStore.increment(
+      input.tenantId,
+      "inference_calls",
+      input.amount ?? 1,
+      config.plan
+    );
+  });
+}
+
+/** Increment usage counters and report Stripe meter events when configured. */
+export function recordInferenceBillingEffect(
+  input: RecordInferenceBillingInput
+): Effect.Effect<void, unknown, PaymentsServices> {
+  return Effect.gen(function* () {
+    if (isInferenceEntitlementEnforcementActive(input.env)) {
+      const configService = yield* PaymentsConfigService;
+      const config = yield* configService.load();
+      const usageStore = yield* UsageStoreService;
+      yield* usageStore.increment(
+        input.tenantId,
+        "inference_calls",
+        input.amount ?? 1,
+        config.plan
+      );
+    }
+    if (isStripeMeterReportingActive(input.env)) {
+      const meter = yield* StripeMeterService;
+      yield* meter.reportInferenceUsageIfEnabled({
+        tenantId: input.tenantId,
+        value: input.amount ?? 1,
+        correlationId: input.correlationId,
+        env: input.env,
+      });
+    }
+  });
+}

--- a/packages/clawql-inference/src/entitlements/effect/index.ts
+++ b/packages/clawql-inference/src/entitlements/effect/index.ts
@@ -1,0 +1,19 @@
+export {
+  assertInferenceEntitlementEffect,
+  recordInferenceBillingEffect,
+  recordInferenceUsageEffect,
+  resolveInferenceTenantIdEffect,
+  type AssertInferenceEntitlementInput,
+  type InferenceTenantContext,
+  type RecordInferenceBillingInput,
+} from "./entitlement-programs.js";
+export {
+  EntitlementEnforcementService,
+  entitlementEnforcementLiveLayer,
+} from "./entitlement-enforcement-service.js";
+export {
+  completeWithEnforcementProgram,
+  makeEntitlementLayer,
+  runEntitlementEffect,
+  type EntitlementServices,
+} from "./entitlement-layer.js";

--- a/packages/clawql-inference/src/entitlements/enforced-gateway.ts
+++ b/packages/clawql-inference/src/entitlements/enforced-gateway.ts
@@ -13,11 +13,7 @@ export class EntitlementEnforcedGateway implements InferenceGateway {
   ) {}
 
   async complete(request: InferenceRequest): Promise<InferenceResponse> {
-    return runEntitlementEffect(
-      completeWithEnforcementProgram(request),
-      this.inner,
-      this.env
-    );
+    return runEntitlementEffect(completeWithEnforcementProgram(request), this.inner, this.env);
   }
 }
 

--- a/packages/clawql-inference/src/entitlements/enforced-gateway.ts
+++ b/packages/clawql-inference/src/entitlements/enforced-gateway.ts
@@ -1,11 +1,10 @@
 import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../gateway.js";
-import {
-  assertInferenceEntitlement,
-  isInferenceEntitlementEnforcementActive,
-  recordInferenceBilling,
-  resolveInferenceTenantId,
-} from "./check.js";
 import { isStripeMeterReportingActive } from "clawql-payments";
+import {
+  completeWithEnforcementProgram,
+  runEntitlementEffect,
+} from "./effect/entitlement-layer.js";
+import { isInferenceEntitlementEnforcementActive } from "./flags.js";
 
 export class EntitlementEnforcedGateway implements InferenceGateway {
   constructor(
@@ -14,26 +13,11 @@ export class EntitlementEnforcedGateway implements InferenceGateway {
   ) {}
 
   async complete(request: InferenceRequest): Promise<InferenceResponse> {
-    const tenantId = await resolveInferenceTenantId(
-      { team: request.team, tenantId: request.tenantId },
+    return runEntitlementEffect(
+      completeWithEnforcementProgram(request),
+      this.inner,
       this.env
     );
-
-    if (isInferenceEntitlementEnforcementActive(this.env)) {
-      await assertInferenceEntitlement({
-        tenantId,
-        correlationId: request.correlationId,
-        env: this.env,
-      });
-    }
-
-    const response = await this.inner.complete(request);
-    await recordInferenceBilling({
-      tenantId,
-      correlationId: request.correlationId,
-      env: this.env,
-    });
-    return response;
   }
 }
 

--- a/packages/clawql-inference/src/entitlements/flags.ts
+++ b/packages/clawql-inference/src/entitlements/flags.ts
@@ -1,0 +1,11 @@
+function parseTruthy(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+export function isInferenceEntitlementEnforcementActive(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return parseTruthy(env.CLAWQL_PAYMENTS_ENFORCE_INFERENCE);
+}

--- a/packages/clawql-inference/src/index.ts
+++ b/packages/clawql-inference/src/index.ts
@@ -43,6 +43,18 @@ export {
   resolveInferenceTenantId,
   withEntitlementEnforcement,
 } from "./entitlements/enforced-gateway.js";
+export {
+  EntitlementEnforcementService,
+  assertInferenceEntitlementEffect,
+  completeWithEnforcementProgram,
+  entitlementEnforcementLiveLayer,
+  makeEntitlementLayer,
+  recordInferenceBillingEffect,
+  recordInferenceUsageEffect,
+  resolveInferenceTenantIdEffect,
+  runEntitlementEffect,
+  type EntitlementServices,
+} from "./entitlements/effect/index.js";
 
 export type {
   InferenceRecord,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Third slice of the `clawql-inference` Effect-TS migration: **plan entitlement enforcement** (`EntitlementEnforcedGateway`).

Public API unchanged — `complete()` remains `Promise`-based. Internals now run through Effect services wired to `clawql-payments` Effect layers, matching the boundary-only pattern from fallback (#600) and semantic cache (#601).

## Changes

- **`EntitlementEnforcementService`** — pre-check limits, post-call usage increment, Stripe meter reporting
- **`entitlement-programs.ts`** — shared Effect programs used by `check.ts` async facades
- **`runEntitlementEffect` / `makeEntitlementLayer`** — composes `InferenceGatewayService` + `paymentsServicesLiveLayer(env)`
- Extract enforcement flags to `entitlements/flags.ts`
- Refactor `enforced-gateway.ts` and `check.ts` to thin async wrappers
- Export Effect modules from package index; doc note added

## Testing

- Build + 72/72 tests passing in `clawql-inference`
- New `EntitlementEnforcementService` unit tests
- Existing gateway + HTTP entitlement tests unchanged

## Migration plan context

Order: fallback (#600 ✅) → semantic cache (#601) → **entitlements (this PR)** → model escalation → SSE streaming
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

