### PR TITLE
feat(inference): wire policy.yaml into runtime gateway

### DIFF
--- a/docs/inference/clawql-inference.md
+++ b/docs/inference/clawql-inference.md
@@ -439,6 +439,8 @@ clawql inference policy show [--json]
 
 `resolveInferencePolicy()` aggregates the effective view from **manifest YAML** (`$CLAWQL_HOME/Inference/policy.yaml` or `CLAWQL_INFERENCE_POLICY_MANIFEST`) merged with environment variables — **env wins on conflicts**. Source is `manifest+env` when a manifest is loaded, otherwise `env`.
 
+`createInferenceGateway()`, `createInferenceGatewayAsync()`, `clawql inference serve`, and the HTTP app use the same merge via `resolveInferenceEffectiveEnv()` so operator YAML governs the live gateway stack (routing, cache, fallback, keys, efficiency layers, observability, pipeline worker) — not only `policy show`.
+
 Example manifest:
 
 ```yaml
@@ -597,7 +599,7 @@ clawql inference <subcommand>
 - **OTLP infra tracing** — `CLAWQL_ENABLE_OTEL_TRACING=1` + `OTEL_EXPORTER_OTLP_*` → Tempo/collector
 - **Langfuse work traces** — ADR 0005 opt-out emission via OTLP to `{LANGFUSE_HOST}/api/public/otel/v1/traces`
 - **Distributed semantic cache** — `clawql_inference_semantic_cache` table with pgvector HNSW index
-- **Manifest YAML policy** — `$CLAWQL_HOME/Inference/policy.yaml` merged into `policy show` (env overrides)
+- **Manifest YAML policy** — `$CLAWQL_HOME/Inference/policy.yaml` merged at runtime (`resolveInferenceEffectiveEnv`) and in `policy show` (env overrides)
 - **Pipeline advisory locks** — Postgres `pg_try_advisory_lock` dedup across `serve` replicas
 
 ---

--- a/packages/clawql-inference/src/api/server.ts
+++ b/packages/clawql-inference/src/api/server.ts
@@ -11,6 +11,7 @@ import { createVirtualKeyAuthMiddleware } from "./auth.js";
 import { createOpenAiCompatRouter } from "./openai-compat.js";
 import { maybeInitInferenceOtelTracing } from "../observability/otel-tracing.js";
 import { registerInferencePoolShutdownHooks } from "../store/postgres-pool.js";
+import { resolveInferenceEffectiveEnv } from "../policy/manifest.js";
 
 export type CreateInferenceHttpAppOptions = {
   gateway?: InferenceGateway;
@@ -19,7 +20,7 @@ export type CreateInferenceHttpAppOptions = {
 };
 
 export function createInferenceHttpApp(options: CreateInferenceHttpAppOptions = {}): Express {
-  const env = options.env;
+  const env = resolveInferenceEffectiveEnv(options.env ?? process.env);
   const registry =
     options.registry ??
     createProviderRegistry({
@@ -70,7 +71,7 @@ export async function runInferenceHttpServer(
     host?: string;
   } = {}
 ): Promise<{ app: Express; port: number; host: string }> {
-  const env = options.env ?? process.env;
+  const env = resolveInferenceEffectiveEnv(options.env ?? process.env);
   registerInferencePoolShutdownHooks();
   await maybeInitInferenceOtelTracing(env);
   const registry = createProviderRegistry({

--- a/packages/clawql-inference/src/cli/serve.ts
+++ b/packages/clawql-inference/src/cli/serve.ts
@@ -3,6 +3,7 @@ import { runInferenceHttpServer } from "../api/server.js";
 import { maybeInitInferenceOtelTracing } from "../observability/otel-tracing.js";
 import { registerInferencePoolShutdownHooks } from "../store/postgres-pool.js";
 import { startPipelineWorker } from "../pipeline/worker.js";
+import { resolveInferenceEffectiveEnv } from "../policy/manifest.js";
 
 function parseTruthy(value: string | undefined): boolean {
   if (value === undefined) return false;
@@ -17,7 +18,7 @@ export type InferenceServeOptions = {
 };
 
 export async function runInferenceServe(options: InferenceServeOptions = {}): Promise<number> {
-  const env = options.env ?? process.env;
+  const env = resolveInferenceEffectiveEnv(options.env ?? process.env);
   registerInferencePoolShutdownHooks();
   await maybeInitInferenceOtelTracing(env);
   const gateway = await createInferenceGatewayAsync({ env });

--- a/packages/clawql-inference/src/gateway.runtime-policy.test.ts
+++ b/packages/clawql-inference/src/gateway.runtime-policy.test.ts
@@ -1,0 +1,66 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import { loadFallbackConfig } from "./fallback/config.js";
+import { createInferenceGateway } from "./gateway.js";
+import { loadModelEscalationConfig } from "./routing/config.js";
+import { resolveInferenceEffectiveEnv } from "./policy/manifest.js";
+
+describe("runtime policy.yaml", () => {
+  it("resolveInferenceEffectiveEnv applies manifest defaults", () => {
+    const dir = join(tmpdir(), `clawql-runtime-policy-${Date.now()}`);
+    mkdirSync(join(dir, "Inference"), { recursive: true });
+    writeFileSync(
+      join(dir, "Inference", "policy.yaml"),
+      `inference:
+  escalation:
+    enabled: true
+  fallback:
+    enabled: true
+`,
+      "utf8"
+    );
+
+    const effective = resolveInferenceEffectiveEnv({ CLAWQL_HOME: dir });
+    expect(loadModelEscalationConfig(effective).enabled).toBe(true);
+    expect(loadFallbackConfig(effective).enabled).toBe(true);
+  });
+
+  it("env overrides manifest for gateway-related loaders", () => {
+    const dir = join(tmpdir(), `clawql-runtime-policy-override-${Date.now()}`);
+    mkdirSync(join(dir, "Inference"), { recursive: true });
+    writeFileSync(
+      join(dir, "Inference", "policy.yaml"),
+      `inference:
+  escalation:
+    enabled: true
+`,
+      "utf8"
+    );
+
+    const effective = resolveInferenceEffectiveEnv({
+      CLAWQL_HOME: dir,
+      CLAWQL_INFERENCE_ROUTING_ENABLED: "0",
+    });
+    expect(loadModelEscalationConfig(effective).enabled).toBe(false);
+  });
+
+  it("createInferenceGateway merges policy manifest into stack env", () => {
+    const dir = join(tmpdir(), `clawql-gateway-policy-${Date.now()}`);
+    mkdirSync(join(dir, "Inference"), { recursive: true });
+    writeFileSync(
+      join(dir, "Inference", "policy.yaml"),
+      `inference:
+  keys:
+    enabled: true
+`,
+      "utf8"
+    );
+
+    const gateway = createInferenceGateway({ env: { CLAWQL_HOME: dir } });
+    expect(gateway).toBeDefined();
+    const effective = resolveInferenceEffectiveEnv({ CLAWQL_HOME: dir });
+    expect(effective.CLAWQL_INFERENCE_KEYS_ENABLED).toBe("1");
+  });
+});

--- a/packages/clawql-inference/src/gateway.ts
+++ b/packages/clawql-inference/src/gateway.ts
@@ -17,6 +17,7 @@ import { withFallbackChain, type WithFallbackChainOptions } from "./fallback/fal
 import { withEntitlementEnforcement } from "./entitlements/enforced-gateway.js";
 import { withTokenEfficiency } from "./efficiency/efficiency-gateway.js";
 import type { CacheIntent } from "./efficiency/types.js";
+import { resolveInferenceEffectiveEnv } from "./policy/manifest.js";
 
 export type ChatRole = "system" | "user" | "assistant";
 
@@ -108,6 +109,13 @@ export class ConfiguredInferenceGateway implements InferenceGateway {
   }
 }
 
+function withRuntimePolicyEnv(
+  options: CreateInferenceGatewayOptions
+): CreateInferenceGatewayOptions {
+  const env = resolveInferenceEffectiveEnv(options.env ?? process.env);
+  return { ...options, env };
+}
+
 function composeInferenceGateway(
   inner: InferenceGateway,
   options: CreateInferenceGatewayOptions
@@ -152,31 +160,33 @@ function composeInferenceGateway(
 export function createInferenceGateway(
   options: CreateInferenceGatewayOptions = {}
 ): InferenceGateway {
-  const env = options.env;
+  const resolved = withRuntimePolicyEnv(options);
+  const env = resolved.env;
   const providers =
-    options.providers ??
+    resolved.providers ??
     createProviderRegistry({
       env,
-      plugins: options.providerPlugins ?? composeDefaultProviderPlugins(),
+      plugins: resolved.providerPlugins ?? composeDefaultProviderPlugins(),
     });
   const inner = new ConfiguredInferenceGateway(providers);
-  return composeInferenceGateway(inner, options);
+  return composeInferenceGateway(inner, resolved);
 }
 
 /** Async gateway bootstrap — selects Postgres pgvector semantic cache when configured. */
 export async function createInferenceGatewayAsync(
   options: CreateInferenceGatewayOptions = {}
 ): Promise<InferenceGateway> {
-  const env = options.env;
+  const resolved = withRuntimePolicyEnv(options);
+  const env = resolved.env;
   const providers =
-    options.providers ??
+    resolved.providers ??
     createProviderRegistry({
       env,
-      plugins: options.providerPlugins ?? composeDefaultProviderPlugins(),
+      plugins: resolved.providerPlugins ?? composeDefaultProviderPlugins(),
     });
   const inner = new ConfiguredInferenceGateway(providers);
 
-  let semanticOptions = options.semanticCache;
+  let semanticOptions = resolved.semanticCache;
   if (semanticOptions !== false && !semanticOptions?.cache) {
     const config = semanticOptions?.config ?? loadSemanticCacheConfig(env);
     if (config.enabled) {
@@ -188,5 +198,5 @@ export async function createInferenceGatewayAsync(
     }
   }
 
-  return composeInferenceGateway(inner, { ...options, semanticCache: semanticOptions });
+  return composeInferenceGateway(inner, { ...resolved, semanticCache: semanticOptions });
 }

--- a/packages/clawql-inference/src/index.ts
+++ b/packages/clawql-inference/src/index.ts
@@ -243,6 +243,7 @@ export { resolveInferencePolicy, type InferencePolicyView } from "./policy/resol
 export {
   loadInferencePolicyManifestSync,
   resolvePolicyManifestPath,
+  resolveInferenceEffectiveEnv,
   parseInferencePolicyManifestText,
   type InferencePolicyManifest,
 } from "./policy/manifest.js";

--- a/packages/clawql-inference/src/policy/manifest.test.ts
+++ b/packages/clawql-inference/src/policy/manifest.test.ts
@@ -6,6 +6,7 @@ import {
   loadInferencePolicyManifestSync,
   manifestToEnvOverrides,
   mergeEnvWithPolicyManifest,
+  resolveInferenceEffectiveEnv,
   parseInferencePolicyManifestText,
 } from "./manifest.js";
 
@@ -67,5 +68,17 @@ inference:
     const loaded = loadInferencePolicyManifestSync({ CLAWQL_HOME: dir });
     expect(loaded?.path).toContain("policy.yaml");
     expect(loaded?.manifest.inference.fallback?.enabled).toBe(true);
+  });
+
+  it("resolveInferenceEffectiveEnv is mergeEnvWithPolicyManifest from disk", () => {
+    const dir = join(tmpdir(), `clawql-effective-env-${Date.now()}`);
+    mkdirSync(join(dir, "Inference"), { recursive: true });
+    writeFileSync(
+      join(dir, "Inference", "policy.yaml"),
+      `inference:\n  pipelineWorker:\n    enabled: true\n`,
+      "utf8"
+    );
+    const effective = resolveInferenceEffectiveEnv({ CLAWQL_HOME: dir });
+    expect(effective.CLAWQL_INFERENCE_PIPELINE_WORKER).toBe("1");
   });
 });

--- a/packages/clawql-inference/src/policy/manifest.ts
+++ b/packages/clawql-inference/src/policy/manifest.ts
@@ -356,3 +356,11 @@ export function mergeEnvWithPolicyManifest(
   const fromManifest = manifestToEnvOverrides(manifest);
   return { ...fromManifest, ...env };
 }
+
+/** Effective process env for inference runtime (manifest YAML merged under env). */
+export function resolveInferenceEffectiveEnv(
+  env: NodeJS.ProcessEnv = process.env
+): NodeJS.ProcessEnv {
+  const loaded = loadInferencePolicyManifestSync(env);
+  return mergeEnvWithPolicyManifest(env, loaded?.manifest ?? null);
+}

--- a/packages/clawql-inference/src/policy/resolve.ts
+++ b/packages/clawql-inference/src/policy/resolve.ts
@@ -14,7 +14,7 @@ import {
 import { resolveSemanticCacheBackend } from "../cache/postgres-pgvector-store.js";
 import {
   loadInferencePolicyManifestSync,
-  mergeEnvWithPolicyManifest,
+  resolveInferenceEffectiveEnv,
   type InferencePolicyManifestBlock,
 } from "./manifest.js";
 
@@ -88,7 +88,7 @@ function resolveExportDefaults(
 
 export function resolveInferencePolicy(env: NodeJS.ProcessEnv = process.env): InferencePolicyView {
   const loaded = loadInferencePolicyManifestSync(env);
-  const effectiveEnv = mergeEnvWithPolicyManifest(env, loaded?.manifest ?? null);
+  const effectiveEnv = resolveInferenceEffectiveEnv(env);
   const backend = resolveStoreBackend(effectiveEnv);
   const policyVersion =
     env.CLAWQL_RELEASE_MANIFEST?.trim() ||


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wires `$CLAWQL_HOME/Inference/policy.yaml` (or `CLAWQL_INFERENCE_POLICY_MANIFEST`) into **runtime**, not only `clawql inference policy show`.

- New `resolveInferenceEffectiveEnv()` merges manifest → env (env wins)
- `createInferenceGateway()` / `createInferenceGatewayAsync()` apply merge before composing the decorator stack
- `createInferenceHttpApp()` / `runInferenceHttpServer()` and `clawql inference serve` use the same effective env for auth, pipeline worker, OTel, etc.

## Testing

- `npm test -w clawql-inference` — 108 passed
- `npm run build -w clawql-inference`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

