### PR TITLE
docs(learn): add Effect-TS architecture enforcement guide

### DIFF
--- a/website/src/app/architecture/page.mdx
+++ b/website/src/app/architecture/page.mdx
@@ -26,6 +26,6 @@ ClawQL is an **agent-first operating system** — not another prompt library. Th
 
 ## Platform architecture
 
-The stack spans **Layer 0 immutable releases** through **LGTMP observability**. Package boundaries and the intelligent MCP gateway are specified in Modularization v2.1; the DAOS specification covers protocol v2.1, HATEOAS approval flows, and decentralized handoff.
+The stack spans **Layer 0 immutable releases** through **LGTMP observability**. Package boundaries and the intelligent MCP gateway are specified in Modularization v2.1; the DAOS specification covers protocol v2.1, HATEOAS approval flows, and decentralized handoff. **Why Effect-TS enforces this model:** [Effect-TS in ClawQL](/learn/effect-ts).
 
 <ArchitectureHubGrid />

--- a/website/src/app/learn/effect-ts/layout.tsx
+++ b/website/src/app/learn/effect-ts/layout.tsx
@@ -1,0 +1,18 @@
+import { docsPageMetadata } from '@/lib/seo'
+
+export const metadata = docsPageMetadata({
+  title: 'Effect-TS in ClawQL (architecture enforcement)',
+  description:
+    'Learn guide: why Effect-TS is the compile-time enforcement mechanism for ClawQL’s acyclic 7-layer architecture, Gateway-only composition, fail-closed errors, optional Layers, and test isolation.',
+  path: '/learn/effect-ts',
+})
+
+import type { ReactNode } from 'react'
+
+export default function DocsSegmentLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return children
+}

