### PR TITLE
feat(inference): Effect.Stream for OpenAI SSE streaming

### DIFF
--- a/docs/inference/clawql-inference.md
+++ b/docs/inference/clawql-inference.md
@@ -122,6 +122,8 @@ Disable layers via options: `{ semanticCache: false }`, `{ fallback: false }`, `
 | `GET`  | `/v1/models/:id`       | Single model                                          |
 | `POST` | `/v1/chat/completions` | Bare `gpt-4o` or `provider/model`; `stream: true` SSE |
 
+When `stream: true`, token chunks are assembled into OpenAI-compatible SSE events via `Effect.Stream` (`openAiCompletionChunkStream`) with `streamCompletionAsOpenAiSseEffect` at the HTTP boundary.
+
 ### Request headers
 
 | Header                                         | Purpose                            |

--- a/packages/clawql-inference/src/api/effect/index.ts
+++ b/packages/clawql-inference/src/api/effect/index.ts
@@ -1,0 +1,6 @@
+export {
+  collectOpenAiCompletionChunks,
+  openAiCompletionChunkStream,
+  type OpenAiCompletionStreamInput,
+  type OpenAiSseChunk,
+} from "./sse-stream.js";

--- a/packages/clawql-inference/src/api/effect/sse-stream.test.ts
+++ b/packages/clawql-inference/src/api/effect/sse-stream.test.ts
@@ -1,0 +1,53 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { collectOpenAiCompletionChunks } from "./sse-stream.js";
+
+describe("openAiCompletionChunkStream", () => {
+  it("emits role, content, and finish chunks in order", async () => {
+    async function* chunks() {
+      yield "hello";
+      yield " world";
+    }
+
+    const collected = await Effect.runPromise(
+      collectOpenAiCompletionChunks({
+        completionId: "chatcmpl-test",
+        model: "gpt-test",
+        created: 1_700_000_000,
+        chunks: chunks(),
+        usage: { inputTokens: 3, outputTokens: 2 },
+      })
+    );
+
+    expect(collected).toHaveLength(4);
+    expect(collected[0]?.choices[0]?.delta).toEqual({ role: "assistant" });
+    expect(collected[1]?.choices[0]?.delta).toEqual({ content: "hello" });
+    expect(collected[2]?.choices[0]?.delta).toEqual({ content: " world" });
+    expect(collected[3]?.choices[0]?.finish_reason).toBe("stop");
+    expect(collected[3]?.usage).toEqual({
+      prompt_tokens: 3,
+      completion_tokens: 2,
+      total_tokens: 5,
+    });
+  });
+
+  it("skips empty content chunks", async () => {
+    async function* chunks() {
+      yield "";
+      yield "ok";
+      yield "";
+    }
+
+    const collected = await Effect.runPromise(
+      collectOpenAiCompletionChunks({
+        completionId: "chatcmpl-test",
+        model: "gpt-test",
+        created: 1_700_000_000,
+        chunks: chunks(),
+      })
+    );
+
+    expect(collected).toHaveLength(3);
+    expect(collected[1]?.choices[0]?.delta).toEqual({ content: "ok" });
+  });
+});

--- a/packages/clawql-inference/src/api/effect/sse-stream.ts
+++ b/packages/clawql-inference/src/api/effect/sse-stream.ts
@@ -1,0 +1,81 @@
+import { Chunk, Effect, Stream } from "effect";
+import type { InferenceResponse } from "../../gateway.js";
+
+export type OpenAiSseChunk = {
+  id: string;
+  object: "chat.completion.chunk";
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    delta: Record<string, unknown>;
+    finish_reason: string | null;
+  }>;
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+};
+
+export type OpenAiCompletionStreamInput = {
+  completionId: string;
+  model: string;
+  created: number;
+  chunks: AsyncIterable<string>;
+  usage?: InferenceResponse["usage"];
+};
+
+function chunkMeta(input: OpenAiCompletionStreamInput) {
+  return {
+    id: input.completionId,
+    object: "chat.completion.chunk" as const,
+    created: input.created,
+    model: input.model,
+  };
+}
+
+function toOpenAiUsage(usage?: InferenceResponse["usage"]) {
+  if (!usage) return undefined;
+  return {
+    prompt_tokens: usage.inputTokens,
+    completion_tokens: usage.outputTokens,
+    total_tokens: usage.inputTokens + usage.outputTokens,
+  };
+}
+
+/** Build OpenAI-compatible SSE chunk stream from token chunks. */
+export function openAiCompletionChunkStream(
+  input: OpenAiCompletionStreamInput
+): Stream.Stream<OpenAiSseChunk> {
+  const meta = chunkMeta(input);
+  const start = Stream.succeed({
+    ...meta,
+    choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
+  });
+
+  const content = Stream.fromAsyncIterable(input.chunks, (cause) => cause).pipe(
+    Stream.filter((text): text is string => Boolean(text)),
+    Stream.map((text) => ({
+      ...meta,
+      choices: [{ index: 0, delta: { content: text }, finish_reason: null }],
+    }))
+  );
+
+  const finish = Stream.succeed({
+    ...meta,
+    choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    usage: toOpenAiUsage(input.usage),
+  });
+
+  return Stream.concat(start, Stream.concat(content, finish));
+}
+
+/** Collect OpenAI SSE chunks via Effect.Stream (for tests and non-HTTP callers). */
+export function collectOpenAiCompletionChunks(
+  input: OpenAiCompletionStreamInput
+): Effect.Effect<readonly OpenAiSseChunk[], unknown> {
+  return Stream.runCollect(openAiCompletionChunkStream(input)).pipe(
+    Effect.map(Chunk.toReadonlyArray)
+  );
+}

--- a/packages/clawql-inference/src/api/stream.ts
+++ b/packages/clawql-inference/src/api/stream.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from "node:crypto";
+import { Effect, Stream } from "effect";
 import type { Response } from "express";
 import type { InferenceResponse } from "../gateway.js";
+import {
+  openAiCompletionChunkStream,
+  type OpenAiCompletionStreamInput,
+} from "./effect/sse-stream.js";
 
 export function writeSse(res: Response, payload: unknown): void {
   res.write(`data: ${JSON.stringify(payload)}\n\n`);
@@ -14,55 +19,28 @@ export function openAiStreamHeaders(res: Response, correlationId?: string): void
   if (correlationId) res.setHeader("X-Correlation-Id", correlationId);
 }
 
+/** Write OpenAI-compatible SSE chunks to an Express response via Effect.Stream. */
+export function streamCompletionAsOpenAiSseEffect(
+  res: Response,
+  input: OpenAiCompletionStreamInput & { correlationId?: string }
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    yield* Effect.sync(() => openAiStreamHeaders(res, input.correlationId));
+    yield* Stream.runForEach(openAiCompletionChunkStream(input), (chunk) =>
+      Effect.sync(() => writeSse(res, chunk))
+    );
+    yield* Effect.sync(() => {
+      res.write("data: [DONE]\n\n");
+      res.end();
+    });
+  });
+}
+
 export async function streamCompletionAsOpenAiSse(
   res: Response,
-  input: {
-    completionId: string;
-    model: string;
-    created: number;
-    correlationId?: string;
-    chunks: AsyncIterable<string>;
-    usage?: InferenceResponse["usage"];
-  }
+  input: OpenAiCompletionStreamInput & { correlationId?: string }
 ): Promise<void> {
-  openAiStreamHeaders(res, input.correlationId);
-  writeSse(res, {
-    id: input.completionId,
-    object: "chat.completion.chunk",
-    created: input.created,
-    model: input.model,
-    choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
-  });
-
-  for await (const text of input.chunks) {
-    if (!text) continue;
-    writeSse(res, {
-      id: input.completionId,
-      object: "chat.completion.chunk",
-      created: input.created,
-      model: input.model,
-      choices: [{ index: 0, delta: { content: text }, finish_reason: null }],
-    });
-  }
-
-  const usage = input.usage
-    ? {
-        prompt_tokens: input.usage.inputTokens,
-        completion_tokens: input.usage.outputTokens,
-        total_tokens: input.usage.inputTokens + input.usage.outputTokens,
-      }
-    : undefined;
-
-  writeSse(res, {
-    id: input.completionId,
-    object: "chat.completion.chunk",
-    created: input.created,
-    model: input.model,
-    choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
-    usage,
-  });
-  res.write("data: [DONE]\n\n");
-  res.end();
+  return Effect.runPromise(streamCompletionAsOpenAiSseEffect(res, input));
 }
 
 export function streamBufferedCompletion(
@@ -87,3 +65,5 @@ export function streamBufferedCompletion(
     usage: input.result.usage,
   });
 }
+
+export { openAiCompletionChunkStream, collectOpenAiCompletionChunks } from "./effect/sse-stream.js";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Final slice of the `clawql-inference` Effect-TS gateway migration: **OpenAI SSE streaming**.

HTTP handlers keep the same public API. Internally, chunk assembly runs through `Effect.Stream` with `streamCompletionAsOpenAiSseEffect` at the Express boundary.

## Changes

- `openAiCompletionChunkStream` — role → content → finish pipeline
- `streamCompletionAsOpenAiSseEffect` — SSE writer via `Stream.runForEach`
- Refactor `stream.ts` to thin async wrapper + unit tests

## Testing

Build + 82/82 tests passing in `clawql-inference`.

## Migration context

Completes: fallback → semantic cache → entitlements → model escalation → **SSE streaming**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

