### PR TITLE
feat(core): CacheService Effect layer for MCP cache tool

### DIFF
--- a/packages/clawql-core/src/cache/cache-effect-runtime.ts
+++ b/packages/clawql-core/src/cache/cache-effect-runtime.ts
@@ -1,0 +1,17 @@
+import { Cause, Effect, Exit } from "effect";
+import { CacheLive, CacheService, cacheOperationProgram } from "./cache-service.js";
+import type { CacheOperationInput, CacheOperationResult } from "./types.js";
+
+/** Run a cache Effect program with the default LRU Layer. */
+export async function runCacheEffect<A, E>(program: Effect.Effect<A, E, CacheService>): Promise<A> {
+  const exit = await Effect.runPromiseExit(program.pipe(Effect.provide(CacheLive)));
+  if (Exit.isSuccess(exit)) {
+    return exit.value;
+  }
+  throw Cause.squash(exit.cause);
+}
+
+/** Execute one cache tool operation via Effect services (MCP bridge). */
+export function runCacheOperation(input: CacheOperationInput): Promise<CacheOperationResult> {
+  return runCacheEffect(cacheOperationProgram(input));
+}

--- a/packages/clawql-core/src/cache/cache-service.test.ts
+++ b/packages/clawql-core/src/cache/cache-service.test.ts
@@ -1,0 +1,112 @@
+import { Effect } from "effect";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  CacheService,
+  CacheTestLayer,
+  cacheOperationProgram,
+  createCacheTestLayer,
+} from "./cache-service.js";
+import { getClawqlCacheMaxEntries } from "./config.js";
+import { resetDefaultLruCacheStoreForTests } from "./lru-store.js";
+
+const run = <A, E>(program: Effect.Effect<A, E, CacheService>) =>
+  Effect.runPromise(program.pipe(Effect.provide(CacheTestLayer)));
+
+describe("CacheService (Effect)", () => {
+  afterEach(() => {
+    resetDefaultLruCacheStoreForTests();
+  });
+
+  it("set get delete via Effect Layer", async () => {
+    await run(
+      Effect.gen(function* () {
+        const cache = yield* CacheService;
+        yield* cache.execute({ operation: "set", key: "k1", value: "v1" });
+        const hit = yield* cache.execute({ operation: "get", key: "k1" });
+        expect(hit).toMatchObject({ ok: true, hit: true, value: "v1" });
+        const del = yield* cache.execute({ operation: "delete", key: "k1" });
+        expect(del).toMatchObject({ deleted: true });
+        const miss = yield* cache.execute({ operation: "get", key: "k1" });
+        expect(miss).toMatchObject({ hit: false });
+      })
+    );
+  });
+
+  it("list with prefix and search", async () => {
+    const list = await run(
+      Effect.gen(function* () {
+        const cache = yield* CacheService;
+        yield* cache.execute({ operation: "set", key: "session:a", value: "1" });
+        yield* cache.execute({ operation: "set", key: "session:b", value: "2" });
+        yield* cache.execute({ operation: "set", key: "other", value: "3" });
+        const listed = yield* cacheOperationProgram({
+          operation: "list",
+          prefix: "session:",
+          limit: 10,
+        });
+        const searched = yield* cacheOperationProgram({
+          operation: "search",
+          query: "ssion:b",
+          limit: 10,
+        });
+        return { listed, searched };
+      })
+    );
+    expect(list.listed).toMatchObject({ keys: ["session:a", "session:b"] });
+    expect(list.searched).toMatchObject({ keys: ["session:b"] });
+  });
+
+  it("rejects oversized values", async () => {
+    const smallValueLayer = createCacheTestLayer(
+      () => 10,
+      () => 10_000
+    );
+    const runSmall = <A, E>(program: Effect.Effect<A, E, CacheService>) =>
+      Effect.runPromise(program.pipe(Effect.provide(smallValueLayer)));
+
+    const result = await runSmall(
+      cacheOperationProgram({
+        operation: "set",
+        key: "big",
+        value: "x".repeat(20),
+      })
+    );
+    expect(result).toMatchObject({ ok: false });
+  });
+
+  it("evicts LRU when at max entries", async () => {
+    const smallLayer = createCacheTestLayer(
+      () => 1024 * 1024,
+      () => 3
+    );
+    const runSmall = <A, E>(program: Effect.Effect<A, E, CacheService>) =>
+      Effect.runPromise(program.pipe(Effect.provide(smallLayer)));
+
+    const store = await runSmall(
+      Effect.gen(function* () {
+        const cache = yield* CacheService;
+        yield* cache.execute({ operation: "set", key: "a", value: "1" });
+        yield* cache.execute({ operation: "set", key: "b", value: "2" });
+        yield* cache.execute({ operation: "set", key: "c", value: "3" });
+        yield* cache.execute({ operation: "get", key: "b" });
+        const setD = yield* cache.execute({ operation: "set", key: "d", value: "4" });
+        const ga = yield* cache.execute({ operation: "get", key: "a" });
+        const gb = yield* cache.execute({ operation: "get", key: "b" });
+        const gd = yield* cache.execute({ operation: "get", key: "d" });
+        return { setD, ga, gb, gd };
+      })
+    );
+    expect(store.setD).toMatchObject({ ok: true, evicted: 1 });
+    expect(store.ga).toMatchObject({ hit: false });
+    expect(store.gb).toMatchObject({ hit: true });
+    expect(store.gd).toMatchObject({ hit: true });
+  });
+
+  it("getClawqlCacheMaxEntries respects env", () => {
+    const saved = process.env.CLAWQL_CACHE_MAX_ENTRIES;
+    process.env.CLAWQL_CACHE_MAX_ENTRIES = "42";
+    expect(getClawqlCacheMaxEntries()).toBe(42);
+    if (saved === undefined) delete process.env.CLAWQL_CACHE_MAX_ENTRIES;
+    else process.env.CLAWQL_CACHE_MAX_ENTRIES = saved;
+  });
+});

