### PR TITLE
fix(docs): repair memory page mermaid diagram

### DIFF
--- a/website/src/app/learn/memory/page.mdx
+++ b/website/src/app/learn/memory/page.mdx
@@ -50,17 +50,17 @@ Today’s shipped stack is a **practical subset** of the full Memory 2.0 triple-
 
 ```mermaid
 flowchart LR
-  subgraph vault["Vault (source of truth)"]
-    MD["Memory/*.md"]
+  subgraph vault [Vault - source of truth]
+    MD[Memory notes]
   end
-  subgraph tools["MCP tools"]
-    MI["memory_ingest"]
-    MR["memory_recall"]
-    PI["pageindex_*"]
+  subgraph tools [MCP tools]
+    MI[memory_ingest]
+    MR[memory_recall]
+    PI[pageindex tools]
   end
-  subgraph index["Derived index"]
-    DB[("memory.db")]
-    PIT["pageindex.db.json"]
+  subgraph index [Derived index]
+    DB[(memory.db)]
+    PIT[pageindex index]
   end
   MD --> MI
   MI --> MD


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the "Diagram failed to render" error on `/learn/memory`.

## Cause

Mermaid `securityLevel: strict` choked on node labels containing glob characters (`Memory/*.md`, `pageindex_*`), quoted cylinder syntax, and quoted subgraph titles with parentheses.

## Fix

Simplify labels to match working diagrams on `/learn/schedule-notify-workflows` and case studies (plain `[Label]` nodes, unquoted subgraph titles, `[(memory.db)]` cylinder without inner quotes).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5923-61ff-77f8-92df-6c4b1fa90953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5923-61ff-77f8-92df-6c4b1fa90953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

