### PR TITLE
feat(memory): recall vector/db pass via Effect services

### DIFF
--- a/packages/clawql-memory/src/effect/index.ts
+++ b/packages/clawql-memory/src/effect/index.ts
@@ -10,7 +10,11 @@ export {
 export { EmbeddingService, embeddingLiveLayer } from "./embedding-service.js";
 export { MemoryDbService, memoryDbLiveLayer, type MemoryDbDocument } from "./memory-db-service.js";
 export { executeMemoryIngestEffect } from "./memory-ingest-effect.js";
-export { executeMemoryRecallEffect, executeMemoryRecallCoreEffect, type MemoryRecallServices } from "./memory-recall-effect.js";
+export {
+  executeMemoryRecallEffect,
+  executeMemoryRecallCoreEffect,
+  type MemoryRecallServices,
+} from "./memory-recall-effect.js";
 export {
   computeRecallVectorScoresEffect,
   loadRecallArtifactsEffect,

--- a/packages/clawql-memory/src/effect/index.ts
+++ b/packages/clawql-memory/src/effect/index.ts
@@ -10,7 +10,17 @@ export {
 export { EmbeddingService, embeddingLiveLayer } from "./embedding-service.js";
 export { MemoryDbService, memoryDbLiveLayer, type MemoryDbDocument } from "./memory-db-service.js";
 export { executeMemoryIngestEffect } from "./memory-ingest-effect.js";
-export { executeMemoryRecallEffect } from "./memory-recall-effect.js";
+export { executeMemoryRecallEffect, executeMemoryRecallCoreEffect, type MemoryRecallServices } from "./memory-recall-effect.js";
+export {
+  computeRecallVectorScoresEffect,
+  loadRecallArtifactsEffect,
+  recallMerkleSnapshotEffect,
+  recallSyncDocumentsOnScanEffect,
+  recallVectorPassEffect,
+  recallWikilinkEdgesEffect,
+  type RecallVectorPassInput,
+  type RecallVectorPassResult,
+} from "./memory-recall-vector-effect.js";
 export { MemoryIngestService, memoryIngestLiveLayer } from "./memory-ingest-service.js";
 export { MemoryRecallService, memoryRecallLiveLayer } from "./memory-recall-service.js";
 export {

--- a/packages/clawql-memory/src/effect/memory-recall-effect.ts
+++ b/packages/clawql-memory/src/effect/memory-recall-effect.ts
@@ -87,7 +87,8 @@ export function executeMemoryRecallCoreEffect(
       return { ok: false, error: "query is required" };
     }
 
-    const limit = input.limit !== undefined ? input.limit : envInt("CLAWQL_MEMORY_RECALL_LIMIT", 10);
+    const limit =
+      input.limit !== undefined ? input.limit : envInt("CLAWQL_MEMORY_RECALL_LIMIT", 10);
     const maxDepth =
       input.maxDepth !== undefined ? input.maxDepth : envInt("CLAWQL_MEMORY_RECALL_MAX_DEPTH", 2);
     const minScore =
@@ -161,15 +162,14 @@ export function executeMemoryRecallCoreEffect(
       return [...new Set([...a, ...b])];
     }
 
-    const { vectorByRel, cuckooVectorChunksDropped, recallArtifacts } = yield* recallVectorPassEffect(
-      {
+    const { vectorByRel, cuckooVectorChunksDropped, recallArtifacts } =
+      yield* recallVectorPassEffect({
         vault,
         query,
         mdFiles,
         topChunks,
         maxDocs,
-      }
-    );
+      });
 
     const vectorBoost = envFloat("CLAWQL_MEMORY_VECTOR_SCORE_BOOST", 50);
     const minVectorSim = envFloat("CLAWQL_MEMORY_VECTOR_MIN_SIM", 0.28);

--- a/packages/clawql-memory/src/effect/memory-recall-effect.ts
+++ b/packages/clawql-memory/src/effect/memory-recall-effect.ts
@@ -1,26 +1,276 @@
-import { Effect } from "effect";
+import { Cause, Effect, Exit } from "effect";
+import { readVaultTextFile } from "../vault/utils.js";
+import { slugifyTitle } from "../ingest/slug.js";
+import { listVaultMarkdownRelPaths, buildSlugToVaultPath } from "../vault/slug-index.js";
+import { extractWikilinkTargets, stripVaultFrontmatter } from "../vault/markdown.js";
 import {
-  executeMemoryRecallCore,
+  keywordScore,
   type MemoryRecallInput,
   type MemoryRecallResult,
+  type RecallHit,
 } from "../recall/recall.js";
 import { MemoryError } from "./memory-errors.js";
+import { EmbeddingService } from "./embedding-service.js";
+import { MemoryDbService } from "./memory-db-service.js";
 import { memoryFromPromise } from "./memory-effect-utils.js";
 import { VaultConfigService } from "./vault-config-service.js";
+import {
+  recallMerkleSnapshotEffect,
+  recallSyncDocumentsOnScanEffect,
+  recallVectorPassEffect,
+  recallWikilinkEdgesEffect,
+} from "./memory-recall-vector-effect.js";
 
 const VAULT_NOT_CONFIGURED =
   "Obsidian vault is not configured. Set CLAWQL_OBSIDIAN_VAULT_PATH to a writable directory.";
 
+function envInt(key: string, def: number): number {
+  const v = process.env[key]?.trim();
+  if (!v) return def;
+  const n = Number.parseInt(v, 10);
+  return Number.isFinite(n) ? n : def;
+}
+
+function envFloat(key: string, def: number): number {
+  const v = process.env[key]?.trim();
+  if (!v) return def;
+  const n = Number.parseFloat(v);
+  return Number.isFinite(n) ? n : def;
+}
+
+function defaultScanRoot(): string {
+  const v = process.env.CLAWQL_MEMORY_RECALL_SCAN_ROOT;
+  if (v === undefined) return "Memory";
+  const t = v.trim();
+  return t === "" ? "" : t;
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length > 1);
+}
+
+function buildSnippet(text: string, query: string, maxLen: number): string {
+  const body = stripVaultFrontmatter(text);
+  const terms = tokenize(query);
+  const lower = body.toLowerCase();
+  let pos = 0;
+  for (const t of terms) {
+    const i = lower.indexOf(t);
+    if (i !== -1) {
+      pos = Math.max(0, i - Math.floor(maxLen / 4));
+      break;
+    }
+  }
+  const slice = body.slice(pos, pos + maxLen).trim();
+  return slice.length < body.length ? `${slice}…` : slice;
+}
+
+export type MemoryRecallServices = EmbeddingService | MemoryDbService;
+
+/** Full recall body as Effect.gen — db/embedding via infrastructure services. */
+export function executeMemoryRecallCoreEffect(
+  vault: string,
+  input: MemoryRecallInput
+): Effect.Effect<MemoryRecallResult, MemoryError, MemoryRecallServices> {
+  return Effect.gen(function* () {
+    yield* memoryFromPromise(async () => {
+      const { runBeforeRecallVaultSync } = await import("../sync/vault-sync-hooks.js");
+      await runBeforeRecallVaultSync();
+    });
+
+    const query = input.query?.trim();
+    if (!query) {
+      return { ok: false, error: "query is required" };
+    }
+
+    const limit = input.limit !== undefined ? input.limit : envInt("CLAWQL_MEMORY_RECALL_LIMIT", 10);
+    const maxDepth =
+      input.maxDepth !== undefined ? input.maxDepth : envInt("CLAWQL_MEMORY_RECALL_MAX_DEPTH", 2);
+    const minScore =
+      input.minScore !== undefined ? input.minScore : envInt("CLAWQL_MEMORY_RECALL_MIN_SCORE", 1);
+    const maxFiles = envInt("CLAWQL_MEMORY_RECALL_MAX_FILES", 2000);
+    const snippetChars = envInt("CLAWQL_MEMORY_RECALL_SNIPPET_CHARS", 520);
+    const topChunks = envInt("CLAWQL_MEMORY_VECTOR_TOP_CHUNKS", 80);
+    const maxDocs = envInt("CLAWQL_MEMORY_VECTOR_MAX_DOCS", 12);
+    const scanRoot = defaultScanRoot();
+
+    const scanExit = yield* Effect.exit(
+      memoryFromPromise(() => listVaultMarkdownRelPaths(vault, scanRoot, maxFiles))
+    );
+    if (Exit.isFailure(scanExit)) {
+      const reason = Cause.squash(scanExit.cause);
+      const msg = reason instanceof Error ? reason.message : String(reason);
+      return { ok: false, error: `Cannot scan vault: ${msg}` };
+    }
+    const mdFiles = scanExit.value;
+
+    const truncated = mdFiles.length >= maxFiles;
+
+    type FileInfo = { rel: string; text: string; score: number };
+    const files: FileInfo[] = [];
+    for (const rel of mdFiles) {
+      const text = yield* memoryFromPromise(() => readVaultTextFile(vault, rel)).pipe(
+        Effect.catchAll(() => Effect.succeed(undefined))
+      );
+      if (text === undefined) continue;
+      files.push({ rel, text, score: keywordScore(query, text) });
+    }
+
+    const now = Date.now();
+    yield* recallSyncDocumentsOnScanEffect(
+      vault,
+      files.map((f) => ({ path: f.rel, text: f.text, mtimeMs: now }))
+    );
+
+    const slugToPath = buildSlugToVaultPath(files.map((f) => ({ path: f.rel, text: f.text })));
+
+    const forward = new Map<string, Set<string>>();
+    const back = new Map<string, Set<string>>();
+    function addEdge(a: string, b: string): void {
+      if (a === b) return;
+      if (!forward.has(a)) forward.set(a, new Set());
+      forward.get(a)!.add(b);
+      if (!back.has(b)) back.set(b, new Set());
+      back.get(b)!.add(a);
+    }
+
+    for (const { rel, text } of files) {
+      for (const target of extractWikilinkTargets(text)) {
+        const slug = slugifyTitle(target);
+        const dest = slugToPath.get(slug);
+        if (dest) addEdge(rel, dest);
+      }
+    }
+
+    const textByRel = new Map(files.map((f) => [f.rel, f.text]));
+    const extraEdges = yield* recallWikilinkEdgesEffect(
+      vault,
+      files.map((f) => f.rel)
+    );
+    for (const e of extraEdges) {
+      if (textByRel.has(e.toPath)) addEdge(e.fromPath, e.toPath);
+    }
+
+    function neighbors(p: string): string[] {
+      const a = [...(forward.get(p) ?? [])];
+      const b = [...(back.get(p) ?? [])];
+      return [...new Set([...a, ...b])];
+    }
+
+    const { vectorByRel, cuckooVectorChunksDropped, recallArtifacts } = yield* recallVectorPassEffect(
+      {
+        vault,
+        query,
+        mdFiles,
+        topChunks,
+        maxDocs,
+      }
+    );
+
+    const vectorBoost = envFloat("CLAWQL_MEMORY_VECTOR_SCORE_BOOST", 50);
+    const minVectorSim = envFloat("CLAWQL_MEMORY_VECTOR_MIN_SIM", 0.28);
+    const scoreByRel = new Map<string, number>();
+    for (const f of files) {
+      const vs = vectorByRel.get(f.rel) ?? 0;
+      scoreByRel.set(f.rel, Math.max(f.score, vs * vectorBoost));
+    }
+    for (const [p, sim] of vectorByRel) {
+      if (!scoreByRel.has(p)) scoreByRel.set(p, sim * vectorBoost);
+    }
+
+    const seedSet = new Set<string>();
+    for (const f of files) {
+      if (f.score >= minScore) seedSet.add(f.rel);
+    }
+    for (const [p, sim] of vectorByRel) {
+      if (sim >= minVectorSim) seedSet.add(p);
+    }
+    const seeds = [...seedSet].sort((a, b) => (scoreByRel.get(b) ?? 0) - (scoreByRel.get(a) ?? 0));
+
+    type Q = { rel: string; depth: number; reason: "keyword" | "link" | "vector"; from?: string };
+    const queue: Q[] = [];
+    const seen = new Set<string>();
+
+    for (const s of seeds) {
+      if (!seen.has(s)) {
+        const kw = files.find((x) => x.rel === s);
+        const kwOk = (kw?.score ?? 0) >= minScore;
+        queue.push({
+          rel: s,
+          depth: 0,
+          reason: kwOk ? "keyword" : "vector",
+        });
+        seen.add(s);
+      }
+    }
+
+    const hits: RecallHit[] = [];
+    while (queue.length > 0 && hits.length < limit) {
+      const cur = queue.shift()!;
+      const t = textByRel.get(cur.rel);
+      if (!t) continue;
+
+      hits.push({
+        path: cur.rel,
+        score: scoreByRel.get(cur.rel) ?? 0,
+        depth: cur.depth,
+        reason: cur.reason,
+        linkFrom: cur.from,
+        snippet: buildSnippet(t, query, snippetChars),
+      });
+
+      if (cur.depth >= maxDepth) continue;
+
+      for (const n of neighbors(cur.rel)) {
+        if (seen.has(n)) continue;
+        seen.add(n);
+        queue.push({
+          rel: n,
+          depth: cur.depth + 1,
+          reason: "link",
+          from: cur.rel,
+        });
+      }
+    }
+
+    hits.sort((a, b) => {
+      if (a.depth !== b.depth) return a.depth - b.depth;
+      return b.score - a.score;
+    });
+
+    const result: MemoryRecallResult = {
+      ok: true,
+      query,
+      results: hits.slice(0, limit),
+      truncated,
+      scannedFiles: files.length,
+    };
+
+    const merkleSnapshot = yield* recallMerkleSnapshotEffect(vault, recallArtifacts);
+    if (merkleSnapshot !== undefined) {
+      result.merkleSnapshot = merkleSnapshot;
+    }
+    if (cuckooVectorChunksDropped !== undefined) {
+      result.cuckooVectorChunksDropped = cuckooVectorChunksDropped;
+    }
+    return result;
+  });
+}
+
 /** Recall pipeline as Effect.gen — vault path via {@link VaultConfigService}. */
 export function executeMemoryRecallEffect(
   input: MemoryRecallInput
-): Effect.Effect<MemoryRecallResult, MemoryError, VaultConfigService> {
+): Effect.Effect<MemoryRecallResult, MemoryError, VaultConfigService | MemoryRecallServices> {
   return Effect.gen(function* () {
     const vaultConfig = yield* VaultConfigService;
     const vault = vaultConfig.getObsidianVaultPath();
     if (!vault) {
       return { ok: false, error: VAULT_NOT_CONFIGURED };
     }
-    return yield* memoryFromPromise(() => executeMemoryRecallCore(vault, input));
+    return yield* executeMemoryRecallCoreEffect(vault, input);
   });
 }

--- a/packages/clawql-memory/src/effect/memory-recall-service.ts
+++ b/packages/clawql-memory/src/effect/memory-recall-service.ts
@@ -1,6 +1,6 @@
 import { Context, Effect, Layer } from "effect";
 import type { MemoryRecallInput, MemoryRecallResult } from "../recall/recall.js";
-import { executeMemoryRecallEffect } from "./memory-recall-effect.js";
+import { executeMemoryRecallEffect, type MemoryRecallServices } from "./memory-recall-effect.js";
 import { MemoryError } from "./memory-errors.js";
 import { VaultConfigService } from "./vault-config-service.js";
 
@@ -10,7 +10,7 @@ export class MemoryRecallService extends Context.Tag("clawql/MemoryRecallService
   {
     readonly recall: (
       input: MemoryRecallInput
-    ) => Effect.Effect<MemoryRecallResult, MemoryError, VaultConfigService>;
+    ) => Effect.Effect<MemoryRecallResult, MemoryError, VaultConfigService | MemoryRecallServices>;
   }
 >() {}
 

--- a/packages/clawql-memory/src/effect/memory-recall-vector-effect.test.ts
+++ b/packages/clawql-memory/src/effect/memory-recall-vector-effect.test.ts
@@ -59,9 +59,9 @@ describe("MemoryDbService in recall infra", () => {
     const edges = await Effect.runPromise(
       Effect.gen(function* () {
         const db = yield* MemoryDbService;
-        return yield* db.loadWikilinkEdgesFromDatabase("/v", ["a.md"]).pipe(
-          Effect.catchAll(() => Effect.succeed([]))
-        );
+        return yield* db
+          .loadWikilinkEdgesFromDatabase("/v", ["a.md"])
+          .pipe(Effect.catchAll(() => Effect.succeed([])));
       }).pipe(Effect.provide(memoryDbLiveLayer()))
     );
     expect(Array.isArray(edges)).toBe(true);

--- a/packages/clawql-memory/src/effect/memory-recall-vector-effect.test.ts
+++ b/packages/clawql-memory/src/effect/memory-recall-vector-effect.test.ts
@@ -1,0 +1,69 @@
+import { Effect, Layer } from "effect";
+import { describe, expect, it } from "vitest";
+import { EmbeddingService, embeddingLiveLayer } from "./embedding-service.js";
+import { MemoryDbService, memoryDbLiveLayer } from "./memory-db-service.js";
+import {
+  loadRecallArtifactsEffect,
+  recallVectorPassEffect,
+} from "./memory-recall-vector-effect.js";
+
+const infraLayer = Layer.mergeAll(memoryDbLiveLayer(), embeddingLiveLayer());
+
+describe("recallVectorPassEffect", () => {
+  it("returns empty vector map when embeddings are not configured", async () => {
+    const result = await Effect.runPromise(
+      recallVectorPassEffect({
+        vault: "/tmp/vault",
+        query: "test query",
+        mdFiles: ["Memory/note.md"],
+        topChunks: 10,
+        maxDocs: 5,
+      }).pipe(Effect.provide(infraLayer))
+    );
+    expect(result.vectorByRel.size).toBe(0);
+    expect(result.recallArtifacts).toBeNull();
+  });
+
+  it("loadRecallArtifactsEffect respects memoryDbSyncEnabled", async () => {
+    const saved = process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+    delete process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+    try {
+      const artifacts = await Effect.runPromise(
+        loadRecallArtifactsEffect("/tmp/v", ["a.md"]).pipe(Effect.provide(infraLayer))
+      );
+      expect(artifacts).toBeNull();
+    } finally {
+      if (saved === undefined) delete process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+      else process.env.CLAWQL_OBSIDIAN_VAULT_PATH = saved;
+    }
+  });
+});
+
+describe("EmbeddingService in vector pass", () => {
+  it("exposes rankDocumentsByChunkSimilarity", async () => {
+    const ranked = await Effect.runPromise(
+      Effect.gen(function* () {
+        const embedding = yield* EmbeddingService;
+        return embedding.rankDocumentsByChunkSimilarity(new Float32Array([1, 0]), [], {
+          topChunks: 5,
+          maxDocs: 3,
+        });
+      }).pipe(Effect.provide(embeddingLiveLayer()))
+    );
+    expect(ranked).toEqual([]);
+  });
+});
+
+describe("MemoryDbService in recall infra", () => {
+  it("skips wikilink load when sync disabled", async () => {
+    const edges = await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* MemoryDbService;
+        return yield* db.loadWikilinkEdgesFromDatabase("/v", ["a.md"]).pipe(
+          Effect.catchAll(() => Effect.succeed([]))
+        );
+      }).pipe(Effect.provide(memoryDbLiveLayer()))
+    );
+    expect(Array.isArray(edges)).toBe(true);
+  });
+});

--- a/packages/clawql-memory/src/effect/memory-recall-vector-effect.ts
+++ b/packages/clawql-memory/src/effect/memory-recall-vector-effect.ts
@@ -98,7 +98,6 @@ export function recallMerkleSnapshotEffect(
   });
 }
 
