### PR TITLE
feat(inference): Effect model escalation service

### DIFF
--- a/docs/inference/clawql-inference.md
+++ b/docs/inference/clawql-inference.md
@@ -165,7 +165,7 @@ Third-party plugins use the same `InferenceProviderPlugin` contract — see [Inf
 
 ## Model tier escalation
 
-`TierEscalationRouter` implements `AdaptiveRouter` with three tiers:
+`TierEscalationRouter` implements `AdaptiveRouter` with three tiers. The public router API remains synchronous; internally, tier decisions run through `ModelEscalationService` with `Effect.sync` and `Effect.runSync` at the boundary (for Ouroboros and other callers that use `AdaptiveRouter` directly).
 
 | Tier         | Default model (env override)                                    | Role                         |
 | ------------ | --------------------------------------------------------------- | ---------------------------- |

--- a/packages/clawql-inference/src/index.ts
+++ b/packages/clawql-inference/src/index.ts
@@ -14,6 +14,10 @@ export {
   loadModelEscalationConfigAsync,
   createModelEscalationRouter,
   TierEscalationRouter,
+  ModelEscalationService,
+  modelEscalationLiveLayer,
+  resolveModelEscalationService,
+  runModelEscalationEffect,
   type ModelEscalationConfig,
 } from "./routing/index.js";
 

--- a/packages/clawql-inference/src/routing/effect/index.ts
+++ b/packages/clawql-inference/src/routing/effect/index.ts
@@ -1,0 +1,7 @@
+export {
+  AGENT_COORDINATION_DRIFT_TRIPWIRE,
+  ModelEscalationService,
+  modelEscalationLiveLayer,
+  resolveModelEscalationService,
+  runModelEscalationEffect,
+} from "./model-escalation-service.js";

--- a/packages/clawql-inference/src/routing/effect/model-escalation-service.test.ts
+++ b/packages/clawql-inference/src/routing/effect/model-escalation-service.test.ts
@@ -1,0 +1,93 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import type { ModelEscalationConfig } from "../config.js";
+import type { RoutingFailureSignal } from "../types.js";
+import {
+  AGENT_COORDINATION_DRIFT_TRIPWIRE,
+  ModelEscalationService,
+  modelEscalationLiveLayer,
+} from "./model-escalation-service.js";
+
+const tierMap = {
+  frugal: "ollama/phi4",
+  standard: "groq/llama",
+  frontier: "anthropic/claude",
+};
+
+function config(overrides: Partial<ModelEscalationConfig> = {}): ModelEscalationConfig {
+  return {
+    enabled: true,
+    tierMap,
+    ...overrides,
+  };
+}
+
+const failure: RoutingFailureSignal = {
+  kind: "eval_below_min",
+  detail: { score: 0.2 },
+  generation: 2,
+};
+
+describe("ModelEscalationService", () => {
+  it("starts decomposed children at frugal", async () => {
+    const layer = modelEscalationLiveLayer(config());
+    const decision = await Effect.runPromise(
+      Effect.gen(function* () {
+        const escalation = yield* ModelEscalationService;
+        return yield* escalation.initialTier({ isDecomposedChild: true, seedId: "child-1" });
+      }).pipe(Effect.provide(layer))
+    );
+    expect(decision.tier).toBe("frugal");
+    expect(decision.modelId).toBe("ollama/phi4");
+    expect(decision.retryAttempt).toBe(0);
+  });
+
+  it("escalates one notch frugal → standard → frontier", async () => {
+    const layer = modelEscalationLiveLayer(config());
+    const run = async () =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const escalation = yield* ModelEscalationService;
+          const d0 = yield* escalation.initialTier({ isDecomposedChild: true, seedId: "s" });
+          const d1 = yield* escalation.escalate(d0, failure);
+          const d2 = yield* escalation.escalate(d1, failure);
+          const d3 = yield* escalation.escalate(d2, failure);
+          return { d0, d1, d2, d3 };
+        }).pipe(Effect.provide(layer))
+      );
+
+    const { d1, d2, d3 } = await run();
+    expect(d1.tier).toBe("standard");
+    expect(d1.escalatedFrom).toBe("frugal");
+    expect(d2.tier).toBe("frontier");
+    expect(d3.tier).toBe("frontier");
+    expect(d3.retryAttempt).toBe(3);
+  });
+
+  it("triggers agent coordination on drift tripwire", async () => {
+    const layer = modelEscalationLiveLayer(config());
+    const triggered = await Effect.runPromise(
+      Effect.gen(function* () {
+        const escalation = yield* ModelEscalationService;
+        const decision = yield* escalation.initialTier({ isDecomposedChild: true, seedId: "s" });
+        return yield* escalation.shouldTriggerAgentCoordination(decision, [failure], {
+          combined: 0.5,
+        });
+      }).pipe(Effect.provide(layer))
+    );
+    expect(triggered).toBe(true);
+    expect(AGENT_COORDINATION_DRIFT_TRIPWIRE).toBe(0.3);
+  });
+
+  it("honors model pin over tier ladder", async () => {
+    const layer = modelEscalationLiveLayer(config({ modelPin: "openai/gpt-4o" }));
+    const decision = await Effect.runPromise(
+      Effect.gen(function* () {
+        const escalation = yield* ModelEscalationService;
+        return yield* escalation.initialTier({ isDecomposedChild: false, seedId: "root" });
+      }).pipe(Effect.provide(layer))
+    );
+    expect(decision.modelId).toBe("openai/gpt-4o");
+    expect(decision.tier).toBe("standard");
+  });
+});

