### PR TITLE
feat(core): ConfigService and centralized env readers

### DIFF
--- a/packages/clawql-core/src/audit/config.ts
+++ b/packages/clawql-core/src/audit/config.ts
@@ -1,8 +1,1 @@
-/** `CLAWQL_AUDIT_MAX_ENTRIES` (default 500, min 1, max 50_000). */
-export function getClawqlAuditMaxEntries(): number {
-  const v = process.env.CLAWQL_AUDIT_MAX_ENTRIES?.trim();
-  if (!v) return 500;
-  const n = Number.parseInt(v, 10);
-  if (!Number.isFinite(n)) return 500;
-  return Math.min(Math.max(n, 1), 50_000);
-}
+export { getClawqlAuditMaxEntries } from "../config/env.js";

--- a/packages/clawql-core/src/cache/config.ts
+++ b/packages/clawql-core/src/cache/config.ts
@@ -1,17 +1,1 @@
-/** `CLAWQL_CACHE_MAX_VALUE_BYTES` (default 1 MiB, max 16 MiB, min 1). */
-export function getClawqlCacheMaxValueBytes(): number {
-  const v = process.env.CLAWQL_CACHE_MAX_VALUE_BYTES?.trim();
-  if (!v) return 1024 * 1024;
-  const n = Number.parseInt(v, 10);
-  if (!Number.isFinite(n)) return 1024 * 1024;
-  return Math.min(Math.max(n, 1), 16 * 1024 * 1024);
-}
-
-/** `CLAWQL_CACHE_MAX_ENTRIES` (default 10_000, min 1, max 10M). */
-export function getClawqlCacheMaxEntries(): number {
-  const v = process.env.CLAWQL_CACHE_MAX_ENTRIES?.trim();
-  if (!v) return 10_000;
-  const n = Number.parseInt(v, 10);
-  if (!Number.isFinite(n)) return 10_000;
-  return Math.min(Math.max(n, 1), 10_000_000);
-}
+export { getClawqlCacheMaxEntries, getClawqlCacheMaxValueBytes } from "../config/env.js";

--- a/packages/clawql-core/src/config/config-effect-runtime.ts
+++ b/packages/clawql-core/src/config/config-effect-runtime.ts
@@ -1,0 +1,13 @@
+import { Cause, Effect, Exit } from "effect";
+import { ConfigLive, ConfigService } from "./config-service.js";
+
+/** Run a config Effect program with the default env-backed Layer. */
+export async function runConfigEffect<A, E>(
+  program: Effect.Effect<A, E, ConfigService>
+): Promise<A> {
+  const exit = await Effect.runPromiseExit(program.pipe(Effect.provide(ConfigLive)));
+  if (Exit.isSuccess(exit)) {
+    return exit.value;
+  }
+  throw Cause.squash(exit.cause);
+}

