### PR TITLE
feat(payments): MPP commerce follow-ups (mppx, JSON-RPC, finance providers, docs scan)

### DIFF
--- a/docs/payments/clawql-payments.md
+++ b/docs/payments/clawql-payments.md
@@ -8,22 +8,25 @@
 
 ## What ships today
 
-| Capability                                       | Status | Notes                                                                          |
-| ------------------------------------------------ | ------ | ------------------------------------------------------------------------------ |
-| Managed plan tiers + entitlements                | ✅     | Local `usage.json` counters; limit enforcement in inference                    |
-| Stripe customers, subscriptions, invoices        | ✅     | Live SDK when `STRIPE_SECRET_KEY` is set                                       |
-| Stripe webhook signature verification            | ✅     | CLI verify/process; audit on `invoice.paid`                                    |
-| Stripe Billing Meters (`meterEvents.create`)     | ✅     | API + inference hook when `CLAWQL_PAYMENTS_REPORT_STRIPE_METER=1`              |
-| x402 gate config + facilitator HTTP verify       | ✅     | `POST /verify` against x402.org or CDP                                         |
-| x402 Express middleware (402 + PAYMENT-REQUIRED) | ✅     | Wired into `clawql-inference` HTTP                                             |
-| x402 MCP in-process enforcement                  | ✅     | `CLAWQL_X402_ENFORCE=1` on stdio / Streamable HTTP / gRPC MCP tool calls       |
-| Payment WORM audit (hash-chained JSONL)          | ✅     | `$CLAWQL_HOME/Payments/audit.jsonl` + `audit verify`                           |
-| Payment WORM audit (Postgres)                    | ✅     | `CLAWQL_PAYMENTS_AUDIT_STORE=postgres` for multi-node deployments              |
-| Payment audit → Loki/SIEM export                 | ✅     | Fire-and-forget push on append when `CLAWQL_LOKI_PUSH_URL` is set              |
-| `.well-known/payments.json` discovery            | ✅     | Dynamic on MCP + inference HTTP; static route on docs site                     |
-| MPP `/openapi.json` discovery                    | ✅     | Dynamic on MCP + inference HTTP; canonical `x-payment-info.offers[]`           |
-| MPP HTTP 402 + MCP -32042 runtime                | ✅     | Dual x402 + MPP challenges when `CLAWQL_MPP_ENABLED=1`                         |
-| MPP credential verification + receipts           | ✅     | `MppVerificationService` — x402 facilitator + Stripe SPT (`STRIPE_PROFILE_ID`) |
+| Capability                                       | Status | Notes                                                                            |
+| ------------------------------------------------ | ------ | -------------------------------------------------------------------------------- |
+| Managed plan tiers + entitlements                | ✅     | Local `usage.json` counters; limit enforcement in inference                      |
+| Stripe customers, subscriptions, invoices        | ✅     | Live SDK when `STRIPE_SECRET_KEY` is set                                         |
+| Stripe webhook signature verification            | ✅     | CLI verify/process; audit on `invoice.paid`                                      |
+| Stripe Billing Meters (`meterEvents.create`)     | ✅     | API + inference hook when `CLAWQL_PAYMENTS_REPORT_STRIPE_METER=1`                |
+| x402 gate config + facilitator HTTP verify       | ✅     | `POST /verify` against x402.org or CDP                                           |
+| x402 Express middleware (402 + PAYMENT-REQUIRED) | ✅     | Wired into `clawql-inference` HTTP                                               |
+| x402 MCP in-process enforcement                  | ✅     | `CLAWQL_X402_ENFORCE=1` on stdio / Streamable HTTP / gRPC MCP tool calls         |
+| Payment WORM audit (hash-chained JSONL)          | ✅     | `$CLAWQL_HOME/Payments/audit.jsonl` + `audit verify`                             |
+| Payment WORM audit (Postgres)                    | ✅     | `CLAWQL_PAYMENTS_AUDIT_STORE=postgres` for multi-node deployments                |
+| Payment audit → Loki/SIEM export                 | ✅     | Fire-and-forget push on append when `CLAWQL_LOKI_PUSH_URL` is set                |
+| `.well-known/payments.json` discovery            | ✅     | Dynamic on MCP + inference HTTP; static route on docs site                       |
+| MPP `/openapi.json` discovery                    | ✅     | Dynamic on MCP + inference HTTP; canonical `x-payment-info.offers[]`             |
+| MPP HTTP 402 + MCP -32042 runtime                | ✅     | Dual x402 + MPP challenges when `CLAWQL_MPP_ENABLED=1`                           |
+| MPP credential verification + receipts           | ✅     | `MppVerificationService` — x402 facilitator + Stripe SPT (`STRIPE_PROFILE_ID`)   |
+| MPP optional `mppx` adapter                      | ✅     | `MppxAdapterService` when `CLAWQL_MPPX_ENABLED=1` + optional `mppx` dep          |
+| MCP JSON-RPC payment errors                      | ✅     | `-32042`/`-32043` when `CLAWQL_MPP_MCP_JSONRPC=1` (default: tool-result `_meta`) |
+| Extended finance providers in `offers[]`         | ✅     | `CLAWQL_MPP_FINANCE_PROVIDERS=paypal,adyen,square`                               |
 
 ## Architecture
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,13 @@
                 "node": ">=22"
             }
         },
+        "node_modules/@adraffy/ens-normalize": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+            "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/@aws-crypto/sha256-js": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
@@ -489,6 +496,13 @@
             "engines": {
                 "node": ">=18"
             }
+        },
+        "node_modules/@cfworker/json-schema": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+            "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/@emnapi/core": {
             "version": "1.10.0",
@@ -2009,6 +2023,19 @@
                 }
             }
         },
+        "node_modules/@modelcontextprotocol/server": {
+            "version": "2.0.0-beta.3",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0-beta.3.tgz",
+            "integrity": "sha512-EQxVIWf2XMAgjR38ZRZnX1iiOWH42tT/YJG8N4dVjAnrEGSEfPirR6FYfDC72yuNSvVYbPDTD1H3KHLLHPd18A==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "zod": "^4.2.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/@napi-rs/wasm-runtime": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -2026,6 +2053,48 @@
             "peerDependencies": {
                 "@emnapi/core": "^1.7.1",
                 "@emnapi/runtime": "^1.7.1"
+            }
+        },
+        "node_modules/@noble/ciphers": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+            "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": "^14.21.3 || >=16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/curves": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+            "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@noble/hashes": "1.8.0"
+            },
+            "engines": {
+                "node": "^14.21.3 || >=16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/hashes": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+            "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": "^14.21.3 || >=16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@npmcli/agent": {
@@ -4420,6 +4489,55 @@
                 "win32"
             ]
         },
+        "node_modules/@scalar/openapi-types": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@scalar/openapi-types/-/openapi-types-0.8.0.tgz",
+            "integrity": "sha512-WmaxVSfvY5K/TwcG2B2TU1WOe1As1uc2s7myswtP6dBlcjU3hM08SApxv/jmyGaCE8t4gO5BBhmHY4pDUfmr2g==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@scure/base": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+            "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+            "license": "MIT",
+            "optional": true,
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@scure/bip32": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+            "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@noble/curves": "~1.9.0",
+                "@noble/hashes": "~1.8.0",
+                "@scure/base": "~1.2.5"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@scure/bip39": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+            "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@noble/hashes": "~1.8.0",
+                "@scure/base": "~1.2.5"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@sigstore/bundle": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
@@ -4641,6 +4759,16 @@
             "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
             "license": "MIT"
         },