-
 /** Load recall artifacts (chunks, cuckoo, merkle) when memory.db sync is enabled. */
 export function loadRecallArtifactsEffect(
   vault: string,
@@ -119,18 +118,20 @@ export function loadRecallArtifactsEffect(
       return null;
     }
 
-    return yield* db.loadRecallDbArtifacts(vault, [...mdFiles], {
-      loadChunks: wantChunks,
-      loadCuckoo: wantCuckoo,
-      loadMerkle: wantMerkle,
-    }).pipe(
-      Effect.catchAll((err) =>
-        Effect.sync(() => {
-          console.error(`[clawql-mcp] memory_recall artifact load failed: ${err.reason}`);
-          return null;
-        })
-      )
-    );
+    return yield* db
+      .loadRecallDbArtifacts(vault, [...mdFiles], {
+        loadChunks: wantChunks,
+        loadCuckoo: wantCuckoo,
+        loadMerkle: wantMerkle,
+      })
+      .pipe(
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            console.error(`[clawql-mcp] memory_recall artifact load failed: ${err.reason}`);
+            return null;
+          })
+        )
+      );
   });
 }
 

--- a/packages/clawql-memory/src/effect/memory-recall-vector-effect.ts
+++ b/packages/clawql-memory/src/effect/memory-recall-vector-effect.ts
@@ -1,0 +1,238 @@
+/**
+ * Recall vector ranking and memory.db artifact loading via Effect services.
+ */
+
+import { Effect } from "effect";
+import type { RecallDbArtifacts } from "../db/memory-db.js";
+import { queryPostgresVectorKnn } from "../vector/pgvector.js";
+import type { MemoryDbDocument } from "./memory-db-service.js";
+import { EmbeddingService } from "./embedding-service.js";
+import { MemoryDbService } from "./memory-db-service.js";
+import { memoryFromPromise } from "./memory-effect-utils.js";
+
+export type RecallVectorPassInput = {
+  readonly vault: string;
+  readonly query: string;
+  readonly mdFiles: readonly string[];
+  readonly topChunks: number;
+  readonly maxDocs: number;
+};
+
+export type RecallVectorPassResult = {
+  readonly vectorByRel: Map<string, number>;
+  readonly cuckooVectorChunksDropped?: number;
+  readonly recallArtifacts: RecallDbArtifacts | null;
+};
+
+function envFlagEnabled(key: string): boolean {
+  return process.env[key] === "1";
+}
+
+/** recallSyncDbEnabled document sync during vault scan. */
+export function recallSyncDocumentsOnScanEffect(
+  vault: string,
+  docs: MemoryDbDocument[]
+): Effect.Effect<void, never, MemoryDbService> {
+  return Effect.gen(function* () {
+    const db = yield* MemoryDbService;
+    if (!db.recallSyncDbEnabled()) return;
+    yield* db.syncMemoryDbFromDocuments(vault, docs).pipe(
+      Effect.catchAll((err) =>
+        Effect.sync(() => {
+          console.error(`[clawql-mcp] memory.db sync on recall failed: ${err.reason}`);
+        })
+      )
+    );
+  });
+}
+
+/** Merge wikilink edges from memory.db into recall graph seeding. */
+export function recallWikilinkEdgesEffect(
+  vault: string,
+  documentPaths: readonly string[]
+): Effect.Effect<readonly { fromPath: string; toPath: string }[], never, MemoryDbService> {
+  return Effect.gen(function* () {
+    const db = yield* MemoryDbService;
+    if (!db.memoryDbSyncEnabled() || documentPaths.length === 0) {
+      return [];
+    }
+    return yield* db.loadWikilinkEdgesFromDatabase(vault, [...documentPaths]).pipe(
+      Effect.catchAll((err) =>
+        Effect.sync(() => {
+          console.error(`[clawql-mcp] memory.db wikilink merge failed: ${err.reason}`);
+          return [];
+        })
+      )
+    );
+  });
+}
+
+export type RecallMerkleSnapshot = {
+  rootHex: string;
+  leafCount: number;
+  treeHeight: number;
+  builtAt: string;
+} | null;
+
+/** Resolve merkle snapshot from artifacts or memory.db. */
+export function recallMerkleSnapshotEffect(
+  vault: string,
+  recallArtifacts: RecallDbArtifacts | null
+): Effect.Effect<RecallMerkleSnapshot | undefined, never, MemoryDbService> {
+  return Effect.gen(function* () {
+    if (!envFlagEnabled("CLAWQL_MERKLE_ENABLED")) {
+      return undefined;
+    }
+    if (recallArtifacts != null) {
+      return recallArtifacts.merkleSnapshot;
+    }
+    const db = yield* MemoryDbService;
+    return yield* db.loadVaultMerkleSnapshotFromDb(vault).pipe(
+      Effect.catchAll((err) =>
+        Effect.sync(() => {
+          console.error(`[clawql-mcp] memory_recall merkle snapshot load failed: ${err.reason}`);
+          return null;
+        })
+      )
+    );
+  });
+}
+
+
+/** Load recall artifacts (chunks, cuckoo, merkle) when memory.db sync is enabled. */
+export function loadRecallArtifactsEffect(
+  vault: string,
+  mdFiles: readonly string[]
+): Effect.Effect<RecallDbArtifacts | null, never, EmbeddingService | MemoryDbService> {
+  return Effect.gen(function* () {
+    const db = yield* MemoryDbService;
+    const embedding = yield* EmbeddingService;
+    if (!db.memoryDbSyncEnabled()) {
+      return null;
+    }
+
+    const embCfg = embedding.resolveEmbeddingConfig();
+    const wantChunks = Boolean(embCfg);
+    const wantCuckoo = wantChunks && envFlagEnabled("CLAWQL_CUCKOO_ENABLED");
+    const wantMerkle = envFlagEnabled("CLAWQL_MERKLE_ENABLED");
+    if (!wantChunks && !wantMerkle) {
+      return null;
+    }
+
+    return yield* db.loadRecallDbArtifacts(vault, [...mdFiles], {
+      loadChunks: wantChunks,
+      loadCuckoo: wantCuckoo,
+      loadMerkle: wantMerkle,
+    }).pipe(
+      Effect.catchAll((err) =>
+        Effect.sync(() => {
+          console.error(`[clawql-mcp] memory_recall artifact load failed: ${err.reason}`);
+          return null;
+        })
+      )
+    );
+  });
+}
+
+/** Hybrid vector ranking: pgvector SQL when configured, else memory.db chunk BLOB KNN. */
+export function computeRecallVectorScoresEffect(
+  input: RecallVectorPassInput,
+  recallArtifacts: RecallDbArtifacts | null
+): Effect.Effect<RecallVectorPassResult, never, EmbeddingService | MemoryDbService> {
+  return Effect.gen(function* () {
+    const vectorByRel = new Map<string, number>();
+    const empty: RecallVectorPassResult = {
+      vectorByRel,
+      recallArtifacts,
+    };
+
+    const db = yield* MemoryDbService;
+    const embedding = yield* EmbeddingService;
+    const embCfg = embedding.resolveEmbeddingConfig();
+    if (!embCfg || !db.memoryDbSyncEnabled()) {
+      return empty;
+    }
+
+    const result = yield* Effect.gen(function* () {
+      const cuckooPred = recallArtifacts?.cuckooPred ?? null;
+      const qEmb = yield* embedding.embedQuery(input.query, embCfg);
+      if (qEmb.length === 0) {
+        return empty;
+      }
+
+      const rankFromMemoryDbBlobs = () => {
+        const chunks = recallArtifacts?.chunks ?? [];
+        if (chunks.length === 0) return [];
+        return embedding.rankDocumentsByChunkSimilarity(qEmb, chunks, {
+          topChunks: input.topChunks,
+          maxDocs: input.maxDocs,
+        });
+      };
+
+      let ranked: { path: string; score: number; chunkId: string }[] = [];
+      const vb = embedding.effectiveVectorBackend();
+      if (vb === "postgres") {
+        ranked = yield* memoryFromPromise(() =>
+          queryPostgresVectorKnn(qEmb, [...input.mdFiles], {
+            topChunks: input.topChunks,
+            maxDocs: input.maxDocs,
+          })
+        ).pipe(
+          Effect.catchAll((err) =>
+            Effect.sync(() => {
+              console.error(
+                `[clawql-mcp] memory_recall pgvector query failed, trying memory.db: ${err.reason}`
+              );
+              return [] as { path: string; score: number; chunkId: string }[];
+            })
+          )
+        );
+        if (ranked.length === 0) {
+          ranked = rankFromMemoryDbBlobs();
+        }
+      } else if (vb === "sqlite") {
+        ranked = rankFromMemoryDbBlobs();
+      }
+
+      let cuckooVectorChunksDropped: number | undefined;
+      if (cuckooPred) {
+        cuckooVectorChunksDropped = 0;
+        const next: typeof ranked = [];
+        for (const r of ranked) {
+          if (cuckooPred(r.chunkId)) next.push(r);
+          else cuckooVectorChunksDropped!++;
+        }
+        ranked = next;
+      }
+
+      for (const r of ranked) {
+        vectorByRel.set(r.path, r.score);
+      }
+
+      return {
+        vectorByRel,
+        cuckooVectorChunksDropped,
+        recallArtifacts,
+      } satisfies RecallVectorPassResult;
+    }).pipe(
+      Effect.catchAll((err) =>
+        Effect.sync(() => {
+          console.error(`[clawql-mcp] memory_recall vector pass failed: ${err.reason}`);
+          return empty;
+        })
+      )
+    );
+
+    return result;
+  });
+}
+
+/** Load artifacts then run vector ranking when embeddings are configured. */
+export function recallVectorPassEffect(
+  input: RecallVectorPassInput
+): Effect.Effect<RecallVectorPassResult, never, EmbeddingService | MemoryDbService> {
+  return Effect.gen(function* () {
+    const recallArtifacts = yield* loadRecallArtifactsEffect(input.vault, input.mdFiles);
+    return yield* computeRecallVectorScoresEffect(input, recallArtifacts);
+  });
+}

