### PR TITLE
feat(documents): Effect bridge for ingest_external_knowledge

### DIFF
--- a/packages/clawql-documents/src/effect/documents-effect-runtime.ts
+++ b/packages/clawql-documents/src/effect/documents-effect-runtime.ts
@@ -1,0 +1,34 @@
+import { Cause, Effect, Exit, Layer } from "effect";
+import { vaultConfigLiveLayer, VaultConfigService } from "clawql-memory/plugin";
+import type { ExternalIngestInput, ExternalIngestResult } from "../ingest/external-ingest.js";
+import { DocumentsIngestService, documentsIngestLiveLayer } from "./documents-ingest-service.js";
+
+export type DocumentsServices = VaultConfigService | DocumentsIngestService;
+
+/** Merged Effect Layer for clawql-documents domain services + memory vault config. */
+export function documentsServicesLiveLayer(): Layer.Layer<DocumentsServices> {
+  return Layer.mergeAll(vaultConfigLiveLayer(), documentsIngestLiveLayer());
+}
+
+/** Run a documents Effect program with default services Layer. */
+export async function runDocumentsEffect<A, E>(
+  program: Effect.Effect<A, E, DocumentsServices>
+): Promise<A> {
+  const exit = await Effect.runPromiseExit(
+    program.pipe(Effect.provide(documentsServicesLiveLayer()))
+  );
+  if (Exit.isSuccess(exit)) {
+    return exit.value;
+  }
+  throw Cause.squash(exit.cause);
+}
+
+/** External ingest via Effect services (used by {@link runIngestExternalKnowledge}). */
+export function documentsIngestProgram(
+  input: ExternalIngestInput
+): Effect.Effect<ExternalIngestResult, unknown, DocumentsServices> {
+  return Effect.gen(function* () {
+    const ingest = yield* DocumentsIngestService;
+    return yield* ingest.ingest(input);
+  });
+}

--- a/packages/clawql-documents/src/effect/documents-effect-utils.ts
+++ b/packages/clawql-documents/src/effect/documents-effect-utils.ts
@@ -1,0 +1,19 @@
+import { Effect } from "effect";
+import { DocumentsError } from "./documents-errors.js";
+
+/** Lift a Promise into Effect with {@link DocumentsError} on failure. */
+export function documentsFromPromise<A>(tryFn: () => Promise<A>): Effect.Effect<A, DocumentsError> {
+  return Effect.tryPromise({
+    try: tryFn,
+    catch: (cause) =>
+      new DocumentsError({
+        reason: "documents async operation failed",
+        cause,
+      }),
+  });
+}
+
+/** Run sync code in Effect. */
+export function documentsSync<A>(fn: () => A): Effect.Effect<A> {
+  return Effect.sync(fn);
+}

--- a/packages/clawql-documents/src/effect/documents-errors.ts
+++ b/packages/clawql-documents/src/effect/documents-errors.ts
@@ -1,0 +1,7 @@
+import { Data } from "effect";
+
+/** Unexpected failure in a documents Effect pipeline (vault I/O, fetch, etc.). */
+export class DocumentsError extends Data.TaggedError("DocumentsError")<{
+  readonly reason: string;
+  readonly cause?: unknown;
+}> {}

--- a/packages/clawql-documents/src/effect/documents-ingest-service.ts
+++ b/packages/clawql-documents/src/effect/documents-ingest-service.ts
@@ -1,0 +1,24 @@
+import { Context, Effect, Layer } from "effect";
+import { VaultConfigService } from "clawql-memory/plugin";
+import type { ExternalIngestInput, ExternalIngestResult } from "../ingest/external-ingest.js";
+import { executeExternalIngestEffect } from "./external-ingest-effect.js";
+import { DocumentsError } from "./documents-errors.js";
+
+/** Effect service for external knowledge ingest (`ingest_external_knowledge`). */
+export class DocumentsIngestService extends Context.Tag("clawql/DocumentsIngestService")<
+  DocumentsIngestService,
+  {
+    readonly ingest: (
+      input: ExternalIngestInput
+    ) => Effect.Effect<ExternalIngestResult, DocumentsError, VaultConfigService>;
+  }
+>() {}
+
+export function documentsIngestLiveLayer(): Layer.Layer<DocumentsIngestService> {
+  return Layer.succeed(
+    DocumentsIngestService,
+    DocumentsIngestService.of({
+      ingest: executeExternalIngestEffect,
+    })
+  );
+}

--- a/packages/clawql-documents/src/effect/external-ingest-effect.test.ts
+++ b/packages/clawql-documents/src/effect/external-ingest-effect.test.ts
@@ -1,0 +1,24 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { documentsServicesLiveLayer } from "./documents-effect-runtime.js";
+import { executeExternalIngestEffect } from "./external-ingest-effect.js";
+
+describe("executeExternalIngestEffect", () => {
+  it("returns disabled stub when CLAWQL_EXTERNAL_INGEST is unset", async () => {
+    const saved = process.env.CLAWQL_EXTERNAL_INGEST;
+    delete process.env.CLAWQL_EXTERNAL_INGEST;
+    try {
+      const result = await Effect.runPromise(
+        executeExternalIngestEffect({ source: "notion" }).pipe(
+          Effect.provide(documentsServicesLiveLayer())
+        )
+      );
+      expect(result.ok).toBe(false);
+      expect(result.enabled).toBe(false);
+      expect(result.stub).toBe(true);
+    } finally {
+      if (saved === undefined) delete process.env.CLAWQL_EXTERNAL_INGEST;
+      else process.env.CLAWQL_EXTERNAL_INGEST = saved;
+    }
+  });
+});

