### PR TITLE
feat(ouroboros): Effect bridge for MCP tool handlers

### DIFF
--- a/packages/clawql-ouroboros/src/effect/index.ts
+++ b/packages/clawql-ouroboros/src/effect/index.ts
@@ -1,0 +1,21 @@
+export { OuroborosError } from "./ouroboros-errors.js";
+export { ouroborosFromPromise } from "./ouroboros-effect-utils.js";
+export { OuroborosContextService, ouroborosContextLiveLayer } from "./ouroboros-context-service.js";
+export {
+  executeCreateSeedFromDocumentEffect,
+  executeGetLineageStatusEffect,
+  executeMeasureDriftEffect,
+  executeProposeSeedRevisionFromEvalEffect,
+  executeRunEvolutionaryLoopEffect,
+} from "./ouroboros-tools-effect.js";
+export { OuroborosToolsService, ouroborosToolsLiveLayer } from "./ouroboros-tools-service.js";
+export {
+  ouroborosCreateSeedProgram,
+  ouroborosLineageProgram,
+  ouroborosMeasureDriftProgram,
+  ouroborosProposeRevisionProgram,
+  ouroborosRunLoopProgram,
+  ouroborosServicesLiveLayer,
+  runOuroborosEffect,
+  type OuroborosServices,
+} from "./ouroboros-effect-runtime.js";

--- a/packages/clawql-ouroboros/src/effect/ouroboros-context-service.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-context-service.ts
@@ -1,0 +1,20 @@
+import { Context, Layer } from "effect";
+import type { OuroborosContext } from "../mcp-hooks.js";
+import { getOuroborosContext } from "../plugin/context.js";
+
+/** Effect service for the Ouroboros loop + event store context. */
+export class OuroborosContextService extends Context.Tag("clawql/OuroborosContextService")<
+  OuroborosContextService,
+  {
+    readonly getContext: () => OuroborosContext;
+  }
+>() {}
+
+export function ouroborosContextLiveLayer(): Layer.Layer<OuroborosContextService> {
+  return Layer.succeed(
+    OuroborosContextService,
+    OuroborosContextService.of({
+      getContext: getOuroborosContext,
+    })
+  );
+}