--- a/website/src/app/learn/effect-ts/page.mdx
+++ b/website/src/app/learn/effect-ts/page.mdx
@@ -1,0 +1,96 @@
+# Effect-TS in ClawQL
+
+**Effect-TS is the mechanism that makes ClawQL’s 7-layer architecture enforceable at the type level** — not merely documented. In plain TypeScript, rules like “no vertical may import another vertical” and “all cross-layer communication routes through the Gateway” are conventions that depend on discipline. Effect-TS turns them into **compile-time guarantees**. {{ className: 'lead' }}
+
+**Canonical references:** [Contributor Technical Specification §3](/contributing/technical-specification) · [Modularization](/vision/modularization) · [Architecture](/architecture) · [Effect + plugin plan](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/design/effect-ts-modularization-rearchitecture-plan.md) · [effect.website](https://effect.website)
+
+## What Effect-TS actually provides
+
+Effect-TS is a TypeScript library that models **effects** — side effects, async work, dependencies, errors, concurrency, and resources — as first-class, composable values. For ClawQL, two features matter most:
+
+- **Layered dependency injection** — Dependencies are typed **`Layer`** values. Layers compose only in controlled ways at the Gateway.
+- **Compile-time dependency enforcement** — The type system rejects invalid dependency graphs before code runs.
+
+This is similar in spirit to ZIO Layers in Scala or strict DI crates in Rust, but tailored for TypeScript.
+
+## Why this matters for ClawQL’s architecture
+
+ClawQL’s design rests on invariants that are hard to maintain with folder discipline alone.
+
+### Strictly acyclic dependency graph (the core rule)
+
+The specification states repeatedly:
+
+> The dependency graph is strictly acyclic. Verticals never import other verticals. All cross-layer and cross-vertical communication routes through the gateway.
+
+In conventional TypeScript, this rule breaks easily — a utility in one layer gets imported by another, a shared helper sneaks in, or a “just this once” shortcut becomes permanent coupling.
+
+**With Effect-TS**, each layer is its own **`Layer`**, composed only through Gateway definitions. The compiler refuses code that bypasses that surface. That is what **compile-time dependency enforcement** means in practice.
+
+### Modularity and disabled features with zero overhead
+
+The architecture claims:
+
+> Disabled features carry negligible runtime overhead.
+
+Effect **`Layer`** composition makes optional capabilities type-safe. Ouroboros coordination, advanced Memory pruning, or security plugins can be **not provided** at startup. Because dependencies are tracked in types, nothing from a disabled layer can leak into the running program.
+
+Without Effect-TS (or an equivalent), you rely on runtime feature flags or conditional imports — more overhead and more risk.
+
+### Fail-closed behavior and structured error handling
+
+ClawQL emphasizes **fail-closed** semantics throughout:
+
+- PEP must halt on invalid Manifest or ATRClaims
+- Circuit Breaker must transition reliably
+- WORM writes must succeed or the action is rejected
+
+Effect-TS requires explicit, typed error handling. You cannot accidentally swallow a failure or let an unexpected error vanish. That aligns with rules like “execution fails-closed if WORM write fails.”
+
+### Testability and isolation of layers
+
+Because each layer’s dependencies are explicit **`Layer`** provisions, you can:
+
+- Test Gateway / PEP in isolation with mock Layers for Memory, Ouroboros, Watchdog, and peers
+- Exercise the Coordinator Watchdog without a live Gateway
+- Rely on types to catch cross-layer breakage when one package changes
+
+That matters for partial-failure scenarios — circuit breaker trips, air-gap breakout, degraded optional plugins.
+
+### Long-term maintainability
+
+ClawQL combines cryptographic verification (Manifest + ActionLeaves), policy enforcement (ATRClaims + two-phase commit), coordination (Ouroboros + Watchdog), observability (LGTMP + WORM), and security redaction. Without structural enforcement, those concerns bleed together over time.
+
+Effect-TS is a **structural contract** that keeps the layered model intact as the codebase and contributor base grow.
+
+## What would happen without Effect-TS?
+
+You would fall back to conventional TypeScript patterns:
+
+- Barrel exports and careful folder naming
+- Runtime checks or DI libraries with weaker compile-time graphs
+- Greater risk of circular dependencies and hidden coupling
+- Harder proof that “acyclic” and “Gateway-only” rules are actually followed
+
+For a platform whose value proposition is **verifiability, governance, and resilience**, relying on discipline alone for core invariants is risky.
+
+## Summary: why Effect-TS is non-negotiable for ClawQL
+
+| Architectural goal | How Effect-TS helps | Without it |
+| --- | --- | --- |
+| Acyclic dependency graph | Compile-time rejection of invalid imports | Easy to violate accidentally |
+| Gateway as single surface | Layers compose only through Gateway definitions | Cross-layer leakage becomes likely |
+| Disabled features ≈ zero overhead | Optional Layers are type-checked | Runtime flags or dead code paths |
+| Fail-closed semantics | Typed, explicit error channels | Swallowed or unexpected errors |
+| Testability and isolation | Mock Layers per concern | Harder to isolate failures |
+| Long-term architectural integrity | Rules live in the type system | Architecture drifts over time |
+
+**Bottom line:** Effect-TS is not merely “the library we use for effects.” It is the **enforcement mechanism** for modularity, verifiable architecture, and reliable failure modes. Without it, the 7-layer model in the spec would be much harder to preserve in practice. With it, the compiler helps protect the design.
+
+## Related guides and references
+
+- [Contributor Technical Specification](/contributing/technical-specification) — §2 architectural constraints, §3 Effect patterns, Layer checklists
+- [Modularization implementation status](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/design/modularization-implementation-status.md) — shipped vs roadmap for Effect Layers
+- [Plugin model & registry](/reference/plugins) — how plugins register today and migrate toward Layers
+- [Architecture & vision](/architecture) — platform layers and DAOS context
+- [Vision & roadmap](/vision/roadmap) — Effect-TS as foundation (honest shipped vs planned)

--- a/website/src/app/learn/effect-ts/page.mdx
+++ b/website/src/app/learn/effect-ts/page.mdx
@@ -76,14 +76,14 @@ For a platform whose value proposition is **verifiability, governance, and resil
 
 ## Summary: why Effect-TS is non-negotiable for ClawQL
 
-| Architectural goal | How Effect-TS helps | Without it |
-| --- | --- | --- |
-| Acyclic dependency graph | Compile-time rejection of invalid imports | Easy to violate accidentally |
-| Gateway as single surface | Layers compose only through Gateway definitions | Cross-layer leakage becomes likely |
-| Disabled features ≈ zero overhead | Optional Layers are type-checked | Runtime flags or dead code paths |
-| Fail-closed semantics | Typed, explicit error channels | Swallowed or unexpected errors |
-| Testability and isolation | Mock Layers per concern | Harder to isolate failures |
-| Long-term architectural integrity | Rules live in the type system | Architecture drifts over time |
+| Architectural goal                | How Effect-TS helps                             | Without it                         |
+| --------------------------------- | ----------------------------------------------- | ---------------------------------- |
+| Acyclic dependency graph          | Compile-time rejection of invalid imports       | Easy to violate accidentally       |
+| Gateway as single surface         | Layers compose only through Gateway definitions | Cross-layer leakage becomes likely |
+| Disabled features ≈ zero overhead | Optional Layers are type-checked                | Runtime flags or dead code paths   |
+| Fail-closed semantics             | Typed, explicit error channels                  | Swallowed or unexpected errors     |
+| Testability and isolation         | Mock Layers per concern                         | Harder to isolate failures         |
+| Long-term architectural integrity | Rules live in the type system                   | Architecture drifts over time      |
 
 **Bottom line:** Effect-TS is not merely “the library we use for effects.” It is the **enforcement mechanism** for modularity, verifiable architecture, and reliable failure modes. Without it, the 7-layer model in the spec would be much harder to preserve in practice. With it, the compiler helps protect the design.
 

--- a/website/src/app/learn/effect-ts/page.mdx
+++ b/website/src/app/learn/effect-ts/page.mdx
@@ -13,7 +13,7 @@ Effect-TS is a TypeScript library that models **effects** — side effects, asyn
 
 This is similar in spirit to ZIO Layers in Scala or strict DI crates in Rust, but tailored for TypeScript.
 
-## Why this matters for ClawQL’s architecture
+## Why this matters for clawql's architecture
 
 ClawQL’s design rests on invariants that are hard to maintain with folder discipline alone.
 
@@ -74,7 +74,7 @@ You would fall back to conventional TypeScript patterns:
 
 For a platform whose value proposition is **verifiability, governance, and resilience**, relying on discipline alone for core invariants is risky.
 
-## Summary: why Effect-TS is non-negotiable for ClawQL
+## Summary: why Effect-TS is non-negotiable for clawql
 
 | Architectural goal                | How Effect-TS helps                             | Without it                         |
 | --------------------------------- | ----------------------------------------------- | ---------------------------------- |

--- a/website/src/app/learn/page.mdx
+++ b/website/src/app/learn/page.mdx
@@ -28,6 +28,7 @@ If you are new to ClawQL, follow this sequence:
 Use these hubs when you care about one slice of the product:
 
 - **Core MCP** — [Tools](/tools), [Spec configuration](/spec-configuration), [Bundled specs](/bundled-specs)
+- **Architecture & platform** — [Effect-TS in ClawQL](/learn/effect-ts), [Architecture](/architecture), [Modularization](/vision/modularization), [Contributor Technical Specification](/contributing/technical-specification)
 - **Session & automation** — [Optional tools hub](/reference/optional-tools), [Schedule & notify workflows](/learn/schedule-notify-workflows), [Audit tool & observability](/learn/audit-tool-and-observability)
 - **Knowledge & documents** — [Document pipeline (seven vendors)](/learn/document-pipeline), [External ingest & knowledge lake](/learn/external-ingest-knowledge), [Onyx enterprise search (`knowledge_search_onyx`)](/learn/knowledge-search-onyx), [Onyx knowledge search](/onyx-knowledge), [Flink Onyx sync](/flink-onyx-sync)
 - **Streams & APIs** — [NATS JetStream](/nats-jetstream), [GraphQL layer](/graphql-proxy)

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -164,6 +164,11 @@ const ENTRIES: Array<Entry> = [
     priority: 0.89,
   },
   {
+    path: '/learn/effect-ts',
+    changeFrequency: 'monthly',
+    priority: 0.89,
+  },
+  {
     path: '/learn/openclaw-and-clawql',
     changeFrequency: 'monthly',
     priority: 0.89,

--- a/website/src/components/WebMcpRegister.tsx
+++ b/website/src/components/WebMcpRegister.tsx
@@ -28,7 +28,7 @@ export function WebMcpRegister() {
         name: 'clawql.docs.navigate',
         title: 'Navigate ClawQL docs',
         description:
-          'Navigate to a page on this documentation site. Use paths like /learn, /learn/search-and-execute-mcp, /learn/external-ingest-knowledge, /learn/knowledge-search-onyx, /learn/document-pipeline, /learn/sandbox-exec, /learn/ouroboros-tools, /learn/openclaw-and-clawql, /learn/schedule-notify-workflows, /learn/cache-handoff-between-chats, /learn/vault-memory-between-chats, /learn/audit-tool-and-observability, /tools, /install, /deployment, /kubernetes, /docker-desktop-observability, or /spec-configuration. Only same-origin relative paths are allowed.',
+          'Navigate to a page on this documentation site. Use paths like /learn, /learn/search-and-execute-mcp, /learn/external-ingest-knowledge, /learn/knowledge-search-onyx, /learn/document-pipeline, /learn/sandbox-exec, /learn/effect-ts, /learn/ouroboros-tools, /learn/openclaw-and-clawql, /learn/schedule-notify-workflows, /learn/cache-handoff-between-chats, /learn/vault-memory-between-chats, /learn/audit-tool-and-observability, /tools, /install, /deployment, /kubernetes, /docker-desktop-observability, or /spec-configuration. Only same-origin relative paths are allowed.',
         inputSchema: {
           $schema: 'https://json-schema.org/draft/2020-12/schema',
           type: 'object',

--- a/website/src/lib/doc-layout-sections.ts
+++ b/website/src/lib/doc-layout-sections.ts
@@ -11,6 +11,7 @@ import { homePageSections } from '@/lib/home-page-sections'
 import { learnAuditObservabilitySections } from '@/lib/learn-audit-observability-sections'
 import { learnCacheHandoffSections } from '@/lib/learn-cache-handoff-sections'
 import { learnDocumentPipelineSections } from '@/lib/learn-document-pipeline-sections'
+import { learnEffectTsSections } from '@/lib/learn-effect-ts-sections'
 import { learnExternalIngestKnowledgeSections } from '@/lib/learn-external-ingest-knowledge-sections'
 import { learnKnowledgeSearchOnyxSections } from '@/lib/learn-knowledge-search-onyx-sections'
 import { learnOpenclawClawqlSections } from '@/lib/learn-openclaw-clawql-sections'
@@ -39,6 +40,7 @@ export const DOC_LAYOUT_SECTIONS_BY_PATH: Record<string, Array<Section>> = {
   '/learn/document-pipeline': learnDocumentPipelineSections,
   '/learn/vault-memory-between-chats': learnVaultMemoryHandoffSections,
   '/learn/audit-tool-and-observability': learnAuditObservabilitySections,
+  '/learn/effect-ts': learnEffectTsSections,
   '/case-studies/cloudflare-docs-mcp': caseStudyCloudflareDocsSections,
   '/case-studies/vault-memory-github-session-2026-04':
     caseStudyVaultMemorySessionSections,

--- a/website/src/lib/docs-nav-data.ts
+++ b/website/src/lib/docs-nav-data.ts
@@ -71,6 +71,7 @@ export const docsNavigation: Array<NavGroup> = [
     title: 'Learn',
     links: [
       { title: 'Learn hub', href: '/learn' },
+      { title: 'Effect-TS in ClawQL', href: '/learn/effect-ts' },
       { title: 'Guides', href: '/guides' },
       { title: 'Token efficiency', href: '/architecture/token-efficiency' },
       { title: 'Security', href: '/security' },

--- a/website/src/lib/docs-site-card-data.ts
+++ b/website/src/lib/docs-site-card-data.ts
@@ -89,6 +89,21 @@ export const learnModuleSiteCards: Array<ReferenceCard> = [
     },
   },
   {
+    href: '/learn/effect-ts',
+    name: 'Effect-TS in ClawQL',
+    description:
+      'Why Effect-TS enforces the 7-layer architecture: Layers, Gateway composition, fail-closed errors, and optional plugins.',
+    icon: CogIcon,
+    pattern: {
+      y: 6,
+      squares: [
+        [0, 0],
+        [1, 2],
+        [2, 1],
+      ],
+    },
+  },
+  {
     href: '/learn/ouroboros-tools',
     name: 'Ouroboros tools',
     description:

--- a/website/src/lib/learn-effect-ts-sections.ts
+++ b/website/src/lib/learn-effect-ts-sections.ts
@@ -1,0 +1,25 @@
+import type { Section } from '@/components/SectionProvider'
+
+/** In-page nav for `/learn/effect-ts` (h2 ids match @sindresorhus/slugify). */
+export const learnEffectTsSections: Array<Section> = [
+  {
+    title: 'What Effect-TS actually provides',
+    id: 'what-effect-ts-actually-provides',
+  },
+  {
+    title: 'Why this matters for ClawQL’s architecture',
+    id: 'why-this-matters-for-claw-qls-architecture',
+  },
+  {
+    title: 'What would happen without Effect-TS?',
+    id: 'what-would-happen-without-effect-ts',
+  },
+  {
+    title: 'Summary: why Effect-TS is non-negotiable for ClawQL',
+    id: 'summary-why-effect-ts-is-non-negotiable-for-claw-ql',
+  },
+  {
+    title: 'Related guides and references',
+    id: 'related-guides-and-references',
+  },
+]

--- a/website/src/lib/learn-effect-ts-sections.ts
+++ b/website/src/lib/learn-effect-ts-sections.ts
@@ -7,16 +7,16 @@ export const learnEffectTsSections: Array<Section> = [
     id: 'what-effect-ts-actually-provides',
   },
   {
-    title: 'Why this matters for ClawQL’s architecture',
-    id: 'why-this-matters-for-claw-qls-architecture',
+    title: "Why this matters for clawql's architecture",
+    id: 'why-this-matters-for-clawqls-architecture',
   },
   {
     title: 'What would happen without Effect-TS?',
     id: 'what-would-happen-without-effect-ts',
   },
   {
-    title: 'Summary: why Effect-TS is non-negotiable for ClawQL',
-    id: 'summary-why-effect-ts-is-non-negotiable-for-claw-ql',
+    title: 'Summary: why Effect-TS is non-negotiable for clawql',
+    id: 'summary-why-effect-ts-is-non-negotiable-for-clawql',
   },
   {
     title: 'Related guides and references',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new **ClawQL Learn** page at `/learn/effect-ts` that explains what Effect-TS is and why ClawQL uses it as the compile-time enforcement mechanism for the 7-layer architecture.

## Content

- What Effect-TS provides (Layers, compile-time dependency graphs)
- Why it matters for ClawQL: acyclic graph, Gateway-only composition, optional plugins, fail-closed errors, test isolation, maintainability
- What breaks without Effect-TS
- Summary comparison table and links to contributor spec, modularization, and architecture docs

## Integration

- Learn hub card + in-page TOC
- Sidebar link under **Learn**
- Sitemap entry
- Cross-link from `/architecture`
- WebMCP navigation path list
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5923-61ff-77f8-92df-6c4b1fa90953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5923-61ff-77f8-92df-6c4b1fa90953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

