### PR TITLE
feat(inference): Langfuse + OTel tracing and pgvector semantic cache

### DIFF
--- a/docs/inference/clawql-inference.md
+++ b/docs/inference/clawql-inference.md
@@ -477,57 +477,57 @@ clawql inference <subcommand>
 
 ## Environment variables
 
-| Variable                                      | Default                              | Purpose                                 |
-| --------------------------------------------- | ------------------------------------ | --------------------------------------- |
-| `OPENAI_API_KEY`                              | —                                    | OpenAI provider                         |
-| `ANTHROPIC_API_KEY`                           | —                                    | Anthropic provider                      |
-| `OLLAMA_BASE_URL`                             | `http://127.0.0.1:11434`             | Ollama runtime                          |
-| `CLAWQL_INFERENCE_PORT`                       | `8080`                               | HTTP listen port                        |
-| `CLAWQL_INFERENCE_HOST`                       | `0.0.0.0`                            | HTTP bind address                       |
-| `CLAWQL_INFERENCE_PROVIDERS`                  | all builtins                         | Provider allowlist                      |
-| `CLAWQL_INFERENCE_DISABLE_PROVIDERS`          | —                                    | Provider denylist                       |
-| `CLAWQL_INFERENCE_ROUTING_ENABLED`            | off                                  | Tier escalation                         |
-| `CLAWQL_INFERENCE_MODEL_FRUGAL`               | `ollama/phi4`                        | Frugal tier model                       |
-| `CLAWQL_INFERENCE_MODEL_STANDARD`             | `groq/llama-3.3-70b`                 | Standard tier model                     |
-| `CLAWQL_INFERENCE_MODEL_FRONTIER`             | `anthropic/claude-sonnet-4`          | Frontier tier model                     |
-| `CLAWQL_INFERENCE_MODEL_PIN`                  | —                                    | Pin single model                        |
-| `CLAWQL_INFERENCE_SEMANTIC_CACHE`             | auto when embeddings configured      | Semantic cache (Layer 5)                |
-| `CLAWQL_INFERENCE_TERSE`                      | on                                   | Terse output post-processor (Layer 3)   |
-| `CLAWQL_INFERENCE_PROMPT_CACHE`               | on                                   | Provider prompt-cache markers (Layer 4) |
-| `CLAWQL_INFERENCE_HISTORY_COMPRESS`           | off                                  | History distillation (Layer 6)          |
-| `CLAWQL_INFERENCE_HISTORY_MAX_CHARS`          | `48000`                              | History compress threshold              |
-| `CLAWQL_INFERENCE_HISTORY_KEEP_RECENT`        | `6`                                  | Recent messages to keep verbatim        |
-| `CLAWQL_INFERENCE_PROMPT_COMPRESS`            | off                                  | Final prompt compression (Layer 7)      |
-| `CLAWQL_INFERENCE_PROMPT_COMPRESS_MAX_CHARS`  | `12000`                              | Per-message cap before send             |
-| `CLAWQL_INFERENCE_HTTP_AUTO_ROUTE`            | on when routing enabled              | HTTP `clawql/auto` aliases (Layer 8)    |
-| `CLAWQL_INFERENCE_STRUCTURED_OUTPUT`          | on                                   | Structured output hints (Layer 9)       |
-| `CLAWQL_INFERENCE_TOKEN_BUDGET`               | on                                   | Token budget signaling (Layer 10)       |
-| `CLAWQL_INFERENCE_PREFILL`                    | off                                  | Assistant prefill opener (Layer 11)     |
-| `CLAWQL_INFERENCE_PREFILL_OPENER`             | —                                    | Prefill text when Layer 11 enabled      |
-| `CLAWQL_INFERENCE_CACHE_THRESHOLD`            | `0.92`                               | Cache similarity floor                  |
-| `CLAWQL_INFERENCE_CACHE_TTL`                  | `24h`                                | Cache TTL                               |
-| `CLAWQL_INFERENCE_CACHE_MAX_ENTRIES`          | `1000`                               | Cache size cap                          |
-| `CLAWQL_EMBEDDING_MODEL`                      | `text-embedding-3-small`             | Embeddings model                        |
-| `CLAWQL_INFERENCE_FALLBACK_ENABLED`           | off                                  | Fallback chains                         |
-| `CLAWQL_INFERENCE_FALLBACK_FRUGAL`            | —                                    | Frugal fallback chain                   |
-| `CLAWQL_INFERENCE_FALLBACK_STANDARD`          | —                                    | Standard fallback chain                 |
-| `CLAWQL_INFERENCE_FALLBACK_FRONTIER`          | —                                    | Frontier fallback chain                 |
-| `CLAWQL_INFERENCE_KEYS_ENABLED`               | off                                  | Require virtual keys                    |
-| `CLAWQL_INFERENCE_STORE`                      | jsonl when `CLAWQL_HOME`             | `memory` / `jsonl` / `postgres` / `off` |
-| `CLAWQL_INFERENCE_DATABASE_URL`               | —                                    | Postgres URL                            |
-| `CLAWQL_INFERENCE_STORE_PATH`                 | `$CLAWQL_HOME/Inference/calls.jsonl` | JSONL path override                     |
-| `CLAWQL_INFERENCE_PIPELINE_WORKER`            | off                                  | Cron worker with serve                  |
-| `CLAWQL_INFERENCE_PIPELINE_POLL_MS`           | `60000`                              | Worker poll interval                    |
-| `CLAWQL_INFERENCE_AGENT_COORDINATION_ENABLED` | off                                  | Agent coordination                      |
-| `HERMES_BASE_URL`                             | —                                    | Hermes MoA endpoint                     |
-| `CLAWQL_PAYMENTS_ENFORCE_INFERENCE`           | off                                  | Plan entitlement gate                   |
-| `CLAWQL_OBSERVABILITY_PROFILE`                | `external`                           | `bundled` / `external` / `minimal`      |
-| `CLAWQL_ENABLE_OTEL_TRACING`                  | off                                  | Infra OTLP spans (Tempo / collector)    |
-| `OTEL_EXPORTER_OTLP_ENDPOINT`                  | —                                    | OTLP ingest URL                         |
-| `CLAWQL_ENABLE_LANGFUSE`                      | on when keys set                     | Langfuse work-trace OTLP (opt-out `=0`) |
-| `LANGFUSE_HOST` / `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` | —                    | Langfuse OTLP credentials               |
-| `CLAWQL_INFERENCE_SEMANTIC_CACHE_BACKEND`     | `postgres` when DB configured        | `memory` / `postgres` / `pgvector`      |
-| `CLAWQL_EMBEDDING_DIMENSION`                  | `1536`                               | pgvector column width for cache         |
+| Variable                                                        | Default                              | Purpose                                 |
+| --------------------------------------------------------------- | ------------------------------------ | --------------------------------------- |
+| `OPENAI_API_KEY`                                                | —                                    | OpenAI provider                         |
+| `ANTHROPIC_API_KEY`                                             | —                                    | Anthropic provider                      |
+| `OLLAMA_BASE_URL`                                               | `http://127.0.0.1:11434`             | Ollama runtime                          |
+| `CLAWQL_INFERENCE_PORT`                                         | `8080`                               | HTTP listen port                        |
+| `CLAWQL_INFERENCE_HOST`                                         | `0.0.0.0`                            | HTTP bind address                       |
+| `CLAWQL_INFERENCE_PROVIDERS`                                    | all builtins                         | Provider allowlist                      |
+| `CLAWQL_INFERENCE_DISABLE_PROVIDERS`                            | —                                    | Provider denylist                       |
+| `CLAWQL_INFERENCE_ROUTING_ENABLED`                              | off                                  | Tier escalation                         |
+| `CLAWQL_INFERENCE_MODEL_FRUGAL`                                 | `ollama/phi4`                        | Frugal tier model                       |
+| `CLAWQL_INFERENCE_MODEL_STANDARD`                               | `groq/llama-3.3-70b`                 | Standard tier model                     |
+| `CLAWQL_INFERENCE_MODEL_FRONTIER`                               | `anthropic/claude-sonnet-4`          | Frontier tier model                     |
+| `CLAWQL_INFERENCE_MODEL_PIN`                                    | —                                    | Pin single model                        |
+| `CLAWQL_INFERENCE_SEMANTIC_CACHE`                               | auto when embeddings configured      | Semantic cache (Layer 5)                |
+| `CLAWQL_INFERENCE_TERSE`                                        | on                                   | Terse output post-processor (Layer 3)   |
+| `CLAWQL_INFERENCE_PROMPT_CACHE`                                 | on                                   | Provider prompt-cache markers (Layer 4) |
+| `CLAWQL_INFERENCE_HISTORY_COMPRESS`                             | off                                  | History distillation (Layer 6)          |
+| `CLAWQL_INFERENCE_HISTORY_MAX_CHARS`                            | `48000`                              | History compress threshold              |
+| `CLAWQL_INFERENCE_HISTORY_KEEP_RECENT`                          | `6`                                  | Recent messages to keep verbatim        |
+| `CLAWQL_INFERENCE_PROMPT_COMPRESS`                              | off                                  | Final prompt compression (Layer 7)      |
+| `CLAWQL_INFERENCE_PROMPT_COMPRESS_MAX_CHARS`                    | `12000`                              | Per-message cap before send             |
+| `CLAWQL_INFERENCE_HTTP_AUTO_ROUTE`                              | on when routing enabled              | HTTP `clawql/auto` aliases (Layer 8)    |
+| `CLAWQL_INFERENCE_STRUCTURED_OUTPUT`                            | on                                   | Structured output hints (Layer 9)       |
+| `CLAWQL_INFERENCE_TOKEN_BUDGET`                                 | on                                   | Token budget signaling (Layer 10)       |
+| `CLAWQL_INFERENCE_PREFILL`                                      | off                                  | Assistant prefill opener (Layer 11)     |
+| `CLAWQL_INFERENCE_PREFILL_OPENER`                               | —                                    | Prefill text when Layer 11 enabled      |
+| `CLAWQL_INFERENCE_CACHE_THRESHOLD`                              | `0.92`                               | Cache similarity floor                  |
+| `CLAWQL_INFERENCE_CACHE_TTL`                                    | `24h`                                | Cache TTL                               |
+| `CLAWQL_INFERENCE_CACHE_MAX_ENTRIES`                            | `1000`                               | Cache size cap                          |
+| `CLAWQL_EMBEDDING_MODEL`                                        | `text-embedding-3-small`             | Embeddings model                        |
+| `CLAWQL_INFERENCE_FALLBACK_ENABLED`                             | off                                  | Fallback chains                         |
+| `CLAWQL_INFERENCE_FALLBACK_FRUGAL`                              | —                                    | Frugal fallback chain                   |
+| `CLAWQL_INFERENCE_FALLBACK_STANDARD`                            | —                                    | Standard fallback chain                 |
+| `CLAWQL_INFERENCE_FALLBACK_FRONTIER`                            | —                                    | Frontier fallback chain                 |
+| `CLAWQL_INFERENCE_KEYS_ENABLED`                                 | off                                  | Require virtual keys                    |
+| `CLAWQL_INFERENCE_STORE`                                        | jsonl when `CLAWQL_HOME`             | `memory` / `jsonl` / `postgres` / `off` |
+| `CLAWQL_INFERENCE_DATABASE_URL`                                 | —                                    | Postgres URL                            |
+| `CLAWQL_INFERENCE_STORE_PATH`                                   | `$CLAWQL_HOME/Inference/calls.jsonl` | JSONL path override                     |
+| `CLAWQL_INFERENCE_PIPELINE_WORKER`                              | off                                  | Cron worker with serve                  |
+| `CLAWQL_INFERENCE_PIPELINE_POLL_MS`                             | `60000`                              | Worker poll interval                    |
+| `CLAWQL_INFERENCE_AGENT_COORDINATION_ENABLED`                   | off                                  | Agent coordination                      |
+| `HERMES_BASE_URL`                                               | —                                    | Hermes MoA endpoint                     |
+| `CLAWQL_PAYMENTS_ENFORCE_INFERENCE`                             | off                                  | Plan entitlement gate                   |
+| `CLAWQL_OBSERVABILITY_PROFILE`                                  | `external`                           | `bundled` / `external` / `minimal`      |
+| `CLAWQL_ENABLE_OTEL_TRACING`                                    | off                                  | Infra OTLP spans (Tempo / collector)    |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`                                   | —                                    | OTLP ingest URL                         |
+| `CLAWQL_ENABLE_LANGFUSE`                                        | on when keys set                     | Langfuse work-trace OTLP (opt-out `=0`) |
+| `LANGFUSE_HOST` / `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` | —                                    | Langfuse OTLP credentials               |
+| `CLAWQL_INFERENCE_SEMANTIC_CACHE_BACKEND`                       | `postgres` when DB configured        | `memory` / `postgres` / `pgvector`      |
+| `CLAWQL_EMBEDDING_DIMENSION`                                    | `1536`                               | pgvector column width for cache         |
 
 ---
 

--- a/docs/inference/clawql-inference.md
+++ b/docs/inference/clawql-inference.md
@@ -48,8 +48,11 @@ Each `complete()` call passes **outward** through these layers before reaching a
 4. **`TokenEfficiencyGateway`** — Layers 3–8 + 9–11 (terse, compress, route, prompt-cache markers)
 5. **`EntitlementEnforcedGateway`** — plan limit checks via `clawql-payments` (when enforcement enabled)
 6. **`ObservedInferenceGateway`** — appends an `InferenceRecord` to the call store
+7. **`TracedInferenceGateway`** — OTLP spans to infra + Langfuse when configured
 
-Call order from outside in: **Observed → Entitlement → Efficiency → Cache → Fallback → Configured → provider**.
+Call order from outside in: **Traced → Observed → Entitlement → Efficiency → Cache → Fallback → Configured → provider**.
+
+HTTP `clawql inference serve` uses `createInferenceGatewayAsync()` so semantic cache backs onto **Postgres pgvector** when an inference database is configured. Sync `createInferenceGateway()` keeps an in-memory cache for one-shot CLI calls.
 
 ### Backends
 
@@ -518,6 +521,13 @@ clawql inference <subcommand>
 | `CLAWQL_INFERENCE_AGENT_COORDINATION_ENABLED` | off                                  | Agent coordination                      |
 | `HERMES_BASE_URL`                             | —                                    | Hermes MoA endpoint                     |
 | `CLAWQL_PAYMENTS_ENFORCE_INFERENCE`           | off                                  | Plan entitlement gate                   |
+| `CLAWQL_OBSERVABILITY_PROFILE`                | `external`                           | `bundled` / `external` / `minimal`      |
+| `CLAWQL_ENABLE_OTEL_TRACING`                  | off                                  | Infra OTLP spans (Tempo / collector)    |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`                  | —                                    | OTLP ingest URL                         |
+| `CLAWQL_ENABLE_LANGFUSE`                      | on when keys set                     | Langfuse work-trace OTLP (opt-out `=0`) |
+| `LANGFUSE_HOST` / `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` | —                    | Langfuse OTLP credentials               |
+| `CLAWQL_INFERENCE_SEMANTIC_CACHE_BACKEND`     | `postgres` when DB configured        | `memory` / `postgres` / `pgvector`      |
+| `CLAWQL_EMBEDDING_DIMENSION`                  | `1536`                               | pgvector column width for cache         |
 
 ---
 