--- a/packages/clawql-core/src/cache/cache-service.ts
+++ b/packages/clawql-core/src/cache/cache-service.ts
@@ -1,0 +1,56 @@
+import { Context, Effect, Layer } from "effect";
+import { getClawqlCacheMaxEntries, getClawqlCacheMaxValueBytes } from "./config.js";
+import { createLruCacheStore, getDefaultLruCacheStore, type LruCacheStore } from "./lru-store.js";
+import type { CacheOperationInput, CacheOperationResult } from "./types.js";
+
+export class CacheService extends Context.Tag("clawql/CacheService")<
+  CacheService,
+  {
+    readonly getMaxValueBytes: () => number;
+    readonly getMaxEntries: () => number;
+    readonly execute: (input: CacheOperationInput) => Effect.Effect<CacheOperationResult>;
+    readonly resetForTests: () => Effect.Effect<void>;
+  }
+>() {}
+
+function serviceFromStore(store: LruCacheStore) {
+  return CacheService.of({
+    getMaxValueBytes: store.getMaxValueBytes,
+    getMaxEntries: store.getMaxEntries,
+    execute: (input) => Effect.sync(() => store.execute(input)),
+    resetForTests: () => Effect.sync(() => store.reset()),
+  });
+}
+
+/** Isolated LRU store for tests; optional caps override env defaults. */
+export function createCacheTestLayer(
+  getMaxValueBytes: () => number = getClawqlCacheMaxValueBytes,
+  getMaxEntries: () => number = getClawqlCacheMaxEntries
+) {
+  return Layer.effect(
+    CacheService,
+    Effect.sync(() => serviceFromStore(createLruCacheStore(getMaxValueBytes, getMaxEntries)))
+  );
+}
+
+/** Default isolated store for unit tests (`Effect.provide(CacheTestLayer)`). */
+export const CacheTestLayer = createCacheTestLayer(
+  () => 1024 * 1024,
+  () => 10_000
+);
+
+/** In-memory LRU store backed by the process-wide default store (MCP bridge). */
+export const CacheLive = Layer.effect(
+  CacheService,
+  Effect.sync(() => serviceFromStore(getDefaultLruCacheStore()))
+);
+
+/** Run a single cache operation via Effect services. */
+export function cacheOperationProgram(
+  input: CacheOperationInput
+): Effect.Effect<CacheOperationResult, never, CacheService> {
+  return Effect.gen(function* () {
+    const cache = yield* CacheService;
+    return yield* cache.execute(input);
+  });
+}