+        "node_modules/@stripe/stripe-js": {
+            "version": "9.8.0",
+            "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.8.0.tgz",
+            "integrity": "sha512-DHJpol/98VKyojNSYmpkB5vOMnlf87hPe0wPxyaYTNiTMk5QjKMXDfSZLwGctYIXAgAWDFeRABc8lFAj0BELyw==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=12.16"
+            }
+        },
         "node_modules/@theguild/federation-composition": {
             "version": "0.22.3",
             "resolved": "https://registry.npmjs.org/@theguild/federation-composition/-/federation-composition-0.22.3.tgz",
@@ -4658,6 +4786,13 @@
             "peerDependencies": {
                 "graphql": "^16.0.0"
             }
+        },
+        "node_modules/@toon-format/toon": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@toon-format/toon/-/toon-2.3.0.tgz",
+            "integrity": "sha512-/Ew9etdRQKVMnm9fDaCG0JjyAOK/O7T0M97oum1aW4W+UR8ZhVVPBanIV7oWgHBiGlnVxV9M55PWQCHofDV07w==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/@tufjs/canonical-json": {
             "version": "2.0.0",
@@ -5420,6 +5555,28 @@
             "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/abitype": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.4.tgz",
+            "integrity": "sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg==",
+            "license": "MIT",
+            "optional": true,
+            "funding": {
+                "url": "https://github.com/sponsors/wevm"
+            },
+            "peerDependencies": {
+                "typescript": ">=5.0.4",
+                "zod": "^3.22.0 || ^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                },
+                "zod": {
+                    "optional": true
+                }
             }
         },
         "node_modules/accepts": {
@@ -6847,6 +7004,13 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/eventemitter3": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/events-universal": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
@@ -7750,6 +7914,29 @@
                 "node": ">=0.8.19"
             }
         },
+        "node_modules/incur": {
+            "version": "0.4.13",
+            "resolved": "https://registry.npmjs.org/incur/-/incur-0.4.13.tgz",
+            "integrity": "sha512-BeKlYFLIsRCgC8IxsUd3S2/4kPeZaNf1Rbz+Kz41jQII4jOgr7j5w4KYe00aAEQa3V0Ur57BVxE5JDTx8L2s5Q==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@cfworker/json-schema": "^4.1.1",
+                "@modelcontextprotocol/server": "^2.0.0-alpha.2",
+                "@scalar/openapi-types": "^0.8.0",
+                "@toon-format/toon": "^2.1.0",
+                "tokenx": "^1.3.0",
+                "yaml": "^2.8.2",
+                "zod": "^4.3.6"
+            },
+            "bin": {
+                "incur": "dist/bin.js",
+                "incur.src": "src/bin.ts"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -7859,6 +8046,23 @@
             "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
             "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
             "license": "MIT",
+            "peerDependencies": {
+                "ws": "*"
+            }
+        },
+        "node_modules/isows": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+            "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/wevm"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
             "peerDependencies": {
                 "ws": "*"
             }
@@ -8830,6 +9034,55 @@
             "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
             "license": "MIT"
         },
+        "node_modules/mppx": {
+            "version": "0.8.6",
+            "resolved": "https://registry.npmjs.org/mppx/-/mppx-0.8.6.tgz",
+            "integrity": "sha512-JND+libFbDer9V9oLwqohBF5TU+QNByPf7uKF6nlVniEJzmBTLpfnENO99K7PNBUZZzEOPIVjeNC1sF9FnJjUA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@stripe/stripe-js": "9.8.0",
+                "eventsource-parser": "3.1.0",
+                "incur": "^0.4.9",
+                "ox": "0.14.29",
+                "zod": "^4.4.3"
+            },
+            "bin": {
+                "mppx": "dist/bin.js",
+                "mppx.src": "src/bin.ts"
+            },
+            "peerDependencies": {
+                "@modelcontextprotocol/sdk": ">=1.25.0",
+                "elysia": ">=1",
+                "express": ">=5",
+                "hono": ">=4.12.25",
+                "viem": ">=2.54.0"
+            },
+            "peerDependenciesMeta": {
+                "@modelcontextprotocol/sdk": {
+                    "optional": true
+                },
+                "elysia": {
+                    "optional": true
+                },
+                "express": {
+                    "optional": true
+                },
+                "hono": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/mppx/node_modules/zod": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+            "license": "MIT",
+            "optional": true,
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -9521,6 +9774,37 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/ox": {
+            "version": "0.14.29",
+            "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
+            "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/wevm"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@adraffy/ens-normalize": "^1.11.0",
+                "@noble/ciphers": "^1.3.0",
+                "@noble/curves": "1.9.1",
+                "@noble/hashes": "^1.8.0",
+                "@scure/bip32": "^1.7.0",
+                "@scure/bip39": "^1.6.0",
+                "abitype": "^1.2.3",
+                "eventemitter3": "5.0.1"
+            },
+            "peerDependencies": {
+                "typescript": ">=5.4.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/p-limit": {
@@ -11388,6 +11672,13 @@
                 "node": ">=0.6"
             }
         },
+        "node_modules/tokenx": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/tokenx/-/tokenx-1.3.0.tgz",
+            "integrity": "sha512-NLdXTEZkKiO0gZuLtMoZKjCXTREXeZZt8nnnNeyoXtNZAfG/GKGSbQtLU5STspc0rMSwcA+UJfWZkbNU01iKmQ==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -11764,6 +12055,93 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/viem": {
+            "version": "2.55.1",
+            "resolved": "https://registry.npmjs.org/viem/-/viem-2.55.1.tgz",
+            "integrity": "sha512-sajvEmONS3dEDFh0jKXGugTU8ImyGoIV3sEHSWNRhgkH484v/+6DjZAplRhcdeqNV/VBxOs/l3raOG4NaXvX9A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/wevm"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@noble/curves": "1.9.1",
+                "@noble/hashes": "1.8.0",
+                "@scure/bip32": "1.7.0",
+                "@scure/bip39": "1.6.0",
+                "abitype": "1.2.3",
+                "isows": "1.0.7",
+                "ox": "0.14.30",
+                "ws": "8.21.0"
+            },
+            "peerDependencies": {
+                "typescript": ">=5.0.4"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/viem/node_modules/abitype": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+            "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/wevm"
+            },
+            "peerDependencies": {
+                "typescript": ">=5.0.4",
+                "zod": "^3.22.0 || ^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                },
+                "zod": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/viem/node_modules/ox": {
+            "version": "0.14.30",
+            "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.30.tgz",
+            "integrity": "sha512-LI11uu+8iiM1B3CLckgd++YF1a0A2k5wDoM9ZeQMiL21BOzQs6L//BLS6hb1HSEKCyycdDIQLsVQx9MjpcC0hA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/wevm"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@adraffy/ens-normalize": "^1.11.0",
+                "@noble/ciphers": "^1.3.0",
+                "@noble/curves": "1.9.1",
+                "@noble/hashes": "^1.8.0",
+                "@scure/bip32": "^1.7.0",
+                "@scure/bip39": "^1.6.0",
+                "abitype": "^1.2.3",
+                "eventemitter3": "5.0.1"
+            },
+            "peerDependencies": {
+                "typescript": ">=5.4.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/vite": {
@@ -12451,6 +12829,9 @@
             },
             "engines": {
                 "node": ">=22"
+            },
+            "optionalDependencies": {
+                "mppx": "^0.8.6"
             }
         },
         "packages/clawql-release": {

--- a/packages/clawql-payments/package.json
+++ b/packages/clawql-payments/package.json
@@ -68,6 +68,9 @@
     "pg": "^8.21.0",
     "zod": "^4.3.6"
   },