--- a/packages/clawql-inference/src/routing/effect/model-escalation-service.ts
+++ b/packages/clawql-inference/src/routing/effect/model-escalation-service.ts
@@ -1,0 +1,125 @@
+import { Context, Effect, Layer } from "effect";
+import type { ModelEscalationConfig } from "../config.js";
+import { nextModelTier } from "../tiers.js";
+import type {
+  ModelEscalationDecision,
+  ModelTier,
+  RoutingFailureSignal,
+} from "../types.js";
+
+/** Combined drift threshold for agent coordination tripwire (#562). */
+export const AGENT_COORDINATION_DRIFT_TRIPWIRE = 0.3;
+
+function computeInitialTier(
+  config: ModelEscalationConfig,
+  ctx: { isDecomposedChild: boolean; seedId: string }
+): ModelEscalationDecision {
+  if (config.modelPin) {
+    return {
+      tier: "standard",
+      modelId: config.modelPin,
+      retryAttempt: 0,
+    };
+  }
+
+  const tier: ModelTier = ctx.isDecomposedChild ? "frugal" : "standard";
+  return {
+    tier,
+    modelId: config.tierMap[tier],
+    retryAttempt: 0,
+  };
+}
+
+function computeEscalation(
+  config: ModelEscalationConfig,
+  decision: ModelEscalationDecision,
+  signal: RoutingFailureSignal
+): ModelEscalationDecision {
+  if (config.modelPin) {
+    return {
+      ...decision,
+      retryAttempt: decision.retryAttempt + 1,
+      trigger: signal,
+    };
+  }
+
+  const nextTier = nextModelTier(decision.tier);
+  if (!nextTier) {
+    return {
+      ...decision,
+      retryAttempt: decision.retryAttempt + 1,
+      trigger: signal,
+    };
+  }
+
+  return {
+    tier: nextTier,
+    modelId: config.tierMap[nextTier],
+    retryAttempt: decision.retryAttempt + 1,
+    escalatedFrom: decision.tier,
+    trigger: signal,
+  };
+}
+
+function computeShouldTriggerAgentCoordination(
+  decision: ModelEscalationDecision,
+  signals: RoutingFailureSignal[],
+  drift?: { combined: number }
+): boolean {
+  if (!signals.length) return false;
+  const driftTripwire = (drift?.combined ?? 0) > AGENT_COORDINATION_DRIFT_TRIPWIRE;
+  const standardTierFailure = decision.tier === "standard" && signals.length > 0;
+  return driftTripwire || standardTierFailure;
+}
+
+/** Effect service for frugal → standard → frontier model tier escalation. */
+export class ModelEscalationService extends Context.Tag("clawql/ModelEscalationService")<
+  ModelEscalationService,
+  {
+    readonly initialTier: (ctx: {
+      isDecomposedChild: boolean;
+      seedId: string;
+    }) => Effect.Effect<ModelEscalationDecision>;
+    readonly escalate: (
+      decision: ModelEscalationDecision,
+      signal: RoutingFailureSignal
+    ) => Effect.Effect<ModelEscalationDecision>;
+    readonly shouldTriggerAgentCoordination: (
+      decision: ModelEscalationDecision,
+      signals: RoutingFailureSignal[],
+      drift?: { combined: number }
+    ) => Effect.Effect<boolean>;
+  }
+>() {}
+
+export function modelEscalationLiveLayer(
+  config: ModelEscalationConfig
+): Layer.Layer<ModelEscalationService> {
+  return Layer.succeed(
+    ModelEscalationService,
+    ModelEscalationService.of({
+      initialTier: (ctx) => Effect.sync(() => computeInitialTier(config, ctx)),
+      escalate: (decision, signal) =>
+        Effect.sync(() => computeEscalation(config, decision, signal)),
+      shouldTriggerAgentCoordination: (decision, signals, drift) =>
+        Effect.sync(() => computeShouldTriggerAgentCoordination(decision, signals, drift)),
+    })
+  );
+}
+
+/** Run a model escalation Effect program with config layer. */
+export async function runModelEscalationEffect<A>(
+  program: Effect.Effect<A, unknown, ModelEscalationService>,
+  config: ModelEscalationConfig
+): Promise<A> {
+  return Effect.runPromise(program.pipe(Effect.provide(modelEscalationLiveLayer(config))));
+}
+
+/** Sync access to model escalation service (used by {@link TierEscalationRouter}). */
+export function resolveModelEscalationService(config: ModelEscalationConfig) {
+  return Effect.runSync(
+    Effect.gen(function* () {
+      return yield* ModelEscalationService;
+    }).pipe(Effect.provide(modelEscalationLiveLayer(config)))
+  );
+}