--- a/packages/clawql-core/src/cache/config.ts
+++ b/packages/clawql-core/src/cache/config.ts
@@ -1,0 +1,17 @@
+/** `CLAWQL_CACHE_MAX_VALUE_BYTES` (default 1 MiB, max 16 MiB, min 1). */
+export function getClawqlCacheMaxValueBytes(): number {
+  const v = process.env.CLAWQL_CACHE_MAX_VALUE_BYTES?.trim();
+  if (!v) return 1024 * 1024;
+  const n = Number.parseInt(v, 10);
+  if (!Number.isFinite(n)) return 1024 * 1024;
+  return Math.min(Math.max(n, 1), 16 * 1024 * 1024);
+}
+
+/** `CLAWQL_CACHE_MAX_ENTRIES` (default 10_000, min 1, max 10M). */
+export function getClawqlCacheMaxEntries(): number {
+  const v = process.env.CLAWQL_CACHE_MAX_ENTRIES?.trim();
+  if (!v) return 10_000;
+  const n = Number.parseInt(v, 10);
+  if (!Number.isFinite(n)) return 10_000;
+  return Math.min(Math.max(n, 1), 10_000_000);
+}

--- a/packages/clawql-core/src/cache/index.ts
+++ b/packages/clawql-core/src/cache/index.ts
@@ -1,0 +1,5 @@
+export * from "./cache-effect-runtime.js";
+export * from "./cache-service.js";
+export * from "./config.js";
+export * from "./lru-store.js";
+export * from "./types.js";

