### PR TITLE
feat(api): port execute-core to native Effect.gen

### DIFF
--- a/packages/clawql-api/src/execute/execute-core.test.ts
+++ b/packages/clawql-api/src/execute/execute-core.test.ts
@@ -1,0 +1,45 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { ExecuteService } from "../execute-service.js";
+import type { LoadedSpec } from "../spec/spec-loader.js";
+import { executeClawqlOperation, executeClawqlOperationEffect } from "./execute-core.js";
+import { makeExecuteLive } from "./execute-live.js";
+
+const emptySpec = (): Promise<LoadedSpec> =>
+  Promise.resolve({
+    operations: [],
+    rawSource: {},
+    openapi: { openapi: "3.0.0", info: { title: "t", version: "1" }, paths: {} },
+    multi: false,
+  });
+
+describe("executeClawqlOperationEffect", () => {
+  it("returns unknown operationId error as MCP text", async () => {
+    const content = await Effect.runPromise(
+      executeClawqlOperationEffect({ operationId: "missing.op", args: {} }, emptySpec)
+    );
+    expect(content).toHaveLength(1);
+    const body = JSON.parse(content[0]!.text) as { error: string };
+    expect(body.error).toContain('Unknown operationId: "missing.op"');
+  });
+
+  it("promise boundary matches Effect program output", async () => {
+    const params = { operationId: "missing.op", args: {} };
+    const fromEffect = await Effect.runPromise(executeClawqlOperationEffect(params, emptySpec));
+    const fromPromise = await executeClawqlOperation(params, emptySpec);
+    expect(fromPromise).toEqual(fromEffect);
+  });
+});
+
+describe("makeExecuteLive", () => {
+  it("wires ExecuteService to native Effect.gen pipeline", async () => {
+    const layer = makeExecuteLive(emptySpec);
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const execute = yield* ExecuteService;
+        return yield* execute.execute({ operationId: "nope", args: {} });
+      }).pipe(Effect.provide(layer))
+    );
+    expect(result.content[0]?.text).toContain("Unknown operationId");
+  });
+});

--- a/packages/clawql-api/src/execute/execute-core.ts
+++ b/packages/clawql-api/src/execute/execute-core.ts
@@ -3,172 +3,210 @@
  * All protocol paths run in-package; optional `loadSpecFn` supports tests and MCP overrides.
  */
 
+import { Effect } from "effect";
 import { executeOperationGraphQL } from "../graphql/in-process-execute.js";
 import { loadSpec, resolveApiBaseUrlForOperation, type OpenAPIDoc } from "../spec/spec-loader.js";
 import type { Operation } from "../spec/operation-types.js";
 import type { LoadSpecFn } from "../search/search-live.js";
+import { maybePresidioRedactText, presidioEnabled } from "../presidio/client.js";
 import { defaultFields, executeOutputFields, projectRestByFields } from "./field-projection.js";
 import { executeNativeGraphQL } from "./native-graphql.js";
 import { executeNativeGrpc } from "./native-grpc.js";
 import { executeNativeMcp } from "./native-mcp.js";
 import { executeNativeCli } from "./native-cli.js";
 import { executeRestOperation } from "./rest-operation.js";
-import { maybePresidioRedactText, presidioEnabled } from "../presidio/client.js";
 import type { ExecuteClawqlOperationParams, McpTextContent } from "./types.js";
 
