### PR TITLE
feat(documents): Effect bridge for pipeline tools

### DIFF
--- a/packages/clawql-documents/src/classify/classify-document.ts
+++ b/packages/clawql-documents/src/classify/classify-document.ts
@@ -171,7 +171,9 @@ export async function handleClassifyDocumentToolInput(
     };
   }
 
-  const result = await classifyDocument(params);
+  const { runDocumentsEffect, documentsClassifyProgram } =
+    await import("../effect/documents-effect-runtime.js");
+  const result = await runDocumentsEffect(documentsClassifyProgram(params));
   return {
     content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
   };

--- a/packages/clawql-documents/src/effect/documents-effect-runtime.ts
+++ b/packages/clawql-documents/src/effect/documents-effect-runtime.ts
@@ -1,13 +1,27 @@
 import { Cause, Effect, Exit, Layer } from "effect";
 import { vaultConfigLiveLayer, VaultConfigService } from "clawql-memory/plugin";
 import type { ExternalIngestInput, ExternalIngestResult } from "../ingest/external-ingest.js";
+import type {
+  ClassifyDocumentInput,
+  ClassifyDocumentResult,
+} from "../classify/classify-document.js";
+import type {
+  ExtractDocumentInput,
+  ExtractDocumentResult,
+} from "../langextract/extract-document.js";
+import type { RunIdpPipelineInput, RunIdpPipelineResult } from "../pipeline/runner.js";
 import { DocumentsIngestService, documentsIngestLiveLayer } from "./documents-ingest-service.js";
+import { DocumentsToolsService, documentsToolsLiveLayer } from "./documents-tools-service.js";
 
-export type DocumentsServices = VaultConfigService | DocumentsIngestService;
+export type DocumentsServices = VaultConfigService | DocumentsIngestService | DocumentsToolsService;
 
 /** Merged Effect Layer for clawql-documents domain services + memory vault config. */
 export function documentsServicesLiveLayer(): Layer.Layer<DocumentsServices> {
-  return Layer.mergeAll(vaultConfigLiveLayer(), documentsIngestLiveLayer());
+  return Layer.mergeAll(
+    vaultConfigLiveLayer(),
+    documentsIngestLiveLayer(),
+    documentsToolsLiveLayer()
+  );
 }
 
 /** Run a documents Effect program with default services Layer. */
@@ -30,5 +44,35 @@ export function documentsIngestProgram(
   return Effect.gen(function* () {
     const ingest = yield* DocumentsIngestService;
     return yield* ingest.ingest(input);
+  });
+}
+
+/** IDP pipeline via Effect services. */
+export function documentsIdpPipelineProgram(
+  input: RunIdpPipelineInput
+): Effect.Effect<RunIdpPipelineResult, unknown, DocumentsServices> {
+  return Effect.gen(function* () {
+    const tools = yield* DocumentsToolsService;
+    return yield* tools.runIdpPipeline(input);
+  });
+}
+
+/** Classify document via Effect services. */
+export function documentsClassifyProgram(
+  input: ClassifyDocumentInput
+): Effect.Effect<ClassifyDocumentResult, unknown, DocumentsServices> {
+  return Effect.gen(function* () {
+    const tools = yield* DocumentsToolsService;
+    return yield* tools.classify(input);
+  });
+}
+
+/** Extract document via Effect services. */
+export function documentsExtractProgram(
+  input: ExtractDocumentInput
+): Effect.Effect<ExtractDocumentResult, unknown, DocumentsServices> {
+  return Effect.gen(function* () {
+    const tools = yield* DocumentsToolsService;
+    return yield* tools.extract(input);
   });
 }

--- a/packages/clawql-documents/src/effect/documents-tools-effect.test.ts
+++ b/packages/clawql-documents/src/effect/documents-tools-effect.test.ts
@@ -1,0 +1,16 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { documentsServicesLiveLayer } from "./documents-effect-runtime.js";
+import { executeClassifyDocumentEffect } from "./documents-tools-effect.js";
+
+describe("executeClassifyDocumentEffect", () => {
+  it("heuristic classify returns ok without remote classifier", async () => {
+    const result = await Effect.runPromise(
+      executeClassifyDocumentEffect({ text: "Form W-2 wage statement" }).pipe(
+        Effect.provide(documentsServicesLiveLayer())
+      )
+    );
+    expect(result.ok).toBe(true);
+    expect(result.label).toBe("w2");
+  });
+});

--- a/packages/clawql-documents/src/effect/documents-tools-effect.ts
+++ b/packages/clawql-documents/src/effect/documents-tools-effect.ts
@@ -1,0 +1,48 @@
+import { Effect } from "effect";
+import {
+  classifyDocument,
+  type ClassifyDocumentInput,
+  type ClassifyDocumentResult,
+} from "../classify/classify-document.js";
+import {
+  extractDocument,
+  type ExtractDocumentInput,
+  type ExtractDocumentResult,
+} from "../langextract/extract-document.js";
+import {
+  runIdpPipeline,
+  type RunIdpPipelineInput,
+  type RunIdpPipelineResult,
+} from "../pipeline/runner.js";
+import { getDocumentsPluginDeps } from "../plugin/deps.js";
+import { DocumentsError } from "./documents-errors.js";
+import { documentsFromPromise } from "./documents-effect-utils.js";
+
+/** IDP pipeline body (deps resolved at call time). */
+export async function executeRunIdpPipelineCore(
+  input: RunIdpPipelineInput
+): Promise<RunIdpPipelineResult> {
+  const deps = getDocumentsPluginDeps();
+  return runIdpPipeline(input, {
+    execute: (p) => deps.execute(p),
+    onHop: deps.onPipelineHop,
+  });
+}
+
+export function executeRunIdpPipelineEffect(
+  input: RunIdpPipelineInput
+): Effect.Effect<RunIdpPipelineResult, DocumentsError> {
+  return documentsFromPromise(() => executeRunIdpPipelineCore(input));
+}
+
+export function executeClassifyDocumentEffect(
+  input: ClassifyDocumentInput
+): Effect.Effect<ClassifyDocumentResult, DocumentsError> {
+  return documentsFromPromise(() => classifyDocument(input));
+}
+
+export function executeExtractDocumentEffect(
+  input: ExtractDocumentInput
+): Effect.Effect<ExtractDocumentResult, DocumentsError> {
+  return documentsFromPromise(() => extractDocument(input));
+}

