### PR TITLE
feat(api): port search pipeline to native Effect.gen

### DIFF
--- a/packages/clawql-api/src/execute/execute-core.ts
+++ b/packages/clawql-api/src/execute/execute-core.ts
@@ -7,7 +7,7 @@ import { Effect } from "effect";
 import { executeOperationGraphQL } from "../graphql/in-process-execute.js";
 import { loadSpec, resolveApiBaseUrlForOperation, type OpenAPIDoc } from "../spec/spec-loader.js";
 import type { Operation } from "../spec/operation-types.js";
-import type { LoadSpecFn } from "../search/search-live.js";
+import type { LoadSpecFn } from "../search/search-core.js";
 import { maybePresidioRedactText, presidioEnabled } from "../presidio/client.js";
 import { defaultFields, executeOutputFields, projectRestByFields } from "./field-projection.js";
 import { executeNativeGraphQL } from "./native-graphql.js";

--- a/packages/clawql-api/src/execute/execute-live.ts
+++ b/packages/clawql-api/src/execute/execute-live.ts
@@ -1,7 +1,7 @@
 import { Effect, Layer } from "effect";
 import { ExecuteService } from "../execute-service.js";
 import { loadSpec } from "../spec/spec-loader.js";
-import type { LoadSpecFn } from "../search/search-live.js";
+import type { LoadSpecFn } from "../search/search-core.js";
 import { executeClawqlOperationEffect } from "./execute-core.js";
 
 /** Build an ExecuteService layer; optional `loadSpecFn` for tests and MCP overrides. */

--- a/packages/clawql-api/src/search/index.ts
+++ b/packages/clawql-api/src/search/index.ts
@@ -1,2 +1,3 @@
+export * from "./search-core.js";
 export * from "./search-live.js";
-export type { LoadSpecFn } from "./search-live.js";
+export type { LoadSpecFn } from "./search-core.js";

--- a/packages/clawql-api/src/search/search-core.test.ts
+++ b/packages/clawql-api/src/search/search-core.test.ts
@@ -1,0 +1,62 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import type { LoadedSpec } from "../spec/spec-loader.js";
+import { SearchService } from "../search-service.js";
+import type { Operation } from "../spec/operation-types.js";
+import { searchClawqlOperations, searchClawqlOperationsEffect } from "./search-core.js";
+import { makeSearchLive } from "./search-live.js";
+
+const baseOp = {
+  method: "GET",
+  path: "v1/services",
+  flatPath: "v1/services",
+  resource: "services",
+  parameters: {},
+} satisfies Partial<Operation>;
+
+const stubSpec = (): Promise<LoadedSpec> =>
+  Promise.resolve({
+    operations: [
+      {
+        ...baseOp,
+        id: "run.projects.locations.services.delete",
+        method: "DELETE",
+        description: "Delete a service",
+      } as Operation,
+    ],
+    rawSource: {},
+    openapi: { openapi: "3.0.0", info: { title: "t", version: "1" }, paths: {} },
+    multi: false,
+  });
+
+describe("searchClawqlOperationsEffect", () => {
+  it("returns formatted search results", async () => {
+    const output = await Effect.runPromise(
+      searchClawqlOperationsEffect({ query: "delete service", limit: 3 }, stubSpec)
+    );
+    const parsed = JSON.parse(output.formattedText) as {
+      results: { id: string }[];
+    };
+    expect(parsed.results[0]?.id).toBe("run.projects.locations.services.delete");
+  });
+
+  it("promise boundary matches Effect program output", async () => {
+    const params = { query: "delete", limit: 5 };
+    const fromEffect = await Effect.runPromise(searchClawqlOperationsEffect(params, stubSpec));
+    const fromPromise = await searchClawqlOperations(params, stubSpec);
+    expect(fromPromise).toEqual(fromEffect);
+  });
+});
+
+describe("makeSearchLive", () => {
+  it("wires SearchService to native Effect.gen pipeline", async () => {
+    const layer = makeSearchLive(stubSpec);
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const search = yield* SearchService;
+        return yield* search.search({ query: "delete", limit: 2 });
+      }).pipe(Effect.provide(layer))
+    );
+    expect(result.formattedText).toContain("run.projects.locations.services.delete");
+  });
+});

