### PR TITLE
feat(payments): full MPP discovery, verification, and runtime alongside x402 and Stripe

### DIFF
--- a/docs/payments/clawql-payments.md
+++ b/docs/payments/clawql-payments.md
@@ -8,21 +8,21 @@
 
 ## What ships today
 
-| Capability                                       | Status | Notes                                                                    |
-| ------------------------------------------------ | ------ | ------------------------------------------------------------------------ |
-| Managed plan tiers + entitlements                | ✅     | Local `usage.json` counters; limit enforcement in inference              |
-| Stripe customers, subscriptions, invoices        | ✅     | Live SDK when `STRIPE_SECRET_KEY` is set                                 |
-| Stripe webhook signature verification            | ✅     | CLI verify/process; audit on `invoice.paid`                              |
-| Stripe Billing Meters (`meterEvents.create`)     | ✅     | API + inference hook when `CLAWQL_PAYMENTS_REPORT_STRIPE_METER=1`        |
-| x402 gate config + facilitator HTTP verify       | ✅     | `POST /verify` against x402.org or CDP                                   |
-| x402 Express middleware (402 + PAYMENT-REQUIRED) | ✅     | Wired into `clawql-inference` HTTP                                       |
-| x402 MCP in-process enforcement                  | ✅     | `CLAWQL_X402_ENFORCE=1` on stdio / Streamable HTTP / gRPC MCP tool calls |
-| Payment WORM audit (hash-chained JSONL)          | ✅     | `$CLAWQL_HOME/Payments/audit.jsonl` + `audit verify`                     |
-| Payment WORM audit (Postgres)                    | ✅     | `CLAWQL_PAYMENTS_AUDIT_STORE=postgres` for multi-node deployments        |
-| Payment audit → Loki/SIEM export                 | ✅     | Fire-and-forget push on append when `CLAWQL_LOKI_PUSH_URL` is set        |
-| `.well-known/payments.json` discovery            | ✅     | Dynamic on MCP + inference HTTP; static route on docs site               |
-| MPP `/openapi.json` discovery                    | ✅     | Dynamic on MCP + inference HTTP; canonical `x-payment-info.offers[]`     |
-| MPP HTTP 402 + MCP -32042 runtime                | ✅     | Dual x402 + MPP challenges when `CLAWQL_MPP_ENABLED=1`                   |
+| Capability                                       | Status | Notes                                                                          |
+| ------------------------------------------------ | ------ | ------------------------------------------------------------------------------ |
+| Managed plan tiers + entitlements                | ✅     | Local `usage.json` counters; limit enforcement in inference                    |
+| Stripe customers, subscriptions, invoices        | ✅     | Live SDK when `STRIPE_SECRET_KEY` is set                                       |
+| Stripe webhook signature verification            | ✅     | CLI verify/process; audit on `invoice.paid`                                    |
+| Stripe Billing Meters (`meterEvents.create`)     | ✅     | API + inference hook when `CLAWQL_PAYMENTS_REPORT_STRIPE_METER=1`              |
+| x402 gate config + facilitator HTTP verify       | ✅     | `POST /verify` against x402.org or CDP                                         |
+| x402 Express middleware (402 + PAYMENT-REQUIRED) | ✅     | Wired into `clawql-inference` HTTP                                             |
+| x402 MCP in-process enforcement                  | ✅     | `CLAWQL_X402_ENFORCE=1` on stdio / Streamable HTTP / gRPC MCP tool calls       |
+| Payment WORM audit (hash-chained JSONL)          | ✅     | `$CLAWQL_HOME/Payments/audit.jsonl` + `audit verify`                           |
+| Payment WORM audit (Postgres)                    | ✅     | `CLAWQL_PAYMENTS_AUDIT_STORE=postgres` for multi-node deployments              |
+| Payment audit → Loki/SIEM export                 | ✅     | Fire-and-forget push on append when `CLAWQL_LOKI_PUSH_URL` is set              |
+| `.well-known/payments.json` discovery            | ✅     | Dynamic on MCP + inference HTTP; static route on docs site                     |
+| MPP `/openapi.json` discovery                    | ✅     | Dynamic on MCP + inference HTTP; canonical `x-payment-info.offers[]`           |
+| MPP HTTP 402 + MCP -32042 runtime                | ✅     | Dual x402 + MPP challenges when `CLAWQL_MPP_ENABLED=1`                         |
 | MPP credential verification + receipts           | ✅     | `MppVerificationService` — x402 facilitator + Stripe SPT (`STRIPE_PROFILE_ID`) |
 
 ## Architecture
@@ -320,23 +320,23 @@ Effect entrypoints: `paymentsServicesLiveLayer()` merges all services; `runPayme
 
 **Effect services** (`clawql-payments/plugin`):
 
-| Service                    | Responsibility                                                    |
-| -------------------------- | ----------------------------------------------------------------- |
-| `PaymentsConfigService`    | `payments.json` load/save/merge                                   |
-| `PaymentAuditService`      | WORM audit append/list/verify (+ ring buffer + Loki side effects) |
-| `X402GateService`          | `x402-gates.json` CRUD                                            |
-| `X402RuntimeConfigService` | Network, facilitator, wallet from config + env                    |
-| `X402FacilitatorService`   | Facilitator verify/settle HTTP                                    |
-| `X402EnforcementService`   | Gate enforcement + settlement reconciliation                      |
-| `UsageStoreService`        | Monthly usage counters                                            |
-| `EntitlementService`       | Plan limit checks (`EntitlementLimitError`)                       |
-| `PaymentsDiscoveryService` | `/.well-known/payments.json` builder                              |
-| `MppOpenApiService`        | MPP `/openapi.json` builder (`x-payment-info.offers[]`)           |
+| Service                    | Responsibility                                                          |
+| -------------------------- | ----------------------------------------------------------------------- |
+| `PaymentsConfigService`    | `payments.json` load/save/merge                                         |
+| `PaymentAuditService`      | WORM audit append/list/verify (+ ring buffer + Loki side effects)       |
+| `X402GateService`          | `x402-gates.json` CRUD                                                  |
+| `X402RuntimeConfigService` | Network, facilitator, wallet from config + env                          |
+| `X402FacilitatorService`   | Facilitator verify/settle HTTP                                          |
+| `X402EnforcementService`   | Gate enforcement + settlement reconciliation                            |
+| `UsageStoreService`        | Monthly usage counters                                                  |
+| `EntitlementService`       | Plan limit checks (`EntitlementLimitError`)                             |
+| `PaymentsDiscoveryService` | `/.well-known/payments.json` builder                                    |
+| `MppOpenApiService`        | MPP `/openapi.json` builder (`x-payment-info.offers[]`)                 |
 | `MppVerificationService`   | MPP credential verify (x402 + Stripe SPT), challenge registry, receipts |
-| `StripeClientService`      | Stripe SDK client lifecycle                                       |
-| `StripeWebhookService`     | Webhook verify + WORM-audited event handling                      |
-| `StripeMeterService`       | Meter events + inference usage reporting                          |
-| `StripeBillingService`     | Setup, customer, subscription, invoice, portal                    |
+| `StripeClientService`      | Stripe SDK client lifecycle                                             |
+| `StripeWebhookService`     | Webhook verify + WORM-audited event handling                            |
+| `StripeMeterService`       | Meter events + inference usage reporting                                |
+| `StripeBillingService`     | Setup, customer, subscription, invoice, portal                          |
 
 Public async exports (`loadPaymentsConfig`, `enforceX402Gate`, `appendPaymentWormEntry`, …) delegate to `runPaymentsEffect`. **Stripe** modules now use Effect services (`StripeClientService`, `StripeWebhookService`, `StripeMeterService`, `StripeBillingService`) with tagged errors (`StripeSignatureError`, `StripeApiError`, …); legacy `Error` subclasses remain at async boundaries for CLI compatibility.
 

--- a/docs/payments/clawql-payments.md
+++ b/docs/payments/clawql-payments.md
@@ -23,6 +23,7 @@
 | `.well-known/payments.json` discovery            | ✅     | Dynamic on MCP + inference HTTP; static route on docs site               |
 | MPP `/openapi.json` discovery                    | ✅     | Dynamic on MCP + inference HTTP; canonical `x-payment-info.offers[]`     |
 | MPP HTTP 402 + MCP -32042 runtime                | ✅     | Dual x402 + MPP challenges when `CLAWQL_MPP_ENABLED=1`                   |
+| MPP credential verification + receipts           | ✅     | `MppVerificationService` — x402 facilitator + Stripe SPT (`STRIPE_PROFILE_ID`) |
 
 ## Architecture
 
@@ -331,6 +332,7 @@ Effect entrypoints: `paymentsServicesLiveLayer()` merges all services; `runPayme
 | `EntitlementService`       | Plan limit checks (`EntitlementLimitError`)                       |
 | `PaymentsDiscoveryService` | `/.well-known/payments.json` builder                              |
 | `MppOpenApiService`        | MPP `/openapi.json` builder (`x-payment-info.offers[]`)           |
+| `MppVerificationService`   | MPP credential verify (x402 + Stripe SPT), challenge registry, receipts |
 | `StripeClientService`      | Stripe SDK client lifecycle                                       |
 | `StripeWebhookService`     | Webhook verify + WORM-audited event handling                      |
 | `StripeMeterService`       | Meter events + inference usage reporting                          |
@@ -480,6 +482,15 @@ curl http://localhost:8080/openapi.json   # MCP HTTP or inference HTTP
 Each paid route includes `x-payment-info.offers[]` with `x402` and `stripe` methods when configured. Set `CLAWQL_MPP_OPENAPI=0` to disable the route. See [MPP discovery](https://mpp.dev/advanced/discovery).
 
 When `CLAWQL_X402_ENFORCE=1`, HTTP 402 responses include both x402 `PAYMENT-REQUIRED` and MPP `WWW-Authenticate: Payment` challenges. MCP paid-tool errors surface MPP metadata on tool results (`org.paymentauth/payment-required`) for clients that expect JSON-RPC **-32042**.
+
+**Credential verification** runs through `MppVerificationService` (Effect) inside `X402EnforcementService.enforceGate()`:
+
+- `Authorization: Payment …` — canonical MPP credentials (Stripe SPT or x402 payload in `payload`)
+- `PAYMENT-SIGNATURE` — legacy x402 credentials (still verified when MPP is enabled)
+- Successful verification returns `Payment-Receipt` on HTTP 200 and records settlement in the payment audit WORM
+- Stripe SPT charges require `STRIPE_SECRET_KEY` and optionally `STRIPE_PROFILE_ID` / `STRIPE_NETWORK_ID` for Business Network profiles
+
+Challenge IDs issued on `402` are registered for single-use verification (replay protection). Failed verification surfaces MCP **-32043** metadata on deny paths when applicable.
 
 ### CLI
 

--- a/docs/payments/clawql-payments.md
+++ b/docs/payments/clawql-payments.md
@@ -20,7 +20,9 @@
 | Payment WORM audit (hash-chained JSONL)          | ✅     | `$CLAWQL_HOME/Payments/audit.jsonl` + `audit verify`                     |
 | Payment WORM audit (Postgres)                    | ✅     | `CLAWQL_PAYMENTS_AUDIT_STORE=postgres` for multi-node deployments        |
 | Payment audit → Loki/SIEM export                 | ✅     | Fire-and-forget push on append when `CLAWQL_LOKI_PUSH_URL` is set        |
-| `.well-known/payments.json` discovery            | ✅     | Dynamic on MCP + inference HTTP; static placeholder on docs site         |
+| `.well-known/payments.json` discovery            | ✅     | Dynamic on MCP + inference HTTP; static route on docs site               |
+| MPP `/openapi.json` discovery                    | ✅     | Dynamic on MCP + inference HTTP; canonical `x-payment-info.offers[]`       |
+| MPP HTTP 402 + MCP -32042 runtime                | ✅     | Dual x402 + MPP challenges when `CLAWQL_MPP_ENABLED=1`                     |
 
 ## Architecture
 
@@ -328,6 +330,7 @@ Effect entrypoints: `paymentsServicesLiveLayer()` merges all services; `runPayme
 | `UsageStoreService`        | Monthly usage counters                                            |
 | `EntitlementService`       | Plan limit checks (`EntitlementLimitError`)                       |
 | `PaymentsDiscoveryService` | `/.well-known/payments.json` builder                              |
+| `MppOpenApiService`        | MPP `/openapi.json` builder (`x-payment-info.offers[]`)           |
 | `StripeClientService`      | Stripe SDK client lifecycle                                       |
 | `StripeWebhookService`     | Webhook verify + WORM-audited event handling                      |
 | `StripeMeterService`       | Meter events + inference usage reporting                          |
@@ -464,7 +467,19 @@ curl http://localhost:8080/.well-known/payments.json   # MCP HTTP (default PORT)
 curl http://localhost:8080/.well-known/payments.json   # inference HTTP (CLAWQL_INFERENCE_PORT)
 ```
 
-The document lists configured x402 gates (HTTP paths and MCP tools), wallet/facilitator metadata, and Stripe plan/meter info when configured. The static docs site ships a placeholder at `website/public/.well-known/payments.json` for [issue #88](https://github.com/danielsmithdevelopment/ClawQL/issues/88).
+The document lists configured x402 gates (HTTP paths and MCP tools), wallet/facilitator metadata, and Stripe plan/meter info when configured. The docs site serves a static commerce discovery route at `/openapi.json` and `/.well-known/payments.json` for agent readiness scanners.
+
+### MPP discovery (`/openapi.json`)
+
+Self-hosted ClawQL serves a **dynamic** MPP OpenAPI document at:
+
+```bash
+curl http://localhost:8080/openapi.json   # MCP HTTP or inference HTTP
+```
+
+Each paid route includes `x-payment-info.offers[]` with `x402` and `stripe` methods when configured. Set `CLAWQL_MPP_OPENAPI=0` to disable the route. See [MPP discovery](https://mpp.dev/advanced/discovery).
+
+When `CLAWQL_X402_ENFORCE=1`, HTTP 402 responses include both x402 `PAYMENT-REQUIRED` and MPP `WWW-Authenticate: Payment` challenges. MCP paid-tool errors surface MPP metadata on tool results (`org.paymentauth/payment-required`) for clients that expect JSON-RPC **-32042**.
 
 ### CLI
 

--- a/docs/payments/clawql-payments.md
+++ b/docs/payments/clawql-payments.md
@@ -21,8 +21,8 @@
 | Payment WORM audit (Postgres)                    | ✅     | `CLAWQL_PAYMENTS_AUDIT_STORE=postgres` for multi-node deployments        |
 | Payment audit → Loki/SIEM export                 | ✅     | Fire-and-forget push on append when `CLAWQL_LOKI_PUSH_URL` is set        |
 | `.well-known/payments.json` discovery            | ✅     | Dynamic on MCP + inference HTTP; static route on docs site               |
-| MPP `/openapi.json` discovery                    | ✅     | Dynamic on MCP + inference HTTP; canonical `x-payment-info.offers[]`       |
-| MPP HTTP 402 + MCP -32042 runtime                | ✅     | Dual x402 + MPP challenges when `CLAWQL_MPP_ENABLED=1`                     |
+| MPP `/openapi.json` discovery                    | ✅     | Dynamic on MCP + inference HTTP; canonical `x-payment-info.offers[]`     |
+| MPP HTTP 402 + MCP -32042 runtime                | ✅     | Dual x402 + MPP challenges when `CLAWQL_MPP_ENABLED=1`                   |
 
 ## Architecture
 

--- a/packages/clawql-inference/src/api/server.ts
+++ b/packages/clawql-inference/src/api/server.ts
@@ -1,6 +1,7 @@
 import express, { type Express } from "express";
 import { createX402PaymentMiddleware } from "clawql-payments/x402";
 import { attachPaymentsWellKnownRoutes } from "clawql-payments/discovery";
+import { attachMppOpenApiRoutes, isMppOpenApiEnabled } from "clawql-payments/mpp";
 import { createInferenceGateway } from "../gateway.js";
 import type { InferenceGateway } from "../gateway.js";
 import { createProviderRegistry } from "../providers/registry.js";
@@ -33,6 +34,9 @@ export function createInferenceHttpApp(options: CreateInferenceHttpAppOptions = 
     });
   });
   attachPaymentsWellKnownRoutes(app, { serverName: "ClawQL Inference" });