--- a/packages/clawql-documents/src/effect/documents-tools-service.ts
+++ b/packages/clawql-documents/src/effect/documents-tools-service.ts
@@ -1,0 +1,43 @@
+import { Context, Effect, Layer } from "effect";
+import type {
+  ClassifyDocumentInput,
+  ClassifyDocumentResult,
+} from "../classify/classify-document.js";
+import type {
+  ExtractDocumentInput,
+  ExtractDocumentResult,
+} from "../langextract/extract-document.js";
+import type { RunIdpPipelineInput, RunIdpPipelineResult } from "../pipeline/runner.js";
+import { DocumentsError } from "./documents-errors.js";
+import {
+  executeClassifyDocumentEffect,
+  executeExtractDocumentEffect,
+  executeRunIdpPipelineEffect,
+} from "./documents-tools-effect.js";
+
+/** Effect service for IDP pipeline, classify, and extract document tools. */
+export class DocumentsToolsService extends Context.Tag("clawql/DocumentsToolsService")<
+  DocumentsToolsService,
+  {
+    readonly runIdpPipeline: (
+      input: RunIdpPipelineInput
+    ) => Effect.Effect<RunIdpPipelineResult, DocumentsError>;
+    readonly classify: (
+      input: ClassifyDocumentInput
+    ) => Effect.Effect<ClassifyDocumentResult, DocumentsError>;
+    readonly extract: (
+      input: ExtractDocumentInput
+    ) => Effect.Effect<ExtractDocumentResult, DocumentsError>;
+  }
+>() {}
+
+export function documentsToolsLiveLayer(): Layer.Layer<DocumentsToolsService> {
+  return Layer.succeed(
+    DocumentsToolsService,
+    DocumentsToolsService.of({
+      runIdpPipeline: executeRunIdpPipelineEffect,
+      classify: executeClassifyDocumentEffect,
+      extract: executeExtractDocumentEffect,
+    })
+  );
+}

--- a/packages/clawql-documents/src/effect/index.ts
+++ b/packages/clawql-documents/src/effect/index.ts
@@ -3,6 +3,16 @@ export { documentsFromPromise, documentsSync } from "./documents-effect-utils.js
 export { executeExternalIngestEffect } from "./external-ingest-effect.js";
 export { DocumentsIngestService, documentsIngestLiveLayer } from "./documents-ingest-service.js";
 export {
+  executeClassifyDocumentEffect,
+  executeExtractDocumentEffect,
+  executeRunIdpPipelineCore,
+  executeRunIdpPipelineEffect,
+} from "./documents-tools-effect.js";
+export { DocumentsToolsService, documentsToolsLiveLayer } from "./documents-tools-service.js";
+export {
+  documentsClassifyProgram,
+  documentsExtractProgram,
+  documentsIdpPipelineProgram,
   documentsIngestProgram,
   documentsServicesLiveLayer,
   runDocumentsEffect,

--- a/packages/clawql-documents/src/langextract/extract-document.ts
+++ b/packages/clawql-documents/src/langextract/extract-document.ts
@@ -518,7 +518,9 @@ export async function handleExtractDocumentToolInput(
     };
   }
 
-  const result = await extractDocument(params);
+  const { runDocumentsEffect, documentsExtractProgram } =
+    await import("../effect/documents-effect-runtime.js");
+  const result = await runDocumentsEffect(documentsExtractProgram(params));
   return {
     content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
   };

--- a/packages/clawql-documents/src/pipeline/run-idp-pipeline.ts
+++ b/packages/clawql-documents/src/pipeline/run-idp-pipeline.ts
@@ -1,8 +1,7 @@
 import { logMcpToolShape } from "clawql-api/mcp/tool-shape-log";
 import { z } from "zod";
 import { idpPipelineRunnerEnabled } from "./env.js";
-import { runIdpPipeline, type RunIdpPipelineInput } from "./runner.js";
-import { getDocumentsPluginDeps } from "../plugin/deps.js";
+import type { RunIdpPipelineInput } from "./runner.js";
 
 const stageEnum = z.enum([
   "nextcloud",
@@ -98,11 +97,9 @@ export async function handleRunIdpPipelineToolInput(
     };
   }
 
-  const deps = getDocumentsPluginDeps();
-  const result = await runIdpPipeline(params, {
-    execute: (p) => deps.execute(p),
-    onHop: deps.onPipelineHop,
-  });
+  const { runDocumentsEffect, documentsIdpPipelineProgram } =
+    await import("../effect/documents-effect-runtime.js");
+  const result = await runDocumentsEffect(documentsIdpPipelineProgram(params));
 
   return {
     content: [{ type: "text", text: JSON.stringify(result, null, 2) }],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Effect bridge for documents pipeline MCP tools.

- `DocumentsToolsService` for run_idp_pipeline, classify_document, extract_document
- Handlers delegate to `runDocumentsEffect`

## Test plan

- [x] Build + 28 package tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