--- a/packages/clawql-ouroboros/src/effect/ouroboros-effect-runtime.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-effect-runtime.ts
@@ -1,0 +1,86 @@
+import { Cause, Effect, Exit, Layer } from "effect";
+import type { z } from "zod";
+import type {
+  CreateSeedFromDocumentSchema,
+  GetLineageStatusSchema,
+  MeasureDriftSchema,
+  ProposeSeedRevisionFromEvalSchema,
+  RunOuroborosSchema,
+} from "../mcp-hooks.js";
+import { OuroborosContextService, ouroborosContextLiveLayer } from "./ouroboros-context-service.js";
+import { OuroborosError } from "./ouroboros-errors.js";
+import { OuroborosToolsService, ouroborosToolsLiveLayer } from "./ouroboros-tools-service.js";
+
+export type OuroborosServices = OuroborosContextService | OuroborosToolsService;
+
+/** Merged Effect Layer for Ouroboros domain services. */
+export function ouroborosServicesLiveLayer(): Layer.Layer<OuroborosServices> {
+  return Layer.mergeAll(ouroborosContextLiveLayer(), ouroborosToolsLiveLayer());
+}
+
+function throwOuroborosFailure(cause: Cause.Cause<unknown>): never {
+  const squashed = Cause.squash(cause);
+  if (squashed instanceof OuroborosError && squashed.cause != null) {
+    if (squashed.cause instanceof Error) throw squashed.cause;
+    throw new Error(String(squashed.cause));
+  }
+  throw squashed;
+}
+
+/** Run an Ouroboros Effect program with default services Layer. */
+export async function runOuroborosEffect<A, E>(
+  program: Effect.Effect<A, E, OuroborosServices>
+): Promise<A> {
+  const exit = await Effect.runPromiseExit(
+    program.pipe(Effect.provide(ouroborosServicesLiveLayer()))
+  );
+  if (Exit.isSuccess(exit)) {
+    return exit.value;
+  }
+  throwOuroborosFailure(exit.cause);
+}
+
+export function ouroborosCreateSeedProgram(
+  input: z.infer<typeof CreateSeedFromDocumentSchema>
+): Effect.Effect<unknown, unknown, OuroborosServices> {
+  return Effect.gen(function* () {
+    const tools = yield* OuroborosToolsService;
+    return yield* tools.createSeedFromDocument(input);
+  });
+}
+
+export function ouroborosRunLoopProgram(
+  input: z.infer<typeof RunOuroborosSchema>
+): Effect.Effect<unknown, unknown, OuroborosServices> {
+  return Effect.gen(function* () {
+    const tools = yield* OuroborosToolsService;
+    return yield* tools.runEvolutionaryLoop(input);
+  });
+}
+
+export function ouroborosLineageProgram(
+  input: z.infer<typeof GetLineageStatusSchema>
+): Effect.Effect<unknown, unknown, OuroborosServices> {
+  return Effect.gen(function* () {
+    const tools = yield* OuroborosToolsService;
+    return yield* tools.getLineageStatus(input);
+  });
+}
+
+export function ouroborosMeasureDriftProgram(
+  input: z.infer<typeof MeasureDriftSchema>
+): Effect.Effect<unknown, unknown, OuroborosServices> {
+  return Effect.gen(function* () {
+    const tools = yield* OuroborosToolsService;
+    return yield* tools.measureDrift(input);
+  });
+}
+
+export function ouroborosProposeRevisionProgram(
+  input: z.infer<typeof ProposeSeedRevisionFromEvalSchema>
+): Effect.Effect<unknown, unknown, OuroborosServices> {
+  return Effect.gen(function* () {
+    const tools = yield* OuroborosToolsService;
+    return yield* tools.proposeSeedRevisionFromEval(input);
+  });
+}

--- a/packages/clawql-ouroboros/src/effect/ouroboros-effect-utils.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-effect-utils.ts
@@ -1,0 +1,14 @@
+import { Effect } from "effect";
+import { OuroborosError } from "./ouroboros-errors.js";
+
+/** Lift a Promise into Effect with {@link OuroborosError} on failure. */
+export function ouroborosFromPromise<A>(tryFn: () => Promise<A>): Effect.Effect<A, OuroborosError> {
+  return Effect.tryPromise({
+    try: tryFn,
+    catch: (cause) =>
+      new OuroborosError({
+        reason: "ouroboros async operation failed",
+        cause,
+      }),
+  });
+}

--- a/packages/clawql-ouroboros/src/effect/ouroboros-errors.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-errors.ts
@@ -1,0 +1,7 @@
+import { Data } from "effect";
+
+/** Unexpected failure in an Ouroboros Effect pipeline. */
+export class OuroborosError extends Data.TaggedError("OuroborosError")<{
+  readonly reason: string;
+  readonly cause?: unknown;
+}> {}