+  if (isMppOpenApiEnabled(env)) {
+    attachMppOpenApiRoutes(app, { serverName: "ClawQL Inference", env });
+  }
   app.use(createX402PaymentMiddleware({ env }));
   app.use(createVirtualKeyAuthMiddleware({ env }));
   app.use(createOpenAiCompatRouter({ gateway, registry, env }));

--- a/packages/clawql-payments/README.md
+++ b/packages/clawql-payments/README.md
@@ -1,6 +1,6 @@
 # clawql-payments
 
-Unified payments layer for ClawQL — Stripe billing, x402 micropayments, managed plan entitlements, and WORM-auditable payment events.
+Unified payments layer for ClawQL — Stripe billing, x402 micropayments, **MPP** (Machine Payments Protocol) discovery and runtime, managed plan entitlements, and WORM-auditable payment events.
 
 ClawQL's own managed tiers (Free / Pro / Team / Enterprise) run on this package internally. The same package is available to ClawQL users to bill their own customers via Stripe, gate MCP tools and HTTP endpoints via x402, and get a correlated payment audit trail across both rails.
 
@@ -10,6 +10,7 @@ ClawQL's own managed tiers (Free / Pro / Team / Enterprise) run on this package 
 clawql-payments
 ├── stripe/     # Subscriptions, invoices, webhooks, metered usage, customer portal
 ├── x402/       # Wallet setup, resource gating, proof verification, settlement reconcile
+├── mpp/        # MPP OpenAPI discovery (`/openapi.json`), Payment 402 challenges, MCP -32042
 ├── plans/      # ClawQL tier definitions, entitlements, usage tracking, limit enforcement
 ├── audit/      # Payment events → hash-chained WORM (jsonl, postgres, or memory) + optional Loki export
 └── cli/        # `clawql payments *` command implementations
@@ -100,7 +101,9 @@ Stripe SDK integration is **live** for customers, subscriptions, invoices, billi
 
 x402 facilitator HTTP verification is **live** (`POST /verify` against x402.org or CDP). Inference HTTP and **native MCP tool calls** can enforce gates with `CLAWQL_X402_ENFORCE=1`.
 
-Payment discovery is served at **`/.well-known/payments.json`** on MCP and inference HTTP apps (dynamic from local gates/config).
+Payment discovery is served at **`/.well-known/payments.json`** and MPP OpenAPI at **`/openapi.json`** on MCP and inference HTTP apps (dynamic from local gates/config).
+
+**MPP** (Machine Payments Protocol): when `CLAWQL_MPP_ENABLED=1` (default when x402 or Stripe is configured), HTTP 402 responses include MPP Payment challenges alongside x402 `PAYMENT-REQUIRED`. MCP tool payment errors include `org.paymentauth/payment-required` metadata. Disable with `CLAWQL_MPP_ENABLED=0`.
 
 Payment audit is **durable** — hash-chained append-only JSONL at `$CLAWQL_HOME/Payments/audit.jsonl` (default), optional Postgres for multi-node, and optional Loki export. Use `clawql payments audit verify` to validate chain integrity.
 

--- a/packages/clawql-payments/package.json
+++ b/packages/clawql-payments/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clawql-payments",
   "version": "7.0.0",
-  "description": "ClawQL payments layer: Stripe billing, x402 micropayments, managed plan entitlements, and WORM-auditable payment events",
+  "description": "ClawQL payments layer: Stripe billing, x402 micropayments, MPP discovery/runtime, managed plan entitlements, and WORM-auditable payment events",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -37,6 +37,11 @@
       "types": "./dist/discovery/index.d.ts",
       "import": "./dist/discovery/index.js",
       "require": "./dist/discovery/index.cjs"
+    },
+    "./mpp": {
+      "types": "./dist/mpp/index.d.ts",
+      "import": "./dist/mpp/index.js",
+      "require": "./dist/mpp/index.cjs"
     },
     "./plugin": {
       "types": "./dist/plugin/index.d.ts",

--- a/packages/clawql-payments/src/index.ts
+++ b/packages/clawql-payments/src/index.ts
@@ -3,6 +3,7 @@ export * from "./stripe/index.js";
 export * from "./x402/index.js";
 export * from "./audit/index.js";
 export * from "./discovery/index.js";
+export * from "./mpp/index.js";
 export * from "./cli/index.js";
 export { loadPaymentsConfig, mergePaymentsConfig, savePaymentsConfig } from "./config/store.js";
 export type { PaymentsConfig } from "./config/store.js";

--- a/packages/clawql-payments/src/mpp/challenge.ts
+++ b/packages/clawql-payments/src/mpp/challenge.ts
@@ -1,0 +1,62 @@
+import { randomUUID } from "node:crypto";
+import type { X402PaymentRequired } from "../x402/types.js";
+import type { MppPaymentChallenge, MppPaymentOffer } from "./types.js";
+import { MPP_METHOD_STRIPE, MPP_METHOD_X402 } from "./types.js";
+
+export function buildChallengesFromOffers(input: {
+  offers: MppPaymentOffer[];
+  resource: string;
+  x402Body?: X402PaymentRequired;
+}): MppPaymentChallenge[] {
+  return input.offers.map((offer) => {
+    const extensions: Record<string, unknown> = {};
+    if (offer.method === MPP_METHOD_X402 && input.x402Body) {
+      extensions.x402 = input.x402Body;
+      extensions.protocol = "x402";
+    }
+    if (offer.method === MPP_METHOD_STRIPE) {
+      extensions.protocol = "stripe";
+      extensions.billing = offer.amount === null ? "metered_or_dynamic" : "fixed";
+    }
+
+    return {
+      id: randomUUID(),
+      intent: offer.intent,
+      method: offer.method,
+      amount: offer.amount,
+      currency: offer.currency,
+      resource: input.resource,
+      description: offer.description,
+      extensions,
+    };
+  });
+}
+
+/** MPP HTTP 402 JSON body (Payment auth scheme + x402 compatibility). */
+export function buildMppPaymentRequiredBody(input: {
+  resource: string;
+  challenges: MppPaymentChallenge[];
+  x402Body?: X402PaymentRequired;
+}): Record<string, unknown> {
+  const payment = input.challenges.map((challenge) => {
+    if (challenge.method === MPP_METHOD_X402 && input.x402Body) {
+      return {
+        protocol: "x402",
+        paymentRequired: input.x402Body,
+        challenge,
+      };
+    }
+    return {
+      protocol: challenge.method,
+      challenge,
+    };
+  });
+
+  return {
+    error: "payment_required",
+    message: "Payment required (MPP)",
+    resource: input.resource,
+    payment,
+    ...(input.x402Body ? { x402: input.x402Body, x402Version: input.x402Body.x402Version } : {}),
+  };
+}

--- a/packages/clawql-payments/src/mpp/config.ts
+++ b/packages/clawql-payments/src/mpp/config.ts
@@ -10,8 +10,7 @@ export function isMppEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   }
   // Default on when any payment rail is configured.
   const x402 = env.CLAWQL_X402_ENFORCE?.trim().toLowerCase();
-  const x402On =
-    x402 === "1" || x402 === "true" || x402 === "yes" || x402 === "on";
+  const x402On = x402 === "1" || x402 === "true" || x402 === "yes" || x402 === "on";
   const stripeOn = Boolean(env.STRIPE_SECRET_KEY?.trim());
   return x402On || stripeOn;
 }

--- a/packages/clawql-payments/src/mpp/config.ts
+++ b/packages/clawql-payments/src/mpp/config.ts
@@ -1,0 +1,23 @@
+/** MPP feature flags and environment configuration. */
+
+export function isMppEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.CLAWQL_MPP_ENABLED?.trim().toLowerCase();
+  if (raw === "0" || raw === "false" || raw === "no" || raw === "off") {
+    return false;
+  }
+  if (raw === "1" || raw === "true" || raw === "yes" || raw === "on") {
+    return true;
+  }
+  // Default on when any payment rail is configured.
+  const x402 = env.CLAWQL_X402_ENFORCE?.trim().toLowerCase();
+  const x402On =
+    x402 === "1" || x402 === "true" || x402 === "yes" || x402 === "on";
+  const stripeOn = Boolean(env.STRIPE_SECRET_KEY?.trim());
+  return x402On || stripeOn;
+}
+
+export function isMppOpenApiEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.CLAWQL_MPP_OPENAPI?.trim().toLowerCase();
+  if (raw === "0" || raw === "false") return false;
+  return isMppEnabled(env);
+}

--- a/packages/clawql-payments/src/mpp/credential.test.ts
+++ b/packages/clawql-payments/src/mpp/credential.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractPaymentCredential,
+  parseAuthorizationPaymentHeader,
+  parseMppCredentialRaw,
+} from "./credential.js";
+
+describe("parseMppCredentialRaw", () => {
+  it("parses base64url-encoded MPP credentials", () => {
+    const credential = {
+      challenge: {
+        id: "chal_test",
+        method: "stripe",
+        intent: "charge",
+        request: "eyJhbW91bnQiOiI1MCIsImN1cnJlbmN5IjoidXNkIn0",
+      },
+      payload: {
+        type: "shared_payment_token",
+        token: "spt_test_123",
+      },
+      source: "did:example:payer",
+    };
+    const raw = Buffer.from(JSON.stringify(credential), "utf8").toString("base64url");
+    expect(parseMppCredentialRaw(raw)).toMatchObject({
+      challenge: { id: "chal_test", method: "stripe" },
+      payload: { token: "spt_test_123" },
+    });
+  });
+});
+
+describe("parseAuthorizationPaymentHeader", () => {
+  it("strips the Payment scheme prefix", () => {
+    const credential = {
+      challenge: { id: "a", method: "x402" },
+      payload: { x402Version: 2 },
+    };
+    const token = Buffer.from(JSON.stringify(credential), "utf8").toString("base64url");
+    expect(parseAuthorizationPaymentHeader(`Payment ${token}`)?.challenge.id).toBe("a");
+  });
+});
+
+describe("extractPaymentCredential", () => {
+  it("prefers Authorization: Payment over legacy x402 headers", () => {
+    const credential = {
+      challenge: { id: "mpp", method: "stripe" },
+      payload: { token: "spt_abc" },
+    };
+    const token = Buffer.from(JSON.stringify(credential), "utf8").toString("base64url");
+    const parsed = extractPaymentCredential({
+      authorization: `Payment ${token}`,
+      "payment-signature": Buffer.from(JSON.stringify({ x402Version: 2 }), "utf8").toString(
+        "base64"
+      ),
+    });
+    expect(parsed?.kind).toBe("mpp");
+  });
+
+  it("falls back to PAYMENT-SIGNATURE x402 credentials", () => {
+    const payload = {
+      x402Version: 2,
+      accepted: {
+        scheme: "exact",
+        network: "eip155:84532",
+        amount: "1000",
+        asset: "0xasset",
+        payTo: "0xpay",
+      },
+      payload: { signature: "0xabc" },
+    };
+    const parsed = extractPaymentCredential({
+      "payment-signature": Buffer.from(JSON.stringify(payload), "utf8").toString("base64"),
+    });
+    expect(parsed?.kind).toBe("x402-signature");
+  });
+});