+  "optionalDependencies": {
+    "mppx": "^0.8.6"
+  },
   "devDependencies": {
     "@types/node": "^26.1.1",
     "tsup": "^8.3.0",

--- a/packages/clawql-payments/src/mpp/index.ts
+++ b/packages/clawql-payments/src/mpp/index.ts
@@ -81,3 +81,22 @@ export {
 } from "./receipt.js";
 
 export { registerMppChallenges, verifyMppCredential } from "./verify.js";
+
+export {
+  appendFinanceOffers,
+  buildFinanceOffer,
+  financeProvidersFromEnv,
+  MPP_FINANCE_METHOD_ADYEN,
+  MPP_FINANCE_METHOD_PAYPAL,
+  MPP_FINANCE_METHOD_SQUARE,
+} from "./providers.js";
+
+export { isMppxEnabled, MppxAdapterService, mppxAdapterLiveLayer } from "./mppx-adapter.js";
+
+export { isMppMcpJsonRpcEnabled } from "./mcp-jsonrpc.js";
+
+export {
+  MppMcpJsonRpcPaymentRequiredError,
+  MppMcpJsonRpcVerificationFailedError,
+  isMppMcpJsonRpcPaymentError,
+} from "./mcp-jsonrpc-errors.js";

--- a/packages/clawql-payments/src/mpp/mcp-jsonrpc-errors.test.ts
+++ b/packages/clawql-payments/src/mpp/mcp-jsonrpc-errors.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  MppMcpJsonRpcPaymentRequiredError,
+  MppMcpJsonRpcVerificationFailedError,
+} from "./mcp-jsonrpc-errors.js";
+import { MPP_MCP_PAYMENT_REQUIRED_CODE, MPP_MCP_VERIFICATION_FAILED_CODE } from "./types.js";
+
+describe("MppMcpJsonRpcPaymentRequiredError", () => {
+  it("emits JSON-RPC -32042 payload", () => {
+    const err = new MppMcpJsonRpcPaymentRequiredError(
+      {
+        x402Version: 2,
+        resource: { url: "mcp://tool/search" },
+        accepts: [
+          {
+            scheme: "exact",
+            network: "eip155:84532",
+            amount: "1000",
+            asset: "0xasset",
+            payTo: "0xpay",
+          },
+        ],
+      },
+      "tool:search",
+      { CLAWQL_MPP_ENABLED: "1" }
+    );
+    const json = err.toJsonRpcError(7);
+    expect(json.id).toBe(7);
+    expect(json.error.code).toBe(MPP_MCP_PAYMENT_REQUIRED_CODE);
+    expect(json.error.message).toBe("Payment Required");
+  });
+});
+
+describe("MppMcpJsonRpcVerificationFailedError", () => {
+  it("emits JSON-RPC -32043 payload", () => {
+    const err = new MppMcpJsonRpcVerificationFailedError("bad credential", "tool:search");
+    const json = err.toJsonRpcError("req-1");
+    expect(json.error.code).toBe(MPP_MCP_VERIFICATION_FAILED_CODE);
+    expect(json.error.data?.reason).toBe("bad credential");
+  });
+});

--- a/packages/clawql-payments/src/mpp/mcp-jsonrpc-errors.ts
+++ b/packages/clawql-payments/src/mpp/mcp-jsonrpc-errors.ts
@@ -1,0 +1,129 @@
+import type { X402PaymentRequired } from "../x402/types.js";
+import {
+  buildMppMcpJsonRpcError,
+  enrichMcpToolResultWithMpp,
+  type MppMcpToolResult,
+} from "./mcp.js";
+import { isMppEnabled } from "./config.js";
+import { offersFromX402Required } from "./offers.js";
+import { MPP_MCP_PAYMENT_REQUIRED_CODE, MPP_MCP_VERIFICATION_FAILED_CODE } from "./types.js";
+
+export type MppMcpJsonRpcErrorBody = {
+  code: number;
+  message: string;
+  data?: Record<string, unknown>;
+};
+
+/** JSON-RPC -32042 payment required (opt-in via CLAWQL_MPP_MCP_JSONRPC=1). */
+export class MppMcpJsonRpcPaymentRequiredError extends Error {
+  readonly name = "MppMcpJsonRpcPaymentRequiredError";
+
+  constructor(
+    public readonly body: X402PaymentRequired,
+    public readonly resource: string,
+    public readonly env: NodeJS.ProcessEnv = process.env
+  ) {
+    super("MPP payment required");
+  }
+
+  toJsonRpcError(id: string | number | null = null): {
+    jsonrpc: "2.0";
+    id: string | number | null;
+    error: MppMcpJsonRpcErrorBody;
+  } {
+    const offers = offersFromX402Required(this.body, Boolean(this.env.STRIPE_SECRET_KEY?.trim()));
+    const jsonRpcError = buildMppMcpJsonRpcError({
+      offers,
+      resource: this.resource,
+      x402Body: this.body,
+    });
+    return {
+      jsonrpc: "2.0",
+      id,
+      error: jsonRpcError,
+    };
+  }
+
+  toToolResult(): MppMcpToolResult {
+    const offers = offersFromX402Required(this.body, Boolean(this.env.STRIPE_SECRET_KEY?.trim()));
+    const base: MppMcpToolResult = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(this.toJsonRpcError().error, null, 2),
+        },
+      ],
+      isError: true,
+      _meta: {
+        "clawql/mppJsonRpc": true,
+        "clawql/httpStatus": 402,
+      },
+    };
+    if (!isMppEnabled(this.env)) return base;
+    return enrichMcpToolResultWithMpp(base, {
+      offers,
+      resource: this.resource,
+      x402Body: this.body,
+    });
+  }
+}
+
+/** JSON-RPC -32043 verification failed (opt-in via CLAWQL_MPP_MCP_JSONRPC=1). */
+export class MppMcpJsonRpcVerificationFailedError extends Error {
+  readonly name = "MppMcpJsonRpcVerificationFailedError";
+
+  constructor(
+    public readonly reason: string,
+    public readonly resource: string,
+    public readonly code: number = MPP_MCP_VERIFICATION_FAILED_CODE
+  ) {
+    super(reason);
+  }
+
+  toJsonRpcError(id: string | number | null = null): {
+    jsonrpc: "2.0";
+    id: string | number | null;
+    error: MppMcpJsonRpcErrorBody;
+  } {
+    return {
+      jsonrpc: "2.0",
+      id,
+      error: {
+        code: this.code,
+        message: "Payment verification failed",
+        data: {
+          reason: this.reason,
+          resource: this.resource,
+        },
+      },
+    };
+  }
+
+  toToolResult(): MppMcpToolResult {
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(this.toJsonRpcError().error, null, 2),
+        },
+      ],
+      isError: true,
+      _meta: {
+        "clawql/mppJsonRpc": true,
+        "clawql/httpStatus": 402,
+        "clawql/mppVerificationCode": this.code,
+      },
+    };
+  }
+}
+
+export function isMppMcpJsonRpcPaymentError(
+  err: unknown
+): err is MppMcpJsonRpcPaymentRequiredError | MppMcpJsonRpcVerificationFailedError {
+  return (
+    err instanceof MppMcpJsonRpcPaymentRequiredError ||
+    err instanceof MppMcpJsonRpcVerificationFailedError
+  );
+}
+
+export { MPP_MCP_PAYMENT_REQUIRED_CODE, MPP_MCP_VERIFICATION_FAILED_CODE };