--- a/packages/clawql-ouroboros/src/effect/ouroboros-tools-effect.test.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-tools-effect.test.ts
@@ -1,0 +1,49 @@
+import { Effect, Layer } from "effect";
+import { describe, expect, it } from "vitest";
+import type { OuroborosContext } from "../mcp-hooks.js";
+import { OuroborosContextService } from "./ouroboros-context-service.js";
+import { executeCreateSeedFromDocumentEffect } from "./ouroboros-tools-effect.js";
+import { OuroborosToolsService, ouroborosToolsLiveLayer } from "./ouroboros-tools-service.js";
+
+const stubContext = {} as OuroborosContext;
+
+const testLayer = Layer.mergeAll(
+  Layer.succeed(
+    OuroborosContextService,
+    OuroborosContextService.of({ getContext: () => stubContext })
+  ),
+  ouroborosToolsLiveLayer()
+);
+
+describe("executeCreateSeedFromDocumentEffect", () => {
+  it("builds a seed via OuroborosToolsService", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const tools = yield* OuroborosToolsService;
+        return yield* tools.createSeedFromDocument({
+          documentId: "doc-effect",
+          extractedText: "Effect bridge test document with enough tokens",
+          goalHint: "Effect goal",
+          metadata: {},
+          taskType: "analysis",
+        });
+      }).pipe(Effect.provide(testLayer))
+    );
+    expect(result).toMatchObject({ success: true });
+    if ("success" in result && result.success) {
+      expect(result.seed.goal).toBe("Effect goal");
+    }
+  });
+
+  it("executeCreateSeedFromDocumentEffect uses context service", async () => {
+    const result = await Effect.runPromise(
+      executeCreateSeedFromDocumentEffect({
+        documentId: "doc-ctx",
+        extractedText: "Context service wiring validation text",
+        metadata: {},
+        taskType: "ingest",
+      }).pipe(Effect.provide(testLayer))
+    );
+    expect(result).toMatchObject({ success: true });
+  });
+});

--- a/packages/clawql-ouroboros/src/effect/ouroboros-tools-effect.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-tools-effect.ts
@@ -1,0 +1,105 @@
+import { Effect } from "effect";
+import type { z } from "zod";
+import type {
+  CreateSeedFromDocumentSchema,
+  GetLineageStatusSchema,
+  MeasureDriftSchema,
+  ProposeSeedRevisionFromEvalSchema,
+  RunOuroborosSchema,
+} from "../mcp-hooks.js";
+import { OuroborosContextService } from "./ouroboros-context-service.js";
+import { OuroborosError } from "./ouroboros-errors.js";
+import { ouroborosFromPromise } from "./ouroboros-effect-utils.js";
+
+export function executeCreateSeedFromDocumentEffect(
+  input: z.infer<typeof CreateSeedFromDocumentSchema>
+): Effect.Effect<
+  Awaited<
+    ReturnType<typeof import("../mcp-hooks.js").ouroborosMcpTools.createSeedFromDocument.handler>
+  >,
+  OuroborosError,
+  OuroborosContextService
+> {
+  return Effect.gen(function* () {
+    const ctxSvc = yield* OuroborosContextService;
+    const ctx = ctxSvc.getContext();
+    return yield* ouroborosFromPromise(async () => {
+      const { ouroborosMcpTools } = await import("../mcp-hooks.js");
+      return ouroborosMcpTools.createSeedFromDocument.handler(input, ctx);
+    });
+  });
+}
+
+export function executeRunEvolutionaryLoopEffect(
+  input: z.infer<typeof RunOuroborosSchema>
+): Effect.Effect<
+  Awaited<
+    ReturnType<typeof import("../mcp-hooks.js").ouroborosMcpTools.runEvolutionaryLoop.handler>
+  >,
+  OuroborosError,
+  OuroborosContextService
+> {
+  return Effect.gen(function* () {
+    const ctxSvc = yield* OuroborosContextService;
+    const ctx = ctxSvc.getContext();
+    return yield* ouroborosFromPromise(async () => {
+      const { ouroborosMcpTools } = await import("../mcp-hooks.js");
+      return ouroborosMcpTools.runEvolutionaryLoop.handler(input, ctx);
+    });
+  });
+}
+
+export function executeGetLineageStatusEffect(
+  input: z.infer<typeof GetLineageStatusSchema>
+): Effect.Effect<
+  Awaited<ReturnType<typeof import("../mcp-hooks.js").ouroborosMcpTools.getLineageStatus.handler>>,
+  OuroborosError,
+  OuroborosContextService
+> {
+  return Effect.gen(function* () {
+    const ctxSvc = yield* OuroborosContextService;
+    const ctx = ctxSvc.getContext();
+    return yield* ouroborosFromPromise(async () => {
+      const { ouroborosMcpTools } = await import("../mcp-hooks.js");
+      return ouroborosMcpTools.getLineageStatus.handler(input, ctx);
+    });
+  });
+}
+
+export function executeMeasureDriftEffect(
+  input: z.infer<typeof MeasureDriftSchema>
+): Effect.Effect<
+  Awaited<ReturnType<typeof import("../mcp-hooks.js").ouroborosMcpTools.measureDrift.handler>>,
+  OuroborosError,
+  OuroborosContextService
+> {
+  return Effect.gen(function* () {
+    const ctxSvc = yield* OuroborosContextService;
+    const ctx = ctxSvc.getContext();
+    return yield* ouroborosFromPromise(async () => {
+      const { ouroborosMcpTools } = await import("../mcp-hooks.js");
+      return ouroborosMcpTools.measureDrift.handler(input, ctx);
+    });
+  });
+}
+
+export function executeProposeSeedRevisionFromEvalEffect(
+  input: z.infer<typeof ProposeSeedRevisionFromEvalSchema>
+): Effect.Effect<
+  Awaited<
+    ReturnType<
+      typeof import("../mcp-hooks.js").ouroborosMcpTools.proposeSeedRevisionFromEval.handler
+    >
+  >,
+  OuroborosError,
+  OuroborosContextService
+> {
+  return Effect.gen(function* () {
+    const ctxSvc = yield* OuroborosContextService;
+    const ctx = ctxSvc.getContext();
+    return yield* ouroborosFromPromise(async () => {
+      const { ouroborosMcpTools } = await import("../mcp-hooks.js");
+      return ouroborosMcpTools.proposeSeedRevisionFromEval.handler(input, ctx);
+    });
+  });
+}