@@ -559,11 +569,15 @@ clawql inference <subcommand>
 | P1       | Agent coordination                                                  | ✅     |
 | Adoption | OpenAI REST, semantic cache, fallback, virtual keys, Postgres store | ✅     |
 
+### Shipped observability
+
+- **OTLP infra tracing** — `CLAWQL_ENABLE_OTEL_TRACING=1` + `OTEL_EXPORTER_OTLP_*` → Tempo/collector
+- **Langfuse work traces** — ADR 0005 opt-out emission via OTLP to `{LANGFUSE_HOST}/api/public/otel/v1/traces`
+- **Distributed semantic cache** — `clawql_inference_semantic_cache` table with pgvector HNSW index
+
 ### Planned (not blockers)
 
-- Langfuse / OpenTelemetry full wiring (ADR 0005)
 - Manifest YAML inference block overrides for `policy show`
-- Distributed semantic cache backend (Redis/pgvector) for multi-instance gateways
 - Postgres advisory locks for multi-instance pipeline dedup
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -12699,6 +12699,11 @@
             "version": "7.0.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "@opentelemetry/api": "^1.9.1",
+                "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
+                "@opentelemetry/resources": "^2.9.0",
+                "@opentelemetry/sdk-trace-base": "^2.9.0",
+                "@opentelemetry/sdk-trace-node": "^2.9.0",
                 "clawql-api": "7.0.0",
                 "clawql-core": "7.0.0",
                 "clawql-payments": "7.0.0",

