### PR TITLE
feat(memory): post-sync vault index via MemoryDbService

### DIFF
--- a/packages/clawql-documents/src/ingest/external-ingest.ts
+++ b/packages/clawql-documents/src/ingest/external-ingest.ts
@@ -113,43 +113,13 @@ function defaultPathForUrl(urlStr: string): string {
 async function loadOptionalArtifactHints(
   vault: string
 ): Promise<Pick<ExternalIngestResult, "merkleSnapshot" | "cuckooMembershipReady">> {
-  let merkleSnapshot: ExternalIngestResult["merkleSnapshot"];
-  let cuckooMembershipReady: boolean | undefined;
-  try {
-    const { loadVaultMerkleSnapshotFromDb, memoryDbSyncEnabled } =
-      await import("clawql-memory/db/memory-db");
-    if (memoryDbSyncEnabled()) {
-      if (process.env.CLAWQL_MERKLE_ENABLED === "1") {
-        merkleSnapshot = await loadVaultMerkleSnapshotFromDb(vault);
-      }
-      if (process.env.CLAWQL_CUCKOO_ENABLED === "1") {
-        cuckooMembershipReady = true;
-      }
-    }
-  } catch {
-    /* ignore */
-  }
-  return {
-    ...(merkleSnapshot !== undefined ? { merkleSnapshot } : {}),
-    ...(cuckooMembershipReady !== undefined ? { cuckooMembershipReady } : {}),
-  };
+  const { runMemoryEffect, vaultArtifactHintsEffect } = await import("clawql-memory/plugin");
+  return runMemoryEffect(vaultArtifactHintsEffect(vault));
 }
 
 async function afterImportSync(vault: string): Promise<void> {
-  try {
-    const { syncMemoryDbForVaultScanRoot } = await import("clawql-memory/db/memory-db");
-    await syncMemoryDbForVaultScanRoot(vault);
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    console.error(`[clawql-mcp] memory.db sync after external ingest failed: ${msg}`);
-  }
-  try {
-    const { updateProviderIndexPage } = await import("clawql-memory/vault/provider-index");
-    await updateProviderIndexPage(vault);
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    console.error(`[clawql-mcp] provider index update after external ingest failed: ${msg}`);
-  }
+  const { runMemoryEffect, vaultWritePostSyncEffect } = await import("clawql-memory/plugin");
+  await runMemoryEffect(vaultWritePostSyncEffect(vault));
 }
 
 async function fetchUrlResource(urlStr: string): Promise<{

--- a/packages/clawql-memory/src/effect/index.ts
+++ b/packages/clawql-memory/src/effect/index.ts
@@ -35,3 +35,12 @@ export {
   type MemoryInfrastructureServices,
   type MemoryServices,
 } from "./memory-effect-runtime.js";
+export {
+  memoryIngestPostSyncExtrasEffect,
+  vaultArtifactHintsEffect,
+  vaultDbScanSyncEffect,
+  vaultProviderIndexEffect,
+  vaultWritePostSyncEffect,
+  type VaultArtifactHints,
+  type VaultPostSyncExtras,
+} from "./memory-vault-post-sync-effect.js";

--- a/packages/clawql-memory/src/effect/memory-vault-post-sync-effect.test.ts
+++ b/packages/clawql-memory/src/effect/memory-vault-post-sync-effect.test.ts
@@ -1,0 +1,36 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { MemoryDbService, memoryDbLiveLayer } from "./memory-db-service.js";
+import {
+  memoryIngestPostSyncExtrasEffect,
+  vaultArtifactHintsEffect,
+  vaultWritePostSyncEffect,
+} from "./memory-vault-post-sync-effect.js";
+
+describe("memory vault post-sync effects", () => {
+  it("vaultArtifactHintsEffect returns empty when sync disabled", async () => {
+    const hints = await Effect.runPromise(
+      vaultArtifactHintsEffect("/tmp/vault").pipe(Effect.provide(memoryDbLiveLayer()))
+    );
+    expect(hints).toEqual({});
+  });
+
+  it("memoryIngestPostSyncExtrasEffect returns empty when sync disabled", async () => {
+    const extras = await Effect.runPromise(
+      memoryIngestPostSyncExtrasEffect("/tmp/vault").pipe(Effect.provide(memoryDbLiveLayer()))
+    );
+    expect(extras).toEqual({});
+  });
+
+  it("vaultWritePostSyncEffect completes when sync disabled", async () => {
+    await Effect.runPromise(
+      vaultWritePostSyncEffect("/tmp/vault").pipe(Effect.provide(memoryDbLiveLayer()))
+    );
+    const db = await Effect.runPromise(
+      Effect.gen(function* () {
+        return yield* MemoryDbService;
+      }).pipe(Effect.provide(memoryDbLiveLayer()))
+    );
+    expect(db.memoryDbSyncEnabled()).toBe(false);
+  });
+});

--- a/packages/clawql-memory/src/effect/memory-vault-post-sync-effect.ts
+++ b/packages/clawql-memory/src/effect/memory-vault-post-sync-effect.ts
@@ -1,0 +1,155 @@
+/**
+ * Post-write vault index sync via MemoryDbService (ingest, external ingest, recall).
+ */
+
+import { Effect, Exit } from "effect";
+import type { MerkleSnapshotPayload } from "../ingest/ingest.js";
+import { MemoryDbService } from "./memory-db-service.js";
+import { memoryFromPromise } from "./memory-effect-utils.js";
+
+export type VaultPostSyncExtras = {
+  merkleSnapshotBefore?: MerkleSnapshotPayload | null;
+  merkleSnapshot?: MerkleSnapshotPayload | null;
+  merkleRootChanged?: boolean;
+  cuckooMembershipReady?: boolean;
+};
+
+export type VaultArtifactHints = {
+  merkleSnapshot?: MerkleSnapshotPayload | null;
+  cuckooMembershipReady?: boolean;
+};
+
+function envFlagEnabled(key: string): boolean {
+  return process.env[key] === "1";
+}
+
+/** Current merkle row + cuckoo flag when memory.db sync is enabled (dry-run hints). */
+export function vaultArtifactHintsEffect(
+  vault: string
+): Effect.Effect<VaultArtifactHints, never, MemoryDbService> {
+  return Effect.gen(function* () {
+    const db = yield* MemoryDbService;
+    const hints: VaultArtifactHints = {};
+    if (!db.memoryDbSyncEnabled()) {
+      return hints;
+    }
+    if (envFlagEnabled("CLAWQL_MERKLE_ENABLED")) {
+      const merkleSnapshot = yield* db.loadVaultMerkleSnapshotFromDb(vault).pipe(
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            console.error(`[clawql-mcp] memory.db merkle snapshot hint load failed: ${err.reason}`);
+            return null;
+          })
+        )
+      );
+      hints.merkleSnapshot = merkleSnapshot;
+    }
+    if (envFlagEnabled("CLAWQL_CUCKOO_ENABLED")) {
+      hints.cuckooMembershipReady = true;
+    }
+    return hints;
+  });
+}
+
+/** Sync memory.db scan root only. */
+export function vaultDbScanSyncEffect(vault: string): Effect.Effect<void, never, MemoryDbService> {
+  return Effect.gen(function* () {
+    const db = yield* MemoryDbService;
+    if (!db.memoryDbSyncEnabled()) return;
+    yield* db.syncMemoryDbForVaultScanRoot(vault).pipe(
+      Effect.catchAll((err) =>
+        Effect.sync(() => {
+          console.error(`[clawql-mcp] memory.db sync failed: ${err.reason}`);
+        })
+      )
+    );
+  });
+}
+
+/** Update vault provider index page after writes. */
+export function vaultProviderIndexEffect(vault: string): Effect.Effect<void, never> {
+  return memoryFromPromise(async () => {
+    const { updateProviderIndexPage } = await import("../vault/provider-index.js");
+    await updateProviderIndexPage(vault);
+  }).pipe(
+    Effect.catchAll((err) =>
+      Effect.sync(() => {
+        console.error(`[clawql-mcp] provider index update failed: ${err.reason}`);
+      })
+    )
+  );
+}
+
+/** Sync memory.db scan root + update provider index page after vault writes. */
+export function vaultWritePostSyncEffect(
+  vault: string
+): Effect.Effect<void, never, MemoryDbService> {
+  return Effect.gen(function* () {
+    yield* vaultDbScanSyncEffect(vault);
+    yield* vaultProviderIndexEffect(vault);
+  });
+}
+
+/** Post-ingest memory.db sync with merkle before/after and cuckoo membership flag. */
+export function memoryIngestPostSyncExtrasEffect(
+  vault: string
+): Effect.Effect<VaultPostSyncExtras, never, MemoryDbService> {
+  return Effect.gen(function* () {
+    const db = yield* MemoryDbService;
+    const extras: VaultPostSyncExtras = {};
+    const merkleOn = envFlagEnabled("CLAWQL_MERKLE_ENABLED");
+
+    let merkleBefore: MerkleSnapshotPayload | null | undefined;
+    if (merkleOn && db.memoryDbSyncEnabled()) {
+      merkleBefore = yield* db.loadVaultMerkleSnapshotFromDb(vault).pipe(
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            console.error(
+              `[clawql-mcp] memory.db merkle snapshot (before ingest sync) failed: ${err.reason}`
+            );
+            return null;
+          })
+        )
+      );
+    }
+
+    if (!db.memoryDbSyncEnabled()) {
+      return extras;
+    }
+
+    const syncExit = yield* Effect.exit(vaultDbScanSyncEffect(vault));
+    if (Exit.isFailure(syncExit)) {
+      const reason = syncExit.cause;
+      console.error(`[clawql-mcp] memory.db sync after ingest failed: ${String(reason)}`);
+      return extras;
+    }
+
+    if (envFlagEnabled("CLAWQL_CUCKOO_ENABLED")) {
+      extras.cuckooMembershipReady = true;
+    }
+
+    if (merkleOn) {
+      const merkleAfter = yield* db.loadVaultMerkleSnapshotFromDb(vault).pipe(
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            console.error(
+              `[clawql-mcp] memory.db merkle snapshot (after ingest sync) failed: ${err.reason}`
+            );
+            return null;
+          })
+        )
+      );
+      const merklePrior = merkleBefore ?? null;
+      extras.merkleSnapshotBefore = merklePrior;
+      extras.merkleSnapshot = merkleAfter;
+      extras.merkleRootChanged =
+        merkleAfter === null
+          ? undefined
+          : merklePrior === null
+            ? true
+            : merklePrior.rootHex !== merkleAfter.rootHex;
+    }
+
+    return extras;
+  });
+}