--- a/packages/clawql-ouroboros/src/effect/ouroboros-tools-service.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-tools-service.ts
@@ -1,0 +1,85 @@
+import { Context, Effect, Layer } from "effect";
+import type { z } from "zod";
+import type {
+  CreateSeedFromDocumentSchema,
+  GetLineageStatusSchema,
+  MeasureDriftSchema,
+  ProposeSeedRevisionFromEvalSchema,
+  RunOuroborosSchema,
+} from "../mcp-hooks.js";
+import { OuroborosContextService } from "./ouroboros-context-service.js";
+import { OuroborosError } from "./ouroboros-errors.js";
+import {
+  executeCreateSeedFromDocumentEffect,
+  executeGetLineageStatusEffect,
+  executeMeasureDriftEffect,
+  executeProposeSeedRevisionFromEvalEffect,
+  executeRunEvolutionaryLoopEffect,
+} from "./ouroboros-tools-effect.js";
+
+/** Effect service for Ouroboros MCP tool bodies. */
+export class OuroborosToolsService extends Context.Tag("clawql/OuroborosToolsService")<
+  OuroborosToolsService,
+  {
+    readonly createSeedFromDocument: (
+      input: z.infer<typeof CreateSeedFromDocumentSchema>
+    ) => Effect.Effect<
+      Awaited<
+        ReturnType<
+          typeof import("../mcp-hooks.js").ouroborosMcpTools.createSeedFromDocument.handler
+        >
+      >,
+      OuroborosError,
+      OuroborosContextService
+    >;
+    readonly runEvolutionaryLoop: (
+      input: z.infer<typeof RunOuroborosSchema>
+    ) => Effect.Effect<
+      Awaited<
+        ReturnType<typeof import("../mcp-hooks.js").ouroborosMcpTools.runEvolutionaryLoop.handler>
+      >,
+      OuroborosError,
+      OuroborosContextService
+    >;
+    readonly getLineageStatus: (
+      input: z.infer<typeof GetLineageStatusSchema>
+    ) => Effect.Effect<
+      Awaited<
+        ReturnType<typeof import("../mcp-hooks.js").ouroborosMcpTools.getLineageStatus.handler>
+      >,
+      OuroborosError,
+      OuroborosContextService
+    >;
+    readonly measureDrift: (
+      input: z.infer<typeof MeasureDriftSchema>
+    ) => Effect.Effect<
+      Awaited<ReturnType<typeof import("../mcp-hooks.js").ouroborosMcpTools.measureDrift.handler>>,
+      OuroborosError,
+      OuroborosContextService
+    >;
+    readonly proposeSeedRevisionFromEval: (
+      input: z.infer<typeof ProposeSeedRevisionFromEvalSchema>
+    ) => Effect.Effect<
+      Awaited<
+        ReturnType<
+          typeof import("../mcp-hooks.js").ouroborosMcpTools.proposeSeedRevisionFromEval.handler
+        >
+      >,
+      OuroborosError,
+      OuroborosContextService
+    >;
+  }
+>() {}
+
+export function ouroborosToolsLiveLayer(): Layer.Layer<OuroborosToolsService> {
+  return Layer.succeed(
+    OuroborosToolsService,
+    OuroborosToolsService.of({
+      createSeedFromDocument: executeCreateSeedFromDocumentEffect,
+      runEvolutionaryLoop: executeRunEvolutionaryLoopEffect,
+      getLineageStatus: executeGetLineageStatusEffect,
+      measureDrift: executeMeasureDriftEffect,
+      proposeSeedRevisionFromEval: executeProposeSeedRevisionFromEvalEffect,
+    })
+  );
+}