--- a/packages/clawql-api/src/search/search-core.ts
+++ b/packages/clawql-api/src/search/search-core.ts
@@ -1,0 +1,38 @@
+/**
+ * Core `search` implementation — keyword search over loaded operations.
+ * Optional `loadSpecFn` supports tests and MCP overrides.
+ */
+
+import { Effect } from "effect";
+import { loadSpec } from "../spec/spec-loader.js";
+import { formatSearchResults, searchOperations } from "../spec/spec-search.js";
+import type { SearchInput, SearchOutput } from "../search-service.js";
+
+export type LoadSpecFn = typeof loadSpec;
+
+function fromPromise<A>(fn: () => Promise<A>): Effect.Effect<A, Error> {
+  return Effect.tryPromise({
+    try: fn,
+    catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+  });
+}
+
+/** Shared search body as an Effect program — returns formatted MCP text. */
+export function searchClawqlOperationsEffect(
+  params: SearchInput,
+  loadSpecFn: LoadSpecFn = loadSpec
+): Effect.Effect<SearchOutput, Error> {
+  return Effect.gen(function* () {
+    const { operations } = yield* fromPromise(() => loadSpecFn());
+    const results = searchOperations(operations, params.query, params.limit ?? 5);
+    return { formattedText: formatSearchResults(results) };
+  });
+}
+
+/** Promise boundary for legacy callers. */
+export async function searchClawqlOperations(
+  params: SearchInput,
+  loadSpecFn: LoadSpecFn = loadSpec
+): Promise<SearchOutput> {
+  return Effect.runPromise(searchClawqlOperationsEffect(params, loadSpecFn));
+}

--- a/packages/clawql-api/src/search/search-live.ts
+++ b/packages/clawql-api/src/search/search-live.ts
@@ -1,21 +1,16 @@
-import { Effect, Layer } from "effect";
+import { Layer } from "effect";
 import { loadSpec } from "../spec/spec-loader.js";
-import { formatSearchResults, searchOperations } from "../spec/spec-search.js";
 import { SearchService } from "../search-service.js";
+import { searchClawqlOperationsEffect, type LoadSpecFn } from "./search-core.js";
 
-export type LoadSpecFn = typeof loadSpec;
+export type { LoadSpecFn };
 
 /** Built-in SearchService layer using clawql-api spec-loader + spec-search. */
 export function makeSearchLive(loadSpecFn: LoadSpecFn = loadSpec): Layer.Layer<SearchService> {
   return Layer.succeed(
     SearchService,
     SearchService.of({
-      search: ({ query, limit }) =>
-        Effect.tryPromise(async () => {
-          const { operations } = await loadSpecFn();
-          const results = searchOperations(operations, query, limit ?? 5);
-          return { formattedText: formatSearchResults(results) };
-        }),
+      search: (input) => searchClawqlOperationsEffect(input, loadSpecFn),
     })
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the `clawql-api` core MCP tool pair: port **search** to native `Effect.gen`, matching the execute migration (#612).

## Changes

- **`search-core.ts`** — new module:
  - `searchClawqlOperationsEffect` — load spec + keyword search as `Effect.gen`
  - `searchClawqlOperations` — thin `Effect.runPromise` boundary
  - `LoadSpecFn` type moved here (re-exported from `search-live`)
- **`search-live.ts`** — `makeSearchLive` maps Effect program directly (no outer `tryPromise`)
- **`search-core.test.ts`** — formatted results, promise parity, service wiring
- **`execute-core.ts` / `execute-live.ts`** — import `LoadSpecFn` from `search-core`

## Architecture

Both MCP gateway tools now use the same pattern:
- `SearchService.search` / `ExecuteService.execute` are native Effect programs
- `Effect.tryPromise` only at async boundaries (`loadSpec`)

## Testing

- `npm run test -w clawql-api` — 48 tests pass (3 new)
- Lint pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

