### PR TITLE
feat(automation): Effect bridge for notify, schedule, workflow, argocd

### DIFF
--- a/packages/clawql-automation/src/argocd/argocd.ts
+++ b/packages/clawql-automation/src/argocd/argocd.ts
@@ -194,7 +194,7 @@ async function getApplication(namespace: string, name: string): Promise<ArgoCdAp
   return res as ArgoCdApplicationObject;
 }
 
-export async function handleArgocdToolInput(
+export async function executeArgocdToolCore(
   params: unknown
 ): Promise<{ content: { type: "text"; text: string }[] }> {
   if (!argocdToolEnabled()) {
@@ -283,4 +283,13 @@ export async function handleArgocdToolInput(
     const message = error instanceof Error ? error.message : String(error);
     return jsonResponse({ ok: false, operation: parsed.operation, error: message });
   }
+}
+
+/** Public async facade for argocd MCP tool. */
+export async function handleArgocdToolInput(
+  params: unknown
+): Promise<{ content: { type: "text"; text: string }[] }> {
+  const { runAutomationEffect, automationArgocdProgram } =
+    await import("../effect/automation-effect-runtime.js");
+  return runAutomationEffect(automationArgocdProgram(params));
 }

--- a/packages/clawql-automation/src/effect/automation-effect-runtime.ts
+++ b/packages/clawql-automation/src/effect/automation-effect-runtime.ts
@@ -10,6 +10,17 @@ export function automationServicesLiveLayer(): Layer.Layer<AutomationServices> {
   return automationToolsLiveLayer();
 }
 
+import { AutomationError } from "./automation-errors.js";
+
+function throwAutomationFailure(cause: Cause.Cause<unknown>): never {
+  const squashed = Cause.squash(cause);
+  if (squashed instanceof AutomationError && squashed.cause != null) {
+    if (squashed.cause instanceof Error) throw squashed.cause;
+    throw new Error(String(squashed.cause));
+  }
+  throw squashed;
+}
+
 /** Run an automation Effect program with default services Layer. */
 export async function runAutomationEffect<A, E>(
   program: Effect.Effect<A, E, AutomationServices>
@@ -20,7 +31,7 @@ export async function runAutomationEffect<A, E>(
   if (Exit.isSuccess(exit)) {
     return exit.value;
   }
-  throw Cause.squash(exit.cause);
+  throwAutomationFailure(exit.cause);
 }
 
 export function automationNotifyProgram(

--- a/packages/clawql-automation/src/effect/automation-effect-runtime.ts
+++ b/packages/clawql-automation/src/effect/automation-effect-runtime.ts
@@ -1,0 +1,60 @@
+import { Cause, Effect, Exit, Layer } from "effect";
+import type { NotifySlackInput } from "../notify/notify.js";
+import { AutomationToolsService, automationToolsLiveLayer } from "./automation-tools-service.js";
+import type { McpTextResult } from "./automation-effect-utils.js";
+
+export type AutomationServices = AutomationToolsService;
+
+/** Merged Effect Layer for clawql-automation domain services. */
+export function automationServicesLiveLayer(): Layer.Layer<AutomationServices> {
+  return automationToolsLiveLayer();
+}
+
+/** Run an automation Effect program with default services Layer. */
+export async function runAutomationEffect<A, E>(
+  program: Effect.Effect<A, E, AutomationServices>
+): Promise<A> {
+  const exit = await Effect.runPromiseExit(
+    program.pipe(Effect.provide(automationServicesLiveLayer()))
+  );
+  if (Exit.isSuccess(exit)) {
+    return exit.value;
+  }
+  throw Cause.squash(exit.cause);
+}
+
+export function automationNotifyProgram(
+  params: NotifySlackInput
+): Effect.Effect<McpTextResult, unknown, AutomationServices> {
+  return Effect.gen(function* () {
+    const tools = yield* AutomationToolsService;
+    return yield* tools.notify(params);
+  });
+}
+
+export function automationScheduleProgram(
+  params: unknown
+): Effect.Effect<McpTextResult, unknown, AutomationServices> {
+  return Effect.gen(function* () {
+    const tools = yield* AutomationToolsService;
+    return yield* tools.schedule(params);
+  });
+}
+
+export function automationWorkflowProgram(
+  params: unknown
+): Effect.Effect<McpTextResult, unknown, AutomationServices> {
+  return Effect.gen(function* () {
+    const tools = yield* AutomationToolsService;
+    return yield* tools.workflow(params);
+  });
+}
+
+export function automationArgocdProgram(
+  params: unknown
+): Effect.Effect<McpTextResult, unknown, AutomationServices> {
+  return Effect.gen(function* () {
+    const tools = yield* AutomationToolsService;
+    return yield* tools.argocd(params);
+  });
+}

--- a/packages/clawql-automation/src/effect/automation-effect-utils.ts
+++ b/packages/clawql-automation/src/effect/automation-effect-utils.ts
@@ -1,0 +1,18 @@
+import { Effect } from "effect";
+import { AutomationError } from "./automation-errors.js";
+
+export type McpTextResult = { content: { type: "text"; text: string }[] };
+
+/** Lift a Promise into Effect with {@link AutomationError} on failure. */
+export function automationFromPromise<A>(
+  tryFn: () => Promise<A>
+): Effect.Effect<A, AutomationError> {
+  return Effect.tryPromise({
+    try: tryFn,
+    catch: (cause) =>
+      new AutomationError({
+        reason: "automation async operation failed",
+        cause,
+      }),
+  });
+}

--- a/packages/clawql-automation/src/effect/automation-error-propagate.test.ts
+++ b/packages/clawql-automation/src/effect/automation-error-propagate.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { handleScheduleToolInput } from "../schedule/schedule.js";
+
+describe("automation error propagation", () => {
+  it("rethrows Zod validation errors from schedule create", async () => {
+    process.env.CLAWQL_SCHEDULE_INTERVAL_MIN_SECONDS = "300";
+    await expect(
+      handleScheduleToolInput({
+        operation: "create",
+        schedule: { frequency: { type: "interval", seconds: 10 } },
+        action: {
+          kind: "synthetic",
+          synthetic_test: {
+            name: "bad",
+            request: { method: "GET", url: "https://example.com" },
+          },
+        },
+      })
+    ).rejects.toThrow(/interval seconds/i);
+  });
+});

--- a/packages/clawql-automation/src/effect/automation-errors.ts
+++ b/packages/clawql-automation/src/effect/automation-errors.ts
@@ -1,0 +1,7 @@
+import { Data } from "effect";
+
+/** Unexpected failure in an automation Effect pipeline. */
+export class AutomationError extends Data.TaggedError("AutomationError")<{
+  readonly reason: string;
+  readonly cause?: unknown;
+}> {}

--- a/packages/clawql-automation/src/effect/automation-tools-effect.test.ts
+++ b/packages/clawql-automation/src/effect/automation-tools-effect.test.ts
@@ -1,0 +1,26 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { automationServicesLiveLayer } from "./automation-effect-runtime.js";
+import { executeNotifySlackEffect } from "./automation-tools-effect.js";
+
+describe("executeNotifySlackEffect", () => {
+  it("returns error when Slack token is missing", async () => {
+    const saved = process.env.CLAWQL_SLACK_TOKEN;
+    delete process.env.CLAWQL_SLACK_TOKEN;
+    delete process.env.SLACK_BOT_TOKEN;
+    delete process.env.SLACK_TOKEN;
+    delete process.env.CLAWQL_SLACK_BOT_TOKEN;
+    try {
+      const result = await Effect.runPromise(
+        executeNotifySlackEffect({ channel: "C1", text: "hi" }).pipe(
+          Effect.provide(automationServicesLiveLayer())
+        )
+      );
+      const body = JSON.parse(result.content[0]!.text) as { error?: string };
+      expect(body.error).toMatch(/Slack bot token missing/);
+    } finally {
+      if (saved === undefined) delete process.env.CLAWQL_SLACK_TOKEN;
+      else process.env.CLAWQL_SLACK_TOKEN = saved;
+    }
+  });
+});

--- a/packages/clawql-automation/src/effect/automation-tools-effect.ts
+++ b/packages/clawql-automation/src/effect/automation-tools-effect.ts
@@ -1,0 +1,40 @@
+import { Effect } from "effect";
+import type { NotifySlackInput } from "../notify/notify.js";
+import { AutomationError } from "./automation-errors.js";
+import { automationFromPromise, type McpTextResult } from "./automation-effect-utils.js";
+
+export function executeNotifySlackEffect(
+  params: NotifySlackInput
+): Effect.Effect<McpTextResult, AutomationError> {
+  return automationFromPromise(async () => {
+    const { executeNotifySlackCore } = await import("../notify/notify.js");
+    return executeNotifySlackCore(params);
+  });
+}
+
+export function executeScheduleToolEffect(
+  params: unknown
+): Effect.Effect<McpTextResult, AutomationError> {
+  return automationFromPromise(async () => {
+    const { executeScheduleToolCore } = await import("../schedule/schedule.js");
+    return executeScheduleToolCore(params);
+  });
+}
+
+export function executeWorkflowToolEffect(
+  params: unknown
+): Effect.Effect<McpTextResult, AutomationError> {
+  return automationFromPromise(async () => {
+    const { executeWorkflowToolCore } = await import("../workflow/workflow.js");
+    return executeWorkflowToolCore(params);
+  });
+}
+
+export function executeArgocdToolEffect(
+  params: unknown
+): Effect.Effect<McpTextResult, AutomationError> {
+  return automationFromPromise(async () => {
+    const { executeArgocdToolCore } = await import("../argocd/argocd.js");
+    return executeArgocdToolCore(params);
+  });
+}

--- a/packages/clawql-automation/src/effect/automation-tools-service.ts
+++ b/packages/clawql-automation/src/effect/automation-tools-service.ts
@@ -1,0 +1,33 @@
+import { Context, Effect, Layer } from "effect";
+import type { NotifySlackInput } from "../notify/notify.js";
+import { AutomationError } from "./automation-errors.js";
+import type { McpTextResult } from "./automation-effect-utils.js";
+import {
+  executeArgocdToolEffect,
+  executeNotifySlackEffect,
+  executeScheduleToolEffect,
+  executeWorkflowToolEffect,
+} from "./automation-tools-effect.js";
+
+/** Effect service for automation MCP tools (notify, schedule, workflow, argocd). */
+export class AutomationToolsService extends Context.Tag("clawql/AutomationToolsService")<
+  AutomationToolsService,
+  {
+    readonly notify: (params: NotifySlackInput) => Effect.Effect<McpTextResult, AutomationError>;
+    readonly schedule: (params: unknown) => Effect.Effect<McpTextResult, AutomationError>;
+    readonly workflow: (params: unknown) => Effect.Effect<McpTextResult, AutomationError>;
+    readonly argocd: (params: unknown) => Effect.Effect<McpTextResult, AutomationError>;
+  }
+>() {}
+
+export function automationToolsLiveLayer(): Layer.Layer<AutomationToolsService> {
+  return Layer.succeed(
+    AutomationToolsService,
+    AutomationToolsService.of({
+      notify: executeNotifySlackEffect,
+      schedule: executeScheduleToolEffect,
+      workflow: executeWorkflowToolEffect,
+      argocd: executeArgocdToolEffect,
+    })
+  );
+}

--- a/packages/clawql-automation/src/effect/index.ts
+++ b/packages/clawql-automation/src/effect/index.ts
@@ -1,0 +1,18 @@
+export { AutomationError } from "./automation-errors.js";
+export { automationFromPromise, type McpTextResult } from "./automation-effect-utils.js";
+export {
+  executeArgocdToolEffect,
+  executeNotifySlackEffect,
+  executeScheduleToolEffect,
+  executeWorkflowToolEffect,
+} from "./automation-tools-effect.js";
+export { AutomationToolsService, automationToolsLiveLayer } from "./automation-tools-service.js";
+export {
+  automationArgocdProgram,
+  automationNotifyProgram,
+  automationScheduleProgram,
+  automationServicesLiveLayer,
+  automationWorkflowProgram,
+  runAutomationEffect,
+  type AutomationServices,
+} from "./automation-effect-runtime.js";

--- a/packages/clawql-automation/src/notify/notify.ts
+++ b/packages/clawql-automation/src/notify/notify.ts
@@ -40,7 +40,7 @@ export type NotifySlackInput = {
   fields?: string[];
 };
 
-export async function runNotifySlack(
+export async function executeNotifySlackCore(
   params: NotifySlackInput
 ): Promise<{ content: { type: "text"; text: string }[] }> {
   const auth = mergedAuthHeaders("slack");
@@ -147,4 +147,13 @@ export async function runNotifySlack(
     // non-JSON execute error — return as-is
   }
   return exec;
+}
+
+/** Public async facade for Slack notify (MCP tools, schedule worker). */
+export async function runNotifySlack(
+  params: NotifySlackInput
+): Promise<{ content: { type: "text"; text: string }[] }> {
+  const { runAutomationEffect, automationNotifyProgram } =
+    await import("../effect/automation-effect-runtime.js");
+  return runAutomationEffect(automationNotifyProgram(params));
 }

--- a/packages/clawql-automation/src/plugin/index.ts
+++ b/packages/clawql-automation/src/plugin/index.ts
@@ -19,3 +19,15 @@ export {
 export { workflowToolSchema } from "../workflow/workflow.js";
 export { argocdToolSchema } from "../argocd/argocd.js";
 export { runVaultDailyDigest } from "../workflow/vault-digest/run-vault-digest.js";
+export {
+  AutomationError,
+  AutomationToolsService,
+  automationArgocdProgram,
+  automationNotifyProgram,
+  automationScheduleProgram,
+  automationServicesLiveLayer,
+  automationToolsLiveLayer,
+  automationWorkflowProgram,
+  runAutomationEffect,
+  type AutomationServices,
+} from "../effect/index.js";

--- a/packages/clawql-automation/src/schedule/schedule.ts
+++ b/packages/clawql-automation/src/schedule/schedule.ts
@@ -878,7 +878,7 @@ export function registerScheduleWorkerShutdownHooks(): void {
   process.once("exit", shutdown);
 }
 
-export async function handleScheduleToolInput(
+export async function executeScheduleToolCore(
   params: unknown
 ): Promise<{ content: { type: "text"; text: string }[] }> {
   const parsed = scheduleInputSchema.parse(params);
@@ -1008,6 +1008,15 @@ export async function handleScheduleToolInput(
   } finally {
     db.close();
   }
+}
+
+/** Public async facade for schedule MCP tool. */
+export async function handleScheduleToolInput(
+  params: unknown
+): Promise<{ content: { type: "text"; text: string }[] }> {
+  const { runAutomationEffect, automationScheduleProgram } =
+    await import("../effect/automation-effect-runtime.js");
+  return runAutomationEffect(automationScheduleProgram(params));
 }
 
 /** Test helper. */

--- a/packages/clawql-automation/src/workflow/workflow.ts
+++ b/packages/clawql-automation/src/workflow/workflow.ts
@@ -297,7 +297,7 @@ async function patchCronSuspend(
   return res as ArgoCronWorkflowObject;
 }
 
-export async function handleWorkflowToolInput(
+export async function executeWorkflowToolCore(
   params: unknown
 ): Promise<{ content: { type: "text"; text: string }[] }> {
   if (!workflowToolEnabled()) {
@@ -725,4 +725,13 @@ export async function handleWorkflowToolInput(
     const message = error instanceof Error ? error.message : String(error);
     return jsonResponse({ ok: false, operation: parsed.operation, error: message });
   }
+}
+
+/** Public async facade for workflow MCP tool. */
+export async function handleWorkflowToolInput(
+  params: unknown
+): Promise<{ content: { type: "text"; text: string }[] }> {
+  const { runAutomationEffect, automationWorkflowProgram } =
+    await import("../effect/automation-effect-runtime.js");
+  return runAutomationEffect(automationWorkflowProgram(params));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Effect bridge for clawql-automation MCP tools: `notify`, `schedule`, `workflow`, and `argocd`.

- Add `AutomationToolsService` with native Effect programs
- Extract `execute*Core` from handlers; public facades delegate to `runAutomationEffect`

## Test plan

- [x] `npm run build -w clawql-automation`
- [x] Automation effect + plugin/argocd/workflow tests (33 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