--- a/packages/clawql-core/src/cache/lru-store.ts
+++ b/packages/clawql-core/src/cache/lru-store.ts
@@ -1,0 +1,147 @@
+import { getClawqlCacheMaxEntries, getClawqlCacheMaxValueBytes } from "./config.js";
+import type {
+  CacheDeleteResult,
+  CacheGetResult,
+  CacheListResult,
+  CacheOperationInput,
+  CacheOperationResult,
+  CacheSearchResult,
+  CacheSetResult,
+} from "./types.js";
+
+export type LruCacheStore = {
+  readonly getMaxValueBytes: () => number;
+  readonly getMaxEntries: () => number;
+  readonly execute: (input: CacheOperationInput) => CacheOperationResult;
+  readonly reset: () => void;
+};
+
+function touchLru(mem: Map<string, string>, key: string): void {
+  const v = mem.get(key);
+  if (v === undefined) return;
+  mem.delete(key);
+  mem.set(key, v);
+}
+
+function evictLruUntilRoomForNewKey(mem: Map<string, string>, maxEntries: number): number {
+  let evicted = 0;
+  while (mem.size >= maxEntries) {
+    const lru = mem.keys().next().value as string | undefined;
+    if (lru === undefined) break;
+    mem.delete(lru);
+    evicted++;
+  }
+  return evicted;
+}
+
+function executeOnStore(
+  mem: Map<string, string>,
+  getMaxValueBytes: () => number,
+  getMaxEntries: () => number,
+  input: CacheOperationInput
+): CacheOperationResult {
+  const maxV = getMaxValueBytes();
+  const maxEntries = getMaxEntries();
+
+  switch (input.operation) {
+    case "set": {
+      const bytes = Buffer.byteLength(input.value, "utf8");
+      if (bytes > maxV) {
+        return {
+          ok: false,
+          error: `value size ${bytes} exceeds CLAWQL_CACHE_MAX_VALUE_BYTES (${maxV})`,
+        } satisfies CacheSetResult;
+      }
+      const isNew = !mem.has(input.key);
+      let evicted = 0;
+      if (isNew) {
+        evicted = evictLruUntilRoomForNewKey(mem, maxEntries);
+      }
+      mem.delete(input.key);
+      mem.set(input.key, input.value);
+      return {
+        ok: true,
+        operation: "set",
+        key: input.key,
+        ...(evicted > 0 ? { evicted } : {}),
+      } satisfies CacheSetResult;
+    }
+    case "get": {
+      const v = mem.get(input.key);
+      if (v === undefined) {
+        return { ok: true, hit: false, key: input.key } satisfies CacheGetResult;
+      }
+      touchLru(mem, input.key);
+      return { ok: true, hit: true, key: input.key, value: v } satisfies CacheGetResult;
+    }
+    case "delete": {
+      const existed = mem.has(input.key);
+      mem.delete(input.key);
+      return {
+        ok: true,
+        operation: "delete",
+        key: input.key,
+        deleted: existed,
+      } satisfies CacheDeleteResult;
+    }
+    case "list": {
+      const prefix = input.prefix ?? "";
+      const listLimit = input.limit ?? 100;
+      const keys = [...mem.keys()]
+        .filter((k) => k.startsWith(prefix))
+        .sort()
+        .slice(0, listLimit);
+      return {
+        ok: true,
+        operation: "list",
+        prefix: prefix === "" ? undefined : prefix,
+        count: keys.length,
+        keys,
+      } satisfies CacheListResult;
+    }
+    case "search": {
+      const q = input.query.toLowerCase();
+      const searchLimit = input.limit ?? 50;
+      const keys = [...mem.keys()]
+        .filter((k) => k.toLowerCase().includes(q))
+        .sort()
+        .slice(0, searchLimit);
+      return {
+        ok: true,
+        operation: "search",
+        query: input.query,
+        count: keys.length,
+        keys,
+      } satisfies CacheSearchResult;
+    }
+  }
+}
+
+export function createLruCacheStore(
+  getMaxValueBytes: () => number = getClawqlCacheMaxValueBytes,
+  getMaxEntries: () => number = getClawqlCacheMaxEntries
+): LruCacheStore {
+  const mem = new Map<string, string>();
+  return {
+    getMaxValueBytes,
+    getMaxEntries,
+    execute: (input) => executeOnStore(mem, getMaxValueBytes, getMaxEntries, input),
+    reset: () => mem.clear(),
+  };
+}
+
+let defaultStore: LruCacheStore | undefined;
+
+/** Shared in-process LRU store for `clawql-mcp` until full Layer bootstrap at API startup. */
+export function getDefaultLruCacheStore(): LruCacheStore {
+  if (!defaultStore) {
+    defaultStore = createLruCacheStore();
+  }
+  return defaultStore;
+}
+
+/** Test helper — drops singleton so the next call creates a fresh store. */
+export function resetDefaultLruCacheStoreForTests(): void {
+  defaultStore?.reset();
+  defaultStore = undefined;
+}

--- a/packages/clawql-core/src/cache/types.ts
+++ b/packages/clawql-core/src/cache/types.ts
@@ -1,0 +1,45 @@
+export type CacheSetResult =
+  | {
+      readonly ok: true;
+      readonly operation: "set";
+      readonly key: string;
+      readonly evicted?: number;
+    }
+  | { readonly ok: false; readonly error: string };
+
+export type CacheGetResult =
+  | { readonly ok: true; readonly hit: true; readonly key: string; readonly value: string }
+  | { readonly ok: true; readonly hit: false; readonly key: string };
+
+export type CacheDeleteResult = {
+  readonly ok: true;
+  readonly operation: "delete";
+  readonly key: string;
+  readonly deleted: boolean;
+};
+
+export type CacheListResult = {
+  readonly ok: true;
+  readonly operation: "list";
+  readonly prefix?: string;
+  readonly count: number;
+  readonly keys: readonly string[];
+};
+
+export type CacheSearchResult = {
+  readonly ok: true;
+  readonly operation: "search";
+  readonly query: string;
+  readonly count: number;
+  readonly keys: readonly string[];
+};
+
+export type CacheOperationInput =
+  | { readonly operation: "set"; readonly key: string; readonly value: string }
+  | { readonly operation: "get"; readonly key: string }
+  | { readonly operation: "delete"; readonly key: string }
+  | { readonly operation: "list"; readonly prefix?: string; readonly limit?: number }
+  | { readonly operation: "search"; readonly query: string; readonly limit?: number };
+
+export type CacheOperationResult =
+  CacheSetResult | CacheGetResult | CacheDeleteResult | CacheListResult | CacheSearchResult;