--- a/packages/clawql-inference/src/routing/effect/model-escalation-service.ts
+++ b/packages/clawql-inference/src/routing/effect/model-escalation-service.ts
@@ -1,11 +1,7 @@
 import { Context, Effect, Layer } from "effect";
 import type { ModelEscalationConfig } from "../config.js";
 import { nextModelTier } from "../tiers.js";
-import type {
-  ModelEscalationDecision,
-  ModelTier,
-  RoutingFailureSignal,
-} from "../types.js";
+import type { ModelEscalationDecision, ModelTier, RoutingFailureSignal } from "../types.js";
 
 /** Combined drift threshold for agent coordination tripwire (#562). */
 export const AGENT_COORDINATION_DRIFT_TRIPWIRE = 0.3;

--- a/packages/clawql-inference/src/routing/index.ts
+++ b/packages/clawql-inference/src/routing/index.ts
@@ -2,3 +2,10 @@ export * from "./types.js";
 export * from "./tiers.js";
 export * from "./config.js";
 export { TierEscalationRouter } from "./tier-escalation-router.js";
+export {
+  AGENT_COORDINATION_DRIFT_TRIPWIRE,
+  ModelEscalationService,
+  modelEscalationLiveLayer,
+  resolveModelEscalationService,
+  runModelEscalationEffect,
+} from "./effect/index.js";

--- a/packages/clawql-inference/src/routing/tier-escalation-router.ts
+++ b/packages/clawql-inference/src/routing/tier-escalation-router.ts
@@ -1,76 +1,42 @@
+import type { ModelEscalationConfig } from "./config.js";
 import type {
   AdaptiveRouter,
   ModelEscalationDecision,
-  ModelTier,
   RoutingFailureSignal,
 } from "./types.js";
-import type { ModelEscalationConfig } from "./config.js";
-import { nextModelTier } from "./tiers.js";
+import { Effect } from "effect";
+import {
+  AGENT_COORDINATION_DRIFT_TRIPWIRE,
+  resolveModelEscalationService,
+} from "./effect/model-escalation-service.js";
 
 export type { ModelEscalationConfig };
+export { AGENT_COORDINATION_DRIFT_TRIPWIRE };
 