--- a/packages/clawql-memory/src/recall/recall.ts
+++ b/packages/clawql-memory/src/recall/recall.ts
@@ -1,27 +1,14 @@
 /**
  * memory_recall MCP tool — keyword search + wikilink graph traversal in the vault.
  * Optional vector seeds when CLAWQL_VECTOR_BACKEND is sqlite (BLOB KNN) or postgres (pgvector).
+ *
+ * Domain logic runs through Effect services in `src/effect/`; this module keeps types,
+ * test helpers, and Promise facades.
  */
 
 import { readVaultTextFile } from "../vault/utils.js";
-import { slugifyTitle } from "../ingest/slug.js";
-import {
-  loadRecallDbArtifacts,
-  loadVaultMerkleSnapshotFromDb,
-  loadWikilinkEdgesFromDatabase,
-  memoryDbSyncEnabled,
-  recallSyncDbEnabled,
-  syncMemoryDbFromDocuments,
-} from "../db/memory-db.js";
-import {
-  embedQuery,
-  rankDocumentsByChunkSimilarity,
-  resolveEmbeddingConfig,
-  effectiveVectorBackend,
-} from "../embedding/embedding.js";
-import { queryPostgresVectorKnn } from "../vector/pgvector.js";
-import { listVaultMarkdownRelPaths, buildSlugToVaultPath } from "../vault/slug-index.js";
-import { extractWikilinkTargets, stripVaultFrontmatter } from "../vault/markdown.js";
+import { listVaultMarkdownRelPaths } from "../vault/slug-index.js";
+import { stripVaultFrontmatter } from "../vault/markdown.js";
 
 /** Re-export for tests and callers that imported from this module. */
 export { extractWikilinkTargets } from "../vault/markdown.js";
