### PR TITLE
feat(memory): Effect services for ingest and recall

### DIFF
--- a/packages/clawql-memory/src/effect/index.ts
+++ b/packages/clawql-memory/src/effect/index.ts
@@ -1,0 +1,10 @@
+export { MemoryError } from "./memory-errors.js";
+export { MemoryIngestService, memoryIngestLiveLayer } from "./memory-ingest-service.js";
+export { MemoryRecallService, memoryRecallLiveLayer } from "./memory-recall-service.js";
+export {
+  memoryIngestProgram,
+  memoryRecallProgram,
+  memoryServicesLiveLayer,
+  runMemoryEffect,
+  type MemoryServices,
+} from "./memory-effect-runtime.js";

--- a/packages/clawql-memory/src/effect/memory-effect-runtime.ts
+++ b/packages/clawql-memory/src/effect/memory-effect-runtime.ts
@@ -1,0 +1,43 @@
+import { Cause, Effect, Exit, Layer } from "effect";
+import type { MemoryIngestInput, MemoryIngestResult } from "../ingest/ingest.js";
+import type { MemoryRecallInput, MemoryRecallResult } from "../recall/recall.js";
+import { MemoryIngestService, memoryIngestLiveLayer } from "./memory-ingest-service.js";
+import { MemoryRecallService, memoryRecallLiveLayer } from "./memory-recall-service.js";
+
+export type MemoryServices = MemoryIngestService | MemoryRecallService;
+
+/** Merged Effect Layer for clawql-memory domain services. */
+export function memoryServicesLiveLayer(): Layer.Layer<MemoryServices> {
+  return Layer.mergeAll(memoryIngestLiveLayer(), memoryRecallLiveLayer());
+}
+
+/** Run a memory Effect program with default services Layer. */
+export async function runMemoryEffect<A, E>(
+  program: Effect.Effect<A, E, MemoryServices>
+): Promise<A> {
+  const exit = await Effect.runPromiseExit(program.pipe(Effect.provide(memoryServicesLiveLayer())));
+  if (Exit.isSuccess(exit)) {
+    return exit.value;
+  }
+  throw Cause.squash(exit.cause);
+}
+
+/** Ingest via Effect services (used by {@link runMemoryIngest}). */
+export function memoryIngestProgram(
+  input: MemoryIngestInput
+): Effect.Effect<MemoryIngestResult, unknown, MemoryIngestService> {
+  return Effect.gen(function* () {
+    const ingest = yield* MemoryIngestService;
+    return yield* ingest.ingest(input);
+  });
+}
+
+/** Recall via Effect services (used by {@link runMemoryRecall}). */
+export function memoryRecallProgram(
+  input: MemoryRecallInput
+): Effect.Effect<MemoryRecallResult, unknown, MemoryRecallService> {
+  return Effect.gen(function* () {
+    const recall = yield* MemoryRecallService;
+    return yield* recall.recall(input);
+  });
+}

--- a/packages/clawql-memory/src/effect/memory-errors.ts
+++ b/packages/clawql-memory/src/effect/memory-errors.ts
@@ -1,0 +1,7 @@
+import { Data } from "effect";
+
+/** Unexpected failure in a memory Effect pipeline (vault I/O, db sync, etc.). */
+export class MemoryError extends Data.TaggedError("MemoryError")<{
+  readonly reason: string;
+  readonly cause?: unknown;
+}> {}

--- a/packages/clawql-memory/src/effect/memory-ingest-service.ts
+++ b/packages/clawql-memory/src/effect/memory-ingest-service.ts
@@ -1,0 +1,34 @@
+import { Context, Effect, Layer } from "effect";
+import {
+  executeMemoryIngest,
+  type MemoryIngestInput,
+  type MemoryIngestResult,
+} from "../ingest/ingest.js";
+import { MemoryError } from "./memory-errors.js";
+
+/** Effect service for vault memory ingest (`memory_ingest`). */
+export class MemoryIngestService extends Context.Tag("clawql/MemoryIngestService")<
+  MemoryIngestService,
+  {
+    readonly ingest: (
+      input: MemoryIngestInput
+    ) => Effect.Effect<MemoryIngestResult, MemoryError>;
+  }
+>() {}
+
+export function memoryIngestLiveLayer(): Layer.Layer<MemoryIngestService> {
+  return Layer.succeed(
+    MemoryIngestService,
+    MemoryIngestService.of({
+      ingest: (input) =>
+        Effect.tryPromise({
+          try: () => executeMemoryIngest(input),
+          catch: (cause) =>
+            new MemoryError({
+              reason: "memory ingest failed",
+              cause,
+            }),
+        }),
+    })
+  );
+}

