### PR TITLE
fix(deploy): keep GitHub Pages default until Cloudflare secrets are set

### DIFF
--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -1,6 +1,7 @@
-# Deploy landing-page/demo (static export) to Cloudflare Pages → https://clawql.com
-# Replaces GitHub Pages so Link headers, Markdown negotiation, and _headers work.
-name: Deploy landing page (Cloudflare Pages)
+# Static export of landing-page/demo → GitHub Pages (https://clawql.com) by default.
+# When CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID are set, also deploy to Cloudflare Pages
+# so Link headers, Markdown negotiation, and functions/ work at the edge.
+name: Deploy landing page
 
 on:
   push:
@@ -16,12 +17,14 @@ concurrency:
 
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
 jobs:
-  deploy:
-    name: Build and deploy to Cloudflare Pages
+  build:
+    name: Build static site
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
@@ -35,12 +38,68 @@ jobs:
         run: npm ci
         working-directory: landing-page/demo
 
-      - name: Build static site
+      - name: Build (static export)
         working-directory: landing-page/demo
         env:
+          # Custom domain at repo root. For project Pages only, set to /ClawQL in repo vars.
           NEXT_PUBLIC_BASE_PATH: ${{ vars.LANDING_PAGE_BASE_PATH || '' }}
           NEXT_PUBLIC_SITE_URL: https://clawql.com
         run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
+        with:
+          path: landing-page/demo/out
+
+      - name: Upload build artifact (Cloudflare)
+        uses: actions/upload-artifact@v7
+        with:
+          name: landing-page-out
+          path: landing-page/demo/out
+          retention-days: 1
+
+  deploy-github-pages:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages (attempt 1)
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
+        continue-on-error: true
+      - name: Deploy to GitHub Pages (attempt 2)
+        id: deployment_retry_2
+        if: steps.deployment.outcome == 'failure'
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
+        continue-on-error: true
+      - name: Deploy to GitHub Pages (attempt 3)
+        id: deployment_retry_3
+        if: steps.deployment.outcome == 'failure' && steps.deployment_retry_2.outcome == 'failure'
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
+      - name: Verify deploy succeeded
+        if: steps.deployment.outcome == 'failure' && steps.deployment_retry_2.outcome == 'failure' && steps.deployment_retry_3.outcome == 'failure'
+        run: |
+          echo "GitHub Pages deploy failed after 3 attempts"
+          exit 1
+
+  deploy-cloudflare-pages:
+    name: Deploy to Cloudflare Pages (optional)
+    needs: build
+    if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: landing-page-out
+          path: landing-page/demo/out
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@6a6c3a8fbb837218b1a676c348aa5de81a9c3066

--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -1,6 +1,6 @@
 # Static export of landing-page/demo → GitHub Pages (https://clawql.com) by default.
-# When CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID are set, also deploy to Cloudflare Pages
-# so Link headers, Markdown negotiation, and functions/ work at the edge.
+# Set repo variable LANDING_PAGE_CLOUDFLARE_DEPLOY=true (and Cloudflare secrets) to also
+# deploy to Cloudflare Pages for Link headers, Markdown negotiation, and functions/.
 name: Deploy landing page
 
 on:
@@ -89,25 +89,19 @@ jobs:
   deploy-cloudflare-pages:
     name: Deploy to Cloudflare Pages (optional)
     needs: build