--- a/packages/clawql-core/src/config/config-service.test.ts
+++ b/packages/clawql-core/src/config/config-service.test.ts
@@ -1,0 +1,88 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { ConfigService, createConfigTestLayer } from "./config-service.js";
+import {
+  getClawqlAuditMaxEntries,
+  getClawqlCacheMaxEntries,
+  getClawqlCacheMaxValueBytes,
+  isClawqlCuckooMetricsEnabled,
+  parseBoundedInt,
+} from "./env.js";
+
+const runWithEnv = <A, E>(env: NodeJS.ProcessEnv, program: Effect.Effect<A, E, ConfigService>) =>
+  Effect.runPromise(program.pipe(Effect.provide(createConfigTestLayer(env))));
+
+describe("ConfigService (Effect)", () => {
+  it("exposes audit, cache, and cuckoo settings from env", async () => {
+    const env = {
+      CLAWQL_AUDIT_MAX_ENTRIES: "42",
+      CLAWQL_CACHE_MAX_VALUE_BYTES: "2048",
+      CLAWQL_CACHE_MAX_ENTRIES: "99",
+      CLAWQL_CUCKOO_METRICS: "1",
+    };
+
+    const snapshot = await runWithEnv(
+      env,
+      Effect.gen(function* () {
+        const config = yield* ConfigService;
+        return {
+          audit: config.getAuditMaxEntries(),
+          cacheBytes: config.getCacheMaxValueBytes(),
+          cacheEntries: config.getCacheMaxEntries(),
+          cuckoo: config.isCuckooMetricsEnabled(),
+        };
+      })
+    );
+
+    expect(snapshot).toEqual({
+      audit: 42,
+      cacheBytes: 2048,
+      cacheEntries: 99,
+      cuckoo: true,
+    });
+  });
+
+  it("re-reads env on each accessor", async () => {
+    const env: NodeJS.ProcessEnv = { CLAWQL_AUDIT_MAX_ENTRIES: "10" };
+    const audit = await runWithEnv(
+      env,
+      Effect.gen(function* () {
+        const config = yield* ConfigService;
+        return config.getAuditMaxEntries();
+      })
+    );
+    expect(audit).toBe(10);
+    env.CLAWQL_AUDIT_MAX_ENTRIES = "20";
+    const audit2 = await runWithEnv(
+      env,
+      Effect.gen(function* () {
+        const config = yield* ConfigService;
+        return config.getAuditMaxEntries();
+      })
+    );
+    expect(audit2).toBe(20);
+  });
+});
+
+describe("env parsers", () => {
+  it("parseBoundedInt clamps and falls back", () => {
+    expect(parseBoundedInt(undefined, 5, 1, 10)).toBe(5);
+    expect(parseBoundedInt("nope", 5, 1, 10)).toBe(5);
+    expect(parseBoundedInt("3", 5, 1, 10)).toBe(3);
+    expect(parseBoundedInt("0", 5, 1, 10)).toBe(1);
+    expect(parseBoundedInt("99", 5, 1, 10)).toBe(10);
+  });
+
+  it("standalone getters respect env", () => {
+    const env = {
+      CLAWQL_AUDIT_MAX_ENTRIES: "42",
+      CLAWQL_CACHE_MAX_VALUE_BYTES: "10",
+      CLAWQL_CACHE_MAX_ENTRIES: "3",
+      CLAWQL_CUCKOO_METRICS: "1",
+    };
+    expect(getClawqlAuditMaxEntries(env)).toBe(42);
+    expect(getClawqlCacheMaxValueBytes(env)).toBe(10);
+    expect(getClawqlCacheMaxEntries(env)).toBe(3);
+    expect(isClawqlCuckooMetricsEnabled(env)).toBe(true);
+  });
+});

--- a/packages/clawql-core/src/config/config-service.ts
+++ b/packages/clawql-core/src/config/config-service.ts
@@ -1,0 +1,34 @@
+import { Context, Layer } from "effect";
+import {
+  getClawqlAuditMaxEntries,
+  getClawqlCacheMaxEntries,
+  getClawqlCacheMaxValueBytes,
+  isClawqlCuckooMetricsEnabled,
+} from "./env.js";
+
+export class ConfigService extends Context.Tag("clawql/ConfigService")<
+  ConfigService,
+  {
+    readonly getAuditMaxEntries: () => number;
+    readonly getCacheMaxValueBytes: () => number;
+    readonly getCacheMaxEntries: () => number;
+    readonly isCuckooMetricsEnabled: () => boolean;
+  }
+>() {}
+
+export function configServiceFromEnv(env: NodeJS.ProcessEnv = process.env) {
+  return ConfigService.of({
+    getAuditMaxEntries: () => getClawqlAuditMaxEntries(env),
+    getCacheMaxValueBytes: () => getClawqlCacheMaxValueBytes(env),
+    getCacheMaxEntries: () => getClawqlCacheMaxEntries(env),
+    isCuckooMetricsEnabled: () => isClawqlCuckooMetricsEnabled(env),
+  });
+}
+
+/** Live config backed by `process.env` (re-read on each accessor for test-friendly overrides). */
+export const ConfigLive = Layer.succeed(ConfigService, configServiceFromEnv());
+
+/** Isolated config for tests with a custom env object. */
+export function createConfigTestLayer(env: NodeJS.ProcessEnv): Layer.Layer<ConfigService> {
+  return Layer.succeed(ConfigService, configServiceFromEnv(env));
+}