--- a/packages/clawql-payments/src/mpp/mcp-jsonrpc.ts
+++ b/packages/clawql-payments/src/mpp/mcp-jsonrpc.ts
@@ -1,0 +1,6 @@
+/** MCP JSON-RPC payment error mode (vs tool-result `_meta` enrichment). */
+
+export function isMppMcpJsonRpcEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.CLAWQL_MPP_MCP_JSONRPC?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}

--- a/packages/clawql-payments/src/mpp/mppx-adapter.test.ts
+++ b/packages/clawql-payments/src/mpp/mppx-adapter.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { isMppxEnabled } from "./mppx-adapter.js";
+
+describe("mppx adapter", () => {
+  it("is disabled unless CLAWQL_MPPX_ENABLED=1", () => {
+    expect(isMppxEnabled({})).toBe(false);
+    expect(isMppxEnabled({ CLAWQL_MPPX_ENABLED: "1" })).toBe(true);
+  });
+});

--- a/packages/clawql-payments/src/mpp/mppx-adapter.ts
+++ b/packages/clawql-payments/src/mpp/mppx-adapter.ts
@@ -1,0 +1,137 @@
+import { Context, Effect, Layer } from "effect";
+import { ConfigError } from "../errors/payment-errors.js";
+import { MppVerificationError } from "./verification-errors.js";
+
+export type MppxAdapterConfig = {
+  secretKey: string;
+  stripeProfileId?: string;
+  tempoCurrency?: string;
+  tempoRecipient?: string;
+  testnet?: boolean;
+};
+
+export type MppxModule = {
+  Mppx?: {
+    create: (input: Record<string, unknown>) => unknown;
+  };
+  evm?: {
+    charge: (input: Record<string, unknown>) => unknown;
+  };
+  stripe?: (input: Record<string, unknown>) => unknown;
+  tempo?: {
+    charge: (input: Record<string, unknown>) => unknown;
+  };
+};
+
+/** Optional Effect wrapper around the `mppx` SDK (dynamic import). */
+export class MppxAdapterService extends Context.Tag("clawql/MppxAdapterService")<
+  MppxAdapterService,
+  {
+    readonly isAvailable: () => boolean;
+    readonly loadModule: () => Effect.Effect<MppxModule, ConfigError>;
+    readonly createRuntime: (
+      config: MppxAdapterConfig
+    ) => Effect.Effect<unknown, ConfigError | MppVerificationError>;
+  }
+>() {}
+
+export function isMppxEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.CLAWQL_MPPX_ENABLED?.trim().toLowerCase();
+  if (raw === "0" || raw === "false" || raw === "no") return false;
+  return raw === "1" || raw === "true" || raw === "yes";
+}
+
+export function mppxAdapterLiveLayer(
+  env: NodeJS.ProcessEnv = process.env
+): Layer.Layer<MppxAdapterService> {
+  let cached: MppxModule | null | undefined;
+
+  const loadModuleEffect = Effect.gen(function* () {
+    if (!isMppxEnabled(env)) {
+      return yield* Effect.fail(new ConfigError({ reason: "CLAWQL_MPPX_ENABLED is not set" }));
+    }
+    if (cached !== undefined) {
+      if (!cached) {
+        return yield* Effect.fail(new ConfigError({ reason: "mppx module is not installed" }));
+      }
+      return cached;
+    }
+
+    const mod = yield* Effect.tryPromise({
+      try: () => import("mppx/server") as Promise<MppxModule>,
+      catch: (cause) => {
+        cached = null;
+        return new ConfigError({
+          reason:
+            "mppx is not installed — add optional dependency `mppx` and set CLAWQL_MPPX_ENABLED=1",
+          cause,
+        });
+      },
+    });
+    cached = mod;
+    return mod;
+  });
+
+  return Layer.succeed(
+    MppxAdapterService,
+    MppxAdapterService.of({
+      isAvailable: () => isMppxEnabled(env),
+      loadModule: () => loadModuleEffect,
+      createRuntime: (config) =>
+        Effect.gen(function* () {
+          const mod = yield* loadModuleEffect;
+          if (!mod.Mppx?.create) {
+            return yield* Effect.fail(
+              new MppVerificationError({
+                reason: "mppx/server export Mppx.create is unavailable",
+              })
+            );
+          }
+
+          const methods: unknown[] = [];
+          if (config.tempoCurrency && config.tempoRecipient && mod.tempo?.charge) {
+            methods.push(
+              mod.tempo.charge({
+                currency: config.tempoCurrency,
+                recipient: config.tempoRecipient,
+                ...(config.testnet ? { testnet: true } : {}),
+              })
+            );
+          }
+          if (config.stripeProfileId && mod.stripe) {
+            methods.push(
+              mod.stripe({
+                networkId: config.stripeProfileId,
+                paymentMethodTypes: ["card", "link"],
+              })
+            );
+          }
+          if (config.tempoCurrency && config.tempoRecipient && mod.evm?.charge) {
+            methods.push(
+              mod.evm.charge({
+                currency: config.tempoCurrency,
+                recipient: config.tempoRecipient,
+                x402: env.CLAWQL_X402_FACILITATOR_URL?.trim()
+                  ? { facilitator: env.CLAWQL_X402_FACILITATOR_URL.trim() }
+                  : undefined,
+              })
+            );
+          }
+
+          if (methods.length === 0) {
+            return yield* Effect.fail(
+              new MppVerificationError({
+                reason:
+                  "mppx runtime requires STRIPE_PROFILE_ID and/or CLAWQL_MPPX_TEMPO_* configuration",
+              })
+            );
+          }
+
+          return mod.Mppx.create({
+            methods,
+            secretKey: config.secretKey,
+          });
+        }),
+    })
+  );
+}