--- a/packages/clawql-core/src/index.ts
+++ b/packages/clawql-core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./audit/index.js";
+export * from "./cache/index.js";
 export * from "./cuckoo/index.js";
 export * from "./errors/index.js";
 export * from "./merkle/index.js";

--- a/src/clawql-cache.ts
+++ b/src/clawql-cache.ts
@@ -1,57 +1,22 @@
 /**
  * Ephemeral in-process KV for MCP `cache` tool (#75) — distinct from Obsidian `memory_*`.
- * **LRU:** `Map` insertion order — first key is least-recently-used; `get`/`set` move entries to MRU.
- * **Not persisted:** use **`memory_ingest`** / **`memory_recall`** for durable vault memory.
+ * LRU store + config live in `clawql-core`; this module adds MCP/Zod validation.
  */
 
+import {
+  getClawqlCacheMaxEntries,
+  getClawqlCacheMaxValueBytes,
+  resetDefaultLruCacheStoreForTests,
+  runCacheOperation,
+} from "clawql-core";
 import { z } from "zod";
 import { logMcpToolShape } from "./mcp-tool-log.js";
 
-/** In-process store only — cleared on restart; never written to disk. */
-const mem = new Map<string, string>();
-
-/** Exported for tests — `CLAWQL_CACHE_MAX_VALUE_BYTES` (default 1 MiB, max 16 MiB, min 1). */
-export function getClawqlCacheMaxValueBytes(): number {
-  const v = process.env.CLAWQL_CACHE_MAX_VALUE_BYTES?.trim();
-  if (!v) return 1024 * 1024;
-  const n = Number.parseInt(v, 10);
-  if (!Number.isFinite(n)) return 1024 * 1024;
-  return Math.min(Math.max(n, 1), 16 * 1024 * 1024);
-}
-
-/** Exported for tests — `CLAWQL_CACHE_MAX_ENTRIES` (default 10_000, min 1, max 10M). */
-export function getClawqlCacheMaxEntries(): number {
-  const v = process.env.CLAWQL_CACHE_MAX_ENTRIES?.trim();
-  if (!v) return 10_000;
-  const n = Number.parseInt(v, 10);
-  if (!Number.isFinite(n)) return 10_000;
-  return Math.min(Math.max(n, 1), 10_000_000);
-}
-
-/** Move key to most-recently-used (end of iteration order). */
-function touchLru(key: string): void {
-  const v = mem.get(key);
-  if (v === undefined) return;
-  mem.delete(key);
-  mem.set(key, v);
-}
-
-/** Evict least-recently-used (first key) until there is room for one more distinct key. */
-function evictLruUntilRoomForNewKey(maxEntries: number): number {
-  let evicted = 0;
-  while (mem.size >= maxEntries) {
-    const lru = mem.keys().next().value as string | undefined;
-    if (lru === undefined) break;
-    mem.delete(lru);
-    evicted++;
-  }
-  return evicted;
-}
-
-/** Test helper: clear all entries (allows isolated tests in one process). */
-export function resetClawqlCacheForTests(): void {
-  mem.clear();
-}
+export {
+  getClawqlCacheMaxEntries,
+  getClawqlCacheMaxValueBytes,
+  resetDefaultLruCacheStoreForTests as resetClawqlCacheForTests,
+};
 
 export const cacheToolSchema = {
   operation: z
@@ -133,78 +98,44 @@ export async function handleCacheToolInput(
     limit: parsed.limit,
   });
 