--- a/packages/clawql-memory/src/effect/memory-ingest-service.ts
+++ b/packages/clawql-memory/src/effect/memory-ingest-service.ts
@@ -10,9 +10,7 @@ import { MemoryError } from "./memory-errors.js";
 export class MemoryIngestService extends Context.Tag("clawql/MemoryIngestService")<
   MemoryIngestService,
   {
-    readonly ingest: (
-      input: MemoryIngestInput
-    ) => Effect.Effect<MemoryIngestResult, MemoryError>;
+    readonly ingest: (input: MemoryIngestInput) => Effect.Effect<MemoryIngestResult, MemoryError>;
   }
 >() {}
 

--- a/packages/clawql-memory/src/effect/memory-recall-service.ts
+++ b/packages/clawql-memory/src/effect/memory-recall-service.ts
@@ -1,0 +1,34 @@
+import { Context, Effect, Layer } from "effect";
+import {
+  executeMemoryRecall,
+  type MemoryRecallInput,
+  type MemoryRecallResult,
+} from "../recall/recall.js";
+import { MemoryError } from "./memory-errors.js";
+
+/** Effect service for vault memory recall (`memory_recall`). */
+export class MemoryRecallService extends Context.Tag("clawql/MemoryRecallService")<
+  MemoryRecallService,
+  {
+    readonly recall: (
+      input: MemoryRecallInput
+    ) => Effect.Effect<MemoryRecallResult, MemoryError>;
+  }
+>() {}
+
+export function memoryRecallLiveLayer(): Layer.Layer<MemoryRecallService> {
+  return Layer.succeed(
+    MemoryRecallService,
+    MemoryRecallService.of({
+      recall: (input) =>
+        Effect.tryPromise({
+          try: () => executeMemoryRecall(input),
+          catch: (cause) =>
+            new MemoryError({
+              reason: "memory recall failed",
+              cause,
+            }),
+        }),
+    })
+  );
+}

--- a/packages/clawql-memory/src/effect/memory-recall-service.ts
+++ b/packages/clawql-memory/src/effect/memory-recall-service.ts
@@ -10,9 +10,7 @@ import { MemoryError } from "./memory-errors.js";
 export class MemoryRecallService extends Context.Tag("clawql/MemoryRecallService")<
   MemoryRecallService,
   {
-    readonly recall: (
-      input: MemoryRecallInput
-    ) => Effect.Effect<MemoryRecallResult, MemoryError>;
+    readonly recall: (input: MemoryRecallInput) => Effect.Effect<MemoryRecallResult, MemoryError>;
   }
 >() {}
 

--- a/packages/clawql-memory/src/effect/memory-services.test.ts
+++ b/packages/clawql-memory/src/effect/memory-services.test.ts
@@ -1,0 +1,77 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect } from "effect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MemoryIngestService, memoryIngestLiveLayer } from "./memory-ingest-service.js";
+import { MemoryRecallService, memoryRecallLiveLayer } from "./memory-recall-service.js";
+
+describe("MemoryIngestService", () => {
+  let home: string;
+  let prevVault: string | undefined;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "clawql-memory-ingest-effect-"));
+    prevVault = process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+    process.env.CLAWQL_OBSIDIAN_VAULT_PATH = home;
+  });
+
+  afterEach(async () => {
+    if (prevVault === undefined) delete process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+    else process.env.CLAWQL_OBSIDIAN_VAULT_PATH = prevVault;
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("ingests a new vault page", async () => {
+    const layer = memoryIngestLiveLayer();
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const ingest = yield* MemoryIngestService;
+        return yield* ingest.ingest({
+          title: "Effect ingest test",
+          insights: "hello from Effect",
+        });
+      }).pipe(Effect.provide(layer))
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.path).toBe("Memory/effect-ingest-test.md");
+  });
+});
+
+describe("MemoryRecallService", () => {
+  let home: string;
+  let prevVault: string | undefined;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "clawql-memory-recall-effect-"));
+    prevVault = process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+    process.env.CLAWQL_OBSIDIAN_VAULT_PATH = home;
+    await mkdir(join(home, "Memory"), { recursive: true });
+    await writeFile(
+      join(home, "Memory", "note.md"),
+      "# Note\n\nkeyword-alpha unique-term\n",
+      "utf8"
+    );
+  });
+
+  afterEach(async () => {
+    if (prevVault === undefined) delete process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+    else process.env.CLAWQL_OBSIDIAN_VAULT_PATH = prevVault;
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("recalls keyword hits from the vault", async () => {
+    const layer = memoryRecallLiveLayer();
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const recall = yield* MemoryRecallService;
+        return yield* recall.recall({ query: "unique-term" });
+      }).pipe(Effect.provide(layer))
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.results?.some((r) => r.path === "Memory/note.md")).toBe(true);
+  });
+});