--- a/packages/clawql-ouroboros/src/plugin/index.ts
+++ b/packages/clawql-ouroboros/src/plugin/index.ts
@@ -10,3 +10,19 @@ export {
 export { createOuroborosPlugin, OUROBOROS_PLUGIN_ID } from "./ouroboros-plugin.js";
 
 export { getOuroborosContext, resetOuroborosContextForTests } from "./context.js";
+
+export {
+  OuroborosContextService,
+  OuroborosError,
+  OuroborosToolsService,
+  ouroborosContextLiveLayer,
+  ouroborosCreateSeedProgram,
+  ouroborosLineageProgram,
+  ouroborosMeasureDriftProgram,
+  ouroborosProposeRevisionProgram,
+  ouroborosRunLoopProgram,
+  ouroborosServicesLiveLayer,
+  ouroborosToolsLiveLayer,
+  runOuroborosEffect,
+  type OuroborosServices,
+} from "../effect/index.js";

--- a/packages/clawql-ouroboros/src/plugin/ouroboros-plugin.ts
+++ b/packages/clawql-ouroboros/src/plugin/ouroboros-plugin.ts
@@ -12,7 +12,6 @@ import {
 } from "../mcp-hooks.js";
 import {
   ensureOuroborosPoolShutdownHooks,
-  getOuroborosContext,
   resetOuroborosContextForTests,
 } from "./context.js";
 
@@ -45,9 +44,10 @@ export function createOuroborosPlugin(options: OuroborosPluginOptions = {}): Plu
               documentIdLen: (args as { documentId?: string }).documentId?.length,
               taskType: (args as { taskType?: string }).taskType,
             });
-            const r = await t.createSeedFromDocument.handler(
-              args as z.infer<typeof CreateSeedFromDocumentSchema>,
-              getOuroborosContext()
+            const { runOuroborosEffect, ouroborosCreateSeedProgram } =
+              await import("../effect/ouroboros-effect-runtime.js");
+            const r = await runOuroborosEffect(
+              ouroborosCreateSeedProgram(args as z.infer<typeof CreateSeedFromDocumentSchema>)
             );
             return textResult(r);
           },
@@ -59,9 +59,10 @@ export function createOuroborosPlugin(options: OuroborosPluginOptions = {}): Plu
             logMcpToolShape(t.runEvolutionaryLoop.name, {
               maxGenerations: (args as { maxGenerations?: number }).maxGenerations,
             });