-async function textContent(text: string): Promise<McpTextContent[]> {
-  const body = presidioEnabled() ? await maybePresidioRedactText(text) : text;
-  return [{ type: "text", text: body }];
+function fromPromise<A>(fn: () => Promise<A>): Effect.Effect<A, Error> {
+  return Effect.tryPromise({
+    try: fn,
+    catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+  });
 }
 
-/** Shared execute body — returns MCP text content blocks. */
+function textContentEffect(text: string): Effect.Effect<McpTextContent[], Error> {
+  return Effect.gen(function* () {
+    const body = presidioEnabled() ? yield* fromPromise(() => maybePresidioRedactText(text)) : text;
+    return [{ type: "text" as const, text: body }];
+  });
+}
+
+/** Shared execute body as an Effect program — returns MCP text content blocks. */
+export function executeClawqlOperationEffect(
+  params: ExecuteClawqlOperationParams,
+  loadSpecFn: LoadSpecFn = loadSpec
+): Effect.Effect<McpTextContent[], Error> {
+  return Effect.gen(function* () {
+    const { operationId, args, fields } = params;
+    const loaded = yield* fromPromise(() => loadSpecFn());
+    const { operations, openapi, openapis, multi } = loaded;
+    const op = operations.find((o) => o.id === operationId);
+
+    if (!op) {
+      return yield* textContentEffect(
+        JSON.stringify({
+          error: `Unknown operationId: "${operationId}". Use search() to find valid operation IDs.`,
+        })
+      );
+    }
+
+    const openapiForOp = (
+      multi && openapis?.length ? openapis[op.specIndex ?? 0] : openapi
+    ) as OpenAPIDoc;
+    const outputFields = executeOutputFields(operationId, fields);
+
+    if (op.protocolKind === "graphql" && op.nativeGraphQL) {
+      const selectedFields = outputFields?.length ? outputFields.join("\n        ") : "__typename";
+      const exec = yield* fromPromise(() =>
+        executeNativeGraphQL(op as Operation, args, selectedFields)
+      );
+      if (!exec.ok) {
+        return yield* textContentEffect(
+          JSON.stringify({
+            error: exec.error,
+            specLabel: op.specLabel ?? null,
+            hint: "Native GraphQL execute failed (check endpoint, auth, and arguments).",
+          })
+        );
+      }
+      const root = exec.data as Record<string, unknown> | null | undefined;
+      const inner =
+        root && typeof root === "object" && op.nativeGraphQL.fieldName in root
+          ? root[op.nativeGraphQL.fieldName]
+          : exec.data;
+      return yield* textContentEffect(
+        JSON.stringify(projectRestByFields(inner, outputFields), null, 2)
+      );
+    }
+
+    if (op.protocolKind === "grpc" && op.nativeGrpc) {
+      const exec = yield* fromPromise(() => executeNativeGrpc(op as Operation, args));
+      if (!exec.ok) {
+        return yield* textContentEffect(
+          JSON.stringify({
+            error: exec.error,
+            specLabel: op.specLabel ?? null,
+            hint: "Native gRPC execute failed (check endpoint, TLS/insecure, proto, and arguments).",
+          })
+        );
+      }
+      return yield* textContentEffect(
+        JSON.stringify(projectRestByFields(exec.data, outputFields), null, 2)
+      );
+    }
+
+    if (op.protocolKind === "mcp" && op.nativeMcp) {
+      const exec = yield* fromPromise(() => executeNativeMcp(op as Operation, args));
+      if (!exec.ok) {
+        return yield* textContentEffect(
+          JSON.stringify({
+            error: exec.error,
+            specLabel: op.specLabel ?? null,
+            hint: "MCP proxy execute failed (check remote server and tool arguments).",
+          })
+        );
+      }
+      return yield* textContentEffect(
+        JSON.stringify(projectRestByFields(exec.data, outputFields), null, 2)
+      );
+    }
+
+    if (op.protocolKind === "cli" && op.nativeCli) {
+      const exec = yield* fromPromise(() => executeNativeCli(op as Operation, args));
+      if (!exec.ok) {
+        return yield* textContentEffect(
+          JSON.stringify({
+            error: exec.error,
+            specLabel: op.specLabel ?? null,
+            hint: "CLI source execute failed (check command, args, and env).",
+          })
+        );
+      }
+      return yield* textContentEffect(
+        JSON.stringify(projectRestByFields(exec.data, outputFields), null, 2)
+      );
+    }
+
+    if (multi) {
+      const fallback = yield* fromPromise(() =>
+        executeRestOperation(op as Operation, args, openapiForOp)
+      );
+      if (!fallback.ok) {
+        return yield* textContentEffect(
+          JSON.stringify({
+            error: fallback.error,
+            specLabel: op.specLabel ?? null,
+            hint: "Multi-spec OpenAPI operations use REST only. Native GraphQL/gRPC ops use protocol execute.",
+          })
+        );
+      }
+      return yield* textContentEffect(
+        JSON.stringify(projectRestByFields(fallback.data, outputFields), null, 2)
+      );
+    }
+
+    if (op.requestBody && op.requestBodyContentType?.toLowerCase() === "application/octet-stream") {
+      const rest = yield* fromPromise(() =>
+        executeRestOperation(op as Operation, args, openapiForOp)
+      );
+      if (!rest.ok) {
+        return yield* textContentEffect(
+          JSON.stringify({
+            error: rest.error,
+            specLabel: op.specLabel ?? null,
+            hint: "application/octet-stream execute uses REST only; GraphQL projection is skipped.",
+          })
+        );
+      }
+      return yield* textContentEffect(
+        JSON.stringify(projectRestByFields(rest.data, outputFields), null, 2)
+      );
+    }
+
+    const selectedFields = outputFields?.length
+      ? outputFields.join("\n        ")
+      : defaultFields(operationId);
+    const baseUrl = resolveApiBaseUrlForOperation(openapiForOp, op as Operation);
+
+    return yield* Effect.gen(function* () {
+      const inProc = yield* fromPromise(() =>
+        executeOperationGraphQL(openapiForOp, baseUrl, op as Operation, args, selectedFields)
+      );
+      if (!inProc.ok) {
+        return yield* Effect.fail(new Error(inProc.error));
+      }
+      return yield* textContentEffect(
+        JSON.stringify(projectRestByFields(inProc.data, outputFields), null, 2)
+      );
+    }).pipe(
+      Effect.catchAll((err) =>
+        Effect.gen(function* () {
+          const fallback = yield* fromPromise(() =>
+            executeRestOperation(op as Operation, args, openapiForOp)
+          );
+          if (!fallback.ok) {
+            const reason = err instanceof Error ? err.message : String(err);
+            return yield* textContentEffect(
+              JSON.stringify({
+                error: reason,
+                fallbackError: fallback.error,
+                hint: "GraphQL execution failed and REST fallback also failed.",
+              })
+            );
+          }
+          return yield* textContentEffect(
+            JSON.stringify(projectRestByFields(fallback.data, outputFields), null, 2)
+          );
+        })
+      )
+    );
+  });
+}
+
+/** Promise boundary for MCP handlers and legacy callers. */
 export async function executeClawqlOperation(
   params: ExecuteClawqlOperationParams,
   loadSpecFn: LoadSpecFn = loadSpec
 ): Promise<McpTextContent[]> {
-  const { operationId, args, fields } = params;
-  const loaded = await loadSpecFn();
-  const { operations, openapi, openapis, multi } = loaded;
-  const op = operations.find((o) => o.id === operationId);
-
-  if (!op) {
-    return await textContent(
-      JSON.stringify({
-        error: `Unknown operationId: "${operationId}". Use search() to find valid operation IDs.`,
-      })
-    );
-  }
-
-  const openapiForOp = (
-    multi && openapis?.length ? openapis[op.specIndex ?? 0] : openapi
-  ) as OpenAPIDoc;
-  const outputFields = executeOutputFields(operationId, fields);
-
-  if (op.protocolKind === "graphql" && op.nativeGraphQL) {
-    const selectedFields = outputFields?.length ? outputFields.join("\n        ") : "__typename";
-    const exec = await executeNativeGraphQL(op as Operation, args, selectedFields);
-    if (!exec.ok) {
-      return await textContent(
-        JSON.stringify({
-          error: exec.error,
-          specLabel: op.specLabel ?? null,
-          hint: "Native GraphQL execute failed (check endpoint, auth, and arguments).",
-        })
-      );
-    }
-    const root = exec.data as Record<string, unknown> | null | undefined;
-    const inner =
-      root && typeof root === "object" && op.nativeGraphQL.fieldName in root
-        ? root[op.nativeGraphQL.fieldName]
-        : exec.data;
-    return await textContent(JSON.stringify(projectRestByFields(inner, outputFields), null, 2));
-  }
-
-  if (op.protocolKind === "grpc" && op.nativeGrpc) {
-    const exec = await executeNativeGrpc(op as Operation, args);
-    if (!exec.ok) {
-      return await textContent(
-        JSON.stringify({
-          error: exec.error,
-          specLabel: op.specLabel ?? null,
-          hint: "Native gRPC execute failed (check endpoint, TLS/insecure, proto, and arguments).",
-        })
-      );
-    }
-    return await textContent(JSON.stringify(projectRestByFields(exec.data, outputFields), null, 2));
-  }
-
-  if (op.protocolKind === "mcp" && op.nativeMcp) {
-    const exec = await executeNativeMcp(op as Operation, args);
-    if (!exec.ok) {
-      return await textContent(
-        JSON.stringify({
-          error: exec.error,
-          specLabel: op.specLabel ?? null,
-          hint: "MCP proxy execute failed (check remote server and tool arguments).",
-        })
-      );
-    }
-    return await textContent(JSON.stringify(projectRestByFields(exec.data, outputFields), null, 2));
-  }
-
-  if (op.protocolKind === "cli" && op.nativeCli) {
-    const exec = await executeNativeCli(op as Operation, args);
-    if (!exec.ok) {
-      return await textContent(
-        JSON.stringify({
-          error: exec.error,
-          specLabel: op.specLabel ?? null,
-          hint: "CLI source execute failed (check command, args, and env).",
-        })
-      );
-    }
-    return await textContent(JSON.stringify(projectRestByFields(exec.data, outputFields), null, 2));
-  }
-
-  if (multi) {
-    const fallback = await executeRestOperation(op as Operation, args, openapiForOp);
-    if (!fallback.ok) {
-      return await textContent(
-        JSON.stringify({
-          error: fallback.error,
-          specLabel: op.specLabel ?? null,
-          hint: "Multi-spec OpenAPI operations use REST only. Native GraphQL/gRPC ops use protocol execute.",
-        })
-      );
-    }
-    return await textContent(
-      JSON.stringify(projectRestByFields(fallback.data, outputFields), null, 2)
-    );
-  }
-
-  if (op.requestBody && op.requestBodyContentType?.toLowerCase() === "application/octet-stream") {
-    const rest = await executeRestOperation(op as Operation, args, openapiForOp);
-    if (!rest.ok) {
-      return await textContent(
-        JSON.stringify({
-          error: rest.error,
-          specLabel: op.specLabel ?? null,
-          hint: "application/octet-stream execute uses REST only; GraphQL projection is skipped.",
-        })
-      );
-    }
-    return await textContent(JSON.stringify(projectRestByFields(rest.data, outputFields), null, 2));
-  }
-
-  try {
-    const selectedFields = outputFields?.length
-      ? outputFields.join("\n        ")
-      : defaultFields(operationId);
-
-    const baseUrl = resolveApiBaseUrlForOperation(openapiForOp, op as Operation);
-    const inProc = await executeOperationGraphQL(
-      openapiForOp,
-      baseUrl,
-      op as Operation,
-      args,
-      selectedFields
-    );
-    if (!inProc.ok) {
-      throw new Error(inProc.error);
-    }
-    return await textContent(
-      JSON.stringify(projectRestByFields(inProc.data, outputFields), null, 2)
-    );
-  } catch (err: unknown) {
-    const fallback = await executeRestOperation(op as Operation, args, openapiForOp);
-    if (!fallback.ok) {
-      const reason = err instanceof Error ? err.message : String(err);
-      return await textContent(
-        JSON.stringify({
-          error: reason,
-          fallbackError: fallback.error,
-          hint: "GraphQL execution failed and REST fallback also failed.",
-        })
-      );
-    }
-    return await textContent(
-      JSON.stringify(projectRestByFields(fallback.data, outputFields), null, 2)
-    );
-  }
+  return Effect.runPromise(executeClawqlOperationEffect(params, loadSpecFn));
 }

--- a/packages/clawql-api/src/execute/execute-live.ts
+++ b/packages/clawql-api/src/execute/execute-live.ts
@@ -2,7 +2,7 @@ import { Effect, Layer } from "effect";
 import { ExecuteService } from "../execute-service.js";
 import { loadSpec } from "../spec/spec-loader.js";
 import type { LoadSpecFn } from "../search/search-live.js";
-import { executeClawqlOperation } from "./execute-core.js";
+import { executeClawqlOperationEffect } from "./execute-core.js";
 
 /** Build an ExecuteService layer; optional `loadSpecFn` for tests and MCP overrides. */
 export function makeExecuteLive(loadSpecFn: LoadSpecFn = loadSpec): Layer.Layer<ExecuteService> {
@@ -10,17 +10,17 @@ export function makeExecuteLive(loadSpecFn: LoadSpecFn = loadSpec): Layer.Layer<
     ExecuteService,
     ExecuteService.of({
       execute: (input) =>
-        Effect.tryPromise(async () => {
-          const content = await executeClawqlOperation(
+        Effect.map(
+          executeClawqlOperationEffect(
             {
               operationId: input.operationId,
               args: input.args ?? {},
               fields: input.fields,
             },
             loadSpecFn
-          );
-          return { content };
-        }),
+          ),
+          (content) => ({ content })
+        ),
     })
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Step 2 of the Effect migration plan: port the `clawql-api` execute pipeline from an outer `Effect.tryPromise` wrapper to a native `Effect.gen` program.

## Changes

- **`execute-core.ts`**
  - New `executeClawqlOperationEffect` — full execute routing as `Effect.gen`
  - `Effect.tryPromise` used only at true async boundaries (`loadSpec`, native protocol executors, Presidio redaction)
  - GraphQL → REST fallback via `Effect.catchAll` (same behavior as prior try/catch)
  - `executeClawqlOperation` retained as a thin `Effect.runPromise` boundary for MCP/legacy callers
- **`execute-live.ts`**
  - `makeExecuteLive` maps `executeClawqlOperationEffect` directly — no outer `tryPromise` shell
- **`execute-core.test.ts`**
  - Unknown `operationId` error path
  - Promise boundary parity test
  - `ExecuteService` wiring test

## Architecture

Boundary-only Effect pattern preserved:
- `ExecuteService.execute` remains `Effect<ExecuteOutput, Error>`
- MCP handlers and `tools-execute-core.ts` keep using the Promise export

## Testing

- `npm run test -w clawql-api` — 45 tests pass (3 new)
- Full `npm run build` + lint pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