--- a/packages/clawql-inference/package.json
+++ b/packages/clawql-inference/package.json
@@ -41,6 +41,11 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
+    "@opentelemetry/resources": "^2.9.0",
+    "@opentelemetry/sdk-trace-base": "^2.9.0",
+    "@opentelemetry/sdk-trace-node": "^2.9.0",
     "clawql-api": "7.0.0",
     "clawql-core": "7.0.0",
     "clawql-payments": "7.0.0",

--- a/packages/clawql-inference/src/api/server.ts
+++ b/packages/clawql-inference/src/api/server.ts
@@ -2,24 +2,30 @@ import express, { type Express } from "express";
 import { createX402PaymentMiddleware } from "clawql-payments/x402";
 import { attachPaymentsWellKnownRoutes } from "clawql-payments/discovery";
 import { attachMppOpenApiRoutes, isMppOpenApiEnabled } from "clawql-payments/mpp";
-import { createInferenceGateway } from "../gateway.js";
+import { createInferenceGateway, createInferenceGatewayAsync } from "../gateway.js";
 import type { InferenceGateway } from "../gateway.js";
 import { createProviderRegistry } from "../providers/registry.js";
 import { composeDefaultProviderPlugins } from "../plugin/compose.js";
+import type { ProviderRegistry } from "../providers/types.js";
 import { createVirtualKeyAuthMiddleware } from "./auth.js";
 import { createOpenAiCompatRouter } from "./openai-compat.js";