--- a/packages/clawql-payments/src/mpp/credential.ts
+++ b/packages/clawql-payments/src/mpp/credential.ts
@@ -1,0 +1,146 @@
+import { parseX402PaymentPayloadHeader, readX402PaymentHeader } from "../x402/headers.js";
+import type { X402PaymentPayloadV2 } from "../x402/types.js";
+import { MPP_METHOD_X402 } from "./types.js";
+
+export type MppCredentialChallenge = {
+  id: string;
+  intent?: string;
+  method: string;
+  realm?: string;
+  request?: string;
+  opaque?: string;
+  expires?: string;
+};
+
+/** Canonical MPP credential (Authorization: Payment base64url JSON). */
+export type MppCredential = {
+  challenge: MppCredentialChallenge;
+  source?: string;
+  payload: Record<string, unknown>;
+};
+
+export type ParsedPaymentCredential =
+  | { kind: "mpp"; credential: MppCredential; raw: string }
+  | { kind: "x402-signature"; headerValue: string; payload: X402PaymentPayloadV2 };
+
+function decodeBase64Url(value: string): string {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = normalized.length % 4 === 0 ? "" : "=".repeat(4 - (normalized.length % 4));
+  return Buffer.from(`${normalized}${pad}`, "base64").toString("utf8");
+}
+
+function tryParseJsonObject(raw: string): Record<string, unknown> | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // fall through
+  }
+  try {
+    const decoded = decodeBase64Url(trimmed);
+    const parsed = JSON.parse(decoded) as unknown;
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function isMppCredentialObject(value: Record<string, unknown>): value is MppCredential {
+  const challenge = value.challenge;
+  if (typeof challenge !== "object" || challenge === null || Array.isArray(challenge)) {
+    return false;
+  }
+  const id = (challenge as Record<string, unknown>).id;
+  const method = (challenge as Record<string, unknown>).method;
+  return typeof id === "string" && id.trim().length > 0 && typeof method === "string";
+}
+
+export function parseMppCredentialRaw(raw: string): MppCredential | undefined {
+  const parsed = tryParseJsonObject(raw);
+  if (!parsed || !isMppCredentialObject(parsed)) return undefined;
+  const payload = parsed.payload;
+  return {
+    challenge: parsed.challenge,
+    source: typeof parsed.source === "string" ? parsed.source : undefined,
+    payload:
+      typeof payload === "object" && payload !== null && !Array.isArray(payload)
+        ? (payload as Record<string, unknown>)
+        : {},
+  };
+}
+
+export function parseAuthorizationPaymentHeader(
+  headerValue: string | undefined
+): MppCredential | undefined {
+  if (!headerValue?.trim()) return undefined;
+  const trimmed = headerValue.trim();
+  const token = trimmed.replace(/^payment\s+/i, "").trim();
+  if (!token) return undefined;
+  return parseMppCredentialRaw(token);
+}
+
+export function extractPaymentCredential(
+  headers: Record<string, string | string[] | undefined>
+): ParsedPaymentCredential | undefined {
+  const auth = headers.authorization ?? headers.Authorization;
+  if (typeof auth === "string" && /^payment\s+/i.test(auth.trim())) {
+    const credential = parseAuthorizationPaymentHeader(auth);
+    if (credential) {
+      return { kind: "mpp", credential, raw: auth.trim() };
+    }
+  }
+
+  const x402Header = readX402PaymentHeader(headers);
+  if (x402Header) {
+    const payload = parseX402PaymentPayloadHeader(x402Header);
+    if (payload) {
+      return { kind: "x402-signature", headerValue: x402Header, payload };
+    }
+  }
+
+  return undefined;
+}
+
+export function x402PayloadFromMppCredential(credential: MppCredential): X402PaymentPayloadV2 | undefined {
+  const payload = credential.payload;
+  if (payload.x402Version !== undefined || payload.accepted !== undefined) {
+    return {
+      x402Version: typeof payload.x402Version === "number" ? payload.x402Version : 2,
+      resource:
+        typeof payload.resource === "object" && payload.resource !== null
+          ? (payload.resource as X402PaymentPayloadV2["resource"])
+          : undefined,
+      accepted:
+        typeof payload.accepted === "object" && payload.accepted !== null
+          ? (payload.accepted as X402PaymentPayloadV2["accepted"])
+          : undefined,
+      payload:
+        typeof payload.payload === "object" && payload.payload !== null
+          ? (payload.payload as Record<string, unknown>)
+          : payload,
+    };
+  }
+
+  if (credential.challenge.method === MPP_METHOD_X402) {
+    return {
+      x402Version: 2,
+      payload,
+    };
+  }
+
+  return undefined;
+}
+
+export function decodeChallengeRequest(
+  request: string | undefined
+): Record<string, unknown> | undefined {
+  if (!request?.trim()) return undefined;
+  return tryParseJsonObject(request) ?? tryParseJsonObject(decodeBase64Url(request.trim()));
+}

--- a/packages/clawql-payments/src/mpp/credential.ts
+++ b/packages/clawql-payments/src/mpp/credential.ts
@@ -108,7 +108,9 @@ export function extractPaymentCredential(
   return undefined;
 }
 
-export function x402PayloadFromMppCredential(credential: MppCredential): X402PaymentPayloadV2 | undefined {
+export function x402PayloadFromMppCredential(
+  credential: MppCredential
+): X402PaymentPayloadV2 | undefined {
   const payload = credential.payload;
   if (payload.x402Version !== undefined || payload.accepted !== undefined) {
     return {

--- a/packages/clawql-payments/src/mpp/headers.ts
+++ b/packages/clawql-payments/src/mpp/headers.ts
@@ -1,0 +1,34 @@
+import type { X402PaymentRequired } from "../x402/types.js";
+import { paymentRequiredHeaders as x402PaymentRequiredHeaders } from "../x402/enforce.js";
+import { buildChallengesFromOffers, buildMppPaymentRequiredBody } from "./challenge.js";
+import type { MppPaymentChallenge, MppPaymentOffer } from "./types.js";
+
+export function mppWwwAuthenticateHeader(challenges: MppPaymentChallenge[]): string {
+  const payload = Buffer.from(JSON.stringify({ challenges }), "utf8").toString("base64url");
+  return `Payment challenge="${payload}"`;
+}
+
+export function mergePaymentRequiredHeaders(input: {
+  x402Body: X402PaymentRequired;
+  offers: MppPaymentOffer[];
+  resource: string;
+}): Record<string, string> {
+  const challenges = buildChallengesFromOffers({
+    offers: input.offers,
+    resource: input.resource,
+    x402Body: input.x402Body,
+  });
+  const mppBody = buildMppPaymentRequiredBody({
+    resource: input.resource,
+    challenges,
+    x402Body: input.x402Body,
+  });
+
+  return {
+    ...x402PaymentRequiredHeaders(input.x402Body),
+    "WWW-Authenticate": mppWwwAuthenticateHeader(challenges),
+    "Payment-Required": Buffer.from(JSON.stringify(mppBody), "utf8").toString("base64"),
+    "Access-Control-Expose-Headers":
+      "PAYMENT-REQUIRED, PAYMENT-RESPONSE, Payment-Required, WWW-Authenticate, Authorization",
+  };
+}

--- a/packages/clawql-payments/src/mpp/http.ts
+++ b/packages/clawql-payments/src/mpp/http.ts
@@ -1,0 +1,46 @@
+import type { Express, Request, Response } from "express";
+import { renderMppOpenApiJson, type BuildMppOpenApiOptions } from "./openapi.js";
+
+export const MPP_OPENAPI_PATH = "/openapi.json";
+
+export type AttachMppOpenApiOptions = BuildMppOpenApiOptions & {
+  maxAgeSeconds?: number;
+};
+
+export async function handleMppOpenApiRequest(
+  req: Request,
+  res: Response,
+  options: AttachMppOpenApiOptions = {}
+): Promise<void> {
+  const origin =
+    options.origin ??
+    (req.get("x-forwarded-proto") && req.get("host")
+      ? `${req.get("x-forwarded-proto")}://${req.get("host")}`
+      : `${req.protocol}://${req.get("host") ?? "localhost"}`);
+
+  const body = await renderMppOpenApiJson({
+    ...options,
+    origin,
+  });
+
+  const maxAge = options.maxAgeSeconds ?? 300;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.setHeader("Cache-Control", `public, max-age=${maxAge}`);
+  res.status(200).send(body);
+}
+
+export function attachMppOpenApiRoutes(
+  app: Express,
+  options: AttachMppOpenApiOptions = {}
+): void {
+  app.get(MPP_OPENAPI_PATH, (req, res) => {
+    void handleMppOpenApiRequest(req, res, options).catch((err: unknown) => {
+      console.error("[clawql-payments] GET /openapi.json error:", err);
+      if (!res.headersSent) {
+        res.status(500).json({
+          error: "failed to render MPP OpenAPI discovery document",
+        });
+      }
+    });
+  });
+}

--- a/packages/clawql-payments/src/mpp/http.ts
+++ b/packages/clawql-payments/src/mpp/http.ts
@@ -29,10 +29,7 @@ export async function handleMppOpenApiRequest(
   res.status(200).send(body);
 }
 
-export function attachMppOpenApiRoutes(
-  app: Express,
-  options: AttachMppOpenApiOptions = {}
-): void {
+export function attachMppOpenApiRoutes(app: Express, options: AttachMppOpenApiOptions = {}): void {
   app.get(MPP_OPENAPI_PATH, (req, res) => {
     void handleMppOpenApiRequest(req, res, options).catch((err: unknown) => {
       console.error("[clawql-payments] GET /openapi.json error:", err);

--- a/packages/clawql-payments/src/mpp/index.ts
+++ b/packages/clawql-payments/src/mpp/index.ts
@@ -1,0 +1,63 @@
+export {
+  MPP_METHOD_STRIPE,
+  MPP_METHOD_X402,
+  MPP_CREDENTIAL_META_KEY,
+  MPP_MCP_PAYMENT_REQUIRED_CODE,
+  MPP_MCP_VERIFICATION_FAILED_CODE,
+  MPP_PAYMENT_REQUIRED_META_KEY,
+  MPP_RECEIPT_META_KEY,
+  type MppPaymentChallenge,
+  type MppPaymentInfo,
+  type MppPaymentIntent,
+  type MppPaymentMethod,
+  type MppPaymentOffer,
+  type MppServiceDocs,
+  type MppServiceInfo,
+} from "./types.js";
+
+export { isMppEnabled, isMppOpenApiEnabled } from "./config.js";
+
+export {
+  buildOffersForGate,
+  buildStripeOffer,
+  buildX402Offer,
+  offersFromX402Required,
+  paymentInfoFromOffers,
+  toPaymentInfo,
+} from "./offers.js";
+
+export {
+  buildChallengesFromOffers,
+  buildMppPaymentRequiredBody,
+} from "./challenge.js";
+
+export { mergePaymentRequiredHeaders, mppWwwAuthenticateHeader } from "./headers.js";
+
+export {
+  buildMppOpenApiDocument,
+  renderMppOpenApiJson,
+  composeMppOpenApiDocument,
+  type BuildMppOpenApiOptions,
+} from "./openapi.js";
+
+export {
+  MppOpenApiService,
+  mppOpenApiLiveLayer,
+} from "./openapi-service.js";
+
+export {
+  attachMppOpenApiRoutes,
+  handleMppOpenApiRequest,
+  MPP_OPENAPI_PATH,
+  type AttachMppOpenApiOptions,
+} from "./http.js";
+
+export {
+  buildMppMcpChallenges,
+  buildMppMcpJsonRpcError,
+  enrichMcpToolResultWithMpp,
+  readMppCredentialFromHeaders,
+  readMppCredentialFromMeta,
+  type MppMcpJsonRpcError,
+  type MppMcpToolResult,
+} from "./mcp.js";

--- a/packages/clawql-payments/src/mpp/index.ts
+++ b/packages/clawql-payments/src/mpp/index.ts
@@ -74,6 +74,10 @@ export {
   type VerifyMppCredentialInput,
 } from "./verification-service.js";
 
-export { buildMppPaymentReceipt, mppPaymentReceiptHeader, type MppPaymentReceipt } from "./receipt.js";
+export {
+  buildMppPaymentReceipt,
+  mppPaymentReceiptHeader,
+  type MppPaymentReceipt,
+} from "./receipt.js";
 
 export { registerMppChallenges, verifyMppCredential } from "./verify.js";

--- a/packages/clawql-payments/src/mpp/index.ts
+++ b/packages/clawql-payments/src/mpp/index.ts
@@ -55,3 +55,25 @@ export {
   type MppMcpJsonRpcError,
   type MppMcpToolResult,
 } from "./mcp.js";
+
+export {
+  parseAuthorizationPaymentHeader,
+  parseMppCredentialRaw,
+  extractPaymentCredential,
+  decodeChallengeRequest,
+  type MppCredential,
+  type ParsedPaymentCredential,
+} from "./credential.js";
+
+export { MppVerificationError } from "./verification-errors.js";
+
+export {
+  MppVerificationService,
+  mppVerificationLiveLayer,
+  type MppVerificationSuccess,
+  type VerifyMppCredentialInput,
+} from "./verification-service.js";
+
+export { buildMppPaymentReceipt, mppPaymentReceiptHeader, type MppPaymentReceipt } from "./receipt.js";
+
+export { registerMppChallenges, verifyMppCredential } from "./verify.js";

--- a/packages/clawql-payments/src/mpp/index.ts
+++ b/packages/clawql-payments/src/mpp/index.ts
@@ -26,10 +26,7 @@ export {
   toPaymentInfo,
 } from "./offers.js";
 
-export {
-  buildChallengesFromOffers,
-  buildMppPaymentRequiredBody,
-} from "./challenge.js";
+export { buildChallengesFromOffers, buildMppPaymentRequiredBody } from "./challenge.js";
 
 export { mergePaymentRequiredHeaders, mppWwwAuthenticateHeader } from "./headers.js";
 
@@ -40,10 +37,7 @@ export {
   type BuildMppOpenApiOptions,
 } from "./openapi.js";
 
-export {
-  MppOpenApiService,
-  mppOpenApiLiveLayer,
-} from "./openapi-service.js";
+export { MppOpenApiService, mppOpenApiLiveLayer } from "./openapi-service.js";
 
 export {
   attachMppOpenApiRoutes,

--- a/packages/clawql-payments/src/mpp/mcp.ts
+++ b/packages/clawql-payments/src/mpp/mcp.ts
@@ -1,0 +1,100 @@
+import type { X402PaymentRequired } from "../x402/types.js";
+import { buildChallengesFromOffers, buildMppPaymentRequiredBody } from "./challenge.js";
+import type { MppPaymentOffer } from "./types.js";
+import {
+  MPP_CREDENTIAL_META_KEY,
+  MPP_MCP_PAYMENT_REQUIRED_CODE,
+  MPP_PAYMENT_REQUIRED_META_KEY,
+  type MppPaymentChallenge,
+} from "./types.js";
+
+export type MppMcpToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  isError: true;
+  _meta?: Record<string, unknown>;
+};
+
+export type MppMcpJsonRpcError = {
+  code: number;
+  message: string;
+  data?: Record<string, unknown>;
+};
+
+export function buildMppMcpChallenges(input: {
+  offers: MppPaymentOffer[];
+  resource: string;
+  x402Body?: X402PaymentRequired;
+}): MppPaymentChallenge[] {
+  return buildChallengesFromOffers(input);
+}
+
+export function buildMppMcpJsonRpcError(input: {
+  offers: MppPaymentOffer[];
+  resource: string;
+  x402Body?: X402PaymentRequired;
+}): MppMcpJsonRpcError {
+  const challenges = buildMppMcpChallenges(input);
+  const body = buildMppPaymentRequiredBody({
+    resource: input.resource,
+    challenges,
+    x402Body: input.x402Body,
+  });
+
+  return {
+    code: MPP_MCP_PAYMENT_REQUIRED_CODE,
+    message: "Payment Required",
+    data: {
+      payment: body.payment,
+      challenges,
+      resource: input.resource,
+    },
+  };
+}
+
+export function enrichMcpToolResultWithMpp(
+  toolResult: MppMcpToolResult,
+  input: {
+    offers: MppPaymentOffer[];
+    resource: string;
+    x402Body?: X402PaymentRequired;
+  }
+): MppMcpToolResult {
+  const challenges = buildMppMcpChallenges(input);
+  const mppBody = buildMppPaymentRequiredBody({
+    resource: input.resource,
+    challenges,
+    x402Body: input.x402Body,
+  });
+
+  return {
+    ...toolResult,
+    _meta: {
+      ...toolResult._meta,
+      [MPP_PAYMENT_REQUIRED_META_KEY]: mppBody,
+      [MPP_CREDENTIAL_META_KEY]: MPP_CREDENTIAL_META_KEY,
+      "clawql/mpp": {
+        challenges,
+        jsonRpcError: buildMppMcpJsonRpcError(input),
+      },
+    },
+  };
+}
+
+export function readMppCredentialFromMeta(
+  meta: Record<string, unknown> | undefined
+): string | undefined {
+  if (!meta) return undefined;
+  const direct = meta[MPP_CREDENTIAL_META_KEY];
+  if (typeof direct === "string" && direct.trim()) return direct.trim();
+  return undefined;
+}
+
+export function readMppCredentialFromHeaders(
+  headers: Record<string, string | string[] | undefined>
+): string | undefined {
+  const auth = headers.authorization ?? headers.Authorization;
+  if (typeof auth === "string" && /^payment\s+/i.test(auth.trim())) {
+    return auth.trim();
+  }
+  return undefined;
+}

--- a/packages/clawql-payments/src/mpp/offers.ts
+++ b/packages/clawql-payments/src/mpp/offers.ts
@@ -1,0 +1,94 @@
+import type { X402PaymentRequired } from "../x402/types.js";
+import type { X402Gate } from "../x402/gate.js";
+import type { X402RuntimeConfig } from "../x402/x402-runtime-config-service.js";
+import { usdcAtomicAmount } from "../x402/x402-runtime-config-service.js";
+import {
+  MPP_METHOD_STRIPE,
+  MPP_METHOD_X402,
+  type MppPaymentInfo,
+  type MppPaymentOffer,
+} from "./types.js";
+
+export function buildX402Offer(input: {
+  gate: X402Gate;
+  config: X402RuntimeConfig;
+}): MppPaymentOffer | undefined {
+  const payTo = input.config.walletAddress?.trim();
+  if (!payTo) return undefined;
+
+  return {
+    intent: "charge",
+    method: MPP_METHOD_X402,
+    amount: usdcAtomicAmount(input.gate.price),
+    currency: input.config.usdcAsset,
+    description: `x402 payment for ${input.gate.resource}`,
+  };
+}
+
+export function buildStripeOffer(input?: {
+  metered?: boolean;
+  description?: string;
+}): MppPaymentOffer {
+  return {
+    intent: "charge",
+    method: MPP_METHOD_STRIPE,
+    amount: null,
+    currency: "usd",
+    description:
+      input?.description ??
+      (input?.metered
+        ? "Stripe metered billing — amount varies by usage."
+        : "Stripe subscription billing."),
+  };
+}
+
+export function buildOffersForGate(input: {
+  gate: X402Gate;
+  config: X402RuntimeConfig;
+  stripeEnabled?: boolean;
+  stripeMetered?: boolean;
+}): MppPaymentOffer[] {
+  const offers: MppPaymentOffer[] = [];
+  const x402 = buildX402Offer({ gate: input.gate, config: input.config });
+  if (x402) offers.push(x402);
+  if (input.stripeEnabled) {
+    offers.push(
+      buildStripeOffer({
+        metered: input.stripeMetered,
+        description: `Stripe billing for ${input.gate.resource}`,
+      })
+    );
+  }
+  return offers;
+}
+
+export function toPaymentInfo(offers: MppPaymentOffer[]): MppPaymentInfo {
+  return { offers };
+}
+
+export function paymentInfoFromOffers(offers: MppPaymentOffer[]): MppPaymentInfo | undefined {
+  if (offers.length === 0) return undefined;
+  return toPaymentInfo(offers);
+}
+
+/** Derive MPP offers from a runtime x402 PaymentRequired body (for 402/MCP enrichment). */
+export function offersFromX402Required(
+  body: X402PaymentRequired,
+  stripeEnabled = false
+): MppPaymentOffer[] {
+  const offers: MppPaymentOffer[] = [];
+  const accept = body.accepts[0];
+  if (accept) {
+    offers.push({
+      intent: "charge",
+      method: MPP_METHOD_X402,
+      amount: accept.amount,
+      currency: accept.asset,
+      description: body.resource.description,
+    });
+  }
+  if (stripeEnabled) {
+    offers.push(buildStripeOffer({ metered: true }));
+  }
+  return offers;
+}

--- a/packages/clawql-payments/src/mpp/openapi-service.ts
+++ b/packages/clawql-payments/src/mpp/openapi-service.ts
@@ -1,0 +1,211 @@
+import { Context, Effect, Layer } from "effect";
+import { ConfigError, X402Error } from "../errors/payment-errors.js";
+import { CLAWQL_PLANS } from "../plans/tiers.js";
+import { PaymentsConfigService } from "../config/payments-config-service.js";
+import { X402GateService } from "../x402/x402-gate-service.js";
+import { X402RuntimeConfigService } from "../x402/x402-runtime-config-service.js";
+import type { X402Gate } from "../x402/gate.js";
+import { buildOffersForGate, paymentInfoFromOffers } from "./offers.js";
+import type { MppPaymentInfo, MppServiceInfo } from "./types.js";
+
+export type BuildMppOpenApiOptions = {
+  env?: NodeJS.ProcessEnv;
+  origin?: string;
+  serverName?: string;
+  documentationUrl?: string;
+  apiVersion?: string;
+  serviceInfo?: MppServiceInfo;
+};
+
+function httpMethodForPath(path: string): "get" | "post" {
+  return path.includes("completions") || path.includes("checkout") ? "post" : "get";
+}
+
+function openApiPathForGate(gate: X402Gate): string {
+  if (gate.tool?.trim()) {
+    return `/mcp/tools/${encodeURIComponent(gate.tool.trim())}`;
+  }
+  return gate.resource.startsWith("/") ? gate.resource : `/${gate.resource}`;
+}
+
+function paidOperation(
+  summary: string,
+  paymentInfo: MppPaymentInfo,
+  method: "get" | "post"
+): Record<string, unknown> {
+  return {
+    [method]: {
+      summary,
+      "x-payment-info": paymentInfo,
+      responses: {
+        "200": { description: "Successful response" },
+        "402": { description: "Payment Required" },
+      },
+    },
+  };
+}
+
+export function composeMppOpenApiDocument(input: {
+  origin: string;
+  serverName: string;
+  documentationUrl: string;
+  apiVersion: string;
+  gates: X402Gate[];
+  x402Config: {
+    walletAddress?: string;
+    usdcAsset: string;
+    network: string;
+  };
+  stripeEnabled: boolean;
+  stripeMetered: boolean;
+  serviceInfo?: MppServiceInfo;
+}): Record<string, unknown> {
+  const paths: Record<string, unknown> = {};
+
+  for (const gate of input.gates) {
+    const offers = buildOffersForGate({
+      gate,
+      config: {
+        network: input.x402Config.network,
+        scheme: "exact",
+        usdcAsset: input.x402Config.usdcAsset,
+        walletAddress: input.x402Config.walletAddress,
+        maxTimeoutSeconds: 300,
+      },
+      stripeEnabled: input.stripeEnabled,
+      stripeMetered: input.stripeMetered,
+    });
+    const paymentInfo = paymentInfoFromOffers(offers);
+    if (!paymentInfo) continue;
+
+    const path = openApiPathForGate(gate);
+    const method = httpMethodForPath(path);
+    paths[path] = paidOperation(
+      gate.tool ? `MCP tool: ${gate.tool}` : `Paid HTTP resource ${gate.resource}`,
+      paymentInfo,
+      method
+    );
+  }
+
+  if (input.x402Config.walletAddress?.trim()) {
+    paths["/api/v1"] = paidOperation(
+      "MPP/x402 commerce discovery probe",
+      paymentInfoFromOffers([
+        {
+          intent: "charge",
+          method: "x402",
+          amount: "1000",
+          currency: input.x402Config.usdcAsset,
+          description: "Low-cost x402 gateway probe ($0.001 USDC).",
+        },
+        ...(input.stripeEnabled
+          ? [
+              {
+                intent: "charge" as const,
+                method: "stripe" as const,
+                amount: null,
+                currency: "usd",
+                description: "Stripe metered or subscription billing.",
+              },
+            ]
+          : []),
+      ])!,
+      "get"
+    );
+  }
+
+  const origin = input.origin.replace(/\/$/, "");
+
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: input.serverName,
+      version: input.apiVersion,
+      description:
+        "ClawQL MPP discovery document — paid routes for x402 and Stripe. Runtime 402 challenges are authoritative.",
+    },
+    servers: [{ url: origin }],
+    "x-service-info": input.serviceInfo ?? {
+      categories: ["developer-tools", "ai", "payments"],
+      docs: {
+        homepage: origin,
+        apiReference: `${origin}/tools`,
+        llms: `${origin}/llms.txt`,
+      },
+    },
+    paths,
+    "x-clawql-payments": {
+      paymentsDiscovery: `${origin}/.well-known/payments.json`,
+      documentation: input.documentationUrl,
+      rails: ["x402", ...(input.stripeEnabled ? ["stripe"] : [])],
+      plans: Object.keys(CLAWQL_PLANS),
+    },
+  };
+}
+
+/** Effect service for `GET /openapi.json` (MPP discovery). */
+export class MppOpenApiService extends Context.Tag("clawql/MppOpenApiService")<
+  MppOpenApiService,
+  {
+    readonly buildDocument: (
+      options?: BuildMppOpenApiOptions
+    ) => Effect.Effect<Record<string, unknown>, ConfigError | X402Error>;
+    readonly renderJson: (
+      options?: BuildMppOpenApiOptions
+    ) => Effect.Effect<string, ConfigError | X402Error>;
+  }
+>() {}
+
+export function mppOpenApiLiveLayer(
+  env: NodeJS.ProcessEnv = process.env
+): Layer.Layer<
+  MppOpenApiService,
+  never,
+  PaymentsConfigService | X402RuntimeConfigService | X402GateService
+> {
+  return Layer.effect(
+    MppOpenApiService,
+    Effect.gen(function* () {
+      const configService = yield* PaymentsConfigService;
+      const runtimeConfig = yield* X402RuntimeConfigService;
+      const gates = yield* X402GateService;
+
+      const buildDocument = (options: BuildMppOpenApiOptions = {}) =>
+        Effect.gen(function* () {
+          const runEnv = options.env ?? env;
+          const gateList = yield* gates.list();
+          const x402Config = yield* runtimeConfig.load();
+          const origin =
+            options.origin?.replace(/\/$/, "") ??
+            runEnv.CLAWQL_MPP_ORIGIN?.trim() ??
+            "http://localhost:8080";
+          const stripeEnabled = Boolean(runEnv.STRIPE_SECRET_KEY?.trim());
+          const stripeMetered = Boolean(runEnv.STRIPE_METER_EVENT_NAME?.trim());
+
+          return composeMppOpenApiDocument({
+            origin,
+            serverName: options.serverName?.trim() || "ClawQL",
+            documentationUrl:
+              options.documentationUrl?.trim() ||
+              "https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/clawql-payments.md",
+            apiVersion: options.apiVersion?.trim() || "1.0.0",
+            gates: gateList,
+            x402Config: {
+              walletAddress: x402Config.walletAddress,
+              usdcAsset: x402Config.usdcAsset,
+              network: x402Config.network,
+            },
+            stripeEnabled,
+            stripeMetered,
+            serviceInfo: options.serviceInfo,
+          });
+        });
+
+      return MppOpenApiService.of({
+        buildDocument,
+        renderJson: (options) =>
+          buildDocument(options).pipe(Effect.map((doc) => `${JSON.stringify(doc, null, 2)}\n`)),
+      });
+    })
+  );
+}

--- a/packages/clawql-payments/src/mpp/openapi-service.ts
+++ b/packages/clawql-payments/src/mpp/openapi-service.ts
@@ -1,7 +1,6 @@
 import { Context, Effect, Layer } from "effect";
 import { ConfigError, X402Error } from "../errors/payment-errors.js";
 import { CLAWQL_PLANS } from "../plans/tiers.js";
-import { PaymentsConfigService } from "../config/payments-config-service.js";
 import { X402GateService } from "../x402/x402-gate-service.js";
 import { X402RuntimeConfigService } from "../x402/x402-runtime-config-service.js";
 import type { X402Gate } from "../x402/gate.js";
@@ -158,15 +157,10 @@ export class MppOpenApiService extends Context.Tag("clawql/MppOpenApiService")<
 
 export function mppOpenApiLiveLayer(
   env: NodeJS.ProcessEnv = process.env
-): Layer.Layer<
-  MppOpenApiService,
-  never,
-  PaymentsConfigService | X402RuntimeConfigService | X402GateService
-> {
+): Layer.Layer<MppOpenApiService, never, X402RuntimeConfigService | X402GateService> {
   return Layer.effect(
     MppOpenApiService,
     Effect.gen(function* () {
-      const configService = yield* PaymentsConfigService;
       const runtimeConfig = yield* X402RuntimeConfigService;
       const gates = yield* X402GateService;
 

--- a/packages/clawql-payments/src/mpp/openapi.test.ts
+++ b/packages/clawql-payments/src/mpp/openapi.test.ts
@@ -1,0 +1,115 @@
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createX402Gate } from "../x402/gate.js";
+import { buildMppOpenApiDocument } from "./openapi.js";
+import { offersFromX402Required, buildOffersForGate } from "./offers.js";
+import { resetPaymentsEffectRuntimeForTests } from "../runtime/payments-effect-runtime.js";
+
+describe("buildMppOpenApiDocument", () => {
+  let home: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "clawql-payments-mpp-"));
+    env = { ...process.env, CLAWQL_HOME: home };
+    await mkdir(join(home, "Payments"), { recursive: true });
+    await writeFile(
+      join(home, "Payments", "payments.json"),
+      `${JSON.stringify(
+        {
+          tenantId: "tenant-a",
+          plan: "pro",
+          x402: {
+            walletAddress: "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+            facilitatorUrl: "https://x402.org/facilitator",
+          },
+          stripe: { meterEventName: "clawql_inference_calls" },
+        },
+        null,
+        2
+      )}\n`
+    );
+  });
+
+  afterEach(async () => {
+    resetPaymentsEffectRuntimeForTests();
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("emits canonical x-payment-info.offers[] for gated routes", async () => {
+    await createX402Gate(
+      { resource: "/v1/chat/completions", price: 0.001, asset: "USDC" },
+      env
+    );
+
+    const doc = await buildMppOpenApiDocument({
+      env: { ...env, STRIPE_SECRET_KEY: "sk_test_xxx" },
+      origin: "https://inference.example.com",
+      serverName: "Test Inference",
+    });
+
+    const op = (doc.paths as Record<string, Record<string, unknown>>)[
+      "/v1/chat/completions"
+    ]?.post as Record<string, unknown>;
+    const paymentInfo = op["x-payment-info"] as { offers: Array<Record<string, unknown>> };
+    expect(paymentInfo.offers.length).toBeGreaterThanOrEqual(2);
+    expect(paymentInfo.offers[0]).toMatchObject({
+      intent: "charge",
+      method: "x402",
+      amount: "1000",
+    });
+    expect(paymentInfo.offers.some((o) => o.method === "stripe")).toBe(true);
+    expect((op.responses as Record<string, unknown>)["402"]).toBeTruthy();
+    expect(doc["x-service-info"]).toBeTruthy();
+  });
+});
+
+describe("offersFromX402Required", () => {
+  it("maps x402 accepts to MPP offers and adds stripe when enabled", () => {
+    const offers = offersFromX402Required(
+      {
+        x402Version: 2,
+        resource: { url: "https://example.com/v1", mimeType: "application/json" },
+        accepts: [
+          {
+            scheme: "exact",
+            network: "eip155:84532",
+            amount: "500",
+            asset: "0xabc",
+            payTo: "0xpay",
+          },
+        ],
+      },
+      true
+    );
+    expect(offers[0]).toMatchObject({ method: "x402", amount: "500" });
+    expect(offers[1]).toMatchObject({ method: "stripe", amount: null });
+  });
+});
+
+describe("buildOffersForGate", () => {
+  it("includes both rails when configured", () => {
+    const gate = {
+      id: "g1",
+      resource: "/v1/test",
+      price: 0.002,
+      asset: "USDC" as const,
+      createdAt: new Date().toISOString(),
+    };
+    const offers = buildOffersForGate({
+      gate,
+      config: {
+        network: "eip155:84532",
+        scheme: "exact",
+        usdcAsset: "0xasset",
+        walletAddress: "0xwallet",
+        maxTimeoutSeconds: 300,
+      },
+      stripeEnabled: true,
+      stripeMetered: true,
+    });
+    expect(offers.map((o) => o.method)).toEqual(["x402", "stripe"]);
+  });
+});

--- a/packages/clawql-payments/src/mpp/openapi.test.ts
+++ b/packages/clawql-payments/src/mpp/openapi.test.ts
@@ -39,10 +39,7 @@ describe("buildMppOpenApiDocument", () => {
   });
 
   it("emits canonical x-payment-info.offers[] for gated routes", async () => {
-    await createX402Gate(
-      { resource: "/v1/chat/completions", price: 0.001, asset: "USDC" },
-      env
-    );
+    await createX402Gate({ resource: "/v1/chat/completions", price: 0.001, asset: "USDC" }, env);
 
     const doc = await buildMppOpenApiDocument({
       env: { ...env, STRIPE_SECRET_KEY: "sk_test_xxx" },
@@ -50,9 +47,8 @@ describe("buildMppOpenApiDocument", () => {
       serverName: "Test Inference",
     });
 
-    const op = (doc.paths as Record<string, Record<string, unknown>>)[
-      "/v1/chat/completions"
-    ]?.post as Record<string, unknown>;
+    const op = (doc.paths as Record<string, Record<string, unknown>>)["/v1/chat/completions"]
+      ?.post as Record<string, unknown>;
     const paymentInfo = op["x-payment-info"] as { offers: Array<Record<string, unknown>> };
     expect(paymentInfo.offers.length).toBeGreaterThanOrEqual(2);
     expect(paymentInfo.offers[0]).toMatchObject({

--- a/packages/clawql-payments/src/mpp/openapi.ts
+++ b/packages/clawql-payments/src/mpp/openapi.ts
@@ -1,0 +1,34 @@
+import { Effect } from "effect";
+import { runPaymentsEffect } from "../runtime/payments-effect-runtime.js";
+import {
+  MppOpenApiService,
+  composeMppOpenApiDocument,
+  type BuildMppOpenApiOptions,
+} from "./openapi-service.js";
+
+export type { BuildMppOpenApiOptions };
+export { composeMppOpenApiDocument };
+
+export async function buildMppOpenApiDocument(
+  options: BuildMppOpenApiOptions = {}
+): Promise<Record<string, unknown>> {
+  return runPaymentsEffect(
+    Effect.gen(function* () {
+      const mpp = yield* MppOpenApiService;
+      return yield* mpp.buildDocument(options);
+    }),
+    options.env
+  );
+}
+
+export async function renderMppOpenApiJson(
+  options: BuildMppOpenApiOptions = {}
+): Promise<string> {
+  return runPaymentsEffect(
+    Effect.gen(function* () {
+      const mpp = yield* MppOpenApiService;
+      return yield* mpp.renderJson(options);
+    }),
+    options.env
+  );
+}

--- a/packages/clawql-payments/src/mpp/openapi.ts
+++ b/packages/clawql-payments/src/mpp/openapi.ts
@@ -21,9 +21,7 @@ export async function buildMppOpenApiDocument(
   );
 }
 
-export async function renderMppOpenApiJson(
-  options: BuildMppOpenApiOptions = {}
-): Promise<string> {
+export async function renderMppOpenApiJson(options: BuildMppOpenApiOptions = {}): Promise<string> {
   return runPaymentsEffect(
     Effect.gen(function* () {
       const mpp = yield* MppOpenApiService;

--- a/packages/clawql-payments/src/mpp/receipt.ts
+++ b/packages/clawql-payments/src/mpp/receipt.ts
@@ -1,0 +1,30 @@
+import type { MppPaymentMethod } from "./types.js";
+
+export type MppPaymentReceipt = {
+  method: MppPaymentMethod;
+  resource: string;
+  settledAt: string;
+  payer?: string;
+  settlementId?: string;
+  stripePaymentIntentId?: string;
+  x402SettlementId?: string;
+};
+
+export function buildMppPaymentReceipt(input: MppPaymentReceipt): Record<string, unknown> {
+  return {
+    version: "1",
+    method: input.method,
+    resource: input.resource,
+    settledAt: input.settledAt,
+    ...(input.payer ? { payer: input.payer } : {}),
+    ...(input.settlementId ? { settlementId: input.settlementId } : {}),
+    ...(input.stripePaymentIntentId
+      ? { stripe: { paymentIntentId: input.stripePaymentIntentId } }
+      : {}),
+    ...(input.x402SettlementId ? { x402: { settlementId: input.x402SettlementId } } : {}),
+  };
+}
+
+export function mppPaymentReceiptHeader(receipt: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(receipt), "utf8").toString("base64url");
+}

--- a/packages/clawql-payments/src/mpp/types.ts
+++ b/packages/clawql-payments/src/mpp/types.ts
@@ -1,0 +1,53 @@
+/** MPP (Machine Payments Protocol) discovery and runtime types. @see https://mpp.dev/advanced/discovery */
+
+export const MPP_METHOD_X402 = "x402" as const;
+export const MPP_METHOD_STRIPE = "stripe" as const;
+
+export type MppPaymentIntent = "charge" | "session";
+
+export type MppPaymentMethod = typeof MPP_METHOD_X402 | typeof MPP_METHOD_STRIPE | string;
+
+/** Canonical MPP payment offer (OpenAPI `x-payment-info.offers[]`). */
+export type MppPaymentOffer = {
+  intent: MppPaymentIntent;
+  method: MppPaymentMethod;
+  amount: string | null;
+  currency?: string;
+  description?: string;
+};
+
+/** Multi-offer `x-payment-info` extension shape. */
+export type MppPaymentInfo = {
+  offers: MppPaymentOffer[];
+};
+
+export type MppServiceDocs = {
+  homepage?: string;
+  apiReference?: string;
+  llms?: string;
+};
+
+export type MppServiceInfo = {
+  categories?: string[];
+  docs?: MppServiceDocs;
+};
+
+/** Runtime payment challenge advertised in HTTP 402 / MCP -32042. */
+export type MppPaymentChallenge = {
+  id: string;
+  intent: MppPaymentIntent;
+  method: MppPaymentMethod;
+  amount: string | null;
+  currency?: string;
+  resource: string;
+  description?: string;
+  /** Protocol-specific payload (x402 PaymentRequired, stripe hints, …). */
+  extensions?: Record<string, unknown>;
+};
+
+export const MPP_MCP_PAYMENT_REQUIRED_CODE = -32042;
+export const MPP_MCP_VERIFICATION_FAILED_CODE = -32043;
+
+export const MPP_CREDENTIAL_META_KEY = "org.paymentauth/credential";
+export const MPP_PAYMENT_REQUIRED_META_KEY = "org.paymentauth/payment-required";
+export const MPP_RECEIPT_META_KEY = "org.paymentauth/receipt";

--- a/packages/clawql-payments/src/mpp/verification-errors.ts
+++ b/packages/clawql-payments/src/mpp/verification-errors.ts
@@ -1,0 +1,9 @@
+import { Data } from "effect";
+
+/** Tagged failure for MPP credential verification (HTTP 402 / MCP -32043). */
+export class MppVerificationError extends Data.TaggedError("MppVerificationError")<{
+  readonly reason: string;
+  readonly method?: string;
+  readonly code?: number;
+  readonly cause?: unknown;
+}> {}

--- a/packages/clawql-payments/src/mpp/verification-service.test.ts
+++ b/packages/clawql-payments/src/mpp/verification-service.test.ts
@@ -162,7 +162,10 @@ describe("MppVerificationService", () => {
   });
 
   it("registers challenges for later single-use verification", async () => {
-    const gate = await createX402Gate({ resource: "/v1/register", price: 0.01, asset: "USDC" }, env);
+    const gate = await createX402Gate(
+      { resource: "/v1/register", price: 0.01, asset: "USDC" },
+      env
+    );
     const configLoaded = {
       walletAddress: "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
       scheme: "exact" as const,
@@ -227,9 +230,10 @@ describe("MppVerificationService", () => {
           }) as unknown as import("stripe").default,
       })
     );
-    const verification = mppVerificationLiveLayer({ ...env, STRIPE_SECRET_KEY: "sk_test_xxx" }).pipe(
-      Layer.provide(Layer.mergeAll(config, audit, runtimeConfig, facilitator, stripe))
-    );
+    const verification = mppVerificationLiveLayer({
+      ...env,
+      STRIPE_SECRET_KEY: "sk_test_xxx",
+    }).pipe(Layer.provide(Layer.mergeAll(config, audit, runtimeConfig, facilitator, stripe)));
 
     await Effect.runPromise(
       Effect.gen(function* () {

--- a/packages/clawql-payments/src/mpp/verification-service.test.ts
+++ b/packages/clawql-payments/src/mpp/verification-service.test.ts
@@ -1,0 +1,258 @@
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Effect, Layer } from "effect";
+import { createX402Gate } from "../x402/gate.js";
+import { resetPaymentsEffectRuntimeForTests } from "../runtime/payments-effect-runtime.js";
+import { MppVerificationService } from "./verification-service.js";
+import { paymentsConfigLiveLayer } from "../config/payments-config-service.js";
+import { paymentAuditLiveLayer } from "../plugin/payment-audit-service.js";
+import { x402RuntimeConfigLiveLayer } from "../x402/x402-runtime-config-service.js";
+import { X402FacilitatorService } from "../x402/x402-facilitator-service.js";
+import { stripeClientLiveLayer, StripeClientService } from "../stripe/stripe-client-service.js";
+import { mppVerificationLiveLayer } from "./verification-service.js";
+import { buildChallengesFromOffers } from "./challenge.js";
+import { offersFromX402Required } from "./offers.js";
+import { buildPaymentRequired } from "../x402/payment-requirements.js";
+import { MPP_MCP_VERIFICATION_FAILED_CODE } from "./types.js";
+
+describe("MppVerificationService", () => {
+  let home: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "clawql-payments-mpp-verify-"));
+    env = {
+      ...process.env,
+      CLAWQL_HOME: home,
+      CLAWQL_X402_ENFORCE: "1",
+      CLAWQL_MPP_ENABLED: "1",
+    };
+    await mkdir(join(home, "Payments"), { recursive: true });
+    await writeFile(
+      join(home, "Payments", "payments.json"),
+      `${JSON.stringify(
+        {
+          tenantId: "tenant-a",
+          plan: "pro",
+          x402: {
+            walletAddress: "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+            facilitatorUrl: "https://x402.org/facilitator",
+          },
+        },
+        null,
+        2
+      )}\n`
+    );
+  });
+
+  afterEach(async () => {
+    resetPaymentsEffectRuntimeForTests();
+    vi.restoreAllMocks();
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("rejects unknown MPP challenge ids for stripe credentials", async () => {
+    const gate = await createX402Gate({ resource: "/v1/test", price: 0.5, asset: "USDC" }, env);
+    const credential = {
+      challenge: {
+        id: "missing-challenge",
+        method: "stripe",
+        intent: "charge",
+        request: Buffer.from(JSON.stringify({ amount: "50", currency: "usd" }), "utf8").toString(
+          "base64url"
+        ),
+      },
+      payload: { token: "spt_test_123" },
+    };
+    const token = Buffer.from(JSON.stringify(credential), "utf8").toString("base64url");
+
+    const config = paymentsConfigLiveLayer(env);
+    const audit = paymentAuditLiveLayer(env);
+    const runtimeConfig = x402RuntimeConfigLiveLayer(env).pipe(Layer.provide(config));
+    const facilitator = Layer.succeed(
+      X402FacilitatorService,
+      X402FacilitatorService.of({
+        verify: () => Effect.succeed({ verified: true as const, settlementId: "settle_1" }),
+        settle: () => Effect.succeed({ settled: true as const, transaction: "0xhash" }),
+      })
+    );
+    const stripe = stripeClientLiveLayer({ ...env, STRIPE_SECRET_KEY: "sk_test_xxx" });
+    const verification = mppVerificationLiveLayer(env).pipe(
+      Layer.provide(Layer.mergeAll(config, audit, runtimeConfig, facilitator, stripe))
+    );
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* MppVerificationService;
+        return yield* service
+          .verifyCredential({
+            resource: gate.resource,
+            requestUrl: "https://example.com/v1/test",
+            gate,
+            headers: { authorization: `Payment ${token}` },
+            env,
+          })
+          .pipe(Effect.either);
+      }).pipe(Effect.provide(verification))
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toMatchObject({
+        _tag: "MppVerificationError",
+        reason: "unknown or expired MPP challenge id",
+        code: MPP_MCP_VERIFICATION_FAILED_CODE,
+      });
+    }
+  });
+
+  it("verifies legacy x402 PAYMENT-SIGNATURE credentials via facilitator", async () => {
+    const gate = await createX402Gate({ resource: "/v1/legacy", price: 0.001, asset: "USDC" }, env);
+    const payload = {
+      x402Version: 2,
+      accepted: {
+        scheme: "exact",
+        network: "eip155:84532",
+        amount: "1000",
+        asset: "0xasset",
+        payTo: "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      },
+      payload: { signature: "0xabc" },
+    };
+    const header = Buffer.from(JSON.stringify(payload), "utf8").toString("base64");
+
+    const verify = vi.fn(() =>
+      Effect.succeed({ verified: true as const, settlementId: "settle_abc", payer: "0xpayer" })
+    );
+
+    const config = paymentsConfigLiveLayer(env);
+    const audit = paymentAuditLiveLayer(env);
+    const runtimeConfig = x402RuntimeConfigLiveLayer(env).pipe(Layer.provide(config));
+    const facilitator = Layer.succeed(
+      X402FacilitatorService,
+      X402FacilitatorService.of({
+        verify: verify,
+        settle: () => Effect.succeed({ settled: true as const, transaction: "0xhash" }),
+      })
+    );
+    const stripe = stripeClientLiveLayer(env);
+    const verification = mppVerificationLiveLayer(env).pipe(
+      Layer.provide(Layer.mergeAll(config, audit, runtimeConfig, facilitator, stripe))
+    );
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* MppVerificationService;
+        return yield* service.verifyCredential({
+          resource: gate.resource,
+          requestUrl: "https://example.com/v1/legacy",
+          gate,
+          headers: { "payment-signature": header },
+          env,
+        });
+      }).pipe(Effect.provide(verification))
+    );
+
+    expect(verify).toHaveBeenCalledTimes(1);
+    expect(result.method).toBe("x402");
+    expect(result.payer).toBe("0xpayer");
+    expect(result.receiptHeader).toBeTruthy();
+  });
+
+  it("registers challenges for later single-use verification", async () => {
+    const gate = await createX402Gate({ resource: "/v1/register", price: 0.01, asset: "USDC" }, env);
+    const configLoaded = {
+      walletAddress: "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      scheme: "exact" as const,
+      network: "eip155:84532",
+      usdcAsset: "0xasset",
+      facilitatorUrl: "https://x402.org/facilitator",
+      maxTimeoutSeconds: 300,
+    };
+    const body = buildPaymentRequired({
+      gate,
+      config: configLoaded,
+      resource: { url: "https://example.com/v1/register", mimeType: "application/json" },
+    });
+    const challenges = buildChallengesFromOffers({
+      offers: offersFromX402Required(body, true),
+      resource: gate.resource,
+      x402Body: body,
+    });
+
+    const stripeChallenge = challenges.find((c) => c.method === "stripe");
+    expect(stripeChallenge).toBeTruthy();
+
+    const credential = {
+      challenge: {
+        id: stripeChallenge!.id,
+        method: "stripe",
+        intent: "charge",
+        request: Buffer.from(JSON.stringify({ amount: "50", currency: "usd" }), "utf8").toString(
+          "base64url"
+        ),
+      },
+      payload: { token: "spt_test_registered" },
+    };
+    const token = Buffer.from(JSON.stringify(credential), "utf8").toString("base64url");
+
+    const create = vi.fn(async () => ({
+      id: "pi_test",
+      status: "succeeded",
+    }));
+
+    const config = paymentsConfigLiveLayer({ ...env, STRIPE_SECRET_KEY: "sk_test_xxx" });
+    const audit = paymentAuditLiveLayer(env);
+    const runtimeConfig = x402RuntimeConfigLiveLayer(env).pipe(Layer.provide(config));
+    const facilitator = Layer.succeed(
+      X402FacilitatorService,
+      X402FacilitatorService.of({
+        verify: () => Effect.succeed({ verified: true as const, settlementId: "settle_1" }),
+        settle: () => Effect.succeed({ settled: true as const, transaction: "0xhash" }),
+      })
+    );
+    const stripe = Layer.succeed(
+      StripeClientService,
+      StripeClientService.of({
+        isConfigured: () => true,
+        getClient: () =>
+          Effect.succeed({
+            paymentIntents: { create },
+          } as unknown as import("stripe").default),
+        getClientOptional: () =>
+          ({
+            paymentIntents: { create },
+          }) as unknown as import("stripe").default,
+      })
+    );
+    const verification = mppVerificationLiveLayer({ ...env, STRIPE_SECRET_KEY: "sk_test_xxx" }).pipe(
+      Layer.provide(Layer.mergeAll(config, audit, runtimeConfig, facilitator, stripe))
+    );
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* MppVerificationService;
+        yield* service.registerChallenges(challenges);
+      }).pipe(Effect.provide(verification))
+    );
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* MppVerificationService;
+        return yield* service.verifyCredential({
+          resource: gate.resource,
+          requestUrl: "https://example.com/v1/register",
+          gate,
+          headers: { authorization: `Payment ${token}` },
+          env: { ...env, STRIPE_SECRET_KEY: "sk_test_xxx" },
+        });
+      }).pipe(Effect.provide(verification))
+    );
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(result.method).toBe("stripe");
+    expect(result.settlementId).toBe("pi_test");
+  });
+});

--- a/packages/clawql-payments/src/mpp/verification-service.ts
+++ b/packages/clawql-payments/src/mpp/verification-service.ts
@@ -8,10 +8,7 @@ import { StripeApiError, StripeNotConfigured } from "../stripe/stripe-errors.js"
 import { ConfigError, X402Error } from "../errors/payment-errors.js";
 import type { X402Gate } from "../x402/gate.js";
 import { X402FacilitatorService } from "../x402/x402-facilitator-service.js";
-import {
-  usdcAtomicAmount,
-  X402RuntimeConfigService,
-} from "../x402/x402-runtime-config-service.js";
+import { usdcAtomicAmount, X402RuntimeConfigService } from "../x402/x402-runtime-config-service.js";
 import { isMppEnabled } from "./config.js";
 import {
   decodeChallengeRequest,
@@ -91,9 +88,7 @@ function amountMinorUnits(amount: unknown, currency: string): number | undefined
 export class MppVerificationService extends Context.Tag("clawql/MppVerificationService")<
   MppVerificationService,
   {
-    readonly registerChallenges: (
-      challenges: MppPaymentChallenge[]
-    ) => Effect.Effect<void, never>;
+    readonly registerChallenges: (challenges: MppPaymentChallenge[]) => Effect.Effect<void, never>;
     readonly verifyCredential: (
       input: VerifyMppCredentialInput
     ) => Effect.Effect<

--- a/packages/clawql-payments/src/mpp/verification-service.ts
+++ b/packages/clawql-payments/src/mpp/verification-service.ts
@@ -1,0 +1,440 @@
+import { Context, Effect, Layer } from "effect";
+import { PaymentsConfigService } from "../config/payments-config-service.js";
+import { PaymentAuditService } from "../plugin/payment-audit-service.js";
+import { buildX402PaymentReceivedEntry } from "../audit/events.js";
+import { stripeTryPromise } from "../stripe/stripe-client-service.js";
+import { StripeClientService } from "../stripe/stripe-client-service.js";
+import { StripeApiError, StripeNotConfigured } from "../stripe/stripe-errors.js";
+import { ConfigError, X402Error } from "../errors/payment-errors.js";
+import type { X402Gate } from "../x402/gate.js";
+import { X402FacilitatorService } from "../x402/x402-facilitator-service.js";
+import {
+  usdcAtomicAmount,
+  X402RuntimeConfigService,
+} from "../x402/x402-runtime-config-service.js";
+import { isMppEnabled } from "./config.js";
+import {
+  decodeChallengeRequest,
+  extractPaymentCredential,
+  x402PayloadFromMppCredential,
+  type ParsedPaymentCredential,
+} from "./credential.js";
+import { buildMppPaymentReceipt, mppPaymentReceiptHeader } from "./receipt.js";
+import { MppVerificationError } from "./verification-errors.js";
+import {
+  MPP_METHOD_STRIPE,
+  MPP_METHOD_X402,
+  MPP_MCP_VERIFICATION_FAILED_CODE,
+  type MppPaymentChallenge,
+  type MppPaymentMethod,
+} from "./types.js";
+
+export type MppVerificationSuccess = {
+  method: MppPaymentMethod;
+  payer?: string;
+  receipt: Record<string, unknown>;
+  receiptHeader: string;
+  settlementId?: string;
+};
+
+export type VerifyMppCredentialInput = {
+  resource: string;
+  requestUrl: string;
+  gate: X402Gate;
+  headers: Record<string, string | string[] | undefined>;
+  correlationId?: string;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+};
+
+type StoredChallenge = {
+  challenge: MppPaymentChallenge;
+  expiresAt?: number;
+};
+
+function parseExpiresMs(expires: string | undefined): number | undefined {
+  if (!expires?.trim()) return undefined;
+  const ms = Date.parse(expires);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+function extractStripeSpt(payload: Record<string, unknown>): string | undefined {
+  const direct = [payload.shared_payment_token, payload.spt, payload.token];
+  for (const value of direct) {
+    if (typeof value === "string" && value.trim().startsWith("spt_")) {
+      return value.trim();
+    }
+  }
+  if (payload.type === "shared_payment_token" && typeof payload.token === "string") {
+    return payload.token.trim();
+  }
+  return undefined;
+}
+
+function amountMinorUnits(amount: unknown, currency: string): number | undefined {
+  if (typeof amount === "number" && Number.isFinite(amount)) {
+    return Math.round(amount);
+  }
+  if (typeof amount === "string" && amount.trim()) {
+    const parsed = Number.parseInt(amount, 10);
+    if (Number.isFinite(parsed)) return parsed;
+    const asFloat = Number.parseFloat(amount);
+    if (Number.isFinite(asFloat)) {
+      const decimals = currency.toLowerCase() === "usd" ? 2 : 6;
+      return Math.round(asFloat * 10 ** decimals);
+    }
+  }
+  return undefined;
+}
+
+/** Effect service for MPP credential verification (x402 + Stripe SPT). */
+export class MppVerificationService extends Context.Tag("clawql/MppVerificationService")<
+  MppVerificationService,
+  {
+    readonly registerChallenges: (
+      challenges: MppPaymentChallenge[]
+    ) => Effect.Effect<void, never>;
+    readonly verifyCredential: (
+      input: VerifyMppCredentialInput
+    ) => Effect.Effect<
+      MppVerificationSuccess,
+      MppVerificationError | ConfigError | X402Error | StripeNotConfigured | StripeApiError
+    >;
+    readonly buildReceiptHeader: (receipt: Record<string, unknown>) => string;
+  }
+>() {}
+
+export function mppVerificationLiveLayer(
+  env: NodeJS.ProcessEnv = process.env
+): Layer.Layer<
+  MppVerificationService,
+  never,
+  | PaymentsConfigService
+  | PaymentAuditService
+  | X402RuntimeConfigService
+  | X402FacilitatorService
+  | StripeClientService
+> {
+  const challengeRegistry = new Map<string, StoredChallenge>();
+
+  return Layer.effect(
+    MppVerificationService,
+    Effect.gen(function* () {
+      const configService = yield* PaymentsConfigService;
+      const audit = yield* PaymentAuditService;
+      const runtimeConfig = yield* X402RuntimeConfigService;
+      const facilitator = yield* X402FacilitatorService;
+      const stripeClient = yield* StripeClientService;
+
+      const registerChallenges = (challenges: MppPaymentChallenge[]) =>
+        Effect.sync(() => {
+          for (const challenge of challenges) {
+            challengeRegistry.set(challenge.id, {
+              challenge,
+              expiresAt: parseExpiresMs(
+                typeof challenge.extensions?.expires === "string"
+                  ? challenge.extensions.expires
+                  : undefined
+              ),
+            });
+          }
+        });
+
+      const consumeChallenge = (id: string): boolean => {
+        const stored = challengeRegistry.get(id);
+        if (!stored) return false;
+        challengeRegistry.delete(id);
+        if (stored.expiresAt !== undefined && Date.now() > stored.expiresAt) {
+          return false;
+        }
+        return true;
+      };
+
+      const verifyX402 = (input: {
+        parsed: ParsedPaymentCredential;
+        gate: X402Gate;
+        requestUrl: string;
+        runEnv: NodeJS.ProcessEnv;
+        fetchImpl?: typeof fetch;
+        tenantId: string;
+        correlationId?: string;
+      }) =>
+        Effect.gen(function* () {
+          const paymentPayload =
+            input.parsed.kind === "x402-signature"
+              ? input.parsed.payload
+              : x402PayloadFromMppCredential(input.parsed.credential);
+
+          if (!paymentPayload) {
+            return yield* Effect.fail(
+              new MppVerificationError({
+                reason: "invalid x402 credential payload",
+                method: MPP_METHOD_X402,
+                code: MPP_MCP_VERIFICATION_FAILED_CODE,
+              })
+            );
+          }
+
+          const config = yield* runtimeConfig.load();
+          if (!config.walletAddress?.trim()) {
+            return yield* Effect.fail(
+              new MppVerificationError({
+                reason: "x402 wallet address is not configured",
+                method: MPP_METHOD_X402,
+                code: MPP_MCP_VERIFICATION_FAILED_CODE,
+              })
+            );
+          }
+          if (!config.facilitatorUrl?.trim()) {
+            return yield* Effect.fail(
+              new MppVerificationError({
+                reason: "x402 facilitator URL is not configured",
+                method: MPP_METHOD_X402,
+                code: MPP_MCP_VERIFICATION_FAILED_CODE,
+              })
+            );
+          }
+
+          const paymentRequirements = {
+            scheme: config.scheme,
+            network: config.network,
+            amount: usdcAtomicAmount(input.gate.price),
+            asset: config.usdcAsset,
+            payTo: config.walletAddress!,
+            maxTimeoutSeconds: config.maxTimeoutSeconds,
+            extra: {
+              name: input.gate.asset,
+              version: "2",
+            },
+          };
+
+          const verified = yield* facilitator.verify({
+            facilitatorUrl: config.facilitatorUrl,
+            paymentPayload,
+            paymentRequirements,
+            env: input.runEnv,
+            fetchImpl: input.fetchImpl,
+          });
+
+          if (!verified.verified) {
+            return yield* Effect.fail(
+              new MppVerificationError({
+                reason: verified.reason,
+                method: MPP_METHOD_X402,
+                code: MPP_MCP_VERIFICATION_FAILED_CODE,
+              })
+            );
+          }
+
+          const settlementId = verified.settlementId;
+          yield* audit
+            .appendEntry(
+              buildX402PaymentReceivedEntry({
+                tenantId: input.tenantId,
+                amountUsdc: input.gate.price,
+                resource: input.gate.resource,
+                agentId: verified.payer,
+                correlationId: input.correlationId,
+              })
+            )
+            .pipe(Effect.catchAll(() => Effect.void));
+
+          const receipt = buildMppPaymentReceipt({
+            method: MPP_METHOD_X402,
+            resource: input.gate.resource,
+            settledAt: new Date().toISOString(),
+            payer: verified.payer,
+            settlementId,
+            x402SettlementId: settlementId,
+          });
+
+          return {
+            method: MPP_METHOD_X402 as MppPaymentMethod,
+            payer: verified.payer,
+            receipt,
+            receiptHeader: mppPaymentReceiptHeader(receipt),
+            settlementId,
+          } satisfies MppVerificationSuccess;
+        });
+
+      const verifyStripe = (input: {
+        credential: import("./credential.js").MppCredential;
+        gate: X402Gate;
+        runEnv: NodeJS.ProcessEnv;
+        tenantId: string;
+        correlationId?: string;
+      }) =>
+        Effect.gen(function* () {
+          const spt = extractStripeSpt(input.credential.payload);
+          if (!spt) {
+            return yield* Effect.fail(
+              new MppVerificationError({
+                reason: "missing Stripe shared payment token in credential payload",
+                method: MPP_METHOD_STRIPE,
+                code: MPP_MCP_VERIFICATION_FAILED_CODE,
+              })
+            );
+          }
+
+          const request = decodeChallengeRequest(input.credential.challenge.request);
+          const currency =
+            (typeof request?.currency === "string" && request.currency) ||
+            input.gate.asset.toLowerCase() ||
+            "usd";
+          const amount =
+            amountMinorUnits(request?.amount, currency) ??
+            amountMinorUnits(input.gate.price, currency);
+
+          if (amount === undefined || amount <= 0) {
+            return yield* Effect.fail(
+              new MppVerificationError({
+                reason: "Stripe MPP challenge is missing a valid amount",
+                method: MPP_METHOD_STRIPE,
+                code: MPP_MCP_VERIFICATION_FAILED_CODE,
+              })
+            );
+          }
+
+          const stripe = yield* stripeClient.getClient();
+          const profileId =
+            input.runEnv.STRIPE_PROFILE_ID?.trim() ||
+            input.runEnv.STRIPE_NETWORK_ID?.trim() ||
+            (typeof request?.networkId === "string" ? request.networkId : undefined);
+
+          const paymentIntent = yield* stripeTryPromise("stripe mpp spt payment", () =>
+            stripe.paymentIntents.create(
+              {
+                amount,
+                currency: currency.toLowerCase(),
+                payment_method: spt,
+                confirm: true,
+                metadata: {
+                  clawql_resource: input.gate.resource,
+                  clawql_tenant: input.tenantId,
+                  ...(profileId ? { stripe_profile_id: profileId } : {}),
+                },
+              },
+              {
+                apiVersion: "2026-03-04.preview",
+              }
+            )
+          );
+
+          if (paymentIntent.status !== "succeeded" && paymentIntent.status !== "processing") {
+            return yield* Effect.fail(
+              new MppVerificationError({
+                reason: `Stripe payment intent status: ${paymentIntent.status}`,
+                method: MPP_METHOD_STRIPE,
+                code: MPP_MCP_VERIFICATION_FAILED_CODE,
+              })
+            );
+          }
+
+          const receipt = buildMppPaymentReceipt({
+            method: MPP_METHOD_STRIPE,
+            resource: input.gate.resource,
+            settledAt: new Date().toISOString(),
+            settlementId: paymentIntent.id,
+            stripePaymentIntentId: paymentIntent.id,
+          });
+
+          return {
+            method: MPP_METHOD_STRIPE as MppPaymentMethod,
+            receipt,
+            receiptHeader: mppPaymentReceiptHeader(receipt),
+            settlementId: paymentIntent.id,
+          } satisfies MppVerificationSuccess;
+        });
+
+      const verifyCredential = (input: VerifyMppCredentialInput) =>
+        Effect.gen(function* () {
+          const runEnv = input.env ?? env;
+          if (!isMppEnabled(runEnv)) {
+            return yield* Effect.fail(
+              new MppVerificationError({
+                reason: "MPP verification is disabled",
+                code: MPP_MCP_VERIFICATION_FAILED_CODE,
+              })
+            );
+          }
+
+          const parsed = extractPaymentCredential(input.headers);
+          if (!parsed) {
+            return yield* Effect.fail(
+              new MppVerificationError({
+                reason: "missing MPP or x402 payment credential",
+                code: MPP_MCP_VERIFICATION_FAILED_CODE,
+              })
+            );
+          }
+
+          if (parsed.kind === "mpp") {
+            const challengeId = parsed.credential.challenge.id?.trim();
+            if (challengeId && !consumeChallenge(challengeId)) {
+              return yield* Effect.fail(
+                new MppVerificationError({
+                  reason: "unknown or expired MPP challenge id",
+                  method: parsed.credential.challenge.method,
+                  code: MPP_MCP_VERIFICATION_FAILED_CODE,
+                })
+              );
+            }
+
+            const expiresAt = parseExpiresMs(parsed.credential.challenge.expires);
+            if (expiresAt !== undefined && Date.now() > expiresAt) {
+              return yield* Effect.fail(
+                new MppVerificationError({
+                  reason: "MPP challenge expired",
+                  method: parsed.credential.challenge.method,
+                  code: MPP_MCP_VERIFICATION_FAILED_CODE,
+                })
+              );
+            }
+          }
+
+          const paymentsConfig = yield* configService.load();
+          const tenantId = paymentsConfig.tenantId ?? "default";
+
+          if (
+            parsed.kind === "x402-signature" ||
+            (parsed.kind === "mpp" && parsed.credential.challenge.method === MPP_METHOD_X402)
+          ) {
+            return yield* verifyX402({
+              parsed,
+              gate: input.gate,
+              requestUrl: input.requestUrl,
+              runEnv,
+              fetchImpl: input.fetchImpl,
+              tenantId,
+              correlationId: input.correlationId,
+            });
+          }
+
+          if (parsed.kind === "mpp" && parsed.credential.challenge.method === MPP_METHOD_STRIPE) {
+            return yield* verifyStripe({
+              credential: parsed.credential,
+              gate: input.gate,
+              runEnv,
+              tenantId,
+              correlationId: input.correlationId,
+            });
+          }
+
+          return yield* Effect.fail(
+            new MppVerificationError({
+              reason: `unsupported MPP payment method: ${
+                parsed.kind === "mpp" ? parsed.credential.challenge.method : "x402"
+              }`,
+              code: MPP_MCP_VERIFICATION_FAILED_CODE,
+            })
+          );
+        });
+
+      return MppVerificationService.of({
+        registerChallenges,
+        verifyCredential,
+        buildReceiptHeader: mppPaymentReceiptHeader,
+      });
+    })
+  );
+}

--- a/packages/clawql-payments/src/mpp/verify.ts
+++ b/packages/clawql-payments/src/mpp/verify.ts
@@ -1,0 +1,35 @@
+import { Effect } from "effect";
+import { runPaymentsEffect } from "../runtime/payments-effect-runtime.js";
+import {
+  MppVerificationService,
+  type MppVerificationSuccess,
+  type VerifyMppCredentialInput,
+} from "./verification-service.js";
+import type { MppPaymentChallenge } from "./types.js";
+
+export type { MppVerificationSuccess, VerifyMppCredentialInput };
+
+export async function registerMppChallenges(
+  challenges: MppPaymentChallenge[],
+  env?: NodeJS.ProcessEnv
+): Promise<void> {
+  return runPaymentsEffect(
+    Effect.gen(function* () {
+      const verification = yield* MppVerificationService;
+      yield* verification.registerChallenges(challenges);
+    }),
+    env
+  );
+}
+
+export async function verifyMppCredential(
+  input: VerifyMppCredentialInput
+): Promise<MppVerificationSuccess> {
+  return runPaymentsEffect(
+    Effect.gen(function* () {
+      const verification = yield* MppVerificationService;
+      return yield* verification.verifyCredential(input);
+    }),
+    input.env
+  );
+}

--- a/packages/clawql-payments/src/plugin/index.ts
+++ b/packages/clawql-payments/src/plugin/index.ts
@@ -34,14 +34,8 @@ export {
   X402EnforcementService,
   x402EnforcementLiveLayer,
 } from "../x402/x402-enforcement-service.js";
-export {
-  MppOpenApiService,
-  mppOpenApiLiveLayer,
-} from "../mpp/openapi-service.js";
-export {
-  MppVerificationService,
-  mppVerificationLiveLayer,
-} from "../mpp/verification-service.js";
+export { MppOpenApiService, mppOpenApiLiveLayer } from "../mpp/openapi-service.js";
+export { MppVerificationService, mppVerificationLiveLayer } from "../mpp/verification-service.js";
 export { UsageStoreService, usageStoreLiveLayer } from "../plans/usage-store-service.js";
 export { EntitlementService, entitlementLiveLayer } from "../plans/entitlement-service.js";
 export {

--- a/packages/clawql-payments/src/plugin/index.ts
+++ b/packages/clawql-payments/src/plugin/index.ts
@@ -34,6 +34,14 @@ export {
   X402EnforcementService,
   x402EnforcementLiveLayer,
 } from "../x402/x402-enforcement-service.js";
+export {
+  MppOpenApiService,
+  mppOpenApiLiveLayer,
+} from "../mpp/openapi-service.js";
+export {
+  MppVerificationService,
+  mppVerificationLiveLayer,
+} from "../mpp/verification-service.js";
 export { UsageStoreService, usageStoreLiveLayer } from "../plans/usage-store-service.js";
 export { EntitlementService, entitlementLiveLayer } from "../plans/entitlement-service.js";
 export {

--- a/packages/clawql-payments/src/runtime/payments-effect-runtime.ts
+++ b/packages/clawql-payments/src/runtime/payments-effect-runtime.ts
@@ -2,6 +2,7 @@ import { Cause, Effect, Exit, Layer } from "effect";
 import { paymentsConfigLiveLayer } from "../config/payments-config-service.js";
 import { paymentsDiscoveryLiveLayer } from "../discovery/payments-discovery-service.js";
 import { mppOpenApiLiveLayer } from "../mpp/openapi-service.js";
+import { mppVerificationLiveLayer } from "../mpp/verification-service.js";
 import { entitlementLiveLayer } from "../plans/entitlement-service.js";
 import { usageStoreLiveLayer } from "../plans/usage-store-service.js";
 import { paymentAuditLiveLayer } from "../plugin/payment-audit-service.js";
@@ -25,6 +26,7 @@ export type PaymentsServices =
   | import("../plans/entitlement-service.js").EntitlementService
   | import("../discovery/payments-discovery-service.js").PaymentsDiscoveryService
   | import("../mpp/openapi-service.js").MppOpenApiService
+  | import("../mpp/verification-service.js").MppVerificationService
   | import("../stripe/stripe-client-service.js").StripeClientService
   | import("../stripe/stripe-webhook-service.js").StripeWebhookService
   | import("../stripe/stripe-meter-service.js").StripeMeterService
@@ -49,14 +51,19 @@ export function paymentsServicesLiveLayer(
   const stripeClient = stripeClientLiveLayer(env);
 
   const runtimeConfig = x402RuntimeConfigLiveLayer(env).pipe(Layer.provide(config));
+  const mppOpenApi = mppOpenApiLiveLayer(env).pipe(
+    Layer.provide(Layer.mergeAll(runtimeConfig, gate))
+  );
+  const mppVerification = mppVerificationLiveLayer(env).pipe(
+    Layer.provide(Layer.mergeAll(config, audit, runtimeConfig, facilitator, stripeClient))
+  );
   const enforcement = x402EnforcementLiveLayer().pipe(
-    Layer.provide(Layer.mergeAll(config, audit, gate, runtimeConfig, facilitator))
+    Layer.provide(
+      Layer.mergeAll(config, audit, gate, runtimeConfig, facilitator, mppVerification)
+    )
   );
   const discovery = paymentsDiscoveryLiveLayer(env).pipe(
     Layer.provide(Layer.mergeAll(config, runtimeConfig, gate))
-  );
-  const mppOpenApi = mppOpenApiLiveLayer(env).pipe(
-    Layer.provide(Layer.mergeAll(runtimeConfig, gate))
   );
   const stripeWebhook = stripeWebhookLiveLayer().pipe(Layer.provide(Layer.mergeAll(config, audit)));
   const stripeMeter = stripeMeterLiveLayer(env).pipe(
@@ -77,6 +84,7 @@ export function paymentsServicesLiveLayer(
     enforcement,
     discovery,
     mppOpenApi,
+    mppVerification,
     stripeClient,
     stripeWebhook,
     stripeMeter,

--- a/packages/clawql-payments/src/runtime/payments-effect-runtime.ts
+++ b/packages/clawql-payments/src/runtime/payments-effect-runtime.ts
@@ -56,7 +56,7 @@ export function paymentsServicesLiveLayer(
     Layer.provide(Layer.mergeAll(config, runtimeConfig, gate))
   );
   const mppOpenApi = mppOpenApiLiveLayer(env).pipe(
-    Layer.provide(Layer.mergeAll(config, runtimeConfig, gate))
+    Layer.provide(Layer.mergeAll(runtimeConfig, gate))
   );
   const stripeWebhook = stripeWebhookLiveLayer().pipe(Layer.provide(Layer.mergeAll(config, audit)));
   const stripeMeter = stripeMeterLiveLayer(env).pipe(

--- a/packages/clawql-payments/src/runtime/payments-effect-runtime.ts
+++ b/packages/clawql-payments/src/runtime/payments-effect-runtime.ts
@@ -1,6 +1,7 @@
 import { Cause, Effect, Exit, Layer } from "effect";
 import { paymentsConfigLiveLayer } from "../config/payments-config-service.js";
 import { paymentsDiscoveryLiveLayer } from "../discovery/payments-discovery-service.js";
+import { mppOpenApiLiveLayer } from "../mpp/openapi-service.js";
 import { entitlementLiveLayer } from "../plans/entitlement-service.js";
 import { usageStoreLiveLayer } from "../plans/usage-store-service.js";
 import { paymentAuditLiveLayer } from "../plugin/payment-audit-service.js";
@@ -23,6 +24,7 @@ export type PaymentsServices =
   | import("../plans/usage-store-service.js").UsageStoreService
   | import("../plans/entitlement-service.js").EntitlementService
   | import("../discovery/payments-discovery-service.js").PaymentsDiscoveryService
+  | import("../mpp/openapi-service.js").MppOpenApiService
   | import("../stripe/stripe-client-service.js").StripeClientService
   | import("../stripe/stripe-webhook-service.js").StripeWebhookService
   | import("../stripe/stripe-meter-service.js").StripeMeterService
@@ -53,6 +55,9 @@ export function paymentsServicesLiveLayer(
   const discovery = paymentsDiscoveryLiveLayer(env).pipe(
     Layer.provide(Layer.mergeAll(config, runtimeConfig, gate))
   );
+  const mppOpenApi = mppOpenApiLiveLayer(env).pipe(
+    Layer.provide(Layer.mergeAll(config, runtimeConfig, gate))
+  );
   const stripeWebhook = stripeWebhookLiveLayer().pipe(Layer.provide(Layer.mergeAll(config, audit)));
   const stripeMeter = stripeMeterLiveLayer(env).pipe(
     Layer.provide(Layer.mergeAll(stripeClient, config, audit))
@@ -71,6 +76,7 @@ export function paymentsServicesLiveLayer(
     runtimeConfig,
     enforcement,
     discovery,
+    mppOpenApi,
     stripeClient,
     stripeWebhook,
     stripeMeter,

--- a/packages/clawql-payments/src/runtime/payments-effect-runtime.ts
+++ b/packages/clawql-payments/src/runtime/payments-effect-runtime.ts
@@ -58,9 +58,7 @@ export function paymentsServicesLiveLayer(
     Layer.provide(Layer.mergeAll(config, audit, runtimeConfig, facilitator, stripeClient))
   );
   const enforcement = x402EnforcementLiveLayer().pipe(
-    Layer.provide(
-      Layer.mergeAll(config, audit, gate, runtimeConfig, facilitator, mppVerification)
-    )
+    Layer.provide(Layer.mergeAll(config, audit, gate, runtimeConfig, facilitator, mppVerification))
   );
   const discovery = paymentsDiscoveryLiveLayer(env).pipe(
     Layer.provide(Layer.mergeAll(config, runtimeConfig, gate))

--- a/packages/clawql-payments/src/x402/mcp-enforce.test.ts
+++ b/packages/clawql-payments/src/x402/mcp-enforce.test.ts
@@ -22,6 +22,7 @@ describe("runMcpX402BeforeCallTool", () => {
       CLAWQL_HOME: home,
       CLAWQL_PAYMENTS_AUDIT_STORE: "memory",
       CLAWQL_X402_ENFORCE: "1",
+      CLAWQL_MPP_ENABLED: "1",
     };
     await mkdir(join(home, "Payments"), { recursive: true });
     await writeFile(

--- a/packages/clawql-payments/src/x402/mcp-errors.ts
+++ b/packages/clawql-payments/src/x402/mcp-errors.ts
@@ -1,4 +1,7 @@
 import type { X402PaymentRequired } from "./types.js";
+import { isMppEnabled } from "../mpp/config.js";
+import { offersFromX402Required } from "../mpp/offers.js";
+import { enrichMcpToolResultWithMpp, type MppMcpToolResult } from "../mpp/mcp.js";
 
 export type X402McpToolResult = {
   content: Array<{ type: "text"; text: string }>;
@@ -13,8 +16,8 @@ export class X402McpPaymentRequiredError extends Error {
     super("x402 payment required");
   }
 
-  toToolResult(): X402McpToolResult {
-    return {
+  toToolResult(env: NodeJS.ProcessEnv = process.env): MppMcpToolResult {
+    const base: MppMcpToolResult = {
       content: [
         {
           type: "text",
@@ -35,6 +38,20 @@ export class X402McpPaymentRequiredError extends Error {
         "clawql/httpStatus": 402,
       },
     };
+
+    if (!isMppEnabled(env)) {
+      return base;
+    }
+
+    const resource = this.body.resource.url ?? "mcp://tool";
+    return enrichMcpToolResultWithMpp(base, {
+      offers: offersFromX402Required(
+        this.body,
+        Boolean(env.STRIPE_SECRET_KEY?.trim())
+      ),
+      resource,
+      x402Body: this.body,
+    });
   }
 }
 

--- a/packages/clawql-payments/src/x402/mcp-errors.ts
+++ b/packages/clawql-payments/src/x402/mcp-errors.ts
@@ -45,10 +45,7 @@ export class X402McpPaymentRequiredError extends Error {
 
     const resource = this.body.resource.url ?? "mcp://tool";
     return enrichMcpToolResultWithMpp(base, {
-      offers: offersFromX402Required(
-        this.body,
-        Boolean(env.STRIPE_SECRET_KEY?.trim())
-      ),
+      offers: offersFromX402Required(this.body, Boolean(env.STRIPE_SECRET_KEY?.trim())),
       resource,
       x402Body: this.body,
     });

--- a/packages/clawql-payments/src/x402/middleware.ts
+++ b/packages/clawql-payments/src/x402/middleware.ts
@@ -1,4 +1,8 @@
 import type { NextFunction, Request, Response } from "express";
+import { isMppEnabled } from "../mpp/config.js";
+import { buildChallengesFromOffers, buildMppPaymentRequiredBody } from "../mpp/challenge.js";
+import { mergePaymentRequiredHeaders } from "../mpp/headers.js";
+import { offersFromX402Required } from "../mpp/offers.js";
 import { isX402EnforcementActive } from "./config.js";
 import {
   enforceX402Gate,
@@ -62,6 +66,31 @@ export function createX402PaymentMiddleware(options: CreateX402PaymentMiddleware
       }
 
       if (result.action === "require_payment") {
+        const stripeEnabled = Boolean(env.STRIPE_SECRET_KEY?.trim());
+        if (isMppEnabled(env)) {
+          const offers = offersFromX402Required(result.body, stripeEnabled);
+          const challenges = buildChallengesFromOffers({
+            offers,
+            resource: result.resource,
+            x402Body: result.body,
+          });
+          const headers = mergePaymentRequiredHeaders({
+            x402Body: result.body,
+            offers,
+            resource: result.resource,
+          });
+          for (const [key, value] of Object.entries(headers)) {
+            res.setHeader(key, value);
+          }
+          const mppBody = buildMppPaymentRequiredBody({
+            resource: result.resource,
+            challenges,
+            x402Body: result.body,
+          });
+          res.status(402).json(mppBody);
+          return;
+        }
+
         const headers = paymentRequiredHeaders(result.body);
         for (const [key, value] of Object.entries(headers)) {
           res.setHeader(key, value);

--- a/packages/clawql-payments/src/x402/middleware.ts
+++ b/packages/clawql-payments/src/x402/middleware.ts
@@ -61,6 +61,13 @@ export function createX402PaymentMiddleware(options: CreateX402PaymentMiddleware
       if (result.action === "allow") {
         if (result.payer) req.x402Payer = result.payer;
         if (result.resource) req.x402Resource = result.resource;
+        if (result.mppReceiptHeader) {
+          res.setHeader("Payment-Receipt", result.mppReceiptHeader);
+          res.setHeader(
+            "Access-Control-Expose-Headers",
+            "PAYMENT-REQUIRED, PAYMENT-RESPONSE, Payment-Required, Payment-Receipt, WWW-Authenticate, Authorization"
+          );
+        }
         next();
         return;
       }
@@ -69,11 +76,13 @@ export function createX402PaymentMiddleware(options: CreateX402PaymentMiddleware
         const stripeEnabled = Boolean(env.STRIPE_SECRET_KEY?.trim());
         if (isMppEnabled(env)) {
           const offers = offersFromX402Required(result.body, stripeEnabled);
-          const challenges = buildChallengesFromOffers({
-            offers,
-            resource: result.resource,
-            x402Body: result.body,
-          });
+          const challenges =
+            result.mppChallenges ??
+            buildChallengesFromOffers({
+              offers,
+              resource: result.resource,
+              x402Body: result.body,
+            });
           const headers = mergePaymentRequiredHeaders({
             x402Body: result.body,
             offers,
@@ -103,6 +112,9 @@ export function createX402PaymentMiddleware(options: CreateX402PaymentMiddleware
         x402Version: 2,
         error: result.reason,
         resource: { url: requestUrl },
+        ...(result.mppVerificationCode
+          ? { mppVerificationCode: result.mppVerificationCode }
+          : {}),
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/packages/clawql-payments/src/x402/middleware.ts
+++ b/packages/clawql-payments/src/x402/middleware.ts
@@ -112,9 +112,7 @@ export function createX402PaymentMiddleware(options: CreateX402PaymentMiddleware
         x402Version: 2,
         error: result.reason,
         resource: { url: requestUrl },
-        ...(result.mppVerificationCode
-          ? { mppVerificationCode: result.mppVerificationCode }
-          : {}),
+        ...(result.mppVerificationCode ? { mppVerificationCode: result.mppVerificationCode } : {}),
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/packages/clawql-payments/src/x402/payment-requirements.ts
+++ b/packages/clawql-payments/src/x402/payment-requirements.ts
@@ -1,0 +1,52 @@
+import type { X402Gate } from "./gate.js";
+import type { X402PaymentRequired, X402PaymentRequirements, X402ResourceInfo } from "./types.js";
+import { X402_VERSION } from "./types.js";
+import { usdcAtomicAmount, type X402RuntimeConfig } from "./x402-runtime-config-service.js";
+
+export function buildPaymentRequirements(input: {
+  gate: X402Gate;
+  config: X402RuntimeConfig;
+  resourceUrl: string;
+}): X402PaymentRequirements {
+  const payTo = input.config.walletAddress;
+  if (!payTo?.trim()) {
+    throw new Error(
+      "x402 wallet address is not configured — run clawql payments x402 wallet setup"
+    );
+  }
+
+  return {
+    scheme: input.config.scheme,
+    network: input.config.network,
+    amount: usdcAtomicAmount(input.gate.price),
+    asset: input.config.usdcAsset,
+    payTo,
+    maxTimeoutSeconds: input.config.maxTimeoutSeconds,
+    extra: {
+      name: input.gate.asset,
+      version: "2",
+    },
+  };
+}
+
+export function buildPaymentRequired(input: {
+  gate: X402Gate;
+  resource: X402ResourceInfo;
+  config: X402RuntimeConfig;
+}): X402PaymentRequired {
+  const requirements = buildPaymentRequirements({
+    gate: input.gate,
+    config: input.config,
+    resourceUrl: input.resource.url,
+  });
+
+  return {
+    x402Version: X402_VERSION,
+    error: "PAYMENT-SIGNATURE header is required",
+    resource: input.resource,
+    accepts: [requirements],
+    extensions: {
+      facilitator: input.config.facilitatorUrl,
+    },
+  };
+}

--- a/packages/clawql-payments/src/x402/requirements.ts
+++ b/packages/clawql-payments/src/x402/requirements.ts
@@ -1,61 +1,11 @@
 import { Effect } from "effect";
 import type { X402Gate } from "./gate.js";
-import type { X402PaymentRequired, X402PaymentRequirements, X402ResourceInfo } from "./types.js";
-import { X402_VERSION } from "./types.js";
+import type { X402PaymentRequired } from "./types.js";
 import { runPaymentsEffect } from "../runtime/payments-effect-runtime.js";
-import {
-  usdcAtomicAmount,
-  X402RuntimeConfigService,
-  type X402RuntimeConfig,
-} from "./x402-runtime-config-service.js";
+import { X402RuntimeConfigService } from "./x402-runtime-config-service.js";
+import { buildPaymentRequired } from "./payment-requirements.js";
 
-export function buildPaymentRequirements(input: {
-  gate: X402Gate;
-  config: X402RuntimeConfig;
-  resourceUrl: string;
-}): X402PaymentRequirements {
-  const payTo = input.config.walletAddress;
-  if (!payTo?.trim()) {
-    throw new Error(
-      "x402 wallet address is not configured — run clawql payments x402 wallet setup"
-    );
-  }
-
-  return {
-    scheme: input.config.scheme,
-    network: input.config.network,
-    amount: usdcAtomicAmount(input.gate.price),
-    asset: input.config.usdcAsset,
-    payTo,
-    maxTimeoutSeconds: input.config.maxTimeoutSeconds,
-    extra: {
-      name: input.gate.asset,
-      version: "2",
-    },
-  };
-}
-
-export function buildPaymentRequired(input: {
-  gate: X402Gate;
-  resource: X402ResourceInfo;
-  config: X402RuntimeConfig;
-}): X402PaymentRequired {
-  const requirements = buildPaymentRequirements({
-    gate: input.gate,
-    config: input.config,
-    resourceUrl: input.resource.url,
-  });
-
-  return {
-    x402Version: X402_VERSION,
-    error: "PAYMENT-SIGNATURE header is required",
-    resource: input.resource,
-    accepts: [requirements],
-    extensions: {
-      facilitator: input.config.facilitatorUrl,
-    },
-  };
-}
+export { buildPaymentRequirements, buildPaymentRequired } from "./payment-requirements.js";
 
 export async function buildPaymentRequiredForGate(input: {
   gate: X402Gate;

--- a/packages/clawql-payments/src/x402/x402-enforcement-service.ts
+++ b/packages/clawql-payments/src/x402/x402-enforcement-service.ts
@@ -1,10 +1,17 @@
-import { Context, Effect, Layer } from "effect";
+import { Context, Effect, Either, Layer } from "effect";
 import { PaymentsConfigService } from "../config/payments-config-service.js";
 import { PaymentAuditService } from "../plugin/payment-audit-service.js";
 import { ConfigError, X402Error } from "../errors/payment-errors.js";
 import { buildX402PaymentFailedEntry, buildX402PaymentReceivedEntry } from "../audit/events.js";
+import { isMppEnabled } from "../mpp/config.js";
+import { extractPaymentCredential } from "../mpp/credential.js";
+import { buildChallengesFromOffers } from "../mpp/challenge.js";
+import { offersFromX402Required } from "../mpp/offers.js";
+import { MppVerificationError } from "../mpp/verification-errors.js";
+import { MppVerificationService } from "../mpp/verification-service.js";
+import type { MppPaymentChallenge } from "../mpp/types.js";
 import { parseX402PaymentPayloadHeader, readX402PaymentHeader } from "./headers.js";
-import { buildPaymentRequired, buildPaymentRequirements } from "./requirements.js";
+import { buildPaymentRequired, buildPaymentRequirements } from "./payment-requirements.js";
 import type { X402PaymentRequired } from "./types.js";
 import { X402FacilitatorService } from "./x402-facilitator-service.js";
 import { X402GateService } from "./x402-gate-service.js";
@@ -12,9 +19,27 @@ import { X402RuntimeConfigService } from "./x402-runtime-config-service.js";
 import type { X402PaymentProof } from "./verify.js";
 
 export type X402EnforceResult =
-  | { action: "allow"; payer?: string; resource: string }
-  | { action: "require_payment"; status: 402; body: X402PaymentRequired; resource: string }
-  | { action: "deny"; status: 402; reason: string; resource: string };
+  | {
+      action: "allow";
+      payer?: string;
+      resource: string;
+      mppReceipt?: Record<string, unknown>;
+      mppReceiptHeader?: string;
+    }
+  | {
+      action: "require_payment";
+      status: 402;
+      body: X402PaymentRequired;
+      resource: string;
+      mppChallenges?: MppPaymentChallenge[];
+    }
+  | {
+      action: "deny";
+      status: 402;
+      reason: string;
+      resource: string;
+      mppVerificationCode?: number;
+    };
 
 export type EnforceX402GateInput = {
   resource: string;
@@ -60,6 +85,7 @@ export function x402EnforcementLiveLayer(): Layer.Layer<
   | X402GateService
   | X402RuntimeConfigService
   | X402FacilitatorService
+  | MppVerificationService
 > {
   return Layer.effect(
     X402EnforcementService,
@@ -69,6 +95,7 @@ export function x402EnforcementLiveLayer(): Layer.Layer<
       const gates = yield* X402GateService;
       const runtimeConfig = yield* X402RuntimeConfigService;
       const facilitator = yield* X402FacilitatorService;
+      const mppVerification = yield* MppVerificationService;
 
       const recordPaymentFailed = (input: {
         tenantId: string;
@@ -130,9 +157,11 @@ export function x402EnforcementLiveLayer(): Layer.Layer<
 
           const paymentsConfig = yield* configService.load();
           const tenantId = paymentsConfig.tenantId ?? "default";
-
+          const mppOn = isMppEnabled(env);
+          const credential = extractPaymentCredential(input.headers);
           const paymentHeader = readX402PaymentHeader(input.headers);
-          if (!paymentHeader) {
+
+          if (!credential && !paymentHeader) {
             const config = yield* runtimeConfig.load();
             const body = buildPaymentRequired({
               gate,
@@ -143,10 +172,86 @@ export function x402EnforcementLiveLayer(): Layer.Layer<
                 mimeType: "application/json",
               },
             });
+
+            let mppChallenges: MppPaymentChallenge[] | undefined;
+            if (mppOn) {
+              const stripeEnabled = Boolean(env.STRIPE_SECRET_KEY?.trim());
+              const offers = offersFromX402Required(body, stripeEnabled);
+              mppChallenges = buildChallengesFromOffers({
+                offers,
+                resource: gate.resource,
+                x402Body: body,
+              });
+              yield* mppVerification.registerChallenges(mppChallenges);
+            }
+
             return {
               action: "require_payment" as const,
               status: 402 as const,
               body,
+              resource: gate.resource,
+              mppChallenges,
+            };
+          }
+
+          if (mppOn && credential) {
+            const verification = yield* mppVerification
+              .verifyCredential({
+                resource: input.resource,
+                requestUrl: input.requestUrl,
+                gate,
+                headers: input.headers,
+                correlationId: input.correlationId,
+                env,
+                fetchImpl: input.fetchImpl,
+              })
+              .pipe(Effect.either);
+
+            if (Either.isLeft(verification)) {
+              const err = verification.left;
+              const reason =
+                err instanceof MppVerificationError
+                  ? err.reason
+                  : "reason" in err && typeof err.reason === "string"
+                    ? err.reason
+                    : "MPP credential verification failed";
+              yield* recordPaymentFailed({
+                tenantId,
+                resource: gate.resource,
+                reason,
+                correlationId: input.correlationId,
+              });
+              return {
+                action: "deny" as const,
+                status: 402 as const,
+                reason,
+                resource: gate.resource,
+                mppVerificationCode:
+                  err instanceof MppVerificationError ? err.code : undefined,
+              };
+            }
+
+            return {
+              action: "allow" as const,
+              payer: verification.right.payer,
+              resource: gate.resource,
+              mppReceipt: verification.right.receipt,
+              mppReceiptHeader: verification.right.receiptHeader,
+            };
+          }
+
+          if (!paymentHeader) {
+            const reason = "payment credential header is required";
+            yield* recordPaymentFailed({
+              tenantId,
+              resource: gate.resource,
+              reason,
+              correlationId: input.correlationId,
+            });
+            return {
+              action: "deny" as const,
+              status: 402 as const,
+              reason,
               resource: gate.resource,
             };
           }

--- a/packages/clawql-payments/src/x402/x402-enforcement-service.ts
+++ b/packages/clawql-payments/src/x402/x402-enforcement-service.ts
@@ -226,8 +226,7 @@ export function x402EnforcementLiveLayer(): Layer.Layer<
                 status: 402 as const,
                 reason,
                 resource: gate.resource,
-                mppVerificationCode:
-                  err instanceof MppVerificationError ? err.code : undefined,
+                mppVerificationCode: err instanceof MppVerificationError ? err.code : undefined,
               };
             }
 

--- a/packages/clawql-payments/tsup.config.ts
+++ b/packages/clawql-payments/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     "plans/index": "src/plans/index.ts",
     "audit/index": "src/audit/index.ts",
     "discovery/index": "src/discovery/index.ts",
+    "mpp/index": "src/mpp/index.ts",
     "plugin/index": "src/plugin/index.ts",
   },
   format: ["esm", "cjs"],

--- a/src/server-http.ts
+++ b/src/server-http.ts
@@ -37,6 +37,7 @@ import { handleLangfuseEvalWebhookRequest } from "./langfuse-eval-webhook.js";
 import { createWebhookRateLimiter } from "./webhook-rate-limit.js";
 import { resolveAtrClaimsFromHeaders } from "clawql-auth";
 import { attachPaymentsWellKnownRoutes } from "clawql-payments/discovery";
+import { attachMppOpenApiRoutes, isMppOpenApiEnabled } from "clawql-payments/mpp";
 import {
   headersFromExpressRequest,
   registerMcpX402TransportHooks,
@@ -161,6 +162,9 @@ export async function createMcpHttpApp(options: CreateMcpHttpAppOptions = {}): P
   app.use(applyCorsIfConfigured);
 
   attachPaymentsWellKnownRoutes(app, { serverName: "ClawQL MCP" });
+  if (isMppOpenApiEnabled(process.env)) {
+    attachMppOpenApiRoutes(app, { serverName: "ClawQL MCP" });
+  }
 
   /** Gateway auth (Phase 1 `clawql-auth`): enforced on MCP routes when `CLAWQL_AUTH_MODE=apiKey`. */
   function applyGatewayAuth(

--- a/website/src/lib/commerce-discovery.ts
+++ b/website/src/lib/commerce-discovery.ts
@@ -72,36 +72,28 @@ export function encodePaymentRequiredHeader(
   return Buffer.from(JSON.stringify(body), 'utf8').toString('base64')
 }
 
-function x402PaymentInfo(description: string): Record<string, unknown> {
+function mppPaymentInfo(description: string): Record<string, unknown> {
   return {
-    description,
-    authMode: 'paid',
-    protocols: [
+    offers: [
       {
-        x402: {
-          scheme: 'exact',
-          network: getX402Network(),
-          asset: getX402Asset(),
-          payTo: getX402PayTo(),
-        },
+        intent: 'charge',
+        method: 'x402',
+        amount: getX402ProbeAmountAtomic(),
+        currency: getX402Asset(),
+        description,
+      },
+      {
+        intent: 'charge',
+        method: 'stripe',
+        amount: null,
+        currency: 'usd',
+        description: 'Stripe subscription or metered billing for ClawQL plans.',
       },
     ],
-    price: {
-      mode: 'fixed',
-      currency: 'USD',
-      amount: '0.001',
-      min: '0.001',
-      max: '0.001',
-    },
-    network: getX402Network(),
-    asset: getX402Asset(),
-    payTo: getX402PayTo(),
-    retryHeader: 'PAYMENT-SIGNATURE',
-    recommendedClient: '@x402/fetch',
   }
 }
 
-/** OpenAPI 3.1 with MPP `x-payment-info` extensions for agent commerce scanners. */
+/** OpenAPI 3.1 with MPP `x-payment-info.offers[]` for agent commerce scanners. */
 export function getCommerceOpenApi(): Record<string, unknown> {
   const origin = getCommerceOrigin()
 
@@ -111,23 +103,30 @@ export function getCommerceOpenApi(): Record<string, unknown> {
       title: 'ClawQL Commerce Discovery API',
       version: '1.0.0',
       description:
-        'Discovery-only commerce surface for docs.clawql.com. Paid routes demonstrate x402 v2; production settlement runs on self-hosted ClawQL MCP and inference gateways.',
+        'MPP discovery surface for docs.clawql.com. Paid routes advertise x402 and Stripe offers; runtime 402 challenges are authoritative.',
     },
     servers: [{ url: origin }],
+    'x-service-info': {
+      categories: ['developer-tools', 'ai', 'payments'],
+      docs: {
+        homepage: origin,
+        apiReference: `${origin}/tools`,
+        llms: `${origin}/llms.txt`,
+      },
+    },
     paths: {
       '/api/v1': {
         get: {
           operationId: 'commerceProbe',
-          summary: 'x402 commerce discovery probe',
+          summary: 'MPP/x402 commerce discovery probe',
           description:
-            'Returns HTTP 402 with PAYMENT-REQUIRED (x402 v2) for agent readiness scanners.',
-          'x-payment-info': x402PaymentInfo(
+            'Returns HTTP 402 with MPP Payment challenge and x402 v2 PAYMENT-REQUIRED.',
+          'x-payment-info': mppPaymentInfo(
             'Low-cost x402 gateway probe priced at $0.001 USDC on Base Sepolia.',
           ),
           responses: {
-            '402': {
-              description: 'Payment required (x402 v2)',
-            },
+            '200': { description: 'Successful response' },
+            '402': { description: 'Payment Required' },
           },
         },
       },
@@ -137,11 +136,11 @@ export function getCommerceOpenApi(): Record<string, unknown> {
           summary: 'Create agentic checkout session',
           description:
             'UCP/ACP-aligned checkout stub for commerce discovery. Configure live checkout on self-hosted ClawQL.',
-          'x-payment-info': x402PaymentInfo(
+          'x-payment-info': mppPaymentInfo(
             'Agentic checkout for ClawQL Pro/Team plans via x402 or Stripe.',
           ),
           responses: {
-            '402': { description: 'Payment required' },
+            '402': { description: 'Payment Required' },
             '200': { description: 'Checkout session created' },
           },
         },
@@ -152,6 +151,7 @@ export function getCommerceOpenApi(): Record<string, unknown> {
       paymentsDiscovery: `${origin}/.well-known/payments.json`,
       ucp: `${origin}/.well-known/ucp`,
       acp: `${origin}/.well-known/acp.json`,
+      mpp: `${origin}/openapi.json`,
     },
   }
 }

--- a/website/tests/agent-readiness.spec.ts
+++ b/website/tests/agent-readiness.spec.ts
@@ -45,13 +45,20 @@ test.describe('agent readiness discovery', () => {
     expect(ap2?.params?.roles).toContain('merchant')
   })
 
-  test('commerce openapi exposes x-payment-info', async ({ request }) => {
+  test('commerce openapi exposes MPP x-payment-info offers', async ({ request }) => {
     const res = await request.get('/openapi.json')
     expect(res.status()).toBe(200)
     const doc = await res.json()
     const probe = doc.paths?.['/api/v1']?.get
-    expect(probe?.['x-payment-info']).toBeTruthy()
-    expect(probe['x-payment-info'].protocols?.[0]?.x402).toBeTruthy()
+    const offers = probe?.['x-payment-info']?.offers
+    expect(offers?.length).toBeGreaterThanOrEqual(2)
+    expect(offers.some((o: { method?: string }) => o.method === 'x402')).toBe(
+      true,
+    )
+    expect(offers.some((o: { method?: string }) => o.method === 'stripe')).toBe(
+      true,
+    )
+    expect(probe?.responses?.['402']).toBeTruthy()
   })
 
   test('x402 probe returns 402 with PAYMENT-REQUIRED', async ({ request }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds native **MPP (Model Payment Protocol)** to `clawql-payments` alongside **x402** and **Stripe** — discovery, runtime challenges, and **Effect-first credential verification**.

## MPP module (`packages/clawql-payments/src/mpp/`)

| Component | Role |
|-----------|------|
| `MppOpenApiService` | Dynamic `GET /openapi.json` with `x-payment-info.offers[]` |
| `MppVerificationService` | Credential verify (x402 facilitator + Stripe SPT), challenge registry, receipts |
| Pure helpers | `offers`, `challenge`, `headers`, `credential`, `receipt` |

## Effect architecture

- `Context.Tag` + `Layer.effect` + `runPaymentsEffect()` facades (same as discovery/x402)
- `MppVerificationService` registered in `paymentsServicesLiveLayer()`
- `X402EnforcementService` orchestrates: register challenges on 402 → verify credentials on retry → `Payment-Receipt` on allow
- Pure x402 builders split to `payment-requirements.ts` to avoid runtime circular imports

## Rails

- **x402** — `PAYMENT-SIGNATURE` (legacy) + `Authorization: Payment` MPP credentials → facilitator verify
- **Stripe** — SPT credentials → `PaymentIntent` create/confirm (`STRIPE_PROFILE_ID` / preview API)

## Integration

- x402 HTTP middleware + MCP enforcement
- `clawql-inference` + MCP HTTP: `/openapi.json`
- Docs site `commerce-discovery.ts` + agent-readiness tests

## Testing

- MPP unit tests (credential parse, verification service, OpenAPI)
- x402 MCP enforce tests (unchanged behavior + MPP enabled)

## Follow-ups

- Optional `mppx` adapter for tempo/evm.charge methods
- Additional traditional-finance providers in `offers[]`
- Raw MCP JSON-RPC `-32042` / `-32043` (vs tool-result `_meta` today)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