@@ -63,20 +50,6 @@ export type MemoryRecallResult = {
   cuckooVectorChunksDropped?: number;
 };
 
-function envInt(key: string, def: number): number {
-  const v = process.env[key]?.trim();
-  if (!v) return def;
-  const n = Number.parseInt(v, 10);
-  return Number.isFinite(n) ? n : def;
-}
-
-function envFloat(key: string, def: number): number {
-  const v = process.env[key]?.trim();
-  if (!v) return def;
-  const n = Number.parseFloat(v);
-  return Number.isFinite(n) ? n : def;
-}
-
 function tokenize(text: string): string[] {
   return text
     .toLowerCase()
@@ -108,29 +81,6 @@ export function keywordScore(query: string, text: string): number {
   return s;
 }
 
-function buildSnippet(text: string, query: string, maxLen: number): string {
-  const body = stripVaultFrontmatter(text);
-  const terms = tokenize(query);
-  const lower = body.toLowerCase();
-  let pos = 0;
-  for (const t of terms) {
-    const i = lower.indexOf(t);
-    if (i !== -1) {
-      pos = Math.max(0, i - Math.floor(maxLen / 4));
-      break;
-    }
-  }
-  const slice = body.slice(pos, pos + maxLen).trim();
-  return slice.length < body.length ? `${slice}…` : slice;
-}
-
-function defaultScanRoot(): string {
-  const v = process.env.CLAWQL_MEMORY_RECALL_SCAN_ROOT;
-  if (v === undefined) return "Memory";
-  const t = v.trim();
-  return t === "" ? "" : t;
-}
-
 /** Public async facade for vault recall (MCP tools, scripts). */
 export async function runMemoryRecall(input: MemoryRecallInput): Promise<MemoryRecallResult> {
   const { runMemoryEffect, memoryRecallProgram } =
@@ -143,269 +93,15 @@ export async function executeMemoryRecall(input: MemoryRecallInput): Promise<Mem
   return runMemoryRecall(input);
 }
 
-/** Recall scan + ranking body (vault path already resolved). */
+/** Recall body (vault path already resolved) — delegates to Effect core program. */
 export async function executeMemoryRecallCore(
   vault: string,
   input: MemoryRecallInput
 ): Promise<MemoryRecallResult> {
-  const { runBeforeRecallVaultSync } = await import("../sync/vault-sync-hooks.js");
-  await runBeforeRecallVaultSync();
-
-  const query = input.query?.trim();
-  if (!query) {
-    return { ok: false, error: "query is required" };
-  }
-
-  const limit = input.limit !== undefined ? input.limit : envInt("CLAWQL_MEMORY_RECALL_LIMIT", 10);
-  const maxDepth =
-    input.maxDepth !== undefined ? input.maxDepth : envInt("CLAWQL_MEMORY_RECALL_MAX_DEPTH", 2);
-  const minScore =
-    input.minScore !== undefined ? input.minScore : envInt("CLAWQL_MEMORY_RECALL_MIN_SCORE", 1);
-  const maxFiles = envInt("CLAWQL_MEMORY_RECALL_MAX_FILES", 2000);
-  const snippetChars = envInt("CLAWQL_MEMORY_RECALL_SNIPPET_CHARS", 520);
-  const scanRoot = defaultScanRoot();
-
-  let mdFiles: string[];
-  try {
-    mdFiles = await listVaultMarkdownRelPaths(vault, scanRoot, maxFiles);
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    return { ok: false, error: `Cannot scan vault: ${msg}` };
-  }
-
-  const truncated = mdFiles.length >= maxFiles;
-
-  type FileInfo = { rel: string; text: string; score: number };
-  const files: FileInfo[] = [];
-  for (const rel of mdFiles) {
-    try {
-      const text = await readVaultTextFile(vault, rel);
-      const score = keywordScore(query, text);
-      files.push({ rel, text, score });
-    } catch {
-      /* skip unreadable */
-    }
-  }
-
-  const now = Date.now();
-  if (recallSyncDbEnabled()) {
-    try {
-      await syncMemoryDbFromDocuments(
-        vault,
-        files.map((f) => ({ path: f.rel, text: f.text, mtimeMs: now }))
-      );
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      console.error(`[clawql-mcp] memory.db sync on recall failed: ${msg}`);
-    }
-  }
-
-  const slugToPath = buildSlugToVaultPath(files.map((f) => ({ path: f.rel, text: f.text })));
-
-  const forward = new Map<string, Set<string>>();
-  const back = new Map<string, Set<string>>();
-  function addEdge(a: string, b: string): void {
-    if (a === b) return;
-    if (!forward.has(a)) forward.set(a, new Set());
-    forward.get(a)!.add(b);
-    if (!back.has(b)) back.set(b, new Set());
-    back.get(b)!.add(a);
-  }
-
-  for (const { rel, text } of files) {
-    for (const target of extractWikilinkTargets(text)) {
-      const slug = slugifyTitle(target);
-      const dest = slugToPath.get(slug);
-      if (dest) addEdge(rel, dest);
-    }
-  }
-
-  const textByRel = new Map(files.map((f) => [f.rel, f.text]));
-  if (memoryDbSyncEnabled() && files.length > 0) {
-    try {
-      const extra = await loadWikilinkEdgesFromDatabase(
-        vault,
-        files.map((f) => f.rel)
-      );
-      for (const e of extra) {
-        if (textByRel.has(e.toPath)) addEdge(e.fromPath, e.toPath);
-      }
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.error(`[clawql-mcp] memory.db wikilink merge failed: ${msg}`);
-    }
-  }
-
-  function neighbors(p: string): string[] {
-    const a = [...(forward.get(p) ?? [])];
-    const b = [...(back.get(p) ?? [])];
-    return [...new Set([...a, ...b])];
-  }
-
-  const embCfg = resolveEmbeddingConfig();
-  let recallArtifacts: Awaited<ReturnType<typeof loadRecallDbArtifacts>> | null = null;
-  if (memoryDbSyncEnabled()) {
-    const wantChunks = Boolean(embCfg);
-    const wantCuckoo = wantChunks && process.env.CLAWQL_CUCKOO_ENABLED === "1";
-    const wantMerkle = process.env.CLAWQL_MERKLE_ENABLED === "1";
-    if (wantChunks || wantMerkle) {
-      recallArtifacts = await loadRecallDbArtifacts(vault, mdFiles, {
-        loadChunks: wantChunks,
-        loadCuckoo: wantCuckoo,
-        loadMerkle: wantMerkle,
-      });
-    }
-  }
-
-  const vectorByRel = new Map<string, number>();
-  let cuckooVectorChunksDropped: number | undefined;
-  if (embCfg && memoryDbSyncEnabled()) {
-    try {
-      const cuckooPred = recallArtifacts?.cuckooPred ?? null;
-      const qEmb = await embedQuery(query, embCfg);
-      if (qEmb.length > 0) {
-        const topChunks = envInt("CLAWQL_MEMORY_VECTOR_TOP_CHUNKS", 80);
-        const maxDocs = envInt("CLAWQL_MEMORY_VECTOR_MAX_DOCS", 12);
-        const vb = effectiveVectorBackend();
-        const rankFromMemoryDbBlobs = async () => {
-          const chunks = recallArtifacts?.chunks ?? [];
-          if (chunks.length === 0) return [];
-          return rankDocumentsByChunkSimilarity(qEmb, chunks, {
-            topChunks,
-            maxDocs,
-          });
-        };
-
-        let ranked: { path: string; score: number; chunkId: string }[] = [];
-        if (vb === "postgres") {
-          try {
-            ranked = await queryPostgresVectorKnn(qEmb, mdFiles, { topChunks, maxDocs });
-          } catch (pgErr: unknown) {
-            const msg = pgErr instanceof Error ? pgErr.message : String(pgErr);
-            console.error(
-              `[clawql-mcp] memory_recall pgvector query failed, trying memory.db: ${msg}`
-            );
-            ranked = [];
-          }
-          if (ranked.length === 0) {
-            ranked = await rankFromMemoryDbBlobs();
-          }
-        } else if (vb === "sqlite") {
-          ranked = await rankFromMemoryDbBlobs();
-        }
-
-        if (cuckooPred) {
-          cuckooVectorChunksDropped = 0;
-          const next: typeof ranked = [];
-          for (const r of ranked) {
-            if (cuckooPred(r.chunkId)) next.push(r);
-            else cuckooVectorChunksDropped++;
-          }
-          ranked = next;
-        }
-
-        for (const r of ranked) {
-          vectorByRel.set(r.path, r.score);
-        }
-      }
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      console.error(`[clawql-mcp] memory_recall vector pass failed: ${msg}`);
-    }
-  }
-
-  const vectorBoost = envFloat("CLAWQL_MEMORY_VECTOR_SCORE_BOOST", 50);
-  const minVectorSim = envFloat("CLAWQL_MEMORY_VECTOR_MIN_SIM", 0.28);
-  const scoreByRel = new Map<string, number>();
-  for (const f of files) {
-    const vs = vectorByRel.get(f.rel) ?? 0;
-    scoreByRel.set(f.rel, Math.max(f.score, vs * vectorBoost));
-  }
-  for (const [p, sim] of vectorByRel) {
-    if (!scoreByRel.has(p)) scoreByRel.set(p, sim * vectorBoost);
-  }
-
-  const seedSet = new Set<string>();
-  for (const f of files) {
-    if (f.score >= minScore) seedSet.add(f.rel);
-  }
-  for (const [p, sim] of vectorByRel) {
-    if (sim >= minVectorSim) seedSet.add(p);
-  }
-  const seeds = [...seedSet].sort((a, b) => (scoreByRel.get(b) ?? 0) - (scoreByRel.get(a) ?? 0));
-
-  type Q = { rel: string; depth: number; reason: "keyword" | "link" | "vector"; from?: string };
-  const queue: Q[] = [];
-  const seen = new Set<string>();
-
-  for (const s of seeds) {
-    if (!seen.has(s)) {
-      const kw = files.find((x) => x.rel === s);
-      const kwOk = (kw?.score ?? 0) >= minScore;
-      queue.push({
-        rel: s,
-        depth: 0,
-        reason: kwOk ? "keyword" : "vector",
-      });
-      seen.add(s);
-    }
-  }
-
-  const hits: RecallHit[] = [];
-  while (queue.length > 0 && hits.length < limit) {
-    const cur = queue.shift()!;
-    const t = textByRel.get(cur.rel);
-    if (!t) continue;
-
-    hits.push({
-      path: cur.rel,
-      score: scoreByRel.get(cur.rel) ?? 0,
-      depth: cur.depth,
-      reason: cur.reason,
-      linkFrom: cur.from,
-      snippet: buildSnippet(t, query, snippetChars),
-    });
-
-    if (cur.depth >= maxDepth) continue;
-
-    for (const n of neighbors(cur.rel)) {
-      if (seen.has(n)) continue;
-      seen.add(n);
-      queue.push({
-        rel: n,
-        depth: cur.depth + 1,
-        reason: "link",
-        from: cur.rel,
-      });
-    }
-  }
-
-  hits.sort((a, b) => {
-    if (a.depth !== b.depth) return a.depth - b.depth;
-    return b.score - a.score;
-  });
-
-  const result: MemoryRecallResult = {
-    ok: true,
-    query,
-    results: hits.slice(0, limit),
-    truncated,
-    scannedFiles: files.length,
-  };
-  if (process.env.CLAWQL_MERKLE_ENABLED === "1") {
-    try {
-      result.merkleSnapshot =
-        recallArtifacts != null
-          ? recallArtifacts.merkleSnapshot
-          : await loadVaultMerkleSnapshotFromDb(vault);
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      console.error(`[clawql-mcp] memory_recall merkle snapshot load failed: ${msg}`);
-      result.merkleSnapshot = null;
-    }
-  }
-  if (cuckooVectorChunksDropped !== undefined) {
-    result.cuckooVectorChunksDropped = cuckooVectorChunksDropped;
-  }
-  return result;
+  const { runMemoryEffect } = await import("../effect/memory-effect-runtime.js");
+  const { executeMemoryRecallCoreEffect } = await import("../effect/memory-recall-effect.js");
+  return runMemoryEffect(executeMemoryRecallCoreEffect(vault, input));
 }
+
+// Re-export vault scan helpers used by integration tests
+export { readVaultTextFile, listVaultMarkdownRelPaths, stripVaultFrontmatter };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the clawql-memory Effect migration (step 3b): recall vector ranking and memory.db artifact loading now run through native `Effect.gen` programs backed by `EmbeddingService` and `MemoryDbService`.

- Add `memory-recall-vector-effect.ts` with `loadRecallArtifactsEffect`, `computeRecallVectorScoresEffect`, `recallVectorPassEffect`, plus db sync / wikilink / merkle helpers
- Move full recall pipeline into `executeMemoryRecallCoreEffect` in `memory-recall-effect.ts`
- Slim `recall.ts` to types, `keywordScore`, and Promise facades
- Add unit tests for vector pass when embeddings/db sync are disabled

## Test plan

- [x] `npm run build -w clawql-memory`
- [x] `npx vitest run packages/clawql-memory/src` (15 tests)
- [x] ESLint on changed files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