--- a/packages/clawql-memory/src/ingest/ingest.ts
+++ b/packages/clawql-memory/src/ingest/ingest.ts
@@ -347,6 +347,7 @@ export async function executeMemoryIngest(input: MemoryIngestInput): Promise<Mem
 
 /** Public async facade for vault ingest (MCP tools, scripts, automation). */
 export async function runMemoryIngest(input: MemoryIngestInput): Promise<MemoryIngestResult> {
-  const { runMemoryEffect, memoryIngestProgram } = await import("../effect/memory-effect-runtime.js");
+  const { runMemoryEffect, memoryIngestProgram } =
+    await import("../effect/memory-effect-runtime.js");
   return runMemoryEffect(memoryIngestProgram(input));
 }

--- a/packages/clawql-memory/src/ingest/ingest.ts
+++ b/packages/clawql-memory/src/ingest/ingest.ts
@@ -173,7 +173,7 @@ function buildFrontmatter(title: string): string {
   ].join("\n");
 }
 
-export async function runMemoryIngest(input: MemoryIngestInput): Promise<MemoryIngestResult> {
+export async function executeMemoryIngest(input: MemoryIngestInput): Promise<MemoryIngestResult> {
   const vault = getObsidianVaultPath();
   if (!vault) {
     return {
@@ -343,4 +343,10 @@ export async function runMemoryIngest(input: MemoryIngestInput): Promise<MemoryI
   }
 
   return result;
+}
+
+/** Public async facade for vault ingest (MCP tools, scripts, automation). */
+export async function runMemoryIngest(input: MemoryIngestInput): Promise<MemoryIngestResult> {
+  const { runMemoryEffect, memoryIngestProgram } = await import("../effect/memory-effect-runtime.js");
+  return runMemoryEffect(memoryIngestProgram(input));
 }

--- a/packages/clawql-memory/src/plugin/index.ts
+++ b/packages/clawql-memory/src/plugin/index.ts
@@ -7,3 +7,15 @@ export {
   memoryRecallToolSchema,
 } from "./memory-plugin.js";
 export { makeMemoryLayer, type MemoryLayerError } from "./memory-layer.js";
+export {
+  MemoryError,
+  MemoryIngestService,
+  MemoryRecallService,
+  memoryIngestLiveLayer,
+  memoryIngestProgram,
+  memoryRecallLiveLayer,
+  memoryRecallProgram,
+  memoryServicesLiveLayer,
+  runMemoryEffect,
+  type MemoryServices,
+} from "../effect/index.js";

--- a/packages/clawql-memory/src/recall/recall.ts
+++ b/packages/clawql-memory/src/recall/recall.ts
@@ -406,6 +406,7 @@ export async function executeMemoryRecall(input: MemoryRecallInput): Promise<Mem
 
 /** Public async facade for vault recall (MCP tools, scripts). */
 export async function runMemoryRecall(input: MemoryRecallInput): Promise<MemoryRecallResult> {
-  const { runMemoryEffect, memoryRecallProgram } = await import("../effect/memory-effect-runtime.js");
+  const { runMemoryEffect, memoryRecallProgram } =
+    await import("../effect/memory-effect-runtime.js");
   return runMemoryEffect(memoryRecallProgram(input));
 }

--- a/packages/clawql-memory/src/recall/recall.ts
+++ b/packages/clawql-memory/src/recall/recall.ts
@@ -132,7 +132,7 @@ function defaultScanRoot(): string {
   return t === "" ? "" : t;
 }
 
-export async function runMemoryRecall(input: MemoryRecallInput): Promise<MemoryRecallResult> {
+export async function executeMemoryRecall(input: MemoryRecallInput): Promise<MemoryRecallResult> {
   const vault = getObsidianVaultPath();
   if (!vault) {
     return {
@@ -402,4 +402,10 @@ export async function runMemoryRecall(input: MemoryRecallInput): Promise<MemoryR
     result.cuckooVectorChunksDropped = cuckooVectorChunksDropped;
   }
   return result;
+}
+
+/** Public async facade for vault recall (MCP tools, scripts). */
+export async function runMemoryRecall(input: MemoryRecallInput): Promise<MemoryRecallResult> {
+  const { runMemoryEffect, memoryRecallProgram } = await import("../effect/memory-effect-runtime.js");
+  return runMemoryEffect(memoryRecallProgram(input));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First domain-level Effect port for a horizontal package: `clawql-memory` ingest/recall.

Public APIs unchanged. Internals route through `MemoryIngestService` / `MemoryRecallService` with Layer DI.

## Changes

- `memoryServicesLiveLayer()` + `runMemoryEffect()`
- `executeMemoryIngest` / `executeMemoryRecall` core + async facades
- Export from `clawql-memory/plugin`; unit tests added

## Broader migration

Slice 1 of horizontal Effect migration. Next: clawql-core CacheService, clawql-api execute pipeline, deeper memory vault/db services, then documents/automation/ouroboros/sandbox/auth.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

