### PR TITLE
docs: announce 7.0.0 and the July 2026 weekend build push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Build push announcement** — comprehensive inventory of 7.0.0 and the July 2026 weekend merge wave: [`docs/announcements/7.0-weekend-build-push-2026-07.md`](docs/announcements/7.0-weekend-build-push-2026-07.md) (inference, payments, Effect migration, agent readiness).
+
 - **Team vault sync (`clawql sync`)** — push/pull `~/.ClawQL` shared paths (Memory/, sources/, chats/) to **Cloudflare R2** (default), **AWS S3**, or **GCS** (S3-compatible HMAC interop API); provider profiles for endpoint/path-style; vault keys **`gcsHmacAccessId`** / **`gcsHmacSecret`** for GCS; `sync.json` for bucket/prefix; secrets never uploaded. **Auto sync:** `CLAWQL_SYNC_AUTO=1` debounced push after `memory_ingest`; `CLAWQL_SYNC_AUTO_PULL=1` throttled pull before `memory_recall`. **Helm:** `teamSync.*` values on `charts/clawql-mcp` (GCS auto-sets endpoint). **Docs:** [`docs/getting-started/getting-started-for-teams.md`](docs/getting-started/getting-started-for-teams.md) (teams hub), [`docs/getting-started/team-vault-sync.md`](docs/getting-started/team-vault-sync.md); site: [`/getting-started/for-teams`](https://docs.clawql.com/getting-started/for-teams).
 
 ### Changed

--- a/docs/announcements/7.0-weekend-build-push-2026-07.md
+++ b/docs/announcements/7.0-weekend-build-push-2026-07.md
@@ -11,14 +11,14 @@
 
 ## Executive summary
 
-| Phase | When | Headline |
-|-------|------|----------|
-| **7.0.0** | 2026-07-10 | Opinionated default stack, vault-first Helm, npm 7.0 publish, Layer 0 release MVP, Desktop, Operator, IDP wave |
-| **Post-7.0 Fri** | 2026-07-10–11 | Team vault sync, GraphQL fix, Packer/Pulumi golden hosts, local sandbox containment, docs table fixes |
-| **Sat Ouroboros + Inference** | 2026-07-11–12 | Q00 drift sync, `clawql-inference` epic #556 (gateway → REST → cache → keys → Postgres) |
-| **Sat–Sun Payments** | 2026-07-12–13 | `clawql-payments` from scaffold → Stripe + x402 + MPP + WORM audit + Effect MCP proxy |
-| **Sun Effect migration** | 2026-07-13 | core (cache, config) → api (search, execute) → memory (ingest, recall, vectors) → documents bridge |
-| **Sun Agent readiness** | 2026-07-13 | clawql.com Level 5 path, docs commerce discovery, learn guides, token-efficiency layers 3–12 |
+| Phase                         | When          | Headline                                                                                                       |
+| ----------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------- |
+| **7.0.0**                     | 2026-07-10    | Opinionated default stack, vault-first Helm, npm 7.0 publish, Layer 0 release MVP, Desktop, Operator, IDP wave |
+| **Post-7.0 Fri**              | 2026-07-10–11 | Team vault sync, GraphQL fix, Packer/Pulumi golden hosts, local sandbox containment, docs table fixes          |
+| **Sat Ouroboros + Inference** | 2026-07-11–12 | Q00 drift sync, `clawql-inference` epic #556 (gateway → REST → cache → keys → Postgres)                        |
+| **Sat–Sun Payments**          | 2026-07-12–13 | `clawql-payments` from scaffold → Stripe + x402 + MPP + WORM audit + Effect MCP proxy                          |
+| **Sun Effect migration**      | 2026-07-13    | core (cache, config) → api (search, execute) → memory (ingest, recall, vectors) → documents bridge             |
+| **Sun Agent readiness**       | 2026-07-13    | clawql.com Level 5 path, docs commerce discovery, learn guides, token-efficiency layers 3–12                   |
 
 ---
 
@@ -32,14 +32,14 @@
 
 ## Breaking changes
 
-| Area | Before (≤6.4.x) | After (7.0.0) |
-|------|-----------------|---------------|
-| **Default provider merge** | npm: implicit growing merge; Helm: `all-providers` | **Default stack** (6 vendors); `CLAWQL_PROVIDER=all-providers` or Helm `provider=all-providers` for full merge |
-| **Legacy env aliases** | `API_BASE_URL`, `OPENAPI_SPEC_URL`, `GOOGLE_DISCOVERY_URL`, `google-top50` preset | **`CLAWQL_API_BASE_URL`**, **`CLAWQL_SPEC_URL`**, **`CLAWQL_DISCOVERY_URL`**, **`CLAWQL_PROVIDER=google`** |
-| **Vault secrets** | Optional | **`secretSourcing.requireVaultBackedSecrets: true`** (default) — render fails without `envFromSecret` / `envFromSecrets` |
-| **HTTP metrics** | `CLAWQL_DISABLE_HTTP_METRICS` | **`CLAWQL_ENABLE_HTTP_METRICS=0`** to opt out |
-| **Loki push** | Implicit when URL set | **`CLAWQL_ENABLE_LOKI_PUSH=0`** to opt out |
-| **Env flag convention** | Mixed | All feature toggles: **`CLAWQL_ENABLE_*`** — unset = default; `=0` opt-out; `=1` opt-in when default-off |
+| Area                       | Before (≤6.4.x)                                                                   | After (7.0.0)                                                                                                            |
+| -------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| **Default provider merge** | npm: implicit growing merge; Helm: `all-providers`                                | **Default stack** (6 vendors); `CLAWQL_PROVIDER=all-providers` or Helm `provider=all-providers` for full merge           |
+| **Legacy env aliases**     | `API_BASE_URL`, `OPENAPI_SPEC_URL`, `GOOGLE_DISCOVERY_URL`, `google-top50` preset | **`CLAWQL_API_BASE_URL`**, **`CLAWQL_SPEC_URL`**, **`CLAWQL_DISCOVERY_URL`**, **`CLAWQL_PROVIDER=google`**               |
+| **Vault secrets**          | Optional                                                                          | **`secretSourcing.requireVaultBackedSecrets: true`** (default) — render fails without `envFromSecret` / `envFromSecrets` |
+| **HTTP metrics**           | `CLAWQL_DISABLE_HTTP_METRICS`                                                     | **`CLAWQL_ENABLE_HTTP_METRICS=0`** to opt out                                                                            |
+| **Loki push**              | Implicit when URL set                                                             | **`CLAWQL_ENABLE_LOKI_PUSH=0`** to opt out                                                                               |
+| **Env flag convention**    | Mixed                                                                             | All feature toggles: **`CLAWQL_ENABLE_*`** — unset = default; `=0` opt-out; `=1` opt-in when default-off                 |
 
 ## Major additions
 
@@ -75,12 +75,12 @@
 
 ### Phase 1 exit — horizontal packages
 
-| Package | Shipped capability |
-|---------|-------------------|
-| **`clawql-auth`** | Gateway `noAuth`/`apiKey`, ATR claims, provider credential headers |
-| **`clawql-pageindex`** | Vectorless hierarchical indexing; `pageindex_*` tools (default on) |
-| **Presidio hooks** | `CLAWQL_ENABLE_PRESIDIO=1` redacts execute, memory ingest, external ingest |
-| **Tier 1 Compose** | `examples/clawql-local-docker-compose` |
+| Package                | Shipped capability                                                         |
+| ---------------------- | -------------------------------------------------------------------------- |
+| **`clawql-auth`**      | Gateway `noAuth`/`apiKey`, ATR claims, provider credential headers         |
+| **`clawql-pageindex`** | Vectorless hierarchical indexing; `pageindex_*` tools (default on)         |
+| **Presidio hooks**     | `CLAWQL_ENABLE_PRESIDIO=1` redacts execute, memory ingest, external ingest |
+| **Tier 1 Compose**     | `examples/clawql-local-docker-compose`                                     |
 
 ### IDP wave (consolidated in 7.0)
 
@@ -98,19 +98,19 @@
 
 ### Helm charts at 7.0.0
 
-| Chart | Chart.version | appVersion |
-|-------|---------------|------------|
-| `charts/clawql-mcp` | 0.7.0 | 7.0.0 |
-| `charts/clawql-operator` | 0.2.0 | 7.0.0 |
-| `charts/clawql-idp` | 0.1.0 | 7.0.0 |
+| Chart                    | Chart.version | appVersion |
+| ------------------------ | ------------- | ---------- |
+| `charts/clawql-mcp`      | 0.7.0         | 7.0.0      |
+| `charts/clawql-operator` | 0.2.0         | 7.0.0      |
+| `charts/clawql-idp`      | 0.1.0         | 7.0.0      |
 
 ### Release-process PRs (same day, pre/post tag)
 
-| PR | Title |
-|----|-------|
-| [#544](https://github.com/danielsmithdevelopment/ClawQL/pull/544) | Finalize 7.0.0 release notes and changelog |
-| [#545](https://github.com/danielsmithdevelopment/ClawQL/pull/545) | Team vault sync to R2/S3/GCS (`clawql sync`) |
-| [#546](https://github.com/danielsmithdevelopment/ClawQL/pull/546) | Lighthouse, SEO, and WCAG polish for 7.0 docs site |
+| PR                                                                | Title                                                                 |
+| ----------------------------------------------------------------- | --------------------------------------------------------------------- |
+| [#544](https://github.com/danielsmithdevelopment/ClawQL/pull/544) | Finalize 7.0.0 release notes and changelog                            |
+| [#545](https://github.com/danielsmithdevelopment/ClawQL/pull/545) | Team vault sync to R2/S3/GCS (`clawql sync`)                          |
+| [#546](https://github.com/danielsmithdevelopment/ClawQL/pull/546) | Lighthouse, SEO, and WCAG polish for 7.0 docs site                    |
 | [#547](https://github.com/danielsmithdevelopment/ClawQL/pull/547) | npm 7.0.0 publish fallback (`bundledDependencies`) — **tag `v7.0.0`** |
 
 ---
@@ -124,23 +124,29 @@ Everything below merged **after** tag **`v7.0.0`** (from [#548](https://github.c
 ## 1. Infrastructure, provisioning, and containment
 
 ### [#548](https://github.com/danielsmithdevelopment/ClawQL/pull/548) — Dashboard Docker image for 7.0.0
+
 Fixes **clawql-dashboard** Docker publish (`Can't resolve 'clawql-api'`) by building workspace packages from monorepo root.
 
 ### [#550](https://github.com/danielsmithdevelopment/ClawQL/pull/550) — Packer golden hosts + Pulumi provisioning
+
 - **`infra/pulumi`** — TypeScript `clawql-provision`: AWS EC2, GCP GCE, Cloudflare R2; tier helpers; boot user-data; Automation API wrapper
 - **ADR 0007** — Pulumi vs Terraform; self-hosted state (R2 preferred)
 - Packer golden-image pipeline with verified team vault bootstrap (+5,401 lines)
 
 ### [#551](https://github.com/danielsmithdevelopment/ClawQL/pull/551) — Local agent sandbox (`clawql sandbox init`)
+
 Fail-closed **Panguard** containment for laptop dev:
+
 - `clawql sandbox init|status|verify|edit`
 - Per-harness Seatbelt profiles (Claude, Codex, Cursor, OpenCode)
 - `clawql doctor --smoke` includes sandbox verify
 
 ### [#552](https://github.com/danielsmithdevelopment/ClawQL/pull/552) — Docs: Packer, Pulumi, sandbox guides
+
 Site routes: `/getting-started/golden-host-images`, `/getting-started/local-agent-sandbox`
 
 ### [#568](https://github.com/danielsmithdevelopment/ClawQL/pull/568) — Cloud Agent R2 vault runbook
+
 - `docs/deployment/cloud-agent-r2-tailscale-runbook.md`
 - `.cursor/environment.json` + `cloud-agent-install.sh`
 - Pulumi `goldenImageId` optional for Cloudflare-only R2 stacks
@@ -150,6 +156,7 @@ Site routes: `/getting-started/golden-host-images`, `/getting-started/local-agen
 ## 2. Execute, API, and provider routing
 
 ### [#549](https://github.com/danielsmithdevelopment/ClawQL/pull/549) — GraphQL list projection + provider-centric routing
+
 - Fixes nested GraphQL field projection (`nodes { id name }` returning `{}`)
 - **Provider-centric model** — users pick providers; ClawQL routes gRPC → GraphQL → OpenAPI internally
 - Removed footgun env vars that crashed startup on misconfigured GraphQL sources
@@ -159,16 +166,21 @@ Site routes: `/getting-started/golden-host-images`, `/getting-started/local-agen
 ## 3. Team vault sync and Cloud Agent memory
 
 ### [#545](https://github.com/danielsmithdevelopment/ClawQL/pull/545) — `clawql sync` (R2 / S3 / GCS)
-*(Merged same day as 7.0.0; documented here as part of the 7.0 wave.)*
+
+_(Merged same day as 7.0.0; documented here as part of the 7.0 wave.)_
+
 - `clawql sync init|push|pull|status`; provider profiles; vault keys for GCS HMAC
 - Auto sync: `CLAWQL_SYNC_AUTO=1` debounced push after `memory_ingest`; `CLAWQL_SYNC_AUTO_PULL=1` before `memory_recall`
 - Helm `teamSync.*`; docs hub `/getting-started/for-teams`
 
 ### [#569](https://github.com/danielsmithdevelopment/ClawQL/pull/569) — `memory_sync` MCP tool
+
 Cloud Agents reconcile vault without shell:
+
 ```
 memory_recall → work → memory_ingest → memory_sync { "direction": "auto" }
 ```
+
 - Guide: `/getting-started/cursor-ios-cloud-agent`
 
 ---
@@ -176,18 +188,23 @@ memory_recall → work → memory_ingest → memory_sync { "direction": "auto" }
 ## 4. Ouroboros — upstream Q00 sync (epic #556 P0-A/B/C)
 
 ### [#565](https://github.com/danielsmithdevelopment/ClawQL/pull/565) — Upstream sync roadmap + GitHub epic
+
 Planning doc for Q00/ouroboros v0.50.3+ composition with ClawQL; epic [#556](https://github.com/danielsmithdevelopment/ClawQL/issues/556) and child issues #557–#564
 
 ### [#570](https://github.com/danielsmithdevelopment/ClawQL/pull/570) — 3-component drift measurement (#557)
+
 ```
 combined_drift = 0.5×goal + 0.3×constraint + 0.2×ontology
 ```
+
 - `ouroboros_measure_drift` MCP tool; `drift_measured` events each generation
 
 ### [#571](https://github.com/danielsmithdevelopment/ClawQL/pull/571) — Drift convergence gate (#558)
+
 Blocks premature converge when `combined_drift > 0.3`; `latest_drift` on lineage
 
 ### [#572](https://github.com/danielsmithdevelopment/ClawQL/pull/572) — Stagnation taxonomy (#559)
+
 Reason codes: `no_drift`, `oscillation`, `spinning`, `diminishing_returns` on `ConvergenceSignal`
 
 ---
@@ -198,46 +215,47 @@ Reason codes: `no_drift`, `oscillation`, `spinning`, `diminishing_returns` on `C
 
 ### Foundation and gateway (Jul 12 early morning)
 
-| PR | Title | What shipped |
-|----|-------|--------------|
-| [#573](https://github.com/danielsmithdevelopment/ClawQL/pull/573) | PAL routing / tier escalation (#560) | `AdaptiveRouter`, `TierEscalationRouter`, `InferenceGateway` interface; Ouroboros loop hooks |
-| [#574](https://github.com/danielsmithdevelopment/ClawQL/pull/574) | Gateway MVP (#556 P0-F) | Provider plugin architecture, `createInferenceGateway()`, decorator stack |
-| [#575](https://github.com/danielsmithdevelopment/ClawQL/pull/575) | Call store + observability (#556 P0-G) | `InferenceRecord`, JSONL store, `clawql inference logs|trace|spend`, `X-Correlation-Id` |
-| [#576](https://github.com/danielsmithdevelopment/ClawQL/pull/576) | Export + finetune (#556 P0-H/I) | Verdict-filtered dataset export (openai-jsonl, anthropic-jsonl, sharegpt); OpenAI/Anthropic finetune; tier-map overrides |
-| [#577](https://github.com/danielsmithdevelopment/ClawQL/pull/577) | Pipeline + escalation CLI (#556 P1) | `clawql inference pipeline|escalation`; audit event builders; agent coordination trigger stub |
-| [#578](https://github.com/danielsmithdevelopment/ClawQL/pull/578) | OpenAI-compatible REST (#556) | Drop-in `POST /v1/chat/completions`, `GET /v1/models`, SSE streaming; `OPENAI_BASE_URL` swap |
-| [#579](https://github.com/danielsmithdevelopment/ClawQL/pull/579) | Semantic cache (#556) | `SemanticCachedGateway`; embedding similarity; `CLAWQL_INFERENCE_SEMANTIC_CACHE=1` |
-| [#580](https://github.com/danielsmithdevelopment/ClawQL/pull/580) | Fallback chains (#556) | `FallbackChainGateway`; per-tier and per-model chains |
-| [#581](https://github.com/danielsmithdevelopment/ClawQL/pull/581) | Virtual keys (#556) | Per-team API keys, USD budgets, rate limits; `clawql inference keys` |
-| [#582](https://github.com/danielsmithdevelopment/ClawQL/pull/582) | Deferred epic close (#556) | Postgres store, Ouroboros audit wiring, agent coordination (Hermes stub), `policy show`, pipeline cron worker |
+| PR                                                                | Title                                  | What shipped                                                                                                             |
+| ----------------------------------------------------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| [#573](https://github.com/danielsmithdevelopment/ClawQL/pull/573) | PAL routing / tier escalation (#560)   | `AdaptiveRouter`, `TierEscalationRouter`, `InferenceGateway` interface; Ouroboros loop hooks                             |
+| [#574](https://github.com/danielsmithdevelopment/ClawQL/pull/574) | Gateway MVP (#556 P0-F)                | Provider plugin architecture, `createInferenceGateway()`, decorator stack                                                |
+| [#575](https://github.com/danielsmithdevelopment/ClawQL/pull/575) | Call store + observability (#556 P0-G) | `InferenceRecord`, JSONL store, `clawql inference logs                                                                   | trace                                                              | spend`, `X-Correlation-Id` |
+| [#576](https://github.com/danielsmithdevelopment/ClawQL/pull/576) | Export + finetune (#556 P0-H/I)        | Verdict-filtered dataset export (openai-jsonl, anthropic-jsonl, sharegpt); OpenAI/Anthropic finetune; tier-map overrides |
+| [#577](https://github.com/danielsmithdevelopment/ClawQL/pull/577) | Pipeline + escalation CLI (#556 P1)    | `clawql inference pipeline                                                                                               | escalation`; audit event builders; agent coordination trigger stub |
+| [#578](https://github.com/danielsmithdevelopment/ClawQL/pull/578) | OpenAI-compatible REST (#556)          | Drop-in `POST /v1/chat/completions`, `GET /v1/models`, SSE streaming; `OPENAI_BASE_URL` swap                             |
+| [#579](https://github.com/danielsmithdevelopment/ClawQL/pull/579) | Semantic cache (#556)                  | `SemanticCachedGateway`; embedding similarity; `CLAWQL_INFERENCE_SEMANTIC_CACHE=1`                                       |
+| [#580](https://github.com/danielsmithdevelopment/ClawQL/pull/580) | Fallback chains (#556)                 | `FallbackChainGateway`; per-tier and per-model chains                                                                    |
+| [#581](https://github.com/danielsmithdevelopment/ClawQL/pull/581) | Virtual keys (#556)                    | Per-team API keys, USD budgets, rate limits; `clawql inference keys`                                                     |
+| [#582](https://github.com/danielsmithdevelopment/ClawQL/pull/582) | Deferred epic close (#556)             | Postgres store, Ouroboros audit wiring, agent coordination (Hermes stub), `policy show`, pipeline cron worker            |
 
 ### Inference Effect-TS migration (Jul 13 overnight) — **complete**
 
-| PR | Component |
-|----|-----------|
-| [#600](https://github.com/danielsmithdevelopment/ClawQL/pull/600) | `FallbackChainService` + `InferenceGatewayService` |
+| PR                                                                | Component                                                              |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| [#600](https://github.com/danielsmithdevelopment/ClawQL/pull/600) | `FallbackChainService` + `InferenceGatewayService`                     |
 | [#601](https://github.com/danielsmithdevelopment/ClawQL/pull/601) | `SemanticCacheService`, `EmbedderService`, `SemanticCacheStoreService` |
-| [#603](https://github.com/danielsmithdevelopment/ClawQL/pull/603) | `EntitlementEnforcementService` wired to `clawql-payments` |
-| [#605](https://github.com/danielsmithdevelopment/ClawQL/pull/605) | `ModelEscalationService` for tier escalation |
-| [#606](https://github.com/danielsmithdevelopment/ClawQL/pull/606) | `Effect.Stream` OpenAI SSE streaming |
+| [#603](https://github.com/danielsmithdevelopment/ClawQL/pull/603) | `EntitlementEnforcementService` wired to `clawql-payments`             |
+| [#605](https://github.com/danielsmithdevelopment/ClawQL/pull/605) | `ModelEscalationService` for tier escalation                           |
+| [#606](https://github.com/danielsmithdevelopment/ClawQL/pull/606) | `Effect.Stream` OpenAI SSE streaming                                   |
 
 ### Token efficiency layers 3–12
 
 ### [#620](https://github.com/danielsmithdevelopment/ClawQL/pull/620) — Token efficiency in gateway
+
 Closes gaps vs [token-efficiency architecture](https://docs.clawql.com/architecture/token-efficiency):
 
-| Layer | Feature | Default |
-|-------|---------|---------|
-| 3 | Terse output post-processor | on |
-| 4 | Anthropic `cache_control` on system prefix | on |
-| 5 | Semantic cache safety + tag invalidation | on when embeddings configured |
-| 6 | History distillation | off (`CLAWQL_INFERENCE_HISTORY_COMPRESS=1`) |
-| 7 | Prompt dedupe + truncation | off (`CLAWQL_INFERENCE_PROMPT_COMPRESS=1`) |
-| 8 | HTTP `clawql/auto` tier routing | on when routing enabled |
-| 9 | Structured output hints | on |
-| 10 | Token budget signaling from `max_tokens` | on |
-| 11 | Assistant prefill opener | off |
-| 12 | Flywheel (export → finetune → frugal) | documented |
+| Layer | Feature                                    | Default                                     |
+| ----- | ------------------------------------------ | ------------------------------------------- |
+| 3     | Terse output post-processor                | on                                          |
+| 4     | Anthropic `cache_control` on system prefix | on                                          |
+| 5     | Semantic cache safety + tag invalidation   | on when embeddings configured               |
+| 6     | History distillation                       | off (`CLAWQL_INFERENCE_HISTORY_COMPRESS=1`) |
+| 7     | Prompt dedupe + truncation                 | off (`CLAWQL_INFERENCE_PROMPT_COMPRESS=1`)  |
+| 8     | HTTP `clawql/auto` tier routing            | on when routing enabled                     |
+| 9     | Structured output hints                    | on                                          |
+| 10    | Token budget signaling from `max_tokens`   | on                                          |
+| 11    | Assistant prefill opener                   | off                                         |
+| 12    | Flywheel (export → finetune → frugal)      | documented                                  |
 
 Gateway stack (outer → inner): `Observed → Entitlement → TokenEfficiency → SemanticCache → Fallback → Configured → provider`
 
@@ -251,28 +269,28 @@ Also: live **Hermes MoA** when `HERMES_BASE_URL` set; `x-clawql-cache-intent: re
 
 ### Scaffold through Stripe + x402 (Jul 12)
 
-| PR | What shipped |
-|----|--------------|
+| PR                                                                | What shipped                                                                                                                  |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | [#583](https://github.com/danielsmithdevelopment/ClawQL/pull/583) | Package scaffold — plans (Free/Pro/Team/Enterprise), Stripe stubs, x402 gating, audit ring buffer, full `clawql payments` CLI |
-| [#586](https://github.com/danielsmithdevelopment/ClawQL/pull/586) | Inference plan limits (`CLAWQL_PAYMENTS_ENFORCE_INFERENCE`) + live Stripe SDK + webhook verification |
-| [#587](https://github.com/danielsmithdevelopment/ClawQL/pull/587) | x402 facilitator HTTP (verify/settle); Express middleware; `docs/payments/clawql-payments.md` |
-| [#589](https://github.com/danielsmithdevelopment/ClawQL/pull/589) | Stripe Billing Meters — `reportInferenceMeterUsageIfEnabled()`, gateway hooks |
-| [#591](https://github.com/danielsmithdevelopment/ClawQL/pull/591) | Durable hash-chained WORM audit (`audit.jsonl`); `clawql payments audit verify` |
-| [#593](https://github.com/danielsmithdevelopment/ClawQL/pull/593) | Postgres audit store, Loki/SIEM export, `X402_PAYMENT_FAILED` events |
+| [#586](https://github.com/danielsmithdevelopment/ClawQL/pull/586) | Inference plan limits (`CLAWQL_PAYMENTS_ENFORCE_INFERENCE`) + live Stripe SDK + webhook verification                          |
+| [#587](https://github.com/danielsmithdevelopment/ClawQL/pull/587) | x402 facilitator HTTP (verify/settle); Express middleware; `docs/payments/clawql-payments.md`                                 |
+| [#589](https://github.com/danielsmithdevelopment/ClawQL/pull/589) | Stripe Billing Meters — `reportInferenceMeterUsageIfEnabled()`, gateway hooks                                                 |
+| [#591](https://github.com/danielsmithdevelopment/ClawQL/pull/591) | Durable hash-chained WORM audit (`audit.jsonl`); `clawql payments audit verify`                                               |
+| [#593](https://github.com/danielsmithdevelopment/ClawQL/pull/593) | Postgres audit store, Loki/SIEM export, `X402_PAYMENT_FAILED` events                                                          |
 
 ### MCP enforcement and Effect migration (Jul 12–13)
 
-| PR | What shipped |
-|----|--------------|
-| [#596](https://github.com/danielsmithdevelopment/ClawQL/pull/596) | In-process MCP x402 on `tools/call`; `/.well-known/payments.json` |
+| PR                                                                | What shipped                                                                             |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| [#596](https://github.com/danielsmithdevelopment/ClawQL/pull/596) | In-process MCP x402 on `tools/call`; `/.well-known/payments.json`                        |
 | [#597](https://github.com/danielsmithdevelopment/ClawQL/pull/597) | Effect `McpProxyPipeline` — 9 services (config, audit, x402, entitlements, discovery, …) |
-| [#599](https://github.com/danielsmithdevelopment/ClawQL/pull/599) | Stripe Effect services — client, webhook, meter, billing (Stripe migration complete) |
+| [#599](https://github.com/danielsmithdevelopment/ClawQL/pull/599) | Stripe Effect services — client, webhook, meter, billing (Stripe migration complete)     |
 
 ### MPP — Model Payment Protocol (Jul 13)
 
-| PR | What shipped |
-|----|--------------|
-| [#610](https://github.com/danielsmithdevelopment/ClawQL/pull/610) | Full MPP — `MppOpenApiService`, `MppVerificationService`, credential verify, challenge registry, receipts; alongside x402 + Stripe |
+| PR                                                                | What shipped                                                                                                                                                                   |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [#610](https://github.com/danielsmithdevelopment/ClawQL/pull/610) | Full MPP — `MppOpenApiService`, `MppVerificationService`, credential verify, challenge registry, receipts; alongside x402 + Stripe                                             |
 | [#616](https://github.com/danielsmithdevelopment/ClawQL/pull/616) | MPP follow-ups — dual `x-payment-info` for commerce scanners, Stripe SPT smoke harness, optional `mppx` adapter, MCP JSON-RPC -32042/-32043, PayPal/Adyen/Square in `offers[]` |
 
 ---
@@ -281,16 +299,16 @@ Also: live **Hermes MoA** when `HERMES_BASE_URL` set; `x-clawql-cache-intent: re
 
 Boundary-only Effect pattern: MCP handlers stay Promise-based; domain logic runs through `Context.Tag` + `Layer`.
 
-| PR | Package | What shipped |
-|----|---------|--------------|
-| [#607](https://github.com/danielsmithdevelopment/ClawQL/pull/607) | `clawql-memory` | `MemoryIngestService` / `MemoryRecallService`, `memoryServicesLiveLayer()` |
-| [#609](https://github.com/danielsmithdevelopment/ClawQL/pull/609) | `clawql-core` | `CacheService` Effect layer for MCP cache tool |
-| [#611](https://github.com/danielsmithdevelopment/ClawQL/pull/611) | `clawql-core` | `ConfigService` — centralized env readers |
-| [#612](https://github.com/danielsmithdevelopment/ClawQL/pull/612) | `clawql-api` | `execute-core` → native `Effect.gen` |
-| [#614](https://github.com/danielsmithdevelopment/ClawQL/pull/614) | `clawql-api` | `search-core` → native `Effect.gen` (both core MCP tools Effect-native) |
-| [#615](https://github.com/danielsmithdevelopment/ClawQL/pull/615) | `clawql-memory` | `VaultConfigService`, `MemoryDbService`, `EmbeddingService` |
-| [#617](https://github.com/danielsmithdevelopment/ClawQL/pull/617) | `clawql-memory` | Recall vector/db pass — `recallVectorPassEffect`, `memory.db` artifacts |
-| [#619](https://github.com/danielsmithdevelopment/ClawQL/pull/619) | `clawql-documents` | Effect bridge for `ingest_external_knowledge` |
+| PR                                                                | Package            | What shipped                                                               |
+| ----------------------------------------------------------------- | ------------------ | -------------------------------------------------------------------------- |
+| [#607](https://github.com/danielsmithdevelopment/ClawQL/pull/607) | `clawql-memory`    | `MemoryIngestService` / `MemoryRecallService`, `memoryServicesLiveLayer()` |
+| [#609](https://github.com/danielsmithdevelopment/ClawQL/pull/609) | `clawql-core`      | `CacheService` Effect layer for MCP cache tool                             |
+| [#611](https://github.com/danielsmithdevelopment/ClawQL/pull/611) | `clawql-core`      | `ConfigService` — centralized env readers                                  |
+| [#612](https://github.com/danielsmithdevelopment/ClawQL/pull/612) | `clawql-api`       | `execute-core` → native `Effect.gen`                                       |
+| [#614](https://github.com/danielsmithdevelopment/ClawQL/pull/614) | `clawql-api`       | `search-core` → native `Effect.gen` (both core MCP tools Effect-native)    |
+| [#615](https://github.com/danielsmithdevelopment/ClawQL/pull/615) | `clawql-memory`    | `VaultConfigService`, `MemoryDbService`, `EmbeddingService`                |
+| [#617](https://github.com/danielsmithdevelopment/ClawQL/pull/617) | `clawql-memory`    | Recall vector/db pass — `recallVectorPassEffect`, `memory.db` artifacts    |
+| [#619](https://github.com/danielsmithdevelopment/ClawQL/pull/619) | `clawql-documents` | Effect bridge for `ingest_external_knowledge`                              |
 
 **Next slices (not yet merged):** automation, ouroboros, sandbox, auth — per modularization plan.
 
@@ -300,110 +318,110 @@ Boundary-only Effect pattern: MCP handlers stay Promise-based; domain logic runs
 
 ### Website fixes (Jul 11–12) — deploy unblockers and mobile tables
 
-| PR | Fix |
-|----|-----|
-| [#553](https://github.com/danielsmithdevelopment/ClawQL/pull/553) | Move `agent-markdown.json` to static assets (Worker 3 MiB limit) |
-| [#554](https://github.com/danielsmithdevelopment/ClawQL/pull/554) | Mobile table alignment in docs prose |
-| [#555](https://github.com/danielsmithdevelopment/ClawQL/pull/555) | Stop table cell content overlap |
-| [#566](https://github.com/danielsmithdevelopment/ClawQL/pull/566) | Site-wide table formatting for 2–8 columns (`data-cols`) |
-| [#588](https://github.com/danielsmithdevelopment/ClawQL/pull/588) | Comprehensive `/inference/clawql-inference` docs page |
-| [#590](https://github.com/danielsmithdevelopment/ClawQL/pull/590) | Inference docs Mermaid + mobile tables |
-| [#592](https://github.com/danielsmithdevelopment/ClawQL/pull/592) | Global search indexes synced `*-body.mdx` (131 pages, 40 chunks) |
-| [#594](https://github.com/danielsmithdevelopment/ClawQL/pull/594) | Cloudflare deploy size fix — client-only Mermaid/Search; handler ~2.25 MiB gzip |
-| [#595](https://github.com/danielsmithdevelopment/ClawQL/pull/595) | Inference mobile tables; text architecture replaces Mermaid |
+| PR                                                                | Fix                                                                                           |
+| ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| [#553](https://github.com/danielsmithdevelopment/ClawQL/pull/553) | Move `agent-markdown.json` to static assets (Worker 3 MiB limit)                              |
+| [#554](https://github.com/danielsmithdevelopment/ClawQL/pull/554) | Mobile table alignment in docs prose                                                          |
+| [#555](https://github.com/danielsmithdevelopment/ClawQL/pull/555) | Stop table cell content overlap                                                               |
+| [#566](https://github.com/danielsmithdevelopment/ClawQL/pull/566) | Site-wide table formatting for 2–8 columns (`data-cols`)                                      |
+| [#588](https://github.com/danielsmithdevelopment/ClawQL/pull/588) | Comprehensive `/inference/clawql-inference` docs page                                         |
+| [#590](https://github.com/danielsmithdevelopment/ClawQL/pull/590) | Inference docs Mermaid + mobile tables                                                        |
+| [#592](https://github.com/danielsmithdevelopment/ClawQL/pull/592) | Global search indexes synced `*-body.mdx` (131 pages, 40 chunks)                              |
+| [#594](https://github.com/danielsmithdevelopment/ClawQL/pull/594) | Cloudflare deploy size fix — client-only Mermaid/Search; handler ~2.25 MiB gzip               |
+| [#595](https://github.com/danielsmithdevelopment/ClawQL/pull/595) | Inference mobile tables; text architecture replaces Mermaid                                   |
 | [#598](https://github.com/danielsmithdevelopment/ClawQL/pull/598) | Site-wide mobile tables + sync-script wrapper consistency + Playwright regression (11 routes) |
 
 ### Agent readiness (Jul 13)
 
-| PR | Domain | What shipped |
-|----|--------|--------------|
+| PR                                                                | Domain          | What shipped                                                                                                                                           |
+| ----------------------------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | [#602](https://github.com/danielsmithdevelopment/ClawQL/pull/602) | docs.clawql.com | `auth.md`, A2A agent card, AP2 extension, commerce discovery (`/openapi.json`, 402 probe, UCP/ACP/payments well-known), DNS-AID runbook, Lighthouse CI |
-| [#604](https://github.com/danielsmithdevelopment/ClawQL/pull/604) | clawql.com | Prebuild discovery assets, Cloudflare Pages `functions/` (Link headers + markdown negotiation), WebMCP, Lighthouse 100 |
-| [#608](https://github.com/danielsmithdevelopment/ClawQL/pull/608) | deploy | Restore GitHub Pages as default until Cloudflare secrets configured |
+| [#604](https://github.com/danielsmithdevelopment/ClawQL/pull/604) | clawql.com      | Prebuild discovery assets, Cloudflare Pages `functions/` (Link headers + markdown negotiation), WebMCP, Lighthouse 100                                 |
+| [#608](https://github.com/danielsmithdevelopment/ClawQL/pull/608) | deploy          | Restore GitHub Pages as default until Cloudflare secrets configured                                                                                    |
 
 ### Learn guides (Jul 13)
 
-| PR | Route | Topic |
-|----|-------|-------|
-| [#613](https://github.com/danielsmithdevelopment/ClawQL/pull/613) | `/learn/effect-ts` | Why ClawQL uses Effect-TS for 7-layer architecture enforcement |
-| [#618](https://github.com/danielsmithdevelopment/ClawQL/pull/618) | `/learn/memory` | clawql-memory (Memory 2.0) — vault, wikilinks, hybrid recall, team sync, flywheel |
+| PR                                                                | Route              | Topic                                                                             |
+| ----------------------------------------------------------------- | ------------------ | --------------------------------------------------------------------------------- |
+| [#613](https://github.com/danielsmithdevelopment/ClawQL/pull/613) | `/learn/effect-ts` | Why ClawQL uses Effect-TS for 7-layer architecture enforcement                    |
+| [#618](https://github.com/danielsmithdevelopment/ClawQL/pull/618) | `/learn/memory`    | clawql-memory (Memory 2.0) — vault, wikilinks, hybrid recall, team sync, flywheel |
 
 ---
 
 ## 9. Chronological merge index (post-tag)
 
-| # | Merged (UTC) | PR | Title |
-|---|--------------|-----|-------|
-| 1 | 2026-07-10 14:34 | [#548](https://github.com/danielsmithdevelopment/ClawQL/pull/548) | fix(docker): dashboard image build |
-| 2 | 2026-07-11 05:07 | [#549](https://github.com/danielsmithdevelopment/ClawQL/pull/549) | fix(execute): GraphQL projection + provider routing |
-| 3 | 2026-07-11 15:24 | [#550](https://github.com/danielsmithdevelopment/ClawQL/pull/550) | feat(packer): golden hosts + Pulumi |
-| 4 | 2026-07-11 16:05 | [#551](https://github.com/danielsmithdevelopment/ClawQL/pull/551) | feat(sandbox): local agent containment |
-| 5 | 2026-07-11 16:15 | [#552](https://github.com/danielsmithdevelopment/ClawQL/pull/552) | docs: Packer/Pulumi/sandbox guides |
-| 6 | 2026-07-11 16:47 | [#553](https://github.com/danielsmithdevelopment/ClawQL/pull/553) | fix(website): agent-markdown static assets |
-| 7 | 2026-07-11 17:54 | [#554](https://github.com/danielsmithdevelopment/ClawQL/pull/554) | fix(website): mobile table alignment |
-| 8 | 2026-07-11 18:17 | [#555](https://github.com/danielsmithdevelopment/ClawQL/pull/555) | fix(website): table cell overlap |
-| 9 | 2026-07-11 18:50 | [#566](https://github.com/danielsmithdevelopment/ClawQL/pull/566) | fix(website): site-wide table formatting |
-| 10 | 2026-07-11 23:50 | [#565](https://github.com/danielsmithdevelopment/ClawQL/pull/565) | docs(ouroboros): Q00 sync roadmap |
-| 11 | 2026-07-11 23:50 | [#568](https://github.com/danielsmithdevelopment/ClawQL/pull/568) | feat(cloud-agent): R2 vault runbook |
-| 12 | 2026-07-11 23:50 | [#569](https://github.com/danielsmithdevelopment/ClawQL/pull/569) | feat(mcp): memory_sync tool |
-| 13 | 2026-07-12 00:25 | [#570](https://github.com/danielsmithdevelopment/ClawQL/pull/570) | feat(ouroboros): drift measurement |
-| 14 | 2026-07-12 00:39 | [#571](https://github.com/danielsmithdevelopment/ClawQL/pull/571) | feat(ouroboros): drift convergence gate |
-| 15 | 2026-07-12 00:59 | [#572](https://github.com/danielsmithdevelopment/ClawQL/pull/572) | feat(ouroboros): stagnation taxonomy |
-| 16 | 2026-07-12 02:43 | [#573](https://github.com/danielsmithdevelopment/ClawQL/pull/573) | feat(inference): tier escalation foundation |
-| 17 | 2026-07-12 03:23 | [#574](https://github.com/danielsmithdevelopment/ClawQL/pull/574) | feat(inference): gateway MVP |
-| 18 | 2026-07-12 03:50 | [#575](https://github.com/danielsmithdevelopment/ClawQL/pull/575) | feat(inference): call store + observability |
-| 19 | 2026-07-12 04:03 | [#576](https://github.com/danielsmithdevelopment/ClawQL/pull/576) | feat(inference): export + finetune |
-| 20 | 2026-07-12 04:24 | [#577](https://github.com/danielsmithdevelopment/ClawQL/pull/577) | feat(inference): pipeline + escalation CLI |
-| 21 | 2026-07-12 05:01 | [#578](https://github.com/danielsmithdevelopment/ClawQL/pull/578) | feat(inference): OpenAI REST surface |
-| 22 | 2026-07-12 05:14 | [#579](https://github.com/danielsmithdevelopment/ClawQL/pull/579) | feat(inference): semantic cache |
-| 23 | 2026-07-12 05:27 | [#580](https://github.com/danielsmithdevelopment/ClawQL/pull/580) | feat(inference): fallback chains |
-| 24 | 2026-07-12 05:43 | [#581](https://github.com/danielsmithdevelopment/ClawQL/pull/581) | feat(inference): virtual keys |
-| 25 | 2026-07-12 09:55 | [#582](https://github.com/danielsmithdevelopment/ClawQL/pull/582) | feat(inference): Postgres + pipeline cron |
-| 26 | 2026-07-12 13:34 | [#583](https://github.com/danielsmithdevelopment/ClawQL/pull/583) | feat(payments): package scaffold |
-| 27 | 2026-07-12 13:35 | [#586](https://github.com/danielsmithdevelopment/ClawQL/pull/586) | feat(payments): Stripe SDK + inference limits |
-| 28 | 2026-07-12 18:53 | [#588](https://github.com/danielsmithdevelopment/ClawQL/pull/588) | docs: inference page on site |
-| 29 | 2026-07-12 19:18 | [#587](https://github.com/danielsmithdevelopment/ClawQL/pull/587) | feat(payments): x402 facilitator HTTP |
-| 30 | 2026-07-12 19:28 | [#589](https://github.com/danielsmithdevelopment/ClawQL/pull/589) | feat(payments): Stripe Billing Meters |
-| 31 | 2026-07-12 19:37 | [#590](https://github.com/danielsmithdevelopment/ClawQL/pull/590) | fix(website): inference mobile/Mermaid |
-| 32 | 2026-07-12 19:49 | [#591](https://github.com/danielsmithdevelopment/ClawQL/pull/591) | feat(payments): WORM audit log |
-| 33 | 2026-07-12 20:10 | [#592](https://github.com/danielsmithdevelopment/ClawQL/pull/592) | fix(website): search index synced docs |
-| 34 | 2026-07-12 20:37 | [#594](https://github.com/danielsmithdevelopment/ClawQL/pull/594) | fix(website): Cloudflare deploy size |
-| 35 | 2026-07-12 21:59 | [#593](https://github.com/danielsmithdevelopment/ClawQL/pull/593) | feat(payments): Postgres audit + Loki |
-| 36 | 2026-07-12 22:22 | [#595](https://github.com/danielsmithdevelopment/ClawQL/pull/595) | fix(website): inference mobile tables |
-| 37 | 2026-07-12 23:17 | [#596](https://github.com/danielsmithdevelopment/ClawQL/pull/596) | feat(payments): MCP x402 + well-known |
-| 38 | 2026-07-13 00:52 | [#597](https://github.com/danielsmithdevelopment/ClawQL/pull/597) | feat(payments): Effect McpProxyPipeline |
-| 39 | 2026-07-13 01:08 | [#598](https://github.com/danielsmithdevelopment/ClawQL/pull/598) | fix(website): site-wide mobile tables |
-| 40 | 2026-07-13 01:19 | [#599](https://github.com/danielsmithdevelopment/ClawQL/pull/599) | feat(payments): Stripe Effect services |
-| 41 | 2026-07-13 01:29 | [#600](https://github.com/danielsmithdevelopment/ClawQL/pull/600) | feat(inference): Effect fallback chains |
-| 42 | 2026-07-13 01:54 | [#601](https://github.com/danielsmithdevelopment/ClawQL/pull/601) | feat(inference): Effect semantic cache |
-| 43 | 2026-07-13 01:54 | [#603](https://github.com/danielsmithdevelopment/ClawQL/pull/603) | feat(inference): Effect entitlements |
-| 44 | 2026-07-13 02:11 | [#605](https://github.com/danielsmithdevelopment/ClawQL/pull/605) | feat(inference): Effect model escalation |
-| 45 | 2026-07-13 02:12 | [#602](https://github.com/danielsmithdevelopment/ClawQL/pull/602) | docs: SEO, WCAG, agent readiness |
-| 46 | 2026-07-13 02:52 | [#606](https://github.com/danielsmithdevelopment/ClawQL/pull/606) | feat(inference): Effect.Stream SSE |
-| 47 | 2026-07-13 03:07 | [#604](https://github.com/danielsmithdevelopment/ClawQL/pull/604) | agent readiness clawql.com |
-| 48 | 2026-07-13 03:29 | [#607](https://github.com/danielsmithdevelopment/ClawQL/pull/607) | feat(memory): Effect ingest/recall |
-| 49 | 2026-07-13 03:29 | [#609](https://github.com/danielsmithdevelopment/ClawQL/pull/609) | feat(core): CacheService Effect |
-| 50 | 2026-07-13 03:32 | [#608](https://github.com/danielsmithdevelopment/ClawQL/pull/608) | fix(deploy): GitHub Pages default |
-| 51 | 2026-07-13 03:39 | [#611](https://github.com/danielsmithdevelopment/ClawQL/pull/611) | feat(core): ConfigService |
-| 52 | 2026-07-13 03:53 | [#612](https://github.com/danielsmithdevelopment/ClawQL/pull/612) | feat(api): execute Effect.gen |
-| 53 | 2026-07-13 04:20 | [#613](https://github.com/danielsmithdevelopment/ClawQL/pull/613) | docs(learn): Effect-TS guide |
-| 54 | 2026-07-13 04:26 | [#614](https://github.com/danielsmithdevelopment/ClawQL/pull/614) | feat(api): search Effect.gen |
-| 55 | 2026-07-13 04:30 | [#610](https://github.com/danielsmithdevelopment/ClawQL/pull/610) | feat(payments): full MPP |
-| 56 | 2026-07-13 04:49 | [#615](https://github.com/danielsmithdevelopment/ClawQL/pull/615) | feat(memory): vault/db/embedding services |
-| 57 | 2026-07-13 04:59 | [#616](https://github.com/danielsmithdevelopment/ClawQL/pull/616) | feat(payments): MPP follow-ups |
-| 58 | 2026-07-13 05:40 | [#617](https://github.com/danielsmithdevelopment/ClawQL/pull/617) | feat(memory): recall vector Effect |
-| 59 | 2026-07-13 05:54 | [#618](https://github.com/danielsmithdevelopment/ClawQL/pull/618) | docs(learn): Memory 2.0 guide |
-| 60 | 2026-07-13 05:54 | [#619](https://github.com/danielsmithdevelopment/ClawQL/pull/619) | feat(documents): ingest Effect bridge |
-| 61 | 2026-07-13 06:04 | [#620](https://github.com/danielsmithdevelopment/ClawQL/pull/620) | feat(inference): token efficiency layers 3–12 |
+| #   | Merged (UTC)     | PR                                                                | Title                                               |
+| --- | ---------------- | ----------------------------------------------------------------- | --------------------------------------------------- |
+| 1   | 2026-07-10 14:34 | [#548](https://github.com/danielsmithdevelopment/ClawQL/pull/548) | fix(docker): dashboard image build                  |
+| 2   | 2026-07-11 05:07 | [#549](https://github.com/danielsmithdevelopment/ClawQL/pull/549) | fix(execute): GraphQL projection + provider routing |
+| 3   | 2026-07-11 15:24 | [#550](https://github.com/danielsmithdevelopment/ClawQL/pull/550) | feat(packer): golden hosts + Pulumi                 |
+| 4   | 2026-07-11 16:05 | [#551](https://github.com/danielsmithdevelopment/ClawQL/pull/551) | feat(sandbox): local agent containment              |
+| 5   | 2026-07-11 16:15 | [#552](https://github.com/danielsmithdevelopment/ClawQL/pull/552) | docs: Packer/Pulumi/sandbox guides                  |
+| 6   | 2026-07-11 16:47 | [#553](https://github.com/danielsmithdevelopment/ClawQL/pull/553) | fix(website): agent-markdown static assets          |
+| 7   | 2026-07-11 17:54 | [#554](https://github.com/danielsmithdevelopment/ClawQL/pull/554) | fix(website): mobile table alignment                |
+| 8   | 2026-07-11 18:17 | [#555](https://github.com/danielsmithdevelopment/ClawQL/pull/555) | fix(website): table cell overlap                    |
+| 9   | 2026-07-11 18:50 | [#566](https://github.com/danielsmithdevelopment/ClawQL/pull/566) | fix(website): site-wide table formatting            |
+| 10  | 2026-07-11 23:50 | [#565](https://github.com/danielsmithdevelopment/ClawQL/pull/565) | docs(ouroboros): Q00 sync roadmap                   |
+| 11  | 2026-07-11 23:50 | [#568](https://github.com/danielsmithdevelopment/ClawQL/pull/568) | feat(cloud-agent): R2 vault runbook                 |
+| 12  | 2026-07-11 23:50 | [#569](https://github.com/danielsmithdevelopment/ClawQL/pull/569) | feat(mcp): memory_sync tool                         |
+| 13  | 2026-07-12 00:25 | [#570](https://github.com/danielsmithdevelopment/ClawQL/pull/570) | feat(ouroboros): drift measurement                  |
+| 14  | 2026-07-12 00:39 | [#571](https://github.com/danielsmithdevelopment/ClawQL/pull/571) | feat(ouroboros): drift convergence gate             |
+| 15  | 2026-07-12 00:59 | [#572](https://github.com/danielsmithdevelopment/ClawQL/pull/572) | feat(ouroboros): stagnation taxonomy                |
+| 16  | 2026-07-12 02:43 | [#573](https://github.com/danielsmithdevelopment/ClawQL/pull/573) | feat(inference): tier escalation foundation         |
+| 17  | 2026-07-12 03:23 | [#574](https://github.com/danielsmithdevelopment/ClawQL/pull/574) | feat(inference): gateway MVP                        |
+| 18  | 2026-07-12 03:50 | [#575](https://github.com/danielsmithdevelopment/ClawQL/pull/575) | feat(inference): call store + observability         |
+| 19  | 2026-07-12 04:03 | [#576](https://github.com/danielsmithdevelopment/ClawQL/pull/576) | feat(inference): export + finetune                  |
+| 20  | 2026-07-12 04:24 | [#577](https://github.com/danielsmithdevelopment/ClawQL/pull/577) | feat(inference): pipeline + escalation CLI          |
+| 21  | 2026-07-12 05:01 | [#578](https://github.com/danielsmithdevelopment/ClawQL/pull/578) | feat(inference): OpenAI REST surface                |
+| 22  | 2026-07-12 05:14 | [#579](https://github.com/danielsmithdevelopment/ClawQL/pull/579) | feat(inference): semantic cache                     |
+| 23  | 2026-07-12 05:27 | [#580](https://github.com/danielsmithdevelopment/ClawQL/pull/580) | feat(inference): fallback chains                    |
+| 24  | 2026-07-12 05:43 | [#581](https://github.com/danielsmithdevelopment/ClawQL/pull/581) | feat(inference): virtual keys                       |
+| 25  | 2026-07-12 09:55 | [#582](https://github.com/danielsmithdevelopment/ClawQL/pull/582) | feat(inference): Postgres + pipeline cron           |
+| 26  | 2026-07-12 13:34 | [#583](https://github.com/danielsmithdevelopment/ClawQL/pull/583) | feat(payments): package scaffold                    |
+| 27  | 2026-07-12 13:35 | [#586](https://github.com/danielsmithdevelopment/ClawQL/pull/586) | feat(payments): Stripe SDK + inference limits       |
+| 28  | 2026-07-12 18:53 | [#588](https://github.com/danielsmithdevelopment/ClawQL/pull/588) | docs: inference page on site                        |
+| 29  | 2026-07-12 19:18 | [#587](https://github.com/danielsmithdevelopment/ClawQL/pull/587) | feat(payments): x402 facilitator HTTP               |
+| 30  | 2026-07-12 19:28 | [#589](https://github.com/danielsmithdevelopment/ClawQL/pull/589) | feat(payments): Stripe Billing Meters               |
+| 31  | 2026-07-12 19:37 | [#590](https://github.com/danielsmithdevelopment/ClawQL/pull/590) | fix(website): inference mobile/Mermaid              |
+| 32  | 2026-07-12 19:49 | [#591](https://github.com/danielsmithdevelopment/ClawQL/pull/591) | feat(payments): WORM audit log                      |
+| 33  | 2026-07-12 20:10 | [#592](https://github.com/danielsmithdevelopment/ClawQL/pull/592) | fix(website): search index synced docs              |
+| 34  | 2026-07-12 20:37 | [#594](https://github.com/danielsmithdevelopment/ClawQL/pull/594) | fix(website): Cloudflare deploy size                |
+| 35  | 2026-07-12 21:59 | [#593](https://github.com/danielsmithdevelopment/ClawQL/pull/593) | feat(payments): Postgres audit + Loki               |
+| 36  | 2026-07-12 22:22 | [#595](https://github.com/danielsmithdevelopment/ClawQL/pull/595) | fix(website): inference mobile tables               |
+| 37  | 2026-07-12 23:17 | [#596](https://github.com/danielsmithdevelopment/ClawQL/pull/596) | feat(payments): MCP x402 + well-known               |
+| 38  | 2026-07-13 00:52 | [#597](https://github.com/danielsmithdevelopment/ClawQL/pull/597) | feat(payments): Effect McpProxyPipeline             |
+| 39  | 2026-07-13 01:08 | [#598](https://github.com/danielsmithdevelopment/ClawQL/pull/598) | fix(website): site-wide mobile tables               |
+| 40  | 2026-07-13 01:19 | [#599](https://github.com/danielsmithdevelopment/ClawQL/pull/599) | feat(payments): Stripe Effect services              |
+| 41  | 2026-07-13 01:29 | [#600](https://github.com/danielsmithdevelopment/ClawQL/pull/600) | feat(inference): Effect fallback chains             |
+| 42  | 2026-07-13 01:54 | [#601](https://github.com/danielsmithdevelopment/ClawQL/pull/601) | feat(inference): Effect semantic cache              |
+| 43  | 2026-07-13 01:54 | [#603](https://github.com/danielsmithdevelopment/ClawQL/pull/603) | feat(inference): Effect entitlements                |
+| 44  | 2026-07-13 02:11 | [#605](https://github.com/danielsmithdevelopment/ClawQL/pull/605) | feat(inference): Effect model escalation            |
+| 45  | 2026-07-13 02:12 | [#602](https://github.com/danielsmithdevelopment/ClawQL/pull/602) | docs: SEO, WCAG, agent readiness                    |
+| 46  | 2026-07-13 02:52 | [#606](https://github.com/danielsmithdevelopment/ClawQL/pull/606) | feat(inference): Effect.Stream SSE                  |
+| 47  | 2026-07-13 03:07 | [#604](https://github.com/danielsmithdevelopment/ClawQL/pull/604) | agent readiness clawql.com                          |
+| 48  | 2026-07-13 03:29 | [#607](https://github.com/danielsmithdevelopment/ClawQL/pull/607) | feat(memory): Effect ingest/recall                  |
+| 49  | 2026-07-13 03:29 | [#609](https://github.com/danielsmithdevelopment/ClawQL/pull/609) | feat(core): CacheService Effect                     |
+| 50  | 2026-07-13 03:32 | [#608](https://github.com/danielsmithdevelopment/ClawQL/pull/608) | fix(deploy): GitHub Pages default                   |
+| 51  | 2026-07-13 03:39 | [#611](https://github.com/danielsmithdevelopment/ClawQL/pull/611) | feat(core): ConfigService                           |
+| 52  | 2026-07-13 03:53 | [#612](https://github.com/danielsmithdevelopment/ClawQL/pull/612) | feat(api): execute Effect.gen                       |
+| 53  | 2026-07-13 04:20 | [#613](https://github.com/danielsmithdevelopment/ClawQL/pull/613) | docs(learn): Effect-TS guide                        |
+| 54  | 2026-07-13 04:26 | [#614](https://github.com/danielsmithdevelopment/ClawQL/pull/614) | feat(api): search Effect.gen                        |
+| 55  | 2026-07-13 04:30 | [#610](https://github.com/danielsmithdevelopment/ClawQL/pull/610) | feat(payments): full MPP                            |
+| 56  | 2026-07-13 04:49 | [#615](https://github.com/danielsmithdevelopment/ClawQL/pull/615) | feat(memory): vault/db/embedding services           |
+| 57  | 2026-07-13 04:59 | [#616](https://github.com/danielsmithdevelopment/ClawQL/pull/616) | feat(payments): MPP follow-ups                      |
+| 58  | 2026-07-13 05:40 | [#617](https://github.com/danielsmithdevelopment/ClawQL/pull/617) | feat(memory): recall vector Effect                  |
+| 59  | 2026-07-13 05:54 | [#618](https://github.com/danielsmithdevelopment/ClawQL/pull/618) | docs(learn): Memory 2.0 guide                       |
+| 60  | 2026-07-13 05:54 | [#619](https://github.com/danielsmithdevelopment/ClawQL/pull/619) | feat(documents): ingest Effect bridge               |
+| 61  | 2026-07-13 06:04 | [#620](https://github.com/danielsmithdevelopment/ClawQL/pull/620) | feat(inference): token efficiency layers 3–12       |
 
 ---
 
 ## 10. New packages and env entrypoints
 
-| Package | First merged | CLI / serve |
-|---------|--------------|-------------|
+| Package                | First merged      | CLI / serve                                                                                  |
+| ---------------------- | ----------------- | -------------------------------------------------------------------------------------------- |
 | **`clawql-inference`** | #573 (2026-07-12) | `clawql inference serve`, `npx clawql-inference`; `OPENAI_BASE_URL=http://127.0.0.1:8080/v1` |
-| **`clawql-payments`** | #583 (2026-07-12) | `clawql payments plan|stripe|x402|audit|spend` |
+| **`clawql-payments`**  | #583 (2026-07-12) | `clawql payments plan                                                                        | stripe | x402 | audit | spend` |
 
 Key env flags introduced post-7.0:
 
@@ -455,4 +473,4 @@ Per merged PR follow-up notes and the modularization plan:
 
 ---
 
-*This document was generated from `git log v7.0.0..main` and GitHub merged-PR metadata on 2026-07-13. For the canonical 7.0.0 breaking-change list, see [`RELEASE_NOTES_v7.0.0.md`](../../RELEASE_NOTES_v7.0.0.md).*
+_This document was generated from `git log v7.0.0..main` and GitHub merged-PR metadata on 2026-07-13. For the canonical 7.0.0 breaking-change list, see [`RELEASE_NOTES_v7.0.0.md`](../../RELEASE_NOTES_v7.0.0.md)._

--- a/docs/announcements/7.0-weekend-build-push-2026-07.md
+++ b/docs/announcements/7.0-weekend-build-push-2026-07.md
@@ -1,0 +1,458 @@
+# ClawQL 7.0.0 and the July 2026 build push
+
+**Published:** 2026-07-13  
+**Scope:** Everything in **`clawql-mcp@7.0.0`** (tag `v7.0.0`, 2026-07-10) plus **61 pull requests** merged to `main` after the tag through **2026-07-13 06:03 UTC** (65 total including the four release-day PRs #544–#547) — the weekend build push that landed two new horizontal packages, completed an inference epic, built a payments stack from scratch, started a monorepo-wide Effect-TS migration, and pushed both **clawql.com** and **docs.clawql.com** to agent-readiness.
+
+**Links:** [RELEASE_NOTES_v7.0.0.md](../../RELEASE_NOTES_v7.0.0.md) · [CHANGELOG.md](../../CHANGELOG.md) · [npm: clawql-mcp@7.0.0](https://www.npmjs.com/package/clawql-mcp/v/7.0.0) · [Docs](https://docs.clawql.com) · [Epic #556 — Inference + upstream Ouroboros](https://github.com/danielsmithdevelopment/ClawQL/issues/556)
+
+**Scale (post-tag delta `v7.0.0..main`):** ~**+41,271 / −1,833** lines across **814 files** · **63** merge commits · **176** non-merge commits
+
+---
+
+## Executive summary
+
+| Phase | When | Headline |
+|-------|------|----------|
+| **7.0.0** | 2026-07-10 | Opinionated default stack, vault-first Helm, npm 7.0 publish, Layer 0 release MVP, Desktop, Operator, IDP wave |
+| **Post-7.0 Fri** | 2026-07-10–11 | Team vault sync, GraphQL fix, Packer/Pulumi golden hosts, local sandbox containment, docs table fixes |
+| **Sat Ouroboros + Inference** | 2026-07-11–12 | Q00 drift sync, `clawql-inference` epic #556 (gateway → REST → cache → keys → Postgres) |
+| **Sat–Sun Payments** | 2026-07-12–13 | `clawql-payments` from scaffold → Stripe + x402 + MPP + WORM audit + Effect MCP proxy |
+| **Sun Effect migration** | 2026-07-13 | core (cache, config) → api (search, execute) → memory (ingest, recall, vectors) → documents bridge |
+| **Sun Agent readiness** | 2026-07-13 | clawql.com Level 5 path, docs commerce discovery, learn guides, token-efficiency layers 3–12 |
+
+---
+
+# Part I — clawql-mcp 7.0.0 (2026-07-10)
+
+**Release date:** 2026-07-10 · **npm:** [`clawql-mcp@7.0.0`](https://www.npmjs.com/package/clawql-mcp/v/7.0.0) · **Helm:** `charts/clawql-mcp` **0.7.0** / appVersion **7.0.0**
+
+## Headline
+
+**One default everywhere, vault-first defense in depth.** Fresh `npx clawql-mcp` and Helm **`provider: default`** load the same opinionated stack (Cloudflare, GitHub, Slack, Linear, Notion, Onyx). Vault-backed provider secrets are required by default; the operator reconciles expected keys against your synced Secret.
+
+## Breaking changes
+
+| Area | Before (≤6.4.x) | After (7.0.0) |
+|------|-----------------|---------------|
+| **Default provider merge** | npm: implicit growing merge; Helm: `all-providers` | **Default stack** (6 vendors); `CLAWQL_PROVIDER=all-providers` or Helm `provider=all-providers` for full merge |
+| **Legacy env aliases** | `API_BASE_URL`, `OPENAPI_SPEC_URL`, `GOOGLE_DISCOVERY_URL`, `google-top50` preset | **`CLAWQL_API_BASE_URL`**, **`CLAWQL_SPEC_URL`**, **`CLAWQL_DISCOVERY_URL`**, **`CLAWQL_PROVIDER=google`** |
+| **Vault secrets** | Optional | **`secretSourcing.requireVaultBackedSecrets: true`** (default) — render fails without `envFromSecret` / `envFromSecrets` |
+| **HTTP metrics** | `CLAWQL_DISABLE_HTTP_METRICS` | **`CLAWQL_ENABLE_HTTP_METRICS=0`** to opt out |
+| **Loki push** | Implicit when URL set | **`CLAWQL_ENABLE_LOKI_PUSH=0`** to opt out |
+| **Env flag convention** | Mixed | All feature toggles: **`CLAWQL_ENABLE_*`** — unset = default; `=0` opt-out; `=1` opt-in when default-off |
+
+## Major additions
+
+### npm distribution and Layer 0
+
+- All horizontal **`clawql-*`** workspace packages aligned to **7.0.0** with publish order in [`scripts/release/npm-publish-order.json`](../../scripts/release/npm-publish-order.json)
+- **`clawql-mcp@7.0.0`** on npm — split packages not individually linked yet; ships via **`bundledDependencies`** fallback ([#547](https://github.com/danielsmithdevelopment/ClawQL/pull/547))
+- **`clawql-release`** — `clawql release init|collect|manifest|publish|verify`; manifest v0.1 with git commit, npm tarball + CycloneDX SBOM SHA-256, GHCR digests, Merkle root; `clawql doctor --smoke` + `CLAWQL_RELEASE_MANIFEST` startup verify
+
+### Onboarding, sources, and harness wrappers
+
+- **`clawql onboard`**, **`init`**, **`secrets`**, **`doctor`**, **`mcp-config`**, **`operator status`**
+- **`clawql sources add <url>`** — OpenAPI, Google Discovery, GraphQL, gRPC, MCP HTTP; persisted in **`~/.ClawQL/sources.json`**
+- MCP-as-source and CLI-as-source (`protocolKind` **mcp** / **cli**)
+- Harness launchers: **`clawql claude`**, **`codex`**, **`cursor`**, **`opencode`**
+- One-line install: `curl -fsSL https://clawql.com/install | bash`
+
+### ClawQL Desktop (macOS, Windows, Linux)
+
+- Electron app (`desktop/`) — Provider secrets, Agent Chat (OpenClaw bridge), Custom sources UI
+- `npm run dist:mac|dist:win|dist:linux`
+
+### Default bundled stack and providers
+
+- Bare `npx clawql-mcp` → **Cloudflare, GitHub, Slack, Linear, Notion, Onyx** ([#528](https://github.com/danielsmithdevelopment/ClawQL/pull/528))
+- **AWS top-50** bundled preset with SigV4 execute
+- **Notion** bundled provider
+
+### ClawQL Operator (opt-in)
+
+- `ClawQLInstance` tier presets, continuous reconcile, MCP rollout on tier-spec change
+- **`ProviderSecretsReady`** auth reconciliation — default-stack keys; full IDP vault catalog when **`documents.enabled`**
+
+### Phase 1 exit — horizontal packages
+
+| Package | Shipped capability |
+|---------|-------------------|
+| **`clawql-auth`** | Gateway `noAuth`/`apiKey`, ATR claims, provider credential headers |
+| **`clawql-pageindex`** | Vectorless hierarchical indexing; `pageindex_*` tools (default on) |
+| **Presidio hooks** | `CLAWQL_ENABLE_PRESIDIO=1` redacts execute, memory ingest, external ingest |
+| **Tier 1 Compose** | `examples/clawql-local-docker-compose` |
+
+### IDP wave (consolidated in 7.0)
+
+- Docling Helm + classifier; LangExtract extraction; IDP pipeline runner (`run_idp_pipeline`)
+- Vault default provider secrets + dashboard Vault UI
+- KEDA NATS JetStream worker; NATS workflow events
+- Langfuse eval → Ouroboros webhook path
+- Lending vertical Docker Compose stack
+- Observability **ADR 0005** — Langfuse default work-trace store (profiles: bundled / external / minimal)
+
+### Docs site (7.0)
+
+- **`/vision/ecosystem`**, **`/getting-started/clawql-release-mvp`**
+- Shared doc link rewriter; consolidated nav
+
+### Helm charts at 7.0.0
+
+| Chart | Chart.version | appVersion |
+|-------|---------------|------------|
+| `charts/clawql-mcp` | 0.7.0 | 7.0.0 |
+| `charts/clawql-operator` | 0.2.0 | 7.0.0 |
+| `charts/clawql-idp` | 0.1.0 | 7.0.0 |
+
+### Release-process PRs (same day, pre/post tag)
+
+| PR | Title |
+|----|-------|
+| [#544](https://github.com/danielsmithdevelopment/ClawQL/pull/544) | Finalize 7.0.0 release notes and changelog |
+| [#545](https://github.com/danielsmithdevelopment/ClawQL/pull/545) | Team vault sync to R2/S3/GCS (`clawql sync`) |
+| [#546](https://github.com/danielsmithdevelopment/ClawQL/pull/546) | Lighthouse, SEO, and WCAG polish for 7.0 docs site |
+| [#547](https://github.com/danielsmithdevelopment/ClawQL/pull/547) | npm 7.0.0 publish fallback (`bundledDependencies`) — **tag `v7.0.0`** |
+
+---
+
+# Part II — Post-7.0.0 build push (2026-07-10 → 2026-07-13)
+
+Everything below merged **after** tag **`v7.0.0`** (from [#548](https://github.com/danielsmithdevelopment/ClawQL/pull/548) through [#620](https://github.com/danielsmithdevelopment/ClawQL/pull/620)).
+
+---
+
+## 1. Infrastructure, provisioning, and containment
+
+### [#548](https://github.com/danielsmithdevelopment/ClawQL/pull/548) — Dashboard Docker image for 7.0.0
+Fixes **clawql-dashboard** Docker publish (`Can't resolve 'clawql-api'`) by building workspace packages from monorepo root.
+
+### [#550](https://github.com/danielsmithdevelopment/ClawQL/pull/550) — Packer golden hosts + Pulumi provisioning
+- **`infra/pulumi`** — TypeScript `clawql-provision`: AWS EC2, GCP GCE, Cloudflare R2; tier helpers; boot user-data; Automation API wrapper
+- **ADR 0007** — Pulumi vs Terraform; self-hosted state (R2 preferred)
+- Packer golden-image pipeline with verified team vault bootstrap (+5,401 lines)
+
+### [#551](https://github.com/danielsmithdevelopment/ClawQL/pull/551) — Local agent sandbox (`clawql sandbox init`)
+Fail-closed **Panguard** containment for laptop dev:
+- `clawql sandbox init|status|verify|edit`
+- Per-harness Seatbelt profiles (Claude, Codex, Cursor, OpenCode)
+- `clawql doctor --smoke` includes sandbox verify
+
+### [#552](https://github.com/danielsmithdevelopment/ClawQL/pull/552) — Docs: Packer, Pulumi, sandbox guides
+Site routes: `/getting-started/golden-host-images`, `/getting-started/local-agent-sandbox`
+
+### [#568](https://github.com/danielsmithdevelopment/ClawQL/pull/568) — Cloud Agent R2 vault runbook
+- `docs/deployment/cloud-agent-r2-tailscale-runbook.md`
+- `.cursor/environment.json` + `cloud-agent-install.sh`
+- Pulumi `goldenImageId` optional for Cloudflare-only R2 stacks
+
+---
+
+## 2. Execute, API, and provider routing
+
+### [#549](https://github.com/danielsmithdevelopment/ClawQL/pull/549) — GraphQL list projection + provider-centric routing
+- Fixes nested GraphQL field projection (`nodes { id name }` returning `{}`)
+- **Provider-centric model** — users pick providers; ClawQL routes gRPC → GraphQL → OpenAPI internally
+- Removed footgun env vars that crashed startup on misconfigured GraphQL sources
+
+---
+
+## 3. Team vault sync and Cloud Agent memory
+
+### [#545](https://github.com/danielsmithdevelopment/ClawQL/pull/545) — `clawql sync` (R2 / S3 / GCS)
+*(Merged same day as 7.0.0; documented here as part of the 7.0 wave.)*
+- `clawql sync init|push|pull|status`; provider profiles; vault keys for GCS HMAC
+- Auto sync: `CLAWQL_SYNC_AUTO=1` debounced push after `memory_ingest`; `CLAWQL_SYNC_AUTO_PULL=1` before `memory_recall`
+- Helm `teamSync.*`; docs hub `/getting-started/for-teams`
+
+### [#569](https://github.com/danielsmithdevelopment/ClawQL/pull/569) — `memory_sync` MCP tool
+Cloud Agents reconcile vault without shell:
+```
+memory_recall → work → memory_ingest → memory_sync { "direction": "auto" }
+```
+- Guide: `/getting-started/cursor-ios-cloud-agent`
+
+---
+
+## 4. Ouroboros — upstream Q00 sync (epic #556 P0-A/B/C)
+
+### [#565](https://github.com/danielsmithdevelopment/ClawQL/pull/565) — Upstream sync roadmap + GitHub epic
+Planning doc for Q00/ouroboros v0.50.3+ composition with ClawQL; epic [#556](https://github.com/danielsmithdevelopment/ClawQL/issues/556) and child issues #557–#564
+
+### [#570](https://github.com/danielsmithdevelopment/ClawQL/pull/570) — 3-component drift measurement (#557)
+```
+combined_drift = 0.5×goal + 0.3×constraint + 0.2×ontology
+```
+- `ouroboros_measure_drift` MCP tool; `drift_measured` events each generation
+
+### [#571](https://github.com/danielsmithdevelopment/ClawQL/pull/571) — Drift convergence gate (#558)
+Blocks premature converge when `combined_drift > 0.3`; `latest_drift` on lineage
+
+### [#572](https://github.com/danielsmithdevelopment/ClawQL/pull/572) — Stagnation taxonomy (#559)
+Reason codes: `no_drift`, `oscillation`, `spinning`, `diminishing_returns` on `ConvergenceSignal`
+
+---
+
+## 5. clawql-inference — new package (epic #556)
+
+**New workspace package:** `packages/clawql-inference` — inference gateway with OpenAI-compatible REST, observability, caching, keys, export/finetune flywheel, and full Effect-TS internal migration.
+
+### Foundation and gateway (Jul 12 early morning)
+
+| PR | Title | What shipped |
+|----|-------|--------------|
+| [#573](https://github.com/danielsmithdevelopment/ClawQL/pull/573) | PAL routing / tier escalation (#560) | `AdaptiveRouter`, `TierEscalationRouter`, `InferenceGateway` interface; Ouroboros loop hooks |
+| [#574](https://github.com/danielsmithdevelopment/ClawQL/pull/574) | Gateway MVP (#556 P0-F) | Provider plugin architecture, `createInferenceGateway()`, decorator stack |
+| [#575](https://github.com/danielsmithdevelopment/ClawQL/pull/575) | Call store + observability (#556 P0-G) | `InferenceRecord`, JSONL store, `clawql inference logs|trace|spend`, `X-Correlation-Id` |
+| [#576](https://github.com/danielsmithdevelopment/ClawQL/pull/576) | Export + finetune (#556 P0-H/I) | Verdict-filtered dataset export (openai-jsonl, anthropic-jsonl, sharegpt); OpenAI/Anthropic finetune; tier-map overrides |
+| [#577](https://github.com/danielsmithdevelopment/ClawQL/pull/577) | Pipeline + escalation CLI (#556 P1) | `clawql inference pipeline|escalation`; audit event builders; agent coordination trigger stub |
+| [#578](https://github.com/danielsmithdevelopment/ClawQL/pull/578) | OpenAI-compatible REST (#556) | Drop-in `POST /v1/chat/completions`, `GET /v1/models`, SSE streaming; `OPENAI_BASE_URL` swap |
+| [#579](https://github.com/danielsmithdevelopment/ClawQL/pull/579) | Semantic cache (#556) | `SemanticCachedGateway`; embedding similarity; `CLAWQL_INFERENCE_SEMANTIC_CACHE=1` |
+| [#580](https://github.com/danielsmithdevelopment/ClawQL/pull/580) | Fallback chains (#556) | `FallbackChainGateway`; per-tier and per-model chains |
+| [#581](https://github.com/danielsmithdevelopment/ClawQL/pull/581) | Virtual keys (#556) | Per-team API keys, USD budgets, rate limits; `clawql inference keys` |
+| [#582](https://github.com/danielsmithdevelopment/ClawQL/pull/582) | Deferred epic close (#556) | Postgres store, Ouroboros audit wiring, agent coordination (Hermes stub), `policy show`, pipeline cron worker |
+
+### Inference Effect-TS migration (Jul 13 overnight) — **complete**
+
+| PR | Component |
+|----|-----------|
+| [#600](https://github.com/danielsmithdevelopment/ClawQL/pull/600) | `FallbackChainService` + `InferenceGatewayService` |
+| [#601](https://github.com/danielsmithdevelopment/ClawQL/pull/601) | `SemanticCacheService`, `EmbedderService`, `SemanticCacheStoreService` |
+| [#603](https://github.com/danielsmithdevelopment/ClawQL/pull/603) | `EntitlementEnforcementService` wired to `clawql-payments` |
+| [#605](https://github.com/danielsmithdevelopment/ClawQL/pull/605) | `ModelEscalationService` for tier escalation |
+| [#606](https://github.com/danielsmithdevelopment/ClawQL/pull/606) | `Effect.Stream` OpenAI SSE streaming |
+
+### Token efficiency layers 3–12
+
+### [#620](https://github.com/danielsmithdevelopment/ClawQL/pull/620) — Token efficiency in gateway
+Closes gaps vs [token-efficiency architecture](https://docs.clawql.com/architecture/token-efficiency):
+
+| Layer | Feature | Default |
+|-------|---------|---------|
+| 3 | Terse output post-processor | on |
+| 4 | Anthropic `cache_control` on system prefix | on |
+| 5 | Semantic cache safety + tag invalidation | on when embeddings configured |
+| 6 | History distillation | off (`CLAWQL_INFERENCE_HISTORY_COMPRESS=1`) |
+| 7 | Prompt dedupe + truncation | off (`CLAWQL_INFERENCE_PROMPT_COMPRESS=1`) |
+| 8 | HTTP `clawql/auto` tier routing | on when routing enabled |
+| 9 | Structured output hints | on |
+| 10 | Token budget signaling from `max_tokens` | on |
+| 11 | Assistant prefill opener | off |
+| 12 | Flywheel (export → finetune → frugal) | documented |
+
+Gateway stack (outer → inner): `Observed → Entitlement → TokenEfficiency → SemanticCache → Fallback → Configured → provider`
+
+Also: live **Hermes MoA** when `HERMES_BASE_URL` set; `x-clawql-cache-intent: read|write` header.
+
+---
+
+## 6. clawql-payments — new package (Jul 12–13)
+
+**New workspace package:** `packages/clawql-payments` — Stripe + x402 + MPP commerce with WORM audit, MCP enforcement, and Effect-first architecture.
+
+### Scaffold through Stripe + x402 (Jul 12)
+
+| PR | What shipped |
+|----|--------------|
+| [#583](https://github.com/danielsmithdevelopment/ClawQL/pull/583) | Package scaffold — plans (Free/Pro/Team/Enterprise), Stripe stubs, x402 gating, audit ring buffer, full `clawql payments` CLI |
+| [#586](https://github.com/danielsmithdevelopment/ClawQL/pull/586) | Inference plan limits (`CLAWQL_PAYMENTS_ENFORCE_INFERENCE`) + live Stripe SDK + webhook verification |
+| [#587](https://github.com/danielsmithdevelopment/ClawQL/pull/587) | x402 facilitator HTTP (verify/settle); Express middleware; `docs/payments/clawql-payments.md` |
+| [#589](https://github.com/danielsmithdevelopment/ClawQL/pull/589) | Stripe Billing Meters — `reportInferenceMeterUsageIfEnabled()`, gateway hooks |
+| [#591](https://github.com/danielsmithdevelopment/ClawQL/pull/591) | Durable hash-chained WORM audit (`audit.jsonl`); `clawql payments audit verify` |
+| [#593](https://github.com/danielsmithdevelopment/ClawQL/pull/593) | Postgres audit store, Loki/SIEM export, `X402_PAYMENT_FAILED` events |
+
+### MCP enforcement and Effect migration (Jul 12–13)
+
+| PR | What shipped |
+|----|--------------|
+| [#596](https://github.com/danielsmithdevelopment/ClawQL/pull/596) | In-process MCP x402 on `tools/call`; `/.well-known/payments.json` |
+| [#597](https://github.com/danielsmithdevelopment/ClawQL/pull/597) | Effect `McpProxyPipeline` — 9 services (config, audit, x402, entitlements, discovery, …) |
+| [#599](https://github.com/danielsmithdevelopment/ClawQL/pull/599) | Stripe Effect services — client, webhook, meter, billing (Stripe migration complete) |
+
+### MPP — Model Payment Protocol (Jul 13)
+
+| PR | What shipped |
+|----|--------------|
+| [#610](https://github.com/danielsmithdevelopment/ClawQL/pull/610) | Full MPP — `MppOpenApiService`, `MppVerificationService`, credential verify, challenge registry, receipts; alongside x402 + Stripe |
+| [#616](https://github.com/danielsmithdevelopment/ClawQL/pull/616) | MPP follow-ups — dual `x-payment-info` for commerce scanners, Stripe SPT smoke harness, optional `mppx` adapter, MCP JSON-RPC -32042/-32043, PayPal/Adyen/Square in `offers[]` |
+
+---
+
+## 7. Effect-TS horizontal migration (Jul 13)
+
+Boundary-only Effect pattern: MCP handlers stay Promise-based; domain logic runs through `Context.Tag` + `Layer`.
+
+| PR | Package | What shipped |
+|----|---------|--------------|
+| [#607](https://github.com/danielsmithdevelopment/ClawQL/pull/607) | `clawql-memory` | `MemoryIngestService` / `MemoryRecallService`, `memoryServicesLiveLayer()` |
+| [#609](https://github.com/danielsmithdevelopment/ClawQL/pull/609) | `clawql-core` | `CacheService` Effect layer for MCP cache tool |
+| [#611](https://github.com/danielsmithdevelopment/ClawQL/pull/611) | `clawql-core` | `ConfigService` — centralized env readers |
+| [#612](https://github.com/danielsmithdevelopment/ClawQL/pull/612) | `clawql-api` | `execute-core` → native `Effect.gen` |
+| [#614](https://github.com/danielsmithdevelopment/ClawQL/pull/614) | `clawql-api` | `search-core` → native `Effect.gen` (both core MCP tools Effect-native) |
+| [#615](https://github.com/danielsmithdevelopment/ClawQL/pull/615) | `clawql-memory` | `VaultConfigService`, `MemoryDbService`, `EmbeddingService` |
+| [#617](https://github.com/danielsmithdevelopment/ClawQL/pull/617) | `clawql-memory` | Recall vector/db pass — `recallVectorPassEffect`, `memory.db` artifacts |
+| [#619](https://github.com/danielsmithdevelopment/ClawQL/pull/619) | `clawql-documents` | Effect bridge for `ingest_external_knowledge` |
+
+**Next slices (not yet merged):** automation, ouroboros, sandbox, auth — per modularization plan.
+
+---
+
+## 8. Docs site, agent readiness, and learn content
+
+### Website fixes (Jul 11–12) — deploy unblockers and mobile tables
+
+| PR | Fix |
+|----|-----|
+| [#553](https://github.com/danielsmithdevelopment/ClawQL/pull/553) | Move `agent-markdown.json` to static assets (Worker 3 MiB limit) |
+| [#554](https://github.com/danielsmithdevelopment/ClawQL/pull/554) | Mobile table alignment in docs prose |
+| [#555](https://github.com/danielsmithdevelopment/ClawQL/pull/555) | Stop table cell content overlap |
+| [#566](https://github.com/danielsmithdevelopment/ClawQL/pull/566) | Site-wide table formatting for 2–8 columns (`data-cols`) |
+| [#588](https://github.com/danielsmithdevelopment/ClawQL/pull/588) | Comprehensive `/inference/clawql-inference` docs page |
+| [#590](https://github.com/danielsmithdevelopment/ClawQL/pull/590) | Inference docs Mermaid + mobile tables |
+| [#592](https://github.com/danielsmithdevelopment/ClawQL/pull/592) | Global search indexes synced `*-body.mdx` (131 pages, 40 chunks) |
+| [#594](https://github.com/danielsmithdevelopment/ClawQL/pull/594) | Cloudflare deploy size fix — client-only Mermaid/Search; handler ~2.25 MiB gzip |
+| [#595](https://github.com/danielsmithdevelopment/ClawQL/pull/595) | Inference mobile tables; text architecture replaces Mermaid |
+| [#598](https://github.com/danielsmithdevelopment/ClawQL/pull/598) | Site-wide mobile tables + sync-script wrapper consistency + Playwright regression (11 routes) |
+
+### Agent readiness (Jul 13)
+
+| PR | Domain | What shipped |
+|----|--------|--------------|
+| [#602](https://github.com/danielsmithdevelopment/ClawQL/pull/602) | docs.clawql.com | `auth.md`, A2A agent card, AP2 extension, commerce discovery (`/openapi.json`, 402 probe, UCP/ACP/payments well-known), DNS-AID runbook, Lighthouse CI |
+| [#604](https://github.com/danielsmithdevelopment/ClawQL/pull/604) | clawql.com | Prebuild discovery assets, Cloudflare Pages `functions/` (Link headers + markdown negotiation), WebMCP, Lighthouse 100 |
+| [#608](https://github.com/danielsmithdevelopment/ClawQL/pull/608) | deploy | Restore GitHub Pages as default until Cloudflare secrets configured |
+
+### Learn guides (Jul 13)
+
+| PR | Route | Topic |
+|----|-------|-------|
+| [#613](https://github.com/danielsmithdevelopment/ClawQL/pull/613) | `/learn/effect-ts` | Why ClawQL uses Effect-TS for 7-layer architecture enforcement |
+| [#618](https://github.com/danielsmithdevelopment/ClawQL/pull/618) | `/learn/memory` | clawql-memory (Memory 2.0) — vault, wikilinks, hybrid recall, team sync, flywheel |
+
+---
+
+## 9. Chronological merge index (post-tag)
+
+| # | Merged (UTC) | PR | Title |
+|---|--------------|-----|-------|
+| 1 | 2026-07-10 14:34 | [#548](https://github.com/danielsmithdevelopment/ClawQL/pull/548) | fix(docker): dashboard image build |
+| 2 | 2026-07-11 05:07 | [#549](https://github.com/danielsmithdevelopment/ClawQL/pull/549) | fix(execute): GraphQL projection + provider routing |
+| 3 | 2026-07-11 15:24 | [#550](https://github.com/danielsmithdevelopment/ClawQL/pull/550) | feat(packer): golden hosts + Pulumi |
+| 4 | 2026-07-11 16:05 | [#551](https://github.com/danielsmithdevelopment/ClawQL/pull/551) | feat(sandbox): local agent containment |
+| 5 | 2026-07-11 16:15 | [#552](https://github.com/danielsmithdevelopment/ClawQL/pull/552) | docs: Packer/Pulumi/sandbox guides |
+| 6 | 2026-07-11 16:47 | [#553](https://github.com/danielsmithdevelopment/ClawQL/pull/553) | fix(website): agent-markdown static assets |
+| 7 | 2026-07-11 17:54 | [#554](https://github.com/danielsmithdevelopment/ClawQL/pull/554) | fix(website): mobile table alignment |
+| 8 | 2026-07-11 18:17 | [#555](https://github.com/danielsmithdevelopment/ClawQL/pull/555) | fix(website): table cell overlap |
+| 9 | 2026-07-11 18:50 | [#566](https://github.com/danielsmithdevelopment/ClawQL/pull/566) | fix(website): site-wide table formatting |
+| 10 | 2026-07-11 23:50 | [#565](https://github.com/danielsmithdevelopment/ClawQL/pull/565) | docs(ouroboros): Q00 sync roadmap |
+| 11 | 2026-07-11 23:50 | [#568](https://github.com/danielsmithdevelopment/ClawQL/pull/568) | feat(cloud-agent): R2 vault runbook |
+| 12 | 2026-07-11 23:50 | [#569](https://github.com/danielsmithdevelopment/ClawQL/pull/569) | feat(mcp): memory_sync tool |
+| 13 | 2026-07-12 00:25 | [#570](https://github.com/danielsmithdevelopment/ClawQL/pull/570) | feat(ouroboros): drift measurement |
+| 14 | 2026-07-12 00:39 | [#571](https://github.com/danielsmithdevelopment/ClawQL/pull/571) | feat(ouroboros): drift convergence gate |
+| 15 | 2026-07-12 00:59 | [#572](https://github.com/danielsmithdevelopment/ClawQL/pull/572) | feat(ouroboros): stagnation taxonomy |
+| 16 | 2026-07-12 02:43 | [#573](https://github.com/danielsmithdevelopment/ClawQL/pull/573) | feat(inference): tier escalation foundation |
+| 17 | 2026-07-12 03:23 | [#574](https://github.com/danielsmithdevelopment/ClawQL/pull/574) | feat(inference): gateway MVP |
+| 18 | 2026-07-12 03:50 | [#575](https://github.com/danielsmithdevelopment/ClawQL/pull/575) | feat(inference): call store + observability |
+| 19 | 2026-07-12 04:03 | [#576](https://github.com/danielsmithdevelopment/ClawQL/pull/576) | feat(inference): export + finetune |
+| 20 | 2026-07-12 04:24 | [#577](https://github.com/danielsmithdevelopment/ClawQL/pull/577) | feat(inference): pipeline + escalation CLI |
+| 21 | 2026-07-12 05:01 | [#578](https://github.com/danielsmithdevelopment/ClawQL/pull/578) | feat(inference): OpenAI REST surface |
+| 22 | 2026-07-12 05:14 | [#579](https://github.com/danielsmithdevelopment/ClawQL/pull/579) | feat(inference): semantic cache |
+| 23 | 2026-07-12 05:27 | [#580](https://github.com/danielsmithdevelopment/ClawQL/pull/580) | feat(inference): fallback chains |
+| 24 | 2026-07-12 05:43 | [#581](https://github.com/danielsmithdevelopment/ClawQL/pull/581) | feat(inference): virtual keys |
+| 25 | 2026-07-12 09:55 | [#582](https://github.com/danielsmithdevelopment/ClawQL/pull/582) | feat(inference): Postgres + pipeline cron |
+| 26 | 2026-07-12 13:34 | [#583](https://github.com/danielsmithdevelopment/ClawQL/pull/583) | feat(payments): package scaffold |
+| 27 | 2026-07-12 13:35 | [#586](https://github.com/danielsmithdevelopment/ClawQL/pull/586) | feat(payments): Stripe SDK + inference limits |
+| 28 | 2026-07-12 18:53 | [#588](https://github.com/danielsmithdevelopment/ClawQL/pull/588) | docs: inference page on site |
+| 29 | 2026-07-12 19:18 | [#587](https://github.com/danielsmithdevelopment/ClawQL/pull/587) | feat(payments): x402 facilitator HTTP |
+| 30 | 2026-07-12 19:28 | [#589](https://github.com/danielsmithdevelopment/ClawQL/pull/589) | feat(payments): Stripe Billing Meters |
+| 31 | 2026-07-12 19:37 | [#590](https://github.com/danielsmithdevelopment/ClawQL/pull/590) | fix(website): inference mobile/Mermaid |
+| 32 | 2026-07-12 19:49 | [#591](https://github.com/danielsmithdevelopment/ClawQL/pull/591) | feat(payments): WORM audit log |
+| 33 | 2026-07-12 20:10 | [#592](https://github.com/danielsmithdevelopment/ClawQL/pull/592) | fix(website): search index synced docs |
+| 34 | 2026-07-12 20:37 | [#594](https://github.com/danielsmithdevelopment/ClawQL/pull/594) | fix(website): Cloudflare deploy size |
+| 35 | 2026-07-12 21:59 | [#593](https://github.com/danielsmithdevelopment/ClawQL/pull/593) | feat(payments): Postgres audit + Loki |
+| 36 | 2026-07-12 22:22 | [#595](https://github.com/danielsmithdevelopment/ClawQL/pull/595) | fix(website): inference mobile tables |
+| 37 | 2026-07-12 23:17 | [#596](https://github.com/danielsmithdevelopment/ClawQL/pull/596) | feat(payments): MCP x402 + well-known |
+| 38 | 2026-07-13 00:52 | [#597](https://github.com/danielsmithdevelopment/ClawQL/pull/597) | feat(payments): Effect McpProxyPipeline |
+| 39 | 2026-07-13 01:08 | [#598](https://github.com/danielsmithdevelopment/ClawQL/pull/598) | fix(website): site-wide mobile tables |
+| 40 | 2026-07-13 01:19 | [#599](https://github.com/danielsmithdevelopment/ClawQL/pull/599) | feat(payments): Stripe Effect services |
+| 41 | 2026-07-13 01:29 | [#600](https://github.com/danielsmithdevelopment/ClawQL/pull/600) | feat(inference): Effect fallback chains |
+| 42 | 2026-07-13 01:54 | [#601](https://github.com/danielsmithdevelopment/ClawQL/pull/601) | feat(inference): Effect semantic cache |
+| 43 | 2026-07-13 01:54 | [#603](https://github.com/danielsmithdevelopment/ClawQL/pull/603) | feat(inference): Effect entitlements |
+| 44 | 2026-07-13 02:11 | [#605](https://github.com/danielsmithdevelopment/ClawQL/pull/605) | feat(inference): Effect model escalation |
+| 45 | 2026-07-13 02:12 | [#602](https://github.com/danielsmithdevelopment/ClawQL/pull/602) | docs: SEO, WCAG, agent readiness |
+| 46 | 2026-07-13 02:52 | [#606](https://github.com/danielsmithdevelopment/ClawQL/pull/606) | feat(inference): Effect.Stream SSE |
+| 47 | 2026-07-13 03:07 | [#604](https://github.com/danielsmithdevelopment/ClawQL/pull/604) | agent readiness clawql.com |
+| 48 | 2026-07-13 03:29 | [#607](https://github.com/danielsmithdevelopment/ClawQL/pull/607) | feat(memory): Effect ingest/recall |
+| 49 | 2026-07-13 03:29 | [#609](https://github.com/danielsmithdevelopment/ClawQL/pull/609) | feat(core): CacheService Effect |
+| 50 | 2026-07-13 03:32 | [#608](https://github.com/danielsmithdevelopment/ClawQL/pull/608) | fix(deploy): GitHub Pages default |
+| 51 | 2026-07-13 03:39 | [#611](https://github.com/danielsmithdevelopment/ClawQL/pull/611) | feat(core): ConfigService |
+| 52 | 2026-07-13 03:53 | [#612](https://github.com/danielsmithdevelopment/ClawQL/pull/612) | feat(api): execute Effect.gen |
+| 53 | 2026-07-13 04:20 | [#613](https://github.com/danielsmithdevelopment/ClawQL/pull/613) | docs(learn): Effect-TS guide |
+| 54 | 2026-07-13 04:26 | [#614](https://github.com/danielsmithdevelopment/ClawQL/pull/614) | feat(api): search Effect.gen |
+| 55 | 2026-07-13 04:30 | [#610](https://github.com/danielsmithdevelopment/ClawQL/pull/610) | feat(payments): full MPP |
+| 56 | 2026-07-13 04:49 | [#615](https://github.com/danielsmithdevelopment/ClawQL/pull/615) | feat(memory): vault/db/embedding services |
+| 57 | 2026-07-13 04:59 | [#616](https://github.com/danielsmithdevelopment/ClawQL/pull/616) | feat(payments): MPP follow-ups |
+| 58 | 2026-07-13 05:40 | [#617](https://github.com/danielsmithdevelopment/ClawQL/pull/617) | feat(memory): recall vector Effect |
+| 59 | 2026-07-13 05:54 | [#618](https://github.com/danielsmithdevelopment/ClawQL/pull/618) | docs(learn): Memory 2.0 guide |
+| 60 | 2026-07-13 05:54 | [#619](https://github.com/danielsmithdevelopment/ClawQL/pull/619) | feat(documents): ingest Effect bridge |
+| 61 | 2026-07-13 06:04 | [#620](https://github.com/danielsmithdevelopment/ClawQL/pull/620) | feat(inference): token efficiency layers 3–12 |
+
+---
+
+## 10. New packages and env entrypoints
+
+| Package | First merged | CLI / serve |
+|---------|--------------|-------------|
+| **`clawql-inference`** | #573 (2026-07-12) | `clawql inference serve`, `npx clawql-inference`; `OPENAI_BASE_URL=http://127.0.0.1:8080/v1` |
+| **`clawql-payments`** | #583 (2026-07-12) | `clawql payments plan|stripe|x402|audit|spend` |
+
+Key env flags introduced post-7.0:
+
+```bash
+# Inference
+CLAWQL_INFERENCE_SEMANTIC_CACHE=1
+CLAWQL_INFERENCE_FALLBACK_ENABLED=1
+CLAWQL_INFERENCE_KEYS_ENABLED=1
+CLAWQL_INFERENCE_STORE=postgres
+CLAWQL_INFERENCE_PIPELINE_WORKER=1
+
+# Payments
+CLAWQL_X402_ENFORCE=1
+CLAWQL_PAYMENTS_ENFORCE_INFERENCE=1
+CLAWQL_PAYMENTS_REPORT_STRIPE_METER=1
+CLAWQL_MPPX_ENABLED=1
+CLAWQL_MPP_MCP_JSONRPC=1
+
+# Team sync
+CLAWQL_SYNC_AUTO=1
+CLAWQL_SYNC_AUTO_PULL=1
+
+# Sandbox
+clawql sandbox init
+```
+
+---
+
+## 11. Operator actions still pending
+
+Called out across merged PRs — not blockers for `main`, but required for full production scores:
+
+1. **Cloudflare secrets** — `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` for clawql.com Pages deploy (until then: GitHub Pages via #608)
+2. **DNS-AID records** — `_index._agents.clawql.com` TXT/SVCB per [`docs/deployment/dns-aid-docs-clawql.md`](../../docs/deployment/dns-aid-docs-clawql.md)
+3. **DNSSEC** on docs.clawql.com (Cloudflare) for commerce scanner validation
+4. **npm split publish** — link `clawql-*` packages on npmjs.com for OIDC trusted publishing (7.0.0 uses bundled fallback)
+5. **Re-scan** — https://isitagentready.com/clawql.com and https://isitagentready.com/docs.clawql.com after deploy propagates
+
+---
+
+## 12. What's next
+
+Per merged PR follow-up notes and the modularization plan:
+
+- **Effect migration** — automation, ouroboros, sandbox, auth packages
+- **Inference** — PAL router Effect port; `@effect/schema` at MCP/HTTP boundaries (optional)
+- **Payments** — additional MPP finance providers live; DNS-AID for commerce Level 5
+- **Release** — semver bump packaging `clawql-inference` + `clawql-payments` into npm/Helm appVersion when ready
+
+---
+
+*This document was generated from `git log v7.0.0..main` and GitHub merged-PR metadata on 2026-07-13. For the canonical 7.0.0 breaking-change list, see [`RELEASE_NOTES_v7.0.0.md`](../../RELEASE_NOTES_v7.0.0.md).*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a comprehensive build-push announcement documenting everything that shipped in **clawql-mcp 7.0.0** and the **61 PRs merged after tag `v7.0.0`** through 2026-07-13 06:03 UTC.

**Document:** [`docs/announcements/7.0-weekend-build-push-2026-07.md`](docs/announcements/7.0-weekend-build-push-2026-07.md)

### Part I — 7.0.0 (2026-07-10)

- Opinionated default stack, vault-first Helm, breaking env changes
- Layer 0 release MVP, Desktop, Operator, IDP wave, onboarding CLI
- npm 7.0.0 publish (`bundledDependencies` fallback)

### Part II — Weekend build push

| Theme | PR range | Highlights |
|-------|----------|------------|
| **Infrastructure** | #548–#552, #568 | Packer/Pulumi golden hosts, local sandbox containment |
| **Team sync** | #545, #569 | `clawql sync`, `memory_sync` MCP tool |
| **Ouroboros** | #565, #570–#572 | Q00 drift sync (measure, gate, stagnation taxonomy) |
| **clawql-inference** | #573–#582, #600–#606, #620 | Full gateway epic #556 + Effect migration + token-efficiency layers 3–12 |
| **clawql-payments** | #583–#597, #599–#610, #616 | Stripe + x402 + MPP + WORM audit + Effect MCP proxy |
| **Effect migration** | #607–#619 | core, api, memory, documents |
| **Agent readiness** | #602, #604, #608 | clawql.com + docs.clawql.com discovery/commerce |
| **Docs site** | #553–#566, #588–#598, #613, #618 | Search fix, deploy size, mobile tables, learn guides |

Includes chronological merge index (all 61 post-tag PRs), scale stats (`v7.0.0..main`: +41k/−1.8k lines), env entrypoints, and pending operator actions.

### CHANGELOG

Links the announcement from `[Unreleased]`.

## Test plan

- [x] Documentation only — no code changes
- [x] Verified PR list against `git log v7.0.0..origin/main` and `gh pr list --state merged`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5a07-15ee-7a2a-828a-9ad0a5c8763c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5a07-15ee-7a2a-828a-9ad0a5c8763c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