+import { maybeInitInferenceOtelTracing } from "../observability/otel-tracing.js";
+import { registerInferencePoolShutdownHooks } from "../store/postgres-pool.js";
 
 export type CreateInferenceHttpAppOptions = {
   gateway?: InferenceGateway;
+  registry?: ProviderRegistry;
   env?: NodeJS.ProcessEnv;
 };
 
 export function createInferenceHttpApp(options: CreateInferenceHttpAppOptions = {}): Express {
   const env = options.env;
-  const registry = createProviderRegistry({
-    env,
-    plugins: composeDefaultProviderPlugins(),
-  });
+  const registry =
+    options.registry ??
+    createProviderRegistry({
+      env,
+      plugins: composeDefaultProviderPlugins(),
+    });
   const gateway = options.gateway ?? createInferenceGateway({ env, providers: registry });
   const app = express();
   app.use(express.json({ limit: "2mb" }));
@@ -65,7 +71,16 @@ export async function runInferenceHttpServer(
   } = {}
 ): Promise<{ app: Express; port: number; host: string }> {
   const env = options.env ?? process.env;
-  const app = createInferenceHttpApp({ gateway: options.gateway, env });
+  registerInferencePoolShutdownHooks();
+  await maybeInitInferenceOtelTracing(env);
+  const registry = createProviderRegistry({
+    env,
+    plugins: composeDefaultProviderPlugins(),
+  });
+  const gateway =
+    options.gateway ??
+    (await createInferenceGatewayAsync({ env, providers: registry }));
+  const app = createInferenceHttpApp({ gateway, registry, env });
   const port = options.port ?? resolveInferencePort(env);
   const host = options.host ?? resolveInferenceHost(env);
   await new Promise<void>((resolve) => {

--- a/packages/clawql-inference/src/api/server.ts
+++ b/packages/clawql-inference/src/api/server.ts
@@ -78,8 +78,7 @@ export async function runInferenceHttpServer(
     plugins: composeDefaultProviderPlugins(),
   });
   const gateway =
-    options.gateway ??
-    (await createInferenceGatewayAsync({ env, providers: registry }));
+    options.gateway ?? (await createInferenceGatewayAsync({ env, providers: registry }));
   const app = createInferenceHttpApp({ gateway, registry, env });
   const port = options.port ?? resolveInferencePort(env);
   const host = options.host ?? resolveInferenceHost(env);

--- a/packages/clawql-inference/src/cache/cached-gateway.ts
+++ b/packages/clawql-inference/src/cache/cached-gateway.ts
@@ -1,6 +1,5 @@
 import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../gateway.js";
 import { createEmbedder, resolveInferenceEmbeddingConfig, type Embedder } from "./embedding.js";
-import { InMemorySemanticCacheStore } from "./in-memory.js";
 import {
   completeWithSemanticCacheProgram,
   runSemanticCacheEffect,
@@ -41,15 +40,6 @@ export type WithSemanticCacheOptions = {
   embedder?: Embedder;
 };
 
-export function createSemanticCacheStore(config: SemanticCacheConfig): InMemorySemanticCacheStore {
-  return new InMemorySemanticCacheStore({
-    enabled: config.enabled,
-    threshold: config.threshold,
-    ttlMs: config.ttlMs,
-    maxEntries: config.maxEntries,
-  });
-}
-
 export function withSemanticCache(
   gateway: InferenceGateway,
   options: WithSemanticCacheOptions = {}
@@ -61,9 +51,15 @@ export function withSemanticCache(
   const embeddingConfig = resolveInferenceEmbeddingConfig(env);
   if (!embeddingConfig && !options.embedder) return gateway;
 
+  if (!options.cache) {
+    console.warn(
+      "[clawql-inference] semantic cache enabled without pre-initialized store; use createSemanticCacheStore() in serve/bootstrap"
+    );
+    return gateway;
+  }
+
   const embedder = options.embedder ?? createEmbedder(embeddingConfig!);
-  const cache = options.cache ?? createSemanticCacheStore(config);
-  return new SemanticCachedGateway(gateway, cache, config, embedder);
+  return new SemanticCachedGateway(gateway, options.cache, config, embedder);
 }
 
 export function isSemanticCachedGateway(

--- a/packages/clawql-inference/src/cache/effect/semantic-cache-store-service.ts
+++ b/packages/clawql-inference/src/cache/effect/semantic-cache-store-service.ts
@@ -26,9 +26,9 @@ export function semanticCacheStoreLiveLayer(
   return Layer.succeed(
     SemanticCacheStoreService,
     SemanticCacheStoreService.of({
-      lookup: (input) => Effect.sync(() => store.lookup(input)),
-      put: (entry) => Effect.sync(() => store.put(entry)),
-      invalidateByTags: (tags, now) => Effect.sync(() => store.invalidateByTags(tags, now)),
+      lookup: (input) => Effect.promise(() => store.lookup(input)),
+      put: (entry) => Effect.promise(() => store.put(entry)),
+      invalidateByTags: (tags, now) => Effect.promise(() => store.invalidateByTags(tags, now)),
     })
   );
 }

--- a/packages/clawql-inference/src/cache/in-memory.ts
+++ b/packages/clawql-inference/src/cache/in-memory.ts
@@ -30,12 +30,12 @@ export class InMemorySemanticCacheStore implements SemanticCacheStore {
     this.maxEntries = options.maxEntries ?? 1000;
   }
 
-  lookup(input: {
+  async lookup(input: {
     modelId: string;
     embedding: Float32Array;
     threshold: number;
     now?: number;
-  }): SemanticCacheLookupResult | null {
+  }): Promise<SemanticCacheLookupResult | null> {
     const now = input.now ?? Date.now();
     this.prune(now);
     let best: SemanticCacheLookupResult | null = null;
@@ -56,7 +56,7 @@ export class InMemorySemanticCacheStore implements SemanticCacheStore {
     return null;
   }
 
-  put(entry: SemanticCacheEntry): void {
+  async put(entry: SemanticCacheEntry): Promise<void> {
     this.entries.push(entry);
     if (this.entries.length > this.maxEntries) {
       this.entries.sort((a, b) => a.createdAt - b.createdAt);
@@ -64,7 +64,7 @@ export class InMemorySemanticCacheStore implements SemanticCacheStore {
     }
   }
 
-  invalidateByTags(tags: string[], now: number = Date.now()): number {
+  async invalidateByTags(tags: string[], now: number = Date.now()): Promise<number> {
     if (!tags.length) return 0;
     const tagSet = new Set(tags.map((tag) => tag.toLowerCase()));
     const before = this.entries.length;
@@ -89,7 +89,7 @@ export class InMemorySemanticCacheStore implements SemanticCacheStore {
     };
   }
 
-  prune(now: number = Date.now()): number {
+  async prune(now: number = Date.now()): Promise<number> {
     const before = this.entries.length;
     const kept = this.entries.filter((e) => e.expiresAt > now);
     this.entries.length = 0;

--- a/packages/clawql-inference/src/cache/postgres-pgvector-store.test.ts
+++ b/packages/clawql-inference/src/cache/postgres-pgvector-store.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { resolveSemanticCacheBackend } from "./postgres-pgvector-store.js";
+
+describe("semantic cache backend", () => {
+  it("defaults to postgres when inference database is configured", () => {
+    expect(
+      resolveSemanticCacheBackend({
+        CLAWQL_INFERENCE_DATABASE_URL: "postgres://user:pass@localhost:5432/clawql",
+      })
+    ).toBe("postgres");
+  });
+
+  it("honors explicit memory backend", () => {
+    expect(
+      resolveSemanticCacheBackend({
+        CLAWQL_INFERENCE_SEMANTIC_CACHE_BACKEND: "memory",
+        CLAWQL_INFERENCE_DATABASE_URL: "postgres://user:pass@localhost:5432/clawql",
+      })
+    ).toBe("memory");
+  });
+});

--- a/packages/clawql-inference/src/cache/postgres-pgvector-store.ts
+++ b/packages/clawql-inference/src/cache/postgres-pgvector-store.ts
@@ -1,0 +1,205 @@
+import type pg from "pg";
+import { ensureInferenceSchema, getInferencePgPool } from "../store/postgres-pool.js";
+import type {
+  SemanticCacheConfig,
+  SemanticCacheEntry,
+  SemanticCacheLookupResult,
+  SemanticCacheStats,
+  SemanticCacheStore,
+} from "./types.js";
+import { parseVectorText, toVectorLiteral } from "./vector.js";
+
+/** Distributed semantic cache backed by Postgres pgvector (Layer 5). */
+export class PostgresSemanticCacheStore implements SemanticCacheStore {
+  private hits = 0;
+  private misses = 0;
+
+  constructor(
+    private readonly pool: pg.Pool,
+    private readonly config: SemanticCacheConfig,
+    private readonly env: NodeJS.ProcessEnv = process.env
+  ) {}
+
+  private async ready(): Promise<void> {
+    await ensureInferenceSchema(this.env);
+  }
+
+  async lookup(input: {
+    modelId: string;
+    embedding: Float32Array;
+    threshold: number;
+    now?: number;
+  }): Promise<SemanticCacheLookupResult | null> {
+    await this.ready();
+    const now = input.now ?? Date.now();
+    await this.prune(now);
+    if (input.embedding.length === 0) {
+      this.misses += 1;
+      return null;
+    }
+
+    const qLit = toVectorLiteral(input.embedding);
+    const result = await this.pool.query<{
+      id: string;
+      model_id: string;
+      signature_text: string;
+      system_prompt_hash: string | null;
+      emb: string;
+      response: unknown;
+      resource_tags: string[] | null;
+      created_at: Date;
+      expires_at: Date;
+      similarity: string;
+    }>(
+      `SELECT id, model_id, signature_text, system_prompt_hash, embedding::text AS emb,
+              response, resource_tags, created_at, expires_at,
+              (1 - (embedding <=> $1::vector))::float8 AS similarity
+       FROM clawql_inference_semantic_cache
+       WHERE model_id = $2 AND expires_at > to_timestamp($3 / 1000.0)
+       ORDER BY embedding <=> $1::vector
+       LIMIT 8`,
+      [qLit, input.modelId, now]
+    );
+
+    let best: SemanticCacheLookupResult | null = null;
+    for (const row of result.rows) {
+      const similarity = Number(row.similarity);
+      if (!Number.isFinite(similarity) || similarity < input.threshold) continue;
+      const entry: SemanticCacheEntry = {
+        id: row.id,
+        modelId: row.model_id,
+        signatureText: row.signature_text,
+        systemPromptHash: row.system_prompt_hash ?? undefined,
+        embedding: parseVectorText(row.emb),
+        response: row.response as SemanticCacheEntry["response"],
+        createdAt: row.created_at.getTime(),
+        expiresAt: row.expires_at.getTime(),
+        resourceTags: row.resource_tags ?? undefined,
+      };
+      if (!best || similarity > best.similarity) {
+        best = { entry, similarity };
+      }
+    }
+
+    if (best) {
+      this.hits += 1;
+      return best;
+    }
+    this.misses += 1;
+    return null;
+  }
+
+  async put(entry: SemanticCacheEntry): Promise<void> {
+    await this.ready();
+    const literal = toVectorLiteral(entry.embedding);
+    await this.pool.query(
+      `INSERT INTO clawql_inference_semantic_cache (
+        id, model_id, signature_text, system_prompt_hash, embedding, embedding_dim,
+        response, resource_tags, created_at, expires_at
+      ) VALUES ($1, $2, $3, $4, $5::vector, $6, $7::jsonb, $8, to_timestamp($9 / 1000.0), to_timestamp($10 / 1000.0))
+      ON CONFLICT (id) DO UPDATE SET
+        response = EXCLUDED.response,
+        expires_at = EXCLUDED.expires_at,
+        resource_tags = EXCLUDED.resource_tags`,
+      [
+        entry.id,
+        entry.modelId,
+        entry.signatureText,
+        entry.systemPromptHash ?? null,
+        literal,
+        entry.embedding.length,
+        JSON.stringify(entry.response),
+        entry.resourceTags ?? [],
+        entry.createdAt,
+        entry.expiresAt,
+      ]
+    );
+
+    const overflow = await this.pool.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM clawql_inference_semantic_cache WHERE model_id = $1`,
+      [entry.modelId]
+    );
+    const count = Number.parseInt(overflow.rows[0]?.count ?? "0", 10);
+    if (count > this.config.maxEntries) {
+      await this.pool.query(
+        `DELETE FROM clawql_inference_semantic_cache
+         WHERE id IN (
+           SELECT id FROM clawql_inference_semantic_cache
+           WHERE model_id = $1
+           ORDER BY created_at ASC
+           LIMIT $2
+         )`,
+        [entry.modelId, count - this.config.maxEntries]
+      );
+    }
+  }
+
+  async invalidateByTags(tags: string[], now: number = Date.now()): Promise<number> {
+    if (!tags.length) return 0;
+    await this.ready();
+    await this.prune(now);
+    const result = await this.pool.query(
+      `DELETE FROM clawql_inference_semantic_cache
+       WHERE resource_tags && $1::text[]`,
+      [tags]
+    );
+    return result.rowCount ?? 0;
+  }
+
+  stats(): SemanticCacheStats {
+    return {
+      entries: 0,
+      hits: this.hits,
+      misses: this.misses,
+      enabled: this.config.enabled,
+      threshold: this.config.threshold,
+      ttlMs: this.config.ttlMs,
+    };
+  }
+
+  async prune(now: number = Date.now()): Promise<number> {
+    await this.ready();
+    const result = await this.pool.query(
+      `DELETE FROM clawql_inference_semantic_cache WHERE expires_at <= to_timestamp($1 / 1000.0)`,
+      [now]
+    );
+    return result.rowCount ?? 0;
+  }
+}
+
+export type SemanticCacheBackend = "memory" | "postgres";
+
+export function resolveSemanticCacheBackend(
+  env: NodeJS.ProcessEnv = process.env
+): SemanticCacheBackend {
+  const raw = env.CLAWQL_INFERENCE_SEMANTIC_CACHE_BACKEND?.trim().toLowerCase();
+  if (raw === "memory" || raw === "inmemory" || raw === "in-memory") return "memory";
+  if (raw === "postgres" || raw === "pg" || raw === "pgvector") return "postgres";
+  if (getInferencePgPool(env)) return "postgres";
+  return "memory";
+}
+
+export async function createSemanticCacheStore(
+  config: SemanticCacheConfig,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<SemanticCacheStore> {
+  const backend = resolveSemanticCacheBackend(env);
+  if (backend === "postgres") {
+    const pool = getInferencePgPool(env);
+    if (!pool) {
+      console.warn(
+        "[clawql-inference] CLAWQL_INFERENCE_SEMANTIC_CACHE_BACKEND=postgres but no inference DB configured; using in-memory cache"
+      );
+    } else {
+      return new PostgresSemanticCacheStore(pool, config, env);
+    }
+  }
+
+  const { InMemorySemanticCacheStore } = await import("./in-memory.js");
+  return new InMemorySemanticCacheStore({
+    enabled: config.enabled,
+    threshold: config.threshold,
+    ttlMs: config.ttlMs,
+    maxEntries: config.maxEntries,
+  });
+}

--- a/packages/clawql-inference/src/cache/types.ts
+++ b/packages/clawql-inference/src/cache/types.ts
@@ -87,9 +87,9 @@ export interface SemanticCacheStore {
     embedding: Float32Array;
     threshold: number;
     now?: number;
-  }): SemanticCacheLookupResult | null;
-  put(entry: SemanticCacheEntry): void;
-  invalidateByTags(tags: string[], now?: number): number;
+  }): Promise<SemanticCacheLookupResult | null>;
+  put(entry: SemanticCacheEntry): Promise<void>;
+  invalidateByTags(tags: string[], now?: number): Promise<number>;
   stats(): SemanticCacheStats;
-  prune(now?: number): number;
+  prune(now?: number): Promise<number>;
 }

--- a/packages/clawql-inference/src/cache/vector.ts
+++ b/packages/clawql-inference/src/cache/vector.ts
@@ -1,0 +1,29 @@
+const DEFAULT_EMBEDDING_DIMENSION = 1536;
+
+export function inferenceEmbeddingDimension(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.CLAWQL_EMBEDDING_DIMENSION?.trim();
+  if (raw) {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_EMBEDDING_DIMENSION;
+}
+
+export function toVectorLiteral(vector: Float32Array): string {
+  return `[${Array.from(vector).join(",")}]`;
+}
+
+export function parseVectorText(value: string): Float32Array {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) {
+    return new Float32Array(0);
+  }
+  const inner = trimmed.slice(1, -1);
+  if (!inner.length) return new Float32Array(0);
+  const parts = inner.split(",");
+  const out = new Float32Array(parts.length);
+  for (let i = 0; i < parts.length; i++) {
+    out[i] = Number.parseFloat(parts[i]!.trim());
+  }
+  return out;
+}

--- a/packages/clawql-inference/src/cli/serve.ts
+++ b/packages/clawql-inference/src/cli/serve.ts
@@ -1,5 +1,7 @@
-import { createInferenceGateway } from "../gateway.js";
+import { createInferenceGatewayAsync } from "../gateway.js";
 import { runInferenceHttpServer } from "../api/server.js";
+import { maybeInitInferenceOtelTracing } from "../observability/otel-tracing.js";
+import { registerInferencePoolShutdownHooks } from "../store/postgres-pool.js";
 import { startPipelineWorker } from "../pipeline/worker.js";
 
 function parseTruthy(value: string | undefined): boolean {
@@ -16,7 +18,9 @@ export type InferenceServeOptions = {
 
 export async function runInferenceServe(options: InferenceServeOptions = {}): Promise<number> {
   const env = options.env ?? process.env;
-  const gateway = createInferenceGateway({ env });
+  registerInferencePoolShutdownHooks();
+  await maybeInitInferenceOtelTracing(env);
+  const gateway = await createInferenceGatewayAsync({ env });
   const { port, host } = await runInferenceHttpServer({
     gateway,
     env,

--- a/packages/clawql-inference/src/gateway.ts
+++ b/packages/clawql-inference/src/gateway.ts
@@ -5,9 +5,13 @@ import { createProviderRegistry, getProviderAdapter } from "./providers/registry
 import type { InferenceProviderPlugin, ProviderRegistry } from "./providers/types.js";
 import { composeDefaultProviderPlugins } from "./plugin/compose.js";
 import { withInferenceStore } from "./observability/observed-gateway.js";
+import { withInferenceTracing } from "./observability/traced-gateway.js";
 import { createInferenceStore } from "./store/create.js";
 import type { InferenceStore } from "./store/types.js";
 import { withSemanticCache, type WithSemanticCacheOptions } from "./cache/cached-gateway.js";
+import { createSemanticCacheStore } from "./cache/postgres-pgvector-store.js";
+import { loadSemanticCacheConfig } from "./cache/types.js";
+import { InMemorySemanticCacheStore } from "./cache/in-memory.js";
 import { loadFallbackConfig } from "./fallback/config.js";
 import { withFallbackChain, type WithFallbackChainOptions } from "./fallback/fallback-gateway.js";
 import { withEntitlementEnforcement } from "./entitlements/enforced-gateway.js";
@@ -73,6 +77,8 @@ export type CreateInferenceGatewayOptions = {
   store?: InferenceStore | null;
   semanticCache?: WithSemanticCacheOptions | false;
   fallback?: WithFallbackChainOptions | false;
+  /** Emit OTLP spans (infra + Langfuse) when configured. Default true. */
+  tracing?: boolean;
 };
 
 export class ConfiguredInferenceGateway implements InferenceGateway {
@@ -102,6 +108,47 @@ export class ConfiguredInferenceGateway implements InferenceGateway {
   }
 }
 
+function composeInferenceGateway(
+  inner: InferenceGateway,
+  options: CreateInferenceGatewayOptions
+): InferenceGateway {
+  const env = options.env;
+  const fallbackConfig =
+    options.fallback === false ? null : (options.fallback?.config ?? loadFallbackConfig(env));
+  const withFallback =
+    options.fallback === false || !fallbackConfig
+      ? inner
+      : withFallbackChain(inner, { config: fallbackConfig });
+
+  let semanticOptions = options.semanticCache;
+  if (semanticOptions !== false && !semanticOptions?.cache) {
+    const config = semanticOptions?.config ?? loadSemanticCacheConfig(env);
+    if (config.enabled) {
+      semanticOptions = {
+        ...semanticOptions,
+        config,
+        cache: new InMemorySemanticCacheStore({
+          enabled: config.enabled,
+          threshold: config.threshold,
+          ttlMs: config.ttlMs,
+          maxEntries: config.maxEntries,
+        }),
+      };
+    }
+  }
+
+  const cached =
+    options.semanticCache === false
+      ? withFallback
+      : withSemanticCache(withFallback, { env, ...semanticOptions });
+  const efficient = withTokenEfficiency(cached, { env });
+  const entitled = withEntitlementEnforcement(efficient, env);
+  const store = options.store === undefined ? createInferenceStore({ env }) : options.store;
+  const observed = withInferenceStore(entitled, store, env);
+  if (options.tracing === false) return observed;
+  return withInferenceTracing(observed, env);
+}
+
 export function createInferenceGateway(
   options: CreateInferenceGatewayOptions = {}
 ): InferenceGateway {
@@ -113,18 +160,33 @@ export function createInferenceGateway(
       plugins: options.providerPlugins ?? composeDefaultProviderPlugins(),
     });
   const inner = new ConfiguredInferenceGateway(providers);
-  const fallbackConfig =
-    options.fallback === false ? null : (options.fallback?.config ?? loadFallbackConfig(env));
-  const withFallback =
-    options.fallback === false || !fallbackConfig
-      ? inner
-      : withFallbackChain(inner, { config: fallbackConfig });
-  const cached =
-    options.semanticCache === false
-      ? withFallback
-      : withSemanticCache(withFallback, { env, ...options.semanticCache });
-  const efficient = withTokenEfficiency(cached, { env });
-  const entitled = withEntitlementEnforcement(efficient, env);
-  const store = options.store === undefined ? createInferenceStore({ env }) : options.store;
-  return withInferenceStore(entitled, store, env);
+  return composeInferenceGateway(inner, options);
+}
+
+/** Async gateway bootstrap — selects Postgres pgvector semantic cache when configured. */
+export async function createInferenceGatewayAsync(
+  options: CreateInferenceGatewayOptions = {}
+): Promise<InferenceGateway> {
+  const env = options.env;
+  const providers =
+    options.providers ??
+    createProviderRegistry({
+      env,
+      plugins: options.providerPlugins ?? composeDefaultProviderPlugins(),
+    });
+  const inner = new ConfiguredInferenceGateway(providers);
+
+  let semanticOptions = options.semanticCache;
+  if (semanticOptions !== false && !semanticOptions?.cache) {
+    const config = semanticOptions?.config ?? loadSemanticCacheConfig(env);
+    if (config.enabled) {
+      semanticOptions = {
+        ...semanticOptions,
+        config,
+        cache: await createSemanticCacheStore(config, env),
+      };
+    }
+  }
+
+  return composeInferenceGateway(inner, { ...options, semanticCache: semanticOptions });
 }

--- a/packages/clawql-inference/src/index.ts
+++ b/packages/clawql-inference/src/index.ts
@@ -35,6 +35,7 @@ export {
   UnconfiguredInferenceGateway,
   ConfiguredInferenceGateway,
   createInferenceGateway,
+  createInferenceGatewayAsync,
 } from "./gateway.js";
 
 export {
@@ -75,6 +76,19 @@ export {
 export { InMemoryInferenceStore } from "./store/in-memory.js";
 export { JsonlInferenceStore } from "./store/jsonl.js";
 export { ObservedInferenceGateway, withInferenceStore } from "./observability/observed-gateway.js";
+export { TracedInferenceGateway, withInferenceTracing } from "./observability/traced-gateway.js";
+export {
+  maybeInitInferenceOtelTracing,
+  inferenceTracingFeatureEnabled,
+  withInferenceSpan,
+} from "./observability/otel-tracing.js";
+export {
+  resolveObservabilityProfile,
+  langfuseTracingEnabled,
+  otelInfraTracingEnabled,
+  inferenceTracingEnabled,
+} from "./observability/profile.js";
+export { resolveLangfuseOtlpConfig } from "./observability/langfuse-config.js";
 export { parseSinceDuration } from "./observability/parse-since.js";
 export { runInferenceLogs, runInferenceTrace, runInferenceSpend } from "./cli/observability.js";
 export { runInferenceExportCli, type InferenceExportCliOptions } from "./cli/export.js";
@@ -152,9 +166,14 @@ export {
   withSemanticCache,
   SemanticCachedGateway,
   isSemanticCachedGateway,
-  createSemanticCacheStore,
   type WithSemanticCacheOptions,
 } from "./cache/cached-gateway.js";
+export {
+  createSemanticCacheStore,
+  resolveSemanticCacheBackend,
+  PostgresSemanticCacheStore,
+  type SemanticCacheBackend,
+} from "./cache/postgres-pgvector-store.js";
 export {
   loadSemanticCacheConfig,
   semanticCacheActive,

--- a/packages/clawql-inference/src/observability/langfuse-config.ts
+++ b/packages/clawql-inference/src/observability/langfuse-config.ts
@@ -1,0 +1,21 @@
+/** Resolve Langfuse OTLP ingest URL and auth headers (ADR 0005). */
+export function resolveLangfuseOtlpConfig(env: NodeJS.ProcessEnv = process.env): {
+  url: string;
+  headers: Record<string, string>;
+} | null {
+  const host = env.LANGFUSE_HOST?.trim() || env.LANGFUSE_BASE_URL?.trim();
+  const publicKey = env.LANGFUSE_PUBLIC_KEY?.trim();
+  const secretKey = env.LANGFUSE_SECRET_KEY?.trim();
+  if (!host || !publicKey || !secretKey) return null;
+
+  const base = host.replace(/\/$/, "");
+  const auth = Buffer.from(`${publicKey}:${secretKey}`, "utf8").toString("base64");
+  return {
+    url: `${base}/api/public/otel/v1/traces`,
+    headers: {
+      Authorization: `Basic ${auth}`,
+      "x-langfuse-public-key": publicKey,
+      "x-langfuse-secret-key": secretKey,
+    },
+  };
+}

--- a/packages/clawql-inference/src/observability/observability.test.ts
+++ b/packages/clawql-inference/src/observability/observability.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { resolveLangfuseOtlpConfig } from "./langfuse-config.js";
+import {
+  inferenceTracingEnabled,
+  langfuseTracingEnabled,
+  otelInfraTracingEnabled,
+  resolveObservabilityProfile,
+} from "./profile.js";
+
+describe("observability profile", () => {
+  it("defaults langfuse on when credentials exist in external profile", () => {
+    expect(
+      langfuseTracingEnabled({
+        CLAWQL_OBSERVABILITY_PROFILE: "external",
+        LANGFUSE_HOST: "https://langfuse.example",
+        LANGFUSE_PUBLIC_KEY: "pk",
+        LANGFUSE_SECRET_KEY: "sk",
+      })
+    ).toBe(true);
+  });
+
+  it("disables langfuse in minimal profile", () => {
+    expect(
+      langfuseTracingEnabled({
+        CLAWQL_OBSERVABILITY_PROFILE: "minimal",
+        LANGFUSE_HOST: "https://langfuse.example",
+        LANGFUSE_PUBLIC_KEY: "pk",
+        LANGFUSE_SECRET_KEY: "sk",
+      })
+    ).toBe(false);
+  });
+
+  it("respects CLAWQL_ENABLE_LANGFUSE=0 opt-out", () => {
+    expect(
+      langfuseTracingEnabled({
+        CLAWQL_ENABLE_LANGFUSE: "0",
+        LANGFUSE_HOST: "https://langfuse.example",
+        LANGFUSE_PUBLIC_KEY: "pk",
+        LANGFUSE_SECRET_KEY: "sk",
+      })
+    ).toBe(false);
+  });
+
+  it("requires OTEL flag and endpoint for infra tracing", () => {
+    expect(
+      otelInfraTracingEnabled({
+        CLAWQL_ENABLE_OTEL_TRACING: "1",
+        OTEL_EXPORTER_OTLP_ENDPOINT: "http://collector:4318",
+      })
+    ).toBe(true);
+    expect(
+      otelInfraTracingEnabled({
+        CLAWQL_ENABLE_OTEL_TRACING: "1",
+      })
+    ).toBe(false);
+  });
+
+  it("enables inference tracing when either backend is active", () => {
+    expect(
+      inferenceTracingEnabled({
+        CLAWQL_ENABLE_OTEL_TRACING: "1",
+        OTEL_EXPORTER_OTLP_ENDPOINT: "http://collector:4318",
+      })
+    ).toBe(true);
+    expect(resolveObservabilityProfile({})).toBe("external");
+  });
+});
+
+describe("langfuse otlp config", () => {
+  it("builds public otlp url and auth headers", () => {
+    const config = resolveLangfuseOtlpConfig({
+      LANGFUSE_HOST: "https://langfuse.example/",
+      LANGFUSE_PUBLIC_KEY: "pk-test",
+      LANGFUSE_SECRET_KEY: "sk-test",
+    });
+    expect(config?.url).toBe("https://langfuse.example/api/public/otel/v1/traces");
+    expect(config?.headers.Authorization).toMatch(/^Basic /);
+    expect(config?.headers["x-langfuse-public-key"]).toBe("pk-test");
+  });
+});

--- a/packages/clawql-inference/src/observability/otel-tracing.ts
+++ b/packages/clawql-inference/src/observability/otel-tracing.ts
@@ -70,10 +70,7 @@ async function initInferenceOtelTracing(
   });
   provider.register();
 
-  const targets = [
-    otelInfraTracingEnabled(env) ? "infra-otlp" : null,
-    langfuse ? "langfuse" : null,
-  ]
+  const targets = [otelInfraTracingEnabled(env) ? "infra-otlp" : null, langfuse ? "langfuse" : null]
     .filter(Boolean)
     .join("+");
   console.log(`[clawql-inference] OTLP tracing enabled (${targets}, service.name=${serviceName})`);

--- a/packages/clawql-inference/src/observability/otel-tracing.ts
+++ b/packages/clawql-inference/src/observability/otel-tracing.ts
@@ -1,0 +1,131 @@
+import { trace, SpanStatusCode, type Span } from "@opentelemetry/api";
+import {
+  inferenceTracingEnabled,
+  langfuseTracingEnabled,
+  otelInfraTracingEnabled,
+} from "./profile.js";
+import { resolveLangfuseOtlpConfig } from "./langfuse-config.js";
+
+export type InferenceOtelShutdownFn = () => Promise<void>;
+
+let initPromise: Promise<InferenceOtelShutdownFn | undefined> | null = null;
+
+/**
+ * Registers NodeTracerProvider with infra OTLP and/or Langfuse OTLP exporters.
+ * Dynamic imports keep OTEL packages off the critical path when tracing is disabled.
+ */
+export async function maybeInitInferenceOtelTracing(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<InferenceOtelShutdownFn | undefined> {
+  if (!inferenceTracingEnabled(env)) return undefined;
+  if (!initPromise) {
+    initPromise = initInferenceOtelTracing(env);
+  }
+  return initPromise;
+}
+
+async function initInferenceOtelTracing(
+  env: NodeJS.ProcessEnv
+): Promise<InferenceOtelShutdownFn | undefined> {
+  const { NodeTracerProvider } = await import("@opentelemetry/sdk-trace-node");
+  const { BatchSpanProcessor } = await import("@opentelemetry/sdk-trace-base");
+  const { OTLPTraceExporter } = await import("@opentelemetry/exporter-trace-otlp-http");
+  const { defaultResource, resourceFromAttributes } = await import("@opentelemetry/resources");
+
+  const processors = [];
+
+  if (otelInfraTracingEnabled(env)) {
+    processors.push(new BatchSpanProcessor(new OTLPTraceExporter()));
+  }
+
+  const langfuse = langfuseTracingEnabled(env) ? resolveLangfuseOtlpConfig(env) : null;
+  if (langfuse) {
+    processors.push(
+      new BatchSpanProcessor(
+        new OTLPTraceExporter({
+          url: langfuse.url,
+          headers: langfuse.headers,
+        })
+      )
+    );
+  }
+
+  if (processors.length === 0) return undefined;
+
+  const serviceName =
+    env.OTEL_SERVICE_NAME?.trim() ||
+    env.CLAWQL_INFERENCE_OTEL_SERVICE_NAME?.trim() ||
+    "clawql-inference";
+
+  const resource = defaultResource().merge(
+    resourceFromAttributes({
+      "service.name": serviceName,
+      "clawql.component": "inference-gateway",
+    })
+  );
+
+  const provider = new NodeTracerProvider({
+    spanProcessors: processors,
+    resource,
+  });
+  provider.register();
+
+  const targets = [
+    otelInfraTracingEnabled(env) ? "infra-otlp" : null,
+    langfuse ? "langfuse" : null,
+  ]
+    .filter(Boolean)
+    .join("+");
+  console.log(`[clawql-inference] OTLP tracing enabled (${targets}, service.name=${serviceName})`);
+
+  const shutdown = async (): Promise<void> => {
+    await provider.shutdown();
+    initPromise = null;
+  };
+
+  const once = (): void => {
+    void shutdown().catch(() => {});
+  };
+  process.once("SIGTERM", once);
+  process.once("SIGINT", once);
+
+  return shutdown;
+}
+
+export function inferenceTracingFeatureEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return inferenceTracingEnabled(env);
+}
+
+/** Wrap gateway completion with gen_ai / clawql span attributes. */
+export function withInferenceSpan<T>(
+  name: string,
+  attributes: Record<string, string | number | boolean | undefined>,
+  fn: (span: Span) => Promise<T>
+): Promise<T> {
+  if (!inferenceTracingFeatureEnabled()) {
+    return fn({
+      setAttribute: () => {},
+      setStatus: () => {},
+      recordException: () => {},
+      end: () => {},
+    } as unknown as Span);
+  }
+
+  const tracer = trace.getTracer("io.clawql.inference", "1.0.0");
+  return tracer.startActiveSpan(name, async (span: Span) => {
+    for (const [key, value] of Object.entries(attributes)) {
+      if (value !== undefined) span.setAttribute(key, value);
+    }
+    try {
+      return await fn(span);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      span.setStatus({ code: SpanStatusCode.ERROR, message });
+      if (error instanceof Error) span.recordException(error);
+      else span.recordException(new Error(message));
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}

--- a/packages/clawql-inference/src/observability/profile.ts
+++ b/packages/clawql-inference/src/observability/profile.ts
@@ -1,0 +1,46 @@
+export type ObservabilityProfile = "bundled" | "external" | "minimal";
+
+function parseTruthy(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+export function resolveObservabilityProfile(
+  env: NodeJS.ProcessEnv = process.env
+): ObservabilityProfile {
+  const raw = env.CLAWQL_OBSERVABILITY_PROFILE?.trim().toLowerCase();
+  if (raw === "bundled" || raw === "external" || raw === "minimal") return raw;
+  return "external";
+}
+
+export function hasOtlpEndpointConfigured(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(
+    env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT?.trim() || env.OTEL_EXPORTER_OTLP_ENDPOINT?.trim()
+  );
+}
+
+/** Infra OTLP (Tempo / collector) — opt-in via CLAWQL_ENABLE_OTEL_TRACING=1. */
+export function otelInfraTracingEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (resolveObservabilityProfile(env) === "minimal") return false;
+  if (!parseTruthy(env.CLAWQL_ENABLE_OTEL_TRACING)) return false;
+  return hasOtlpEndpointConfigured(env);
+}
+
+function langfuseCredentialsPresent(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(
+    env.LANGFUSE_HOST?.trim() && env.LANGFUSE_PUBLIC_KEY?.trim() && env.LANGFUSE_SECRET_KEY?.trim()
+  );
+}
+
+/** Langfuse work-trace OTLP — on by default in bundled/external when keys exist (ADR 0005). */
+export function langfuseTracingEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (resolveObservabilityProfile(env) === "minimal") return false;
+  const flag = env.CLAWQL_ENABLE_LANGFUSE?.trim().toLowerCase();
+  if (flag === "0" || flag === "false" || flag === "no" || flag === "off") return false;
+  return langfuseCredentialsPresent(env);
+}
+
+export function inferenceTracingEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return otelInfraTracingEnabled(env) || langfuseTracingEnabled(env);
+}

--- a/packages/clawql-inference/src/observability/traced-gateway.ts
+++ b/packages/clawql-inference/src/observability/traced-gateway.ts
@@ -1,0 +1,62 @@
+import type { InferenceGateway, InferenceRequest, InferenceResponse } from "../gateway.js";
+import { withInferenceSpan } from "./otel-tracing.js";
+
+function estimateMessageChars(messages: Array<{ content: string }>): number {
+  return messages.reduce((sum, message) => sum + message.content.length, 0);
+}
+
+/** Gateway decorator emitting OTLP spans for each completion (Langfuse + infra backends). */
+export class TracedInferenceGateway implements InferenceGateway {
+  constructor(
+    private readonly inner: InferenceGateway,
+    private readonly env: NodeJS.ProcessEnv = process.env
+  ) {}
+
+  async complete(request: InferenceRequest): Promise<InferenceResponse> {
+    const modelId = request.model ?? request.routing?.modelId ?? "unknown";
+    const planningChars = estimateMessageChars(request.messages);
+
+    return withInferenceSpan(
+      "inference.complete",
+      {
+        "clawql.correlation_id": request.correlationId,
+        "clawql.tool_name": "inference.complete",
+        "clawql.planning_bytes": planningChars,
+        "gen_ai.request.model": modelId,
+        "gen_ai.system": "clawql-inference",
+        "clawql.cache_intent": request.cacheIntent,
+        "clawql.team": request.team,
+      },
+      async (span) => {
+        const started = Date.now();
+        const response = await this.inner.complete(request);
+        const latencyMs = Date.now() - started;
+
+        span.setAttribute("gen_ai.response.model", response.model);
+        span.setAttribute("clawql.cache_hit", Boolean(response.cacheHit));
+        span.setAttribute("clawql.latency_ms", latencyMs);
+        if (response.routing?.tier) {
+          span.setAttribute("clawql.routing.tier", response.routing.tier);
+        }
+        if (response.usage) {
+          span.setAttribute("gen_ai.usage.input_tokens", response.usage.inputTokens);
+          span.setAttribute("gen_ai.usage.output_tokens", response.usage.outputTokens);
+        }
+        if (response.cacheHit && response.usage) {
+          const saved = response.usage.inputTokens + response.usage.outputTokens;
+          span.setAttribute("clawql.token_savings_estimate", saved);
+        }
+
+        return response;
+      }
+    );
+  }
+}
+
+export function withInferenceTracing(
+  gateway: InferenceGateway,
+  env: NodeJS.ProcessEnv = process.env
+): InferenceGateway {
+  if (!gateway) return gateway;
+  return new TracedInferenceGateway(gateway, env);
+}

--- a/packages/clawql-inference/src/policy/resolve.ts
+++ b/packages/clawql-inference/src/policy/resolve.ts
@@ -5,6 +5,13 @@ import { loadModelEscalationConfig } from "../routing/config.js";
 import { resolveInferenceStoreBackend, resolveInferenceStorePath } from "../store/create.js";
 import type { InferenceStoreBackend } from "../store/types.js";
 import { loadTokenEfficiencyConfig, listEfficiencyLayerStatus } from "../efficiency/config.js";
+import {
+  inferenceTracingEnabled,
+  langfuseTracingEnabled,
+  otelInfraTracingEnabled,
+  resolveObservabilityProfile,
+} from "../observability/profile.js";
+import { resolveSemanticCacheBackend } from "../cache/postgres-pgvector-store.js";
 
 export type InferencePolicyView = {
   source: "env";
@@ -33,6 +40,13 @@ export type InferencePolicyView = {
   };
   efficiency: ReturnType<typeof loadTokenEfficiencyConfig>;
   layers: ReturnType<typeof listEfficiencyLayerStatus>;
+  observability: {
+    profile: ReturnType<typeof resolveObservabilityProfile>;
+    otelInfra: boolean;
+    langfuse: boolean;
+    tracing: boolean;
+    semanticCacheBackend: ReturnType<typeof resolveSemanticCacheBackend>;
+  };
 };
 
 function parseTruthy(value: string | undefined): boolean {
@@ -85,5 +99,12 @@ export function resolveInferencePolicy(env: NodeJS.ProcessEnv = process.env): In
     },
     efficiency: loadTokenEfficiencyConfig(env),
     layers: listEfficiencyLayerStatus(env),
+    observability: {
+      profile: resolveObservabilityProfile(env),
+      otelInfra: otelInfraTracingEnabled(env),
+      langfuse: langfuseTracingEnabled(env),
+      tracing: inferenceTracingEnabled(env),
+      semanticCacheBackend: resolveSemanticCacheBackend(env),
+    },
   };
 }

--- a/packages/clawql-inference/src/store/postgres-migrations.ts
+++ b/packages/clawql-inference/src/store/postgres-migrations.ts
@@ -1,24 +1,83 @@
 import type { PoolClient } from "pg";
+import { inferenceEmbeddingDimension } from "../cache/vector.js";
+
+export const INFERENCE_PG_SCHEMA_VERSION = 2;
+
+async function currentSchemaVersion(client: PoolClient): Promise<number> {
+  const result = await client.query<{ version: number | null }>(
+    `SELECT MAX(version) AS version FROM clawql_inference_schema_migrations`
+  );
+  return result.rows[0]?.version ?? 0;
+}
 
 export async function runInferencePostgresMigrations(client: PoolClient): Promise<void> {
   await client.query(`
-    CREATE TABLE IF NOT EXISTS clawql_inference_calls (
-      id text PRIMARY KEY,
-      correlation_id text,
-      record jsonb NOT NULL,
-      created_at timestamptz NOT NULL DEFAULT now()
+    CREATE TABLE IF NOT EXISTS clawql_inference_schema_migrations (
+      version INTEGER PRIMARY KEY,
+      name TEXT NOT NULL,
+      applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
     )
   `);
-  await client.query(`
-    CREATE INDEX IF NOT EXISTS clawql_inference_calls_correlation_idx
-    ON clawql_inference_calls (correlation_id)
-  `);
-  await client.query(`
-    CREATE INDEX IF NOT EXISTS clawql_inference_calls_created_idx
-    ON clawql_inference_calls (created_at DESC)
-  `);
-  await client.query(`
-    CREATE INDEX IF NOT EXISTS clawql_inference_calls_model_idx
-    ON clawql_inference_calls ((record->>'modelId'))
-  `);
+
+  let version = await currentSchemaVersion(client);
+
+  if (version < 1) {
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS clawql_inference_calls (
+        id text PRIMARY KEY,
+        correlation_id text,
+        record jsonb NOT NULL,
+        created_at timestamptz NOT NULL DEFAULT now()
+      )
+    `);
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS clawql_inference_calls_correlation_idx
+      ON clawql_inference_calls (correlation_id)
+    `);
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS clawql_inference_calls_created_idx
+      ON clawql_inference_calls (created_at DESC)
+    `);
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS clawql_inference_calls_model_idx
+      ON clawql_inference_calls ((record->>'modelId'))
+    `);
+    await client.query(
+      `INSERT INTO clawql_inference_schema_migrations (version, name) VALUES (1, 'inference_calls_v1')
+       ON CONFLICT (version) DO NOTHING`
+    );
+    version = 1;
+  }
+
+  if (version < 2) {
+    await client.query("CREATE EXTENSION IF NOT EXISTS vector");
+    const dim = inferenceEmbeddingDimension();
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS clawql_inference_semantic_cache (
+        id text PRIMARY KEY,
+        model_id text NOT NULL,
+        signature_text text NOT NULL,
+        system_prompt_hash text,
+        embedding vector(${dim}) NOT NULL,
+        embedding_dim integer NOT NULL,
+        response jsonb NOT NULL,
+        resource_tags text[] NOT NULL DEFAULT '{}',
+        created_at timestamptz NOT NULL DEFAULT now(),
+        expires_at timestamptz NOT NULL
+      )
+    `);
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS clawql_inference_semantic_cache_model_exp_idx
+      ON clawql_inference_semantic_cache (model_id, expires_at DESC)
+    `);
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS clawql_inference_semantic_cache_embedding_idx
+      ON clawql_inference_semantic_cache
+      USING hnsw (embedding vector_cosine_ops)
+    `);
+    await client.query(
+      `INSERT INTO clawql_inference_schema_migrations (version, name) VALUES (2, 'semantic_cache_pgvector_v1')
+       ON CONFLICT (version) DO NOTHING`
+    );
+  }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements full Langfuse + OpenTelemetry tracing and distributed semantic cache for the inference gateway.

### Observability (ADR 0005)

- **`TracedInferenceGateway`** — wraps every completion with `inference.complete` spans
- Attributes: `clawql.correlation_id`, `gen_ai.request.model`, `gen_ai.usage.*`, `clawql.cache_hit`, `clawql.token_savings_estimate`
- **Dual OTLP export:**
  - Infra: `CLAWQL_ENABLE_OTEL_TRACING=1` + `OTEL_EXPORTER_OTLP_*`
  - Langfuse: opt-out (`CLAWQL_ENABLE_LANGFUSE=0`) when `LANGFUSE_HOST` + keys set
- `maybeInitInferenceOtelTracing()` runs on `inference serve` / `runInferenceHttpServer`
- `clawql inference policy show` reports observability profile + cache backend

### Distributed semantic cache (pgvector)

- New table `clawql_inference_semantic_cache` with HNSW cosine index
- **`PostgresSemanticCacheStore`** — shared across gateway replicas via inference Postgres
- Auto-selects postgres backend when `CLAWQL_INFERENCE_DATABASE_URL` is set
- Override: `CLAWQL_INFERENCE_SEMANTIC_CACHE_BACKEND=memory|postgres`
- `createInferenceGatewayAsync()` for serve bootstrap; sync `createInferenceGateway()` keeps in-memory for CLI one-shots

## Test plan

- [x] `npm test -w clawql-inference` (97 passed)
- [x] `npm run build -w clawql-inference`
- [ ] CI green on PR

## Operator quick start

```bash
export CLAWQL_INFERENCE_DATABASE_URL=postgres://...
export CLAWQL_ENABLE_OTEL_TRACING=1
export OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318
export LANGFUSE_HOST=https://langfuse.example
export LANGFUSE_PUBLIC_KEY=pk-...
export LANGFUSE_SECRET_KEY=sk-...
clawql inference serve
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