-/** Combined drift threshold for agent coordination tripwire (#562). */
-export const AGENT_COORDINATION_DRIFT_TRIPWIRE = 0.3;
-
+/** Tier escalation router implementing {@link AdaptiveRouter} (sync boundary over Effect). */
 export class TierEscalationRouter implements AdaptiveRouter {
-  constructor(private readonly config: ModelEscalationConfig) {}
+  private readonly service: ReturnType<typeof resolveModelEscalationService>;
+
+  constructor(config: ModelEscalationConfig) {
+    this.service = resolveModelEscalationService(config);
+  }
 
   initialTier(ctx: { isDecomposedChild: boolean; seedId: string }): ModelEscalationDecision {
-    if (this.config.modelPin) {
-      return {
-        tier: "standard",
-        modelId: this.config.modelPin,
-        retryAttempt: 0,
-      };
-    }
-
-    const tier: ModelTier = ctx.isDecomposedChild ? "frugal" : "standard";
-    return {
-      tier,
-      modelId: this.config.tierMap[tier],
-      retryAttempt: 0,
-    };
+    return Effect.runSync(this.service.initialTier(ctx));
   }
 
   escalate(
     decision: ModelEscalationDecision,
     signal: RoutingFailureSignal
   ): ModelEscalationDecision {
-    if (this.config.modelPin) {
-      return {
-        ...decision,
-        retryAttempt: decision.retryAttempt + 1,
-        trigger: signal,
-      };
-    }
-
-    const nextTier = nextModelTier(decision.tier);
-    if (!nextTier) {
-      return {
-        ...decision,
-        retryAttempt: decision.retryAttempt + 1,
-        trigger: signal,
-      };
-    }
-
-    return {
-      tier: nextTier,
-      modelId: this.config.tierMap[nextTier],
-      retryAttempt: decision.retryAttempt + 1,
-      escalatedFrom: decision.tier,
-      trigger: signal,
-    };
+    return Effect.runSync(this.service.escalate(decision, signal));
   }
 
-  /** Agent coordination at standard-tier exhaustion + drift tripwire (#562). */
   shouldTriggerAgentCoordination(
     decision: ModelEscalationDecision,
     signals: RoutingFailureSignal[],
     drift?: { combined: number }
   ): boolean {
-    if (!signals.length) return false;
-    const driftTripwire = (drift?.combined ?? 0) > AGENT_COORDINATION_DRIFT_TRIPWIRE;
-    const standardTierFailure = decision.tier === "standard" && signals.length > 0;
-    return driftTripwire || standardTierFailure;
+    return Effect.runSync(this.service.shouldTriggerAgentCoordination(decision, signals, drift));
   }
 }

--- a/packages/clawql-inference/src/routing/tier-escalation-router.ts
+++ b/packages/clawql-inference/src/routing/tier-escalation-router.ts
@@ -1,9 +1,5 @@
 import type { ModelEscalationConfig } from "./config.js";
-import type {
-  AdaptiveRouter,
-  ModelEscalationDecision,
-  RoutingFailureSignal,
-} from "./types.js";
+import type { AdaptiveRouter, ModelEscalationDecision, RoutingFailureSignal } from "./types.js";
 import { Effect } from "effect";
 import {
   AGENT_COORDINATION_DRIFT_TRIPWIRE,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fourth slice of the `clawql-inference` Effect-TS migration: **model tier escalation** (`TierEscalationRouter` / `ModelEscalationService`).

The public `AdaptiveRouter` API stays synchronous for Ouroboros and other callers. Internally, tier decisions run through `ModelEscalationService` with `Effect.sync` and `Effect.runSync` at the boundary.

## Changes

- **`ModelEscalationService`** — `initialTier`, `escalate`, `shouldTriggerAgentCoordination` as pure Effect programs
- **`modelEscalationLiveLayer` / `runModelEscalationEffect`** — Layer DI for Effect-native callers
- Refactor `TierEscalationRouter` to thin sync wrapper over the service
- Export from `routing/` and package index
- Brief doc note under Model tier escalation

## Testing

- `npm run build -w clawql-inference` ✅
- `npm test -w clawql-inference` — 80 passed, 1 skipped ✅
- New `ModelEscalationService` unit tests
- Existing `TierEscalationRouter` tests unchanged

## Migration plan context

Order: fallback (#600 ✅) → semantic cache (#601 ✅) → entitlements (#603 ✅) → **model escalation (this PR)** → SSE streaming

## Related

- #601, #603 (merged)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