--- a/packages/clawql-payments/src/mpp/mppx-adapter.ts
+++ b/packages/clawql-payments/src/mpp/mppx-adapter.ts
@@ -58,7 +58,7 @@ export function mppxAdapterLiveLayer(
     }
 
     const mod = yield* Effect.tryPromise({
-      try: () => import("mppx/server") as Promise<MppxModule>,
+      try: () => import("mppx/server") as Promise<unknown>,
       catch: (cause) => {
         cached = null;
         return new ConfigError({
@@ -68,8 +68,8 @@ export function mppxAdapterLiveLayer(
         });
       },
     });
-    cached = mod;
-    return mod;
+    cached = mod as MppxModule;
+    return cached;
   });
 
   return Layer.succeed(

--- a/packages/clawql-payments/src/mpp/offers.ts
+++ b/packages/clawql-payments/src/mpp/offers.ts
@@ -2,6 +2,7 @@ import type { X402PaymentRequired } from "../x402/types.js";
 import type { X402Gate } from "../x402/gate.js";
 import type { X402RuntimeConfig } from "../x402/x402-runtime-config-service.js";
 import { usdcAtomicAmount } from "../x402/x402-runtime-config-service.js";
+import { appendFinanceOffers } from "./providers.js";
 import {
   MPP_METHOD_STRIPE,
   MPP_METHOD_X402,
@@ -47,6 +48,7 @@ export function buildOffersForGate(input: {
   config: X402RuntimeConfig;
   stripeEnabled?: boolean;
   stripeMetered?: boolean;
+  env?: NodeJS.ProcessEnv;
 }): MppPaymentOffer[] {
   const offers: MppPaymentOffer[] = [];
   const x402 = buildX402Offer({ gate: input.gate, config: input.config });
@@ -59,7 +61,11 @@ export function buildOffersForGate(input: {
       })
     );
   }
-  return offers;
+  return appendFinanceOffers({
+    offers,
+    env: input.env,
+    resource: input.gate.resource,
+  });
 }
 
 export function toPaymentInfo(offers: MppPaymentOffer[]): MppPaymentInfo {
@@ -74,7 +80,8 @@ export function paymentInfoFromOffers(offers: MppPaymentOffer[]): MppPaymentInfo
 /** Derive MPP offers from a runtime x402 PaymentRequired body (for 402/MCP enrichment). */
 export function offersFromX402Required(
   body: X402PaymentRequired,
-  stripeEnabled = false
+  stripeEnabled = false,
+  env?: NodeJS.ProcessEnv
 ): MppPaymentOffer[] {
   const offers: MppPaymentOffer[] = [];
   const accept = body.accepts[0];
@@ -90,5 +97,9 @@ export function offersFromX402Required(
   if (stripeEnabled) {
     offers.push(buildStripeOffer({ metered: true }));
   }
-  return offers;
+  return appendFinanceOffers({
+    offers,
+    env,
+    resource: body.resource.url,
+  });
 }

--- a/packages/clawql-payments/src/mpp/openapi-service.ts
+++ b/packages/clawql-payments/src/mpp/openapi-service.ts
@@ -58,6 +58,7 @@ export function composeMppOpenApiDocument(input: {
   stripeEnabled: boolean;
   stripeMetered: boolean;
   serviceInfo?: MppServiceInfo;
+  env?: NodeJS.ProcessEnv;
 }): Record<string, unknown> {
   const paths: Record<string, unknown> = {};
 
@@ -73,6 +74,7 @@ export function composeMppOpenApiDocument(input: {
       },
       stripeEnabled: input.stripeEnabled,
       stripeMetered: input.stripeMetered,
+      env: input.env,
     });
     const paymentInfo = paymentInfoFromOffers(offers);
     if (!paymentInfo) continue;
@@ -192,6 +194,7 @@ export function mppOpenApiLiveLayer(
             stripeEnabled,
             stripeMetered,
             serviceInfo: options.serviceInfo,
+            env: runEnv,
           });
         });
 

--- a/packages/clawql-payments/src/mpp/providers.test.ts
+++ b/packages/clawql-payments/src/mpp/providers.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { appendFinanceOffers, financeProvidersFromEnv } from "./providers.js";
+
+describe("financeProvidersFromEnv", () => {
+  it("parses comma-separated provider list", () => {
+    expect(financeProvidersFromEnv({ CLAWQL_MPP_FINANCE_PROVIDERS: "paypal, adyen" })).toEqual([
+      "paypal",
+      "adyen",
+    ]);
+  });
+});
+
+describe("appendFinanceOffers", () => {
+  it("adds configured finance providers without duplicating stripe/x402", () => {
+    const offers = appendFinanceOffers({
+      offers: [
+        { intent: "charge", method: "x402", amount: "1000", currency: "usdc" },
+        { intent: "charge", method: "stripe", amount: null, currency: "usd" },
+      ],
+      env: { CLAWQL_MPP_FINANCE_PROVIDERS: "paypal,square" },
+      resource: "/v1/test",
+    });
+    expect(offers.map((o) => o.method)).toEqual(["x402", "stripe", "paypal", "square"]);
+  });
+});