--- a/packages/clawql-documents/src/effect/external-ingest-effect.ts
+++ b/packages/clawql-documents/src/effect/external-ingest-effect.ts
@@ -1,0 +1,20 @@
+import { Effect } from "effect";
+import { VaultConfigService } from "clawql-memory/plugin";
+import {
+  executeExternalIngestCore,
+  type ExternalIngestInput,
+  type ExternalIngestResult,
+} from "../ingest/external-ingest.js";
+import { DocumentsError } from "./documents-errors.js";
+import { documentsFromPromise } from "./documents-effect-utils.js";
+
+/** External ingest pipeline as Effect.gen — vault path via {@link VaultConfigService}. */
+export function executeExternalIngestEffect(
+  input: ExternalIngestInput
+): Effect.Effect<ExternalIngestResult, DocumentsError, VaultConfigService> {
+  return Effect.gen(function* () {
+    const vaultConfig = yield* VaultConfigService;
+    const vault = vaultConfig.getObsidianVaultPath();
+    return yield* documentsFromPromise(() => executeExternalIngestCore(vault, input));
+  });
+}

--- a/packages/clawql-documents/src/effect/index.ts
+++ b/packages/clawql-documents/src/effect/index.ts
@@ -1,0 +1,10 @@
+export { DocumentsError } from "./documents-errors.js";
+export { documentsFromPromise, documentsSync } from "./documents-effect-utils.js";
+export { executeExternalIngestEffect } from "./external-ingest-effect.js";
+export { DocumentsIngestService, documentsIngestLiveLayer } from "./documents-ingest-service.js";
+export {
+  documentsIngestProgram,
+  documentsServicesLiveLayer,
+  runDocumentsEffect,
+  type DocumentsServices,
+} from "./documents-effect-runtime.js";

--- a/packages/clawql-documents/src/ingest/external-ingest.ts
+++ b/packages/clawql-documents/src/ingest/external-ingest.ts
@@ -10,7 +10,6 @@ import { getClawqlOptionalToolFlags } from "clawql-api";
 import { maybePresidioRedactText, presidioEnabled } from "clawql-api";
 import { buildUrlIngestNote, formatUrlResponseAsMarkdown } from "./url-format.js";
 import { slugifyTitle } from "clawql-memory/ingest/slug";
-import { getObsidianVaultPath } from "clawql-memory/vault/config";
 import {
   resolveVaultPath,
   withVaultWriteLock,
@@ -198,11 +197,13 @@ async function fetchUrlResource(urlStr: string): Promise<{
 
 /**
  * Run external ingest: Markdown documents and/or (opt-in) URL fetch.
+ * Vault path is resolved by the caller (Effect layer or tests).
  */
-export async function runIngestExternalKnowledge(
+export async function executeExternalIngestCore(
+  vault: string | null,
   input: ExternalIngestInput
 ): Promise<ExternalIngestResult> {
-  const vaultConfigured = getObsidianVaultPath() !== null;
+  const vaultConfigured = vault !== null;
   if (!getClawqlOptionalToolFlags().enableDocuments) {
     return {
       ok: false,
@@ -217,7 +218,6 @@ export async function runIngestExternalKnowledge(
   }
   const enabled = externalIngestFeatureEnabled();
   const dryRun = input.dryRun !== false;
-  const vault = getObsidianVaultPath();
 
   if (!enabled) {
     return {
@@ -475,4 +475,13 @@ export async function runIngestExternalKnowledge(
     relatedIssues: [40, 24, 25, 27],
     ...hints,
   };
+}
+
+/** Public async facade for external ingest (MCP tools, scripts). */
+export async function runIngestExternalKnowledge(
+  input: ExternalIngestInput
+): Promise<ExternalIngestResult> {
+  const { runDocumentsEffect, documentsIngestProgram } =
+    await import("../effect/documents-effect-runtime.js");
+  return runDocumentsEffect(documentsIngestProgram(input));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First clawql-documents Effect migration slice: route `ingest_external_knowledge` through native Effect services, mirroring the clawql-memory ingest bridge pattern.

- Add `packages/clawql-documents/src/effect/` with `DocumentsIngestService`, `executeExternalIngestEffect`, and `documentsServicesLiveLayer` (reuses memory `VaultConfigService`)
- Extract `executeExternalIngestCore(vault, input)` from async facade
- `runIngestExternalKnowledge` delegates to `runDocumentsEffect(documentsIngestProgram(input))`

No MCP behavior change; domain I/O remains async inside the core until a later native Effect rewrite.

## Test plan

- [x] `npm run build -w clawql-documents`
- [x] `npx vitest run packages/clawql-documents/src` (27 tests)
- [x] `npx vitest run src/external-ingest.test.ts` (8 tests)
- [x] ESLint + Prettier on changed files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