--- a/packages/clawql-core/src/config/env.ts
+++ b/packages/clawql-core/src/config/env.ts
@@ -1,0 +1,50 @@
+/** Parse a bounded integer from an env string with fallback when missing or invalid. */
+export function parseBoundedInt(
+  raw: string | undefined,
+  fallback: number,
+  min: number,
+  max: number
+): number {
+  const v = raw?.trim();
+  if (!v) return fallback;
+  const n = Number.parseInt(v, 10);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(Math.max(n, min), max);
+}
+
+/** `CLAWQL_AUDIT_MAX_ENTRIES` (default 500, min 1, max 50_000). */
+export function getClawqlAuditMaxEntries(env: NodeJS.ProcessEnv = process.env): number {
+  return parseBoundedInt(env.CLAWQL_AUDIT_MAX_ENTRIES, 500, 1, 50_000);
+}
+
+/** `CLAWQL_CACHE_MAX_VALUE_BYTES` (default 1 MiB, max 16 MiB, min 1). */
+export function getClawqlCacheMaxValueBytes(env: NodeJS.ProcessEnv = process.env): number {
+  return parseBoundedInt(env.CLAWQL_CACHE_MAX_VALUE_BYTES, 1024 * 1024, 1, 16 * 1024 * 1024);
+}
+
+/** `CLAWQL_CACHE_MAX_ENTRIES` (default 10_000, min 1, max 10M). */
+export function getClawqlCacheMaxEntries(env: NodeJS.ProcessEnv = process.env): number {
+  return parseBoundedInt(env.CLAWQL_CACHE_MAX_ENTRIES, 10_000, 1, 10_000_000);
+}
+
+/** `CLAWQL_CUCKOO_METRICS=1` enables in-process Cuckoo observability counters. */
+export function isClawqlCuckooMetricsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.CLAWQL_CUCKOO_METRICS?.trim() === "1";
+}
+
+export type ClawqlCoreEnvConfig = {
+  readonly auditMaxEntries: number;
+  readonly cacheMaxValueBytes: number;
+  readonly cacheMaxEntries: number;
+  readonly cuckooMetricsEnabled: boolean;
+};
+
+/** Snapshot of all clawql-core env-backed settings (re-reads env on each accessor via service). */
+export function readClawqlCoreEnvConfig(env: NodeJS.ProcessEnv = process.env): ClawqlCoreEnvConfig {
+  return {
+    auditMaxEntries: getClawqlAuditMaxEntries(env),
+    cacheMaxValueBytes: getClawqlCacheMaxValueBytes(env),
+    cacheMaxEntries: getClawqlCacheMaxEntries(env),
+    cuckooMetricsEnabled: isClawqlCuckooMetricsEnabled(env),
+  };
+}

--- a/packages/clawql-core/src/config/index.ts
+++ b/packages/clawql-core/src/config/index.ts
@@ -1,0 +1,3 @@
+export * from "./config-effect-runtime.js";
+export * from "./config-service.js";
+export * from "./env.js";

--- a/packages/clawql-core/src/cuckoo/metrics.ts
+++ b/packages/clawql-core/src/cuckoo/metrics.ts
@@ -1,3 +1,5 @@
+import { isClawqlCuckooMetricsEnabled } from "../config/env.js";
+
 /**
  * In-process observability for Cuckoo membership (issue #30): rebuild events + optional
  * lookup verification against `vault_chunk` to estimate false-positive rate.
@@ -22,7 +24,7 @@ let verifiedInDb = 0;
 let falsePositives = 0;
 
 export function cuckooMetricsEnabled(): boolean {
-  return process.env.CLAWQL_CUCKOO_METRICS?.trim() === "1";
+  return isClawqlCuckooMetricsEnabled();
 }
 
 export function recordCuckooRebuild(info: CuckooRebuildInfo): void {

--- a/packages/clawql-core/src/errors/clawql-error.ts
+++ b/packages/clawql-core/src/errors/clawql-error.ts
@@ -15,3 +15,10 @@ export class McpToolAlreadyRegisteredError extends Data.TaggedError(
 )<{
   readonly toolName: string;
 }> {}
+
+/** Invalid or unreadable configuration (env, file, or schema). */
+export class ConfigError extends Data.TaggedError("ConfigError")<{
+  readonly key?: string;
+  readonly reason: string;
+  readonly cause?: unknown;
+}> {}

--- a/packages/clawql-core/src/index.ts
+++ b/packages/clawql-core/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./audit/index.js";
 export * from "./cache/index.js";
+export * from "./config/index.js";
 export * from "./cuckoo/index.js";
 export * from "./errors/index.js";
 export * from "./merkle/index.js";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Second slice of **clawql-core** Effect migration (step 1b): centralize env-backed configuration behind `ConfigService`.

## Changes

- **`packages/clawql-core/src/config/`** — new module:
  - `env.ts` — `parseBoundedInt`, `getClawqlAuditMaxEntries`, cache caps, `isClawqlCuckooMetricsEnabled`
  - `config-service.ts` — `ConfigService` Context.Tag, `ConfigLive`, `createConfigTestLayer`
  - `config-effect-runtime.ts` — `runConfigEffect` boundary bridge
  - `config-service.test.ts` — unit tests
- **`audit/config.ts`** / **`cache/config.ts`** — thin re-exports from `config/env.ts` (no behavior change)
- **`cuckoo/metrics.ts`** — delegates to centralized env reader
- **`errors/clawql-error.ts`** — add `ConfigError` tagged error

## Architecture

`ConfigService` re-reads env on each accessor (test-friendly). Standalone `getClawql*` functions remain exported for sync MCP bridges.

## Testing

- `npm run test -w clawql-core` — 21 tests pass
- Full build + lint pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