--- a/packages/clawql-payments/src/mpp/providers.ts
+++ b/packages/clawql-payments/src/mpp/providers.ts
@@ -1,0 +1,69 @@
+import type { MppPaymentOffer } from "./types.js";
+import { MPP_METHOD_STRIPE, MPP_METHOD_X402 } from "./types.js";
+
+/** Known traditional-finance MPP method identifiers (extensible via env). */
+export const MPP_FINANCE_METHOD_PAYPAL = "paypal" as const;
+export const MPP_FINANCE_METHOD_ADYEN = "adyen" as const;
+export const MPP_FINANCE_METHOD_SQUARE = "square" as const;
+
+export type MppFinanceMethod =
+  | typeof MPP_FINANCE_METHOD_PAYPAL
+  | typeof MPP_FINANCE_METHOD_ADYEN
+  | typeof MPP_FINANCE_METHOD_SQUARE
+  | string;
+
+const DEFAULT_FINANCE_METHODS: MppFinanceMethod[] = [];
+
+export function parseFinanceProviderList(raw: string | undefined): MppFinanceMethod[] {
+  if (!raw?.trim()) return DEFAULT_FINANCE_METHODS;
+  return raw
+    .split(/[,\s]+/)
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function financeProvidersFromEnv(env: NodeJS.ProcessEnv = process.env): MppFinanceMethod[] {
+  return parseFinanceProviderList(env.CLAWQL_MPP_FINANCE_PROVIDERS);
+}
+
+export function buildFinanceOffer(input: {
+  method: MppFinanceMethod;
+  description?: string;
+  metered?: boolean;
+}): MppPaymentOffer {
+  return {
+    intent: "charge",
+    method: input.method,
+    amount: null,
+    currency: "usd",
+    description:
+      input.description ?? `${input.method} billing — configure credentials on self-hosted ClawQL.`,
+  };
+}
+
+export function appendFinanceOffers(input: {
+  offers: MppPaymentOffer[];
+  env?: NodeJS.ProcessEnv;
+  resource?: string;
+}): MppPaymentOffer[] {
+  const env = input.env ?? process.env;
+  const stripeEnabled = Boolean(env.STRIPE_SECRET_KEY?.trim());
+  const providers = financeProvidersFromEnv(env);
+  if (providers.length === 0) return input.offers;
+
+  const existing = new Set(input.offers.map((o) => o.method));
+  const appended = [...input.offers];
+  for (const method of providers) {
+    if (method === MPP_METHOD_STRIPE || method === MPP_METHOD_X402) continue;
+    if (existing.has(method)) continue;
+    appended.push(
+      buildFinanceOffer({
+        method,
+        description: input.resource ? `${method} billing for ${input.resource}` : undefined,
+        metered: !stripeEnabled,
+      })
+    );
+    existing.add(method);
+  }
+  return appended;
+}

--- a/packages/clawql-payments/src/mpp/stripe-spt-smoke.test.ts
+++ b/packages/clawql-payments/src/mpp/stripe-spt-smoke.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+const runLive =
+  process.env.CLAWQL_STRIPE_SPT_SMOKE === "1" &&
+  Boolean(process.env.STRIPE_SECRET_KEY?.trim()) &&
+  Boolean(process.env.STRIPE_PROFILE_ID?.trim());
+
+describe.runIf(runLive)("Stripe SPT live smoke", () => {
+  it("documents link-cli mpp pay flow for operators", async () => {
+    // Live SPT settlement requires operator credentials and link-cli spend requests.
+    // This test gate ensures CI skips unless explicitly enabled in a credentialed environment.
+    expect(process.env.STRIPE_PROFILE_ID).toMatch(/^profile(_test)?_/);
+    expect(process.env.STRIPE_SECRET_KEY).toMatch(/^sk_(test|live)_/);
+  });
+});
+
+describe("Stripe SPT smoke harness", () => {
+  it("skips live verification when CLAWQL_STRIPE_SPT_SMOKE is unset", () => {
+    if (runLive) return;
+    expect(runLive).toBe(false);
+  });
+});

--- a/packages/clawql-payments/src/plugin/payments-x402-proxy-plugin.ts
+++ b/packages/clawql-payments/src/plugin/payments-x402-proxy-plugin.ts
@@ -42,7 +42,8 @@ export function createPaymentsX402ProxyPlugin(
   };
 
   if (!passive) {
-    plugin.beforeCallTool = ({ toolName }) => mcpX402BeforeCallToolEffect({ toolName, env });
+    plugin.beforeCallTool = (({ toolName }) =>
+      mcpX402BeforeCallToolEffect({ toolName, env })) as NonNullable<Plugin["beforeCallTool"]>;
   }
 
   return plugin;

--- a/packages/clawql-payments/src/runtime/payments-effect-runtime.ts
+++ b/packages/clawql-payments/src/runtime/payments-effect-runtime.ts
@@ -4,7 +4,6 @@ import { paymentsDiscoveryLiveLayer } from "../discovery/payments-discovery-serv
 import { mppOpenApiLiveLayer } from "../mpp/openapi-service.js";
 import { mppVerificationLiveLayer } from "../mpp/verification-service.js";
 import { mppxAdapterLiveLayer } from "../mpp/mppx-adapter.js";
-import { isMppxEnabled } from "../mpp/mppx-adapter.js";
 import { entitlementLiveLayer } from "../plans/entitlement-service.js";
 import { usageStoreLiveLayer } from "../plans/usage-store-service.js";
 import { paymentAuditLiveLayer } from "../plugin/payment-audit-service.js";
@@ -60,7 +59,7 @@ export function paymentsServicesLiveLayer(
   const mppVerification = mppVerificationLiveLayer(env).pipe(
     Layer.provide(Layer.mergeAll(config, audit, runtimeConfig, facilitator, stripeClient))
   );
-  const mppxAdapter = isMppxEnabled(env) ? mppxAdapterLiveLayer(env) : Layer.empty;
+  const mppxAdapter = mppxAdapterLiveLayer(env);
   const enforcement = x402EnforcementLiveLayer().pipe(
     Layer.provide(Layer.mergeAll(config, audit, gate, runtimeConfig, facilitator, mppVerification))
   );

--- a/packages/clawql-payments/src/runtime/payments-effect-runtime.ts
+++ b/packages/clawql-payments/src/runtime/payments-effect-runtime.ts
@@ -3,6 +3,8 @@ import { paymentsConfigLiveLayer } from "../config/payments-config-service.js";
 import { paymentsDiscoveryLiveLayer } from "../discovery/payments-discovery-service.js";
 import { mppOpenApiLiveLayer } from "../mpp/openapi-service.js";
 import { mppVerificationLiveLayer } from "../mpp/verification-service.js";
+import { mppxAdapterLiveLayer } from "../mpp/mppx-adapter.js";
+import { isMppxEnabled } from "../mpp/mppx-adapter.js";
 import { entitlementLiveLayer } from "../plans/entitlement-service.js";
 import { usageStoreLiveLayer } from "../plans/usage-store-service.js";
 import { paymentAuditLiveLayer } from "../plugin/payment-audit-service.js";
@@ -27,6 +29,7 @@ export type PaymentsServices =
   | import("../discovery/payments-discovery-service.js").PaymentsDiscoveryService
   | import("../mpp/openapi-service.js").MppOpenApiService
   | import("../mpp/verification-service.js").MppVerificationService
+  | import("../mpp/mppx-adapter.js").MppxAdapterService
   | import("../stripe/stripe-client-service.js").StripeClientService
   | import("../stripe/stripe-webhook-service.js").StripeWebhookService
   | import("../stripe/stripe-meter-service.js").StripeMeterService
@@ -57,6 +60,7 @@ export function paymentsServicesLiveLayer(
   const mppVerification = mppVerificationLiveLayer(env).pipe(
     Layer.provide(Layer.mergeAll(config, audit, runtimeConfig, facilitator, stripeClient))
   );
+  const mppxAdapter = isMppxEnabled(env) ? mppxAdapterLiveLayer(env) : Layer.empty;
   const enforcement = x402EnforcementLiveLayer().pipe(
     Layer.provide(Layer.mergeAll(config, audit, gate, runtimeConfig, facilitator, mppVerification))
   );
@@ -83,6 +87,7 @@ export function paymentsServicesLiveLayer(
     discovery,
     mppOpenApi,
     mppVerification,
+    mppxAdapter,
     stripeClient,
     stripeWebhook,
     stripeMeter,

--- a/packages/clawql-payments/src/x402/mcp-enforce-effect.ts
+++ b/packages/clawql-payments/src/x402/mcp-enforce-effect.ts
@@ -1,5 +1,10 @@
 import { Effect } from "effect";
 import { getMcpX402Context } from "./mcp-context.js";
+import { isMppMcpJsonRpcEnabled } from "../mpp/mcp-jsonrpc.js";
+import {
+  MppMcpJsonRpcPaymentRequiredError,
+  MppMcpJsonRpcVerificationFailedError,
+} from "../mpp/mcp-jsonrpc-errors.js";
 import { X402McpPaymentDeniedError, X402McpPaymentRequiredError } from "./mcp-errors.js";
 import { isX402EnforcementActive } from "./x402-runtime-config-service.js";
 import { X402EnforcementService } from "./x402-enforcement-service.js";
@@ -37,7 +42,21 @@ export function mcpX402BeforeCallToolEffect(
       return;
     }
     if (result.action === "require_payment") {
+      if (isMppMcpJsonRpcEnabled(env)) {
+        return yield* Effect.fail(
+          new MppMcpJsonRpcPaymentRequiredError(result.body, resource, env)
+        );
+      }
       return yield* Effect.fail(new X402McpPaymentRequiredError(result.body));
+    }
+    if (isMppMcpJsonRpcEnabled(env) && result.mppVerificationCode) {
+      return yield* Effect.fail(
+        new MppMcpJsonRpcVerificationFailedError(
+          result.reason,
+          result.resource,
+          result.mppVerificationCode
+        )
+      );
     }
     return yield* Effect.fail(new X402McpPaymentDeniedError(result.reason, result.resource));
   }).pipe(Effect.provide(paymentsServicesLiveLayer(env)));

--- a/packages/clawql-payments/src/x402/mcp-enforce.test.ts
+++ b/packages/clawql-payments/src/x402/mcp-enforce.test.ts
@@ -59,6 +59,18 @@ describe("runMcpX402BeforeCallTool", () => {
     ).rejects.toBeInstanceOf(X402McpPaymentRequiredError);
   });
 
+  it("throws MppMcpJsonRpcPaymentRequiredError when JSON-RPC mode enabled", async () => {
+    await createX402Gate({ tool: "knowledge_search", price: 0.0005, asset: "USDC" }, env);
+    const { MppMcpJsonRpcPaymentRequiredError } = await import("../mpp/mcp-jsonrpc-errors.js");
+
+    await expect(
+      runMcpX402BeforeCallTool({
+        toolName: "knowledge_search",
+        env: { ...env, CLAWQL_MPP_MCP_JSONRPC: "1" },
+      })
+    ).rejects.toBeInstanceOf(MppMcpJsonRpcPaymentRequiredError);
+  });
+
   it("allows gated tool when facilitator verifies proof from MCP context headers", async () => {
     await createX402Gate({ tool: "knowledge_search", price: 0.0005, asset: "USDC" }, env);
 

--- a/packages/clawql-payments/src/x402/middleware.ts
+++ b/packages/clawql-payments/src/x402/middleware.ts
@@ -75,7 +75,7 @@ export function createX402PaymentMiddleware(options: CreateX402PaymentMiddleware
       if (result.action === "require_payment") {
         const stripeEnabled = Boolean(env.STRIPE_SECRET_KEY?.trim());
         if (isMppEnabled(env)) {
-          const offers = offersFromX402Required(result.body, stripeEnabled);
+          const offers = offersFromX402Required(result.body, stripeEnabled, env);
           const challenges =
             result.mppChallenges ??
             buildChallengesFromOffers({

--- a/packages/clawql-payments/src/x402/x402-enforcement-service.ts
+++ b/packages/clawql-payments/src/x402/x402-enforcement-service.ts
@@ -176,7 +176,7 @@ export function x402EnforcementLiveLayer(): Layer.Layer<
             let mppChallenges: MppPaymentChallenge[] | undefined;
             if (mppOn) {
               const stripeEnabled = Boolean(env.STRIPE_SECRET_KEY?.trim());
-              const offers = offersFromX402Required(body, stripeEnabled);
+              const offers = offersFromX402Required(body, stripeEnabled, env);
               mppChallenges = buildChallengesFromOffers({
                 offers,
                 resource: gate.resource,

--- a/src/mcp-tool-wrap.ts
+++ b/src/mcp-tool-wrap.ts
@@ -1,4 +1,5 @@
 import { isX402McpPaymentError } from "clawql-payments/x402";
+import { isMppMcpJsonRpcPaymentError } from "clawql-payments/mpp";
 import { runMcpProxyBeforeCallTool } from "./clawql-api-adapters.js";
 import { wrapMcpToolHandler } from "./otel-tracing.js";
 
@@ -14,6 +15,9 @@ export function wrapRegisteredMcpToolHandler<TArgs extends unknown[], TResult>(
     try {
       await runMcpProxyBeforeCallTool(toolName, args[0]);
     } catch (err: unknown) {
+      if (isMppMcpJsonRpcPaymentError(err)) {
+        return err.toToolResult() as TResult;
+      }
       if (isX402McpPaymentError(err)) {
         return err.toToolResult() as TResult;
       }

--- a/website/src/app/api/v1/route.ts
+++ b/website/src/app/api/v1/route.ts
@@ -1,14 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import {
+  buildCommerce402Headers,
   buildX402PaymentRequired,
-  encodePaymentRequiredHeader,
 } from '@/lib/commerce-discovery'
 
 export function GET(request: NextRequest) {
   const requestUrl = request.nextUrl.origin + request.nextUrl.pathname
   const paymentRequired = buildX402PaymentRequired(requestUrl)
-  const paymentHeader = encodePaymentRequiredHeader(paymentRequired)
   const accepts = paymentRequired.accepts as Array<{
     amount?: string
     network?: string
@@ -17,10 +16,14 @@ export function GET(request: NextRequest) {
 
   return new NextResponse(
     JSON.stringify({
+      type: 'https://paymentauth.org/problems/payment-required',
+      title: 'Payment Required',
+      status: 402,
+      detail: 'Payment is required.',
       protocol: 'x402',
       error: 'payment_required',
       message:
-        'ClawQL docs commerce discovery probe — retry with PAYMENT-SIGNATURE after settling x402 payment.',
+        'ClawQL docs commerce discovery probe — retry with PAYMENT-SIGNATURE or Authorization: Payment after settling.',
       x402Probe: {
         tier: 'discovery',
         amountUsd: '0.001',
@@ -28,33 +31,26 @@ export function GET(request: NextRequest) {
         network: firstAccept?.network,
         documentation: `${request.nextUrl.origin}/payments/clawql-payments`,
       },
+      x402: paymentRequired,
     }),
     {
       status: 402,
-      headers: {
-        'Content-Type': 'application/json; charset=utf-8',
-        'Cache-Control': 'no-store',
-        'WWW-Authenticate': 'x402',
-        'PAYMENT-REQUIRED': paymentHeader,
-        'Access-Control-Expose-Headers':
-          'PAYMENT-REQUIRED, PAYMENT-RESPONSE, WWW-Authenticate',
-      },
+      headers: buildCommerce402Headers({
+        requestUrl,
+        origin: request.nextUrl.origin,
+      }),
     },
   )
 }
 
 export function HEAD(request: NextRequest) {
   const requestUrl = request.nextUrl.origin + request.nextUrl.pathname
-  const paymentRequired = buildX402PaymentRequired(requestUrl)
-  const paymentHeader = encodePaymentRequiredHeader(paymentRequired)
 
   return new NextResponse(null, {
     status: 402,
-    headers: {
-      'Content-Type': 'application/json; charset=utf-8',
-      'Cache-Control': 'no-store',
-      'WWW-Authenticate': 'x402',
-      'PAYMENT-REQUIRED': paymentHeader,
-    },
+    headers: buildCommerce402Headers({
+      requestUrl,
+      origin: request.nextUrl.origin,
+    }),
   })
 }

--- a/website/src/lib/commerce-discovery.ts
+++ b/website/src/lib/commerce-discovery.ts
@@ -72,24 +72,73 @@ export function encodePaymentRequiredHeader(
   return Buffer.from(JSON.stringify(body), 'utf8').toString('base64')
 }
 
+function financeProvidersForDocs(): string[] {
+  const raw = process.env.DOCS_MPP_FINANCE_PROVIDERS?.trim()
+  if (!raw) return []
+  return raw
+    .split(/[,\s]+/)
+    .map((p) => p.trim().toLowerCase())
+    .filter(Boolean)
+}
+
 function mppPaymentInfo(description: string): Record<string, unknown> {
+  const offers: Array<Record<string, unknown>> = [
+    {
+      intent: 'charge',
+      method: 'x402',
+      amount: getX402ProbeAmountAtomic(),
+      currency: getX402Asset(),
+      description,
+    },
+    {
+      intent: 'charge',
+      method: 'stripe',
+      amount: null,
+      currency: 'usd',
+      description: 'Stripe subscription or metered billing for ClawQL plans.',
+    },
+  ]
+
+  for (const method of financeProvidersForDocs()) {
+    if (method === 'x402' || method === 'stripe') continue
+    offers.push({
+      intent: 'charge',
+      method,
+      amount: null,
+      currency: 'usd',
+      description: `${method} billing for ClawQL plans (discovery).`,
+    })
+  }
+
   return {
-    offers: [
+    offers,
+    authMode: 'paid',
+    protocols: [
       {
-        intent: 'charge',
-        method: 'x402',
-        amount: getX402ProbeAmountAtomic(),
-        currency: getX402Asset(),
-        description,
+        x402: {
+          scheme: 'exact',
+          network: getX402Network(),
+          asset: getX402Asset(),
+          payTo: getX402PayTo(),
+        },
       },
-      {
-        intent: 'charge',
-        method: 'stripe',
-        amount: null,
-        currency: 'usd',
-        description: 'Stripe subscription or metered billing for ClawQL plans.',
-      },
+      { mpp: { method: 'stripe', intent: 'charge' } },
+      ...financeProvidersForDocs()
+        .filter((m) => m !== 'x402' && m !== 'stripe')
+        .map((method) => ({ mpp: { method, intent: 'charge' } })),
     ],
+    price: {
+      mode: 'fixed',
+      currency: 'USD',
+      amount: '0.001',
+      min: '0.001',
+      max: '0.001',
+    },
+    network: getX402Network(),
+    asset: getX402Asset(),
+    payTo: getX402PayTo(),
+    retryHeader: 'PAYMENT-SIGNATURE',
+    recommendedClient: '@x402/fetch',
   }
 }
 
@@ -104,6 +153,9 @@ export function getCommerceOpenApi(): Record<string, unknown> {
       version: '1.0.0',
       description:
         'MPP discovery surface for docs.clawql.com. Paid routes advertise x402 and Stripe offers; runtime 402 challenges are authoritative.',
+      'x-commerce': true,
+      'x-guidance':
+        'Commerce discovery API for agent scanners. Runtime 402 challenges on /api/v1 are authoritative.',
     },
     servers: [{ url: origin }],
     'x-service-info': {
@@ -279,3 +331,49 @@ export function getPaymentsWellKnown(): Record<string, unknown> {
 }
 
 export { AP2_EXTENSION_URI }
+
+/** MPP + x402 response headers for GET /api/v1 discovery probe. */
+export function buildCommerce402Headers(input: {
+  requestUrl: string
+  origin: string
+}): Record<string, string> {
+  const paymentRequired = buildX402PaymentRequired(input.requestUrl)
+  const paymentHeader = encodePaymentRequiredHeader(paymentRequired)
+  const offers = mppPaymentInfo('').offers as Array<Record<string, unknown>>
+  const challenges = offers.map((offer, index) => ({
+    id: `docs-chal-${index}`,
+    intent: offer.intent ?? 'charge',
+    method: offer.method,
+    amount: offer.amount ?? null,
+    currency: offer.currency,
+    resource: '/api/v1',
+    description: offer.description,
+  }))
+  const mppBody = {
+    error: 'payment_required',
+    message: 'Payment required (MPP)',
+    resource: '/api/v1',
+    payment: challenges.map((challenge) => ({
+      protocol: challenge.method,
+      challenge,
+    })),
+    x402: paymentRequired,
+    x402Version: paymentRequired.x402Version,
+  }
+  const mppChallengePayload = Buffer.from(
+    JSON.stringify({ challenges }),
+    'utf8',
+  ).toString('base64url')
+
+  return {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store',
+    'WWW-Authenticate': `Payment challenge="${mppChallengePayload}", x402`,
+    'PAYMENT-REQUIRED': paymentHeader,
+    'Payment-Required': Buffer.from(JSON.stringify(mppBody), 'utf8').toString(
+      'base64',
+    ),
+    'Access-Control-Expose-Headers':
+      'PAYMENT-REQUIRED, PAYMENT-RESPONSE, Payment-Required, Payment-Receipt, WWW-Authenticate, Authorization',
+  }
+}

--- a/website/tests/agent-readiness.spec.ts
+++ b/website/tests/agent-readiness.spec.ts
@@ -14,7 +14,9 @@ test.describe('agent readiness discovery', () => {
     expect(body).toContain('/.well-known/oauth-protected-resource')
   })
 
-  test('oauth-authorization-server includes agent_auth', async ({ request }) => {
+  test('oauth-authorization-server includes agent_auth', async ({
+    request,
+  }) => {
     const res = await request.get('/.well-known/oauth-authorization-server')
     expect(res.status()).toBe(200)
     const doc = await res.json()
@@ -39,18 +41,20 @@ test.describe('agent readiness discovery', () => {
       expect(iface.protocol_binding).toBeTruthy()
     }
     const extensions = card.capabilities?.extensions ?? []
-    const ap2 = extensions.find(
-      (e: { uri?: string }) => e.uri === AP2_URI,
-    )
+    const ap2 = extensions.find((e: { uri?: string }) => e.uri === AP2_URI)
     expect(ap2?.params?.roles).toContain('merchant')
   })
 
-  test('commerce openapi exposes MPP x-payment-info offers', async ({ request }) => {
+  test('commerce openapi exposes MPP x-payment-info offers', async ({
+    request,
+  }) => {
     const res = await request.get('/openapi.json')
     expect(res.status()).toBe(200)
     const doc = await res.json()
+    expect(doc.info?.['x-commerce']).toBe(true)
     const probe = doc.paths?.['/api/v1']?.get
-    const offers = probe?.['x-payment-info']?.offers
+    const paymentInfo = probe?.['x-payment-info']
+    const offers = paymentInfo?.offers
     expect(offers?.length).toBeGreaterThanOrEqual(2)
     expect(offers.some((o: { method?: string }) => o.method === 'x402')).toBe(
       true,
@@ -58,14 +62,19 @@ test.describe('agent readiness discovery', () => {
     expect(offers.some((o: { method?: string }) => o.method === 'stripe')).toBe(
       true,
     )
+    expect(paymentInfo?.protocols?.length).toBeGreaterThanOrEqual(2)
     expect(probe?.responses?.['402']).toBeTruthy()
   })
 
-  test('x402 probe returns 402 with PAYMENT-REQUIRED', async ({ request }) => {
+  test('x402 probe returns 402 with PAYMENT-REQUIRED and MPP Payment challenge', async ({
+    request,
+  }) => {
     const res = await request.get('/api/v1')
     expect(res.status()).toBe(402)
     const paymentRequired = res.headers()['payment-required']
     expect(paymentRequired).toBeTruthy()
+    const wwwAuth = res.headers()['www-authenticate'] ?? ''
+    expect(wwwAuth.toLowerCase()).toContain('payment')
     const decoded = JSON.parse(
       Buffer.from(paymentRequired!, 'base64').toString('utf8'),
     )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the post-#610 MPP commerce follow-up plan in suggested order.

## 1. Live docs validation + scanner fixes

- Dual `x-payment-info` shape on docs `/openapi.json`: canonical `offers[]` **plus** AgentCash-compatible `protocols`/`price`
- `info.x-commerce` marker for commerce scanners
- `/api/v1` returns dual x402 + MPP `WWW-Authenticate: Payment` headers
- Agent-readiness Playwright tests updated

## 2. Stripe SPT smoke harness

- `stripe-spt-smoke.test.ts` gated by `CLAWQL_STRIPE_SPT_SMOKE=1` + `STRIPE_SECRET_KEY` + `STRIPE_PROFILE_ID`
- Documents operator link-cli flow for credentialed environments

## 3. `mppx` adapter (Effect)

- `MppxAdapterService` + `mppxAdapterLiveLayer` (dynamic import)
- Optional dependency `mppx`; enable with `CLAWQL_MPPX_ENABLED=1`

## 4. Raw MCP JSON-RPC payment errors

- `MppMcpJsonRpcPaymentRequiredError` (-32042) and `MppMcpJsonRpcVerificationFailedError` (-32043)
- Opt-in via `CLAWQL_MPP_MCP_JSONRPC=1` (default remains tool-result `_meta`)

## 5. Extended finance providers

- `CLAWQL_MPP_FINANCE_PROVIDERS=paypal,adyen,square` appended to `offers[]`
- Docs: `DOCS_MPP_FINANCE_PROVIDERS` for discovery OpenAPI

## Notes

- DNS-AID on docs.clawql.com still fails DNSSEC validation until enabled in Cloudflare (infra)
- isitagentready Level 5 already achieved; MPP check should improve after this deploy (CDN cache may lag ~1h)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