-  const maxV = getClawqlCacheMaxValueBytes();
-  const maxEntries = getClawqlCacheMaxEntries();
-  const listLimit = parsed.limit ?? 100;
-  const searchLimit = parsed.limit ?? 50;
-
   switch (parsed.operation) {
-    case "set": {
-      const value = parsed.value!;
-      const key = parsed.key!;
-      const bytes = Buffer.byteLength(value, "utf8");
-      if (bytes > maxV) {
-        return jsonResponse({
-          ok: false,
-          error: `value size ${bytes} exceeds CLAWQL_CACHE_MAX_VALUE_BYTES (${maxV})`,
-        });
-      }
-      const isNew = !mem.has(key);
-      let evicted = 0;
-      if (isNew) {
-        evicted = evictLruUntilRoomForNewKey(maxEntries);
-      }
-      mem.delete(key);
-      mem.set(key, value);
-      return jsonResponse({
-        ok: true,
-        operation: "set",
-        key,
-        ...(evicted > 0 ? { evicted } : {}),
-      });
-    }
-    case "get": {
-      const key = parsed.key!;
-      const v = mem.get(key);
-      if (v === undefined) {
-        return jsonResponse({ ok: true, hit: false, key });
-      }
-      touchLru(key);
-      return jsonResponse({ ok: true, hit: true, key, value: v });
-    }
-    case "delete": {
-      const key = parsed.key!;
-      const existed = mem.has(key);
-      mem.delete(key);
-      return jsonResponse({ ok: true, operation: "delete", key, deleted: existed });
-    }
-    case "list": {
-      const prefix = parsed.prefix ?? "";
-      const keys = [...mem.keys()]
-        .filter((k) => k.startsWith(prefix))
-        .sort()
-        .slice(0, listLimit);
-      return jsonResponse({
-        ok: true,
-        operation: "list",
-        prefix: prefix === "" ? undefined : prefix,
-        count: keys.length,
-        keys,
-      });
-    }
-    case "search": {
-      const q = parsed.query!.toLowerCase();
-      const keys = [...mem.keys()]
-        .filter((k) => k.toLowerCase().includes(q))
-        .sort()
-        .slice(0, searchLimit);
-      return jsonResponse({
-        ok: true,
-        operation: "search",
-        query: parsed.query,
-        count: keys.length,
-        keys,
-      });
-    }
+    case "set":
+      return jsonResponse(
+        await runCacheOperation({
+          operation: "set",
+          key: parsed.key!,
+          value: parsed.value!,
+        })
+      );
+    case "get":
+      return jsonResponse(
+        await runCacheOperation({
+          operation: "get",
+          key: parsed.key!,
+        })
+      );
+    case "delete":
+      return jsonResponse(
+        await runCacheOperation({
+          operation: "delete",
+          key: parsed.key!,
+        })
+      );
+    case "list":
+      return jsonResponse(
+        await runCacheOperation({
+          operation: "list",
+          prefix: parsed.prefix,
+          limit: parsed.limit,
+        })
+      );
+    case "search":
+      return jsonResponse(
+        await runCacheOperation({
+          operation: "search",
+          query: parsed.query!,
+          limit: parsed.limit,
+        })
+      );
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First slice of the **clawql-core** Effect migration (step 1 in the modularization plan): move ephemeral MCP `cache` tool logic into `clawql-core` with a proper `CacheService` Effect layer.

## Changes

- **`packages/clawql-core/src/cache/`** — new module:
  - `config.ts` — `CLAWQL_CACHE_MAX_VALUE_BYTES` / `CLAWQL_CACHE_MAX_ENTRIES` helpers
  - `lru-store.ts` — in-process LRU `Map` store with process-wide singleton (mirrors audit ring buffer pattern)
  - `cache-service.ts` — `CacheService` Context.Tag, `CacheLive`, `CacheTestLayer`, `createCacheTestLayer`
  - `cache-effect-runtime.ts` — `runCacheEffect` / `runCacheOperation` boundary bridge
  - `types.ts` — operation input/result types
  - `cache-service.test.ts` — unit tests (set/get/delete, list, search, size caps, LRU eviction)
- **`src/clawql-cache.ts`** — slimmed to Zod validation + `runCacheOperation` at MCP boundary
- Export from `clawql-core` index

## Architecture

Follows **boundary-only Effect** pattern used by payments/inference:
- Public MCP API remains `Promise`-based (`handleCacheToolInput`)
- Domain logic runs through `Effect` + `Layer` internally via `runCacheOperation`

## Testing

- `npm run test -w clawql-core` — 17 tests pass (includes 5 new cache tests)
- `npx vitest run src/clawql-cache.test.ts` — 5 MCP integration tests pass
- Full `npm run build` succeeds

## Next in migration order

After merge: `ConfigService` + tagged errors expansion in core, then clawql-api `execute-core` native `Effect.gen`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