+    if: ${{ vars.LANDING_PAGE_CLOUDFLARE_DEPLOY == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Skip without Cloudflare credentials
-        if: ${{ secrets.CLOUDFLARE_API_TOKEN == '' || secrets.CLOUDFLARE_ACCOUNT_ID == '' }}
-        run: echo "Cloudflare secrets not configured; skipping Pages deploy."
-
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-        if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
 
       - name: Download build artifact
-        if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
         uses: actions/download-artifact@v7
         with:
           name: landing-page-out
           path: landing-page/demo/out
 
       - name: Deploy to Cloudflare Pages
-        if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
         uses: cloudflare/wrangler-action@6a6c3a8fbb837218b1a676c348aa5de81a9c3066
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -117,7 +111,6 @@ jobs:
           command: pages deploy out --project-name=clawql-website --branch=main
 
       - name: Ensure DNS-AID records (optional)
-        if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -89,19 +89,25 @@ jobs:
   deploy-cloudflare-pages:
     name: Deploy to Cloudflare Pages (optional)
     needs: build
-    if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - name: Skip without Cloudflare credentials
+        if: ${{ secrets.CLOUDFLARE_API_TOKEN == '' || secrets.CLOUDFLARE_ACCOUNT_ID == '' }}
+        run: echo "Cloudflare secrets not configured; skipping Pages deploy."
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
 
       - name: Download build artifact
+        if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
         uses: actions/download-artifact@v7
         with:
           name: landing-page-out
           path: landing-page/demo/out
 
       - name: Deploy to Cloudflare Pages
+        if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
         uses: cloudflare/wrangler-action@6a6c3a8fbb837218b1a676c348aa5de81a9c3066
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -111,6 +117,7 @@ jobs:
           command: pages deploy out --project-name=clawql-website --branch=main
 
       - name: Ensure DNS-AID records (optional)
+        if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/landing-page/README.md
+++ b/landing-page/README.md
@@ -90,7 +90,7 @@ Workflow [`.github/workflows/deploy-landing-page.yml`](../.github/workflows/depl
 
 ### Cloudflare Pages (optional, for full agent score)
 
-When `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` repo secrets are set, the same workflow also deploys to **Cloudflare Pages** (`clawql-website`). Wrangler runs from `landing-page/demo/` so the sibling `functions/` directory (Link headers + markdown negotiation) is bundled with `out/`.
+When `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, and repo variable **`LANDING_PAGE_CLOUDFLARE_DEPLOY=true`** are set, the same workflow also deploys to **Cloudflare Pages** (`clawql-website`). Wrangler runs from `landing-page/demo/` so the sibling `functions/` directory (Link headers + markdown negotiation) is bundled with `out/`.
 
 **DNS (one-time, when switching):** Point apex `clawql.com` to Cloudflare Pages (not GitHub Pages A records). Attach custom domain `clawql.com` to the Pages project in the Cloudflare dashboard.
 

--- a/landing-page/README.md
+++ b/landing-page/README.md
@@ -80,23 +80,29 @@ Signup forms POST to **hello@clawql.com** via [FormSubmit](https://formsubmit.co
 
 For local dev, set `NEXT_PUBLIC_SITE_URL=http://localhost:3000` so the post-submit redirect lands on `/signup/thanks/`.
 
-### Cloudflare Pages (on merge to `main`)
+### Deploy on merge to `main`
 
-A workflow at [`.github/workflows/deploy-landing-page.yml`](../.github/workflows/deploy-landing-page.yml) builds and deploys to **Cloudflare Pages** (`clawql-website` project) when `landing-page/**` changes. Wrangler runs from `landing-page/demo/` so the sibling `functions/` directory (Link headers + markdown negotiation) is bundled with `out/`.
+Workflow [`.github/workflows/deploy-landing-page.yml`](../.github/workflows/deploy-landing-page.yml) builds `landing-page/demo` and deploys to **GitHub Pages** on every push to `main` that touches `landing-page/**`.
 
-**DNS (one-time):** Point apex `clawql.com` to Cloudflare Pages (not GitHub Pages A records). Attach custom domain `clawql.com` to the Pages project in the Cloudflare dashboard.
-
-**Agent readiness:** The prebuild step writes `robots.txt`, `sitemap.xml`, `auth.md`, `/.well-known/*`, `llms.txt`, and `agent-markdown.json`. Cloudflare Pages `functions/` adds **Link** response headers and **Accept: text/markdown** negotiation. Optional CI step `scripts/deploy/ensure-dns-aid-records.sh` creates DNS-AID records when `CLOUDFLARE_API_TOKEN` is set.
+**Agent readiness (GitHub Pages):** The prebuild step writes `robots.txt`, `sitemap.xml`, `auth.md`, `/.well-known/*`, `llms.txt`, and `agent-markdown.json` into the static export. These work on GitHub Pages. **Link** response headers and **Accept: text/markdown** negotiation require Cloudflare Pages `functions/` or edge rules (see below).
 
 **Lighthouse CI:** [`.github/workflows/landing-page-lighthouse.yml`](../.github/workflows/landing-page-lighthouse.yml) asserts accessibility, SEO, and best-practices scores of 1.0 on the static export.
 
-### Staying on GitHub Pages?
+### Cloudflare Pages (optional, for full agent score)
+
+When `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` repo secrets are set, the same workflow also deploys to **Cloudflare Pages** (`clawql-website`). Wrangler runs from `landing-page/demo/` so the sibling `functions/` directory (Link headers + markdown negotiation) is bundled with `out/`.
+
+**DNS (one-time, when switching):** Point apex `clawql.com` to Cloudflare Pages (not GitHub Pages A records). Attach custom domain `clawql.com` to the Pages project in the Cloudflare dashboard.
+
+Optional CI step `scripts/deploy/ensure-dns-aid-records.sh` creates DNS-AID records when the Cloudflare token is set.
+
+### Staying on GitHub Pages with Cloudflare DNS?
 
 Pure GitHub Pages **cannot** pass **Link headers** or **Markdown for Agents** checks (no custom response headers or content negotiation). You can keep GitHub Pages as the origin if `clawql.com` stays on Cloudflare: enable **Markdown for Agents** on the zone and add a **Transform Rule** (or thin Worker) for `Link` headers. Static `.well-known` files and `robots.txt` work on either host.
 
 ### Legacy GitHub Pages
 
-`public/CNAME` remains `clawql.com` for reference. Production deploy target is Cloudflare Pages so Link headers and Markdown for Agents work without extra edge rules.
+`public/CNAME` remains `clawql.com`. GitHub Pages is the default deploy target until Cloudflare API secrets are configured.
 
 ### Other hosts
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR #604 merged agent-readiness work but switched `deploy-landing-page.yml` to **Cloudflare Pages only**. Without `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`, that workflow would fail and **GitHub Pages would stop receiving updates**.

This restores the previous GitHub Pages deploy path as the default while keeping the Cloudflare Pages path ready for when secrets are configured.

## Changes

- **GitHub Pages** — always deploys on `landing-page/**` pushes (same as before #604)
- **Cloudflare Pages** — optional second job, runs only when both Cloudflare secrets are set; reuses the build artifact (no duplicate build)
- **README** — documents interim GitHub Pages hosting vs full agent score on Cloudflare

## Tomorrow (operator)

1. Add `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` repo secrets
2. Point `clawql.com` DNS to Cloudflare Pages (`clawql-website`)
3. Re-run or push to trigger deploy; optional DNS-AID step runs automatically
4. Re-scan https://isitagentready.com/clawql.com

Until then, clawql.com stays on GitHub Pages with static agent assets (`robots.txt`, `/.well-known/*`, etc.). Link headers and markdown negotiation activate once Cloudflare Pages is live.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5923-61ff-77f8-92df-6c4b1fa90953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5923-61ff-77f8-92df-6c4b1fa90953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