-            const r = await t.runEvolutionaryLoop.handler(
-              args as z.infer<typeof RunOuroborosSchema>,
-              getOuroborosContext()
+            const { runOuroborosEffect, ouroborosRunLoopProgram } =
+              await import("../effect/ouroboros-effect-runtime.js");
+            const r = await runOuroborosEffect(
+              ouroborosRunLoopProgram(args as z.infer<typeof RunOuroborosSchema>)
             );
             return textResult(r);
           },
@@ -73,9 +74,10 @@ export function createOuroborosPlugin(options: OuroborosPluginOptions = {}): Plu
             logMcpToolShape(t.getLineageStatus.name, {
               seedIdLen: (args as { seedId?: string }).seedId?.length,
             });
-            const r = await t.getLineageStatus.handler(
-              args as z.infer<typeof GetLineageStatusSchema>,
-              getOuroborosContext()
+            const { runOuroborosEffect, ouroborosLineageProgram } =
+              await import("../effect/ouroboros-effect-runtime.js");
+            const r = await runOuroborosEffect(
+              ouroborosLineageProgram(args as z.infer<typeof GetLineageStatusSchema>)
             );
             return textResult(r);
           },
@@ -88,9 +90,10 @@ export function createOuroborosPlugin(options: OuroborosPluginOptions = {}): Plu
               seedIdLen: (args as { seedId?: string }).seedId?.length,
               outputLen: (args as { currentOutput?: string }).currentOutput?.length,
             });
-            const r = await t.measureDrift.handler(
-              args as z.infer<typeof MeasureDriftSchema>,
-              getOuroborosContext()
+            const { runOuroborosEffect, ouroborosMeasureDriftProgram } =
+              await import("../effect/ouroboros-effect-runtime.js");
+            const r = await runOuroborosEffect(
+              ouroborosMeasureDriftProgram(args as z.infer<typeof MeasureDriftSchema>)
             );
             return textResult(r);
           },
@@ -104,9 +107,12 @@ export function createOuroborosPlugin(options: OuroborosPluginOptions = {}): Plu
                 hasPayload: (args as { payload?: unknown }).payload !== undefined,
                 scoreValue: (args as { scoreValue?: number }).scoreValue,
               });
-              const r = await t.proposeSeedRevisionFromEval.handler(
-                args as z.infer<typeof ProposeSeedRevisionFromEvalSchema>,
-                getOuroborosContext()
+              const { runOuroborosEffect, ouroborosProposeRevisionProgram } =
+                await import("../effect/ouroboros-effect-runtime.js");
+              const r = await runOuroborosEffect(
+                ouroborosProposeRevisionProgram(
+                  args as z.infer<typeof ProposeSeedRevisionFromEvalSchema>
+                )
               );
               return textResult(r);
             },

--- a/packages/clawql-ouroboros/src/plugin/ouroboros-plugin.ts
+++ b/packages/clawql-ouroboros/src/plugin/ouroboros-plugin.ts
@@ -10,10 +10,7 @@ import {
   RunOuroborosSchema,
   ouroborosMcpTools,
 } from "../mcp-hooks.js";
-import {
-  ensureOuroborosPoolShutdownHooks,
-  resetOuroborosContextForTests,
-} from "./context.js";
+import { ensureOuroborosPoolShutdownHooks, resetOuroborosContextForTests } from "./context.js";
 
 export type OuroborosPluginOptions = {
   /** ([#250](https://github.com/danielsmithdevelopment/ClawQL/issues/250)): register `ouroboros_propose_seed_revision_from_eval`. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First `clawql-ouroboros` Effect migration slice: route all `ouroboros_*` MCP tool handlers through native Effect services.

- Add `OuroborosContextService`, `OuroborosToolsService`, and `runOuroborosEffect`
- Plugin handlers delegate to Effect programs; domain logic stays in `mcp-hooks.ts`

## Test plan

- [x] Build + 55 package tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