--- a/packages/clawql-memory/src/ingest/ingest.ts
+++ b/packages/clawql-memory/src/ingest/ingest.ts
@@ -280,69 +280,11 @@ export async function executeMemoryIngestCore(
   });
 
   if (result.ok && !result.skipped) {
-    const indexExtras: Pick<
-      MemoryIngestResult,
-      "merkleSnapshotBefore" | "merkleSnapshot" | "merkleRootChanged" | "cuckooMembershipReady"
-    > = {};
-
-    const { syncMemoryDbForVaultScanRoot, loadVaultMerkleSnapshotFromDb, memoryDbSyncEnabled } =
-      await import("../db/memory-db.js");
-
-    const merkleOn = process.env.CLAWQL_MERKLE_ENABLED === "1";
-    let merkleBefore: Awaited<ReturnType<typeof loadVaultMerkleSnapshotFromDb>> | undefined;
-    if (merkleOn && memoryDbSyncEnabled()) {
-      try {
-        merkleBefore = await loadVaultMerkleSnapshotFromDb(vault);
-      } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e);
-        console.error(`[clawql-mcp] memory.db merkle snapshot (before ingest sync) failed: ${msg}`);
-        merkleBefore = null;
-      }
-    }
-
-    let syncOk = false;
-    if (memoryDbSyncEnabled()) {
-      try {
-        await syncMemoryDbForVaultScanRoot(vault);
-        syncOk = true;
-      } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e);
-        console.error(`[clawql-mcp] memory.db sync after ingest failed: ${msg}`);
-      }
-    }
-
-    if (syncOk) {
-      if (process.env.CLAWQL_CUCKOO_ENABLED === "1") {
-        indexExtras.cuckooMembershipReady = true;
-      }
-      if (merkleOn) {
-        try {
-          const merkleAfter = await loadVaultMerkleSnapshotFromDb(vault);
-          const merklePrior = merkleBefore ?? null;
-          indexExtras.merkleSnapshotBefore = merklePrior;
-          indexExtras.merkleSnapshot = merkleAfter;
-          indexExtras.merkleRootChanged =
-            merkleAfter === null
-              ? undefined
-              : merklePrior === null
-                ? true
-                : merklePrior.rootHex !== merkleAfter.rootHex;
-        } catch (e: unknown) {
-          const msg = e instanceof Error ? e.message : String(e);
-          console.error(
-            `[clawql-mcp] memory.db merkle snapshot (after ingest sync) failed: ${msg}`
-          );
-        }
-      }
-    }
-
-    try {
-      const { updateProviderIndexPage } = await import("../vault/provider-index.js");
-      await updateProviderIndexPage(vault);
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      console.error(`[clawql-mcp] provider index update after ingest failed: ${msg}`);
-    }
+    const { runMemoryEffect } = await import("../effect/memory-effect-runtime.js");
+    const { memoryIngestPostSyncExtrasEffect, vaultProviderIndexEffect } =
+      await import("../effect/memory-vault-post-sync-effect.js");
+    const indexExtras = await runMemoryEffect(memoryIngestPostSyncExtrasEffect(vault));
+    await runMemoryEffect(vaultProviderIndexEffect(vault));
     const { runAfterIngestVaultSync } = await import("../sync/vault-sync-hooks.js");
     await runAfterIngestVaultSync();
     return { ...result, ...indexExtras };

--- a/packages/clawql-memory/src/plugin/index.ts
+++ b/packages/clawql-memory/src/plugin/index.ts
@@ -27,4 +27,11 @@ export {
   executeMemoryRecallEffect,
   type MemoryServices,
   type MemoryInfrastructureServices,
+  memoryIngestPostSyncExtrasEffect,
+  vaultArtifactHintsEffect,
+  vaultDbScanSyncEffect,
+  vaultProviderIndexEffect,
+  vaultWritePostSyncEffect,
+  type VaultArtifactHints,
+  type VaultPostSyncExtras,
 } from "../effect/index.js";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Route memory ingest and external ingest post-write sync through `MemoryDbService` Effect programs.

- Add `memory-vault-post-sync-effect.ts`: ingest extras (merkle before/after, cuckoo), artifact hints, db scan sync, provider index
- `executeMemoryIngestCore` uses `runMemoryEffect` instead of direct `memory-db.js` imports
- `external-ingest` `afterImportSync` / `loadOptionalArtifactHints` use shared memory vault sync effects

## Test plan

- [x] `npm run build -w clawql-memory -w clawql-documents`
- [x] `npx vitest run packages/clawql-memory/src` (26 tests)
- [x] `npx vitest run src/external-ingest.test.ts` (8 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

