### PR TITLE
docs(inference): policy.yaml example and quickstart updates

### DIFF
--- a/docs/inference/clawql-inference.md
+++ b/docs/inference/clawql-inference.md
@@ -28,6 +28,34 @@
 
 ---
 
+## Quick start
+
+**Example policy + walkthrough:** [`examples/inference/`](../../examples/inference/) (`policy.yaml` + README).
+
+```bash
+export CLAWQL_HOME="${CLAWQL_HOME:-$HOME/.clawql}"
+mkdir -p "$CLAWQL_HOME/Inference"
+cp examples/inference/policy.yaml "$CLAWQL_HOME/Inference/policy.yaml"
+
+export OPENAI_API_KEY=sk-...          # and/or OLLAMA_BASE_URL for local frugal tier
+export OLLAMA_BASE_URL=http://127.0.0.1:11434
+
+clawql inference policy show          # expect policy_source: manifest+env
+clawql inference serve --port 8080
+```
+
+Point clients at `OPENAI_BASE_URL=http://127.0.0.1:8080/v1`. Manifest YAML merges at **runtime** (`resolveInferenceEffectiveEnv`); env vars override YAML on conflicts.
+
+One-shot CLI (no HTTP):
+
+```bash
+clawql inference complete --model ollama/phi4 --message "hello"
+```
+
+See [Policy](#policy) for the full manifest schema and [Persistence layout](#persistence-layout) for other files under `$CLAWQL_HOME/Inference/`.
+
+---
+
 ## Architecture overview
 
 ### Entry points
@@ -441,7 +469,7 @@ clawql inference policy show [--json]
 
 `createInferenceGateway()`, `createInferenceGatewayAsync()`, `clawql inference serve`, and the HTTP app use the same merge via `resolveInferenceEffectiveEnv()` so operator YAML governs the live gateway stack (routing, cache, fallback, keys, efficiency layers, observability, pipeline worker) — not only `policy show`.
 
-Example manifest:
+Example manifest (full copy: [`examples/inference/policy.yaml`](../../examples/inference/policy.yaml)):
 
 ```yaml
 policyVersion: "2026.07.01"

--- a/examples/clawql-local-docker-compose/README.md
+++ b/examples/clawql-local-docker-compose/README.md
@@ -23,6 +23,22 @@ docker compose -f docker-compose.yml -f docker-compose.presidio.override.yml up 
 
 Set `documents.presidio.enabled: true` in `clawql.local.yaml` when using Presidio.
 
+## Inference gateway (optional)
+
+OpenAI-compatible LLM gateway with operator policy in YAML:
+
+```bash
+export CLAWQL_HOME="${CLAWQL_HOME:-$HOME/.clawql}"
+mkdir -p "$CLAWQL_HOME/Inference"
+cp examples/inference/policy.yaml "$CLAWQL_HOME/Inference/policy.yaml"
+export OPENAI_API_KEY=sk-...   # and/or OLLAMA_BASE_URL=http://127.0.0.1:11434
+
+clawql inference policy show
+clawql inference serve --port 8080
+```
+
+Full walkthrough: [`examples/inference/README.md`](../../examples/inference/README.md) · Reference: [clawql-inference](/inference/clawql-inference).
+
 ## Smoke / CI
 
 ```bash
@@ -33,11 +49,11 @@ From repo root: `make compose-tier1-config-test`
 
 ## Files
 
-| File | Purpose |
-|------|---------|
-| `bootstrap.sh` | Prerequisites, `.env`, `clawql.local.yaml`, local secrets |
-| `docker-compose.yml` | Base Tier 1 stack |
-| `docker-compose.presidio.override.yml` | Optional analyzer + anonymizer |
-| `clawql.local.yaml` | Generated local config (editable) |
+| File                                   | Purpose                                                   |
+| -------------------------------------- | --------------------------------------------------------- |
+| `bootstrap.sh`                         | Prerequisites, `.env`, `clawql.local.yaml`, local secrets |
+| `docker-compose.yml`                   | Base Tier 1 stack                                         |
+| `docker-compose.presidio.override.yml` | Optional analyzer + anonymizer                            |
+| `clawql.local.yaml`                    | Generated local config (editable)                         |
 
 For Kubernetes parity, use `make local-k8s-up` and [`charts/clawql-mcp`](../../charts/clawql-mcp).

--- a/examples/inference/README.md
+++ b/examples/inference/README.md
@@ -1,0 +1,105 @@
+# Inference gateway quick start
+
+Run the **OpenAI-compatible** `clawql-inference` gateway with operator policy in YAML instead of dozens of env vars.
+
+**Reference:** [`docs/inference/clawql-inference.md`](../../docs/inference/clawql-inference.md) · **Package:** [`packages/clawql-inference`](../../packages/clawql-inference)
+
+## 1. Create `CLAWQL_HOME`
+
+```bash
+export CLAWQL_HOME="${CLAWQL_HOME:-$HOME/.clawql}"
+mkdir -p "$CLAWQL_HOME/Inference"
+```
+
+## 2. Install the policy manifest
+
+Copy the example policy (edit tier models and toggles as needed):
+
+```bash
+cp examples/inference/policy.yaml "$CLAWQL_HOME/Inference/policy.yaml"
+```
+
+Or point at this repo copy:
+
+```bash
+export CLAWQL_INFERENCE_POLICY_MANIFEST="$(pwd)/examples/inference/policy.yaml"
+```
+
+**Merge rule:** manifest defaults apply first; any matching `CLAWQL_*` env var overrides the YAML.
+
+## 3. Set provider credentials
+
+At minimum, configure a provider your tier map can reach:
+
+```bash
+# OpenAI (also used for embeddings when semantic cache is enabled)
+export OPENAI_API_KEY=sk-...
+
+# and/or local Ollama (default frugal tier in policy.yaml)
+export OLLAMA_BASE_URL=http://127.0.0.1:11434
+```
+
+## 4. Verify effective policy
+
+```bash
+clawql inference policy show
+# policy_source: manifest+env
+# manifest_path: .../Inference/policy.yaml
+```
+
+Use `--json` for the full merged view (escalation, cache, layers, observability).
+
+## 5. Start the gateway
+
+```bash
+clawql inference serve --port 8080
+# or: npx clawql-inference
+```
+
+Point any OpenAI client at the gateway:
+
+```bash
+export OPENAI_BASE_URL=http://127.0.0.1:8080/v1
+export OPENAI_API_KEY=sk-...   # or a virtual key when keys.enabled: true
+```
+
+```bash
+curl -s http://127.0.0.1:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"ollama/phi4","messages":[{"role":"user","content":"Say hi in one sentence."}]}'
+```
+
+## 6. Optional: Postgres + multi-replica pipeline
+
+When `CLAWQL_INFERENCE_DATABASE_URL` is set, semantic cache can use pgvector and the pipeline worker uses Postgres advisory locks so only one replica runs each cron tick.
+
+```bash
+export CLAWQL_INFERENCE_DATABASE_URL=postgres://user:pass@localhost:5432/clawql_inference
+# policy.yaml observability.semanticCacheBackend: postgres
+```
+
+Enable the flywheel worker in policy (or env), then configure the pipeline:
+
+```bash
+# Edit policy.yaml: pipelineWorker.enabled: true
+clawql inference pipeline enable --schedule "0 2 * * 0" --min-samples 50
+export CLAWQL_INFERENCE_PIPELINE_WORKER=1   # env override example
+clawql inference serve --port 8080
+```
+
+## Files under `$CLAWQL_HOME/Inference/`
+
+| File                   | Purpose                                 |
+| ---------------------- | --------------------------------------- |
+| `policy.yaml`          | Operator policy manifest (this example) |
+| `calls.jsonl`          | Call store when `store.backend: jsonl`  |
+| `tier-map.json`        | Fine-tune / escalation overrides        |
+| `fallback-chains.json` | Persisted fallback chains               |
+| `virtual-keys.json`    | Virtual API keys                        |
+| `pipeline.json`        | Cron export config                      |
+
+## Next steps
+
+- [Token efficiency layers](../../docs/architecture/clawql-token-efficiency.md)
+- [Inference provider plugins](../../docs/plugins/inference-providers.md)
+- [Payments / entitlements](../../docs/payments/clawql-payments.md)

--- a/examples/inference/policy.yaml
+++ b/examples/inference/policy.yaml
@@ -1,0 +1,72 @@
+# ClawQL inference operator policy manifest
+# Copy to: $CLAWQL_HOME/Inference/policy.yaml
+# Or set:  CLAWQL_INFERENCE_POLICY_MANIFEST=/path/to/policy.yaml
+#
+# Merged at runtime via resolveInferenceEffectiveEnv() — process env wins on conflicts.
+# Verify: clawql inference policy show
+
+policyVersion: "2026.07.01"
+
+inference:
+  # Tier escalation (Layer 8) — off unless enabled or modelPin set
+  escalation:
+    enabled: true
+    tierMap:
+      frugal: ollama/phi4
+      standard: groq/llama-3.3-70b
+      frontier: anthropic/claude-sonnet-4
+    # modelPin: openai/gpt-4o-mini   # bypass ladder when set
+
+  # Semantic cache (Layer 5) — requires embedding credentials (OPENAI_API_KEY or CLAWQL_EMBEDDING_API_KEY)
+  cache:
+    enabled: true
+    threshold: 0.92
+    ttlMs: 86400000 # 24h
+    maxEntries: 1000
+
+  # Try alternates before hard failure
+  fallback:
+    enabled: false
+
+  # Virtual keys for /v1/* (persist keys with: clawql inference keys create ...)
+  keys:
+    enabled: false
+
+  # Call store backend: memory | jsonl | postgres
+  store:
+    backend: jsonl
+
+  export:
+    defaultVerdict: passed
+    piiScrubDefault: true
+    writeManifestDefault: true
+
+  # Cron export worker (also needs: clawql inference pipeline enable ...)
+  pipelineWorker:
+    enabled: false
+    pollMs: 60000
+
+  agentCoordination:
+    enabled: false
+    # hermesBaseUrl: http://hermes:8080
+
+  observability:
+    profile: external # bundled | external | minimal
+    otelInfra: false
+    langfuse: true
+    semanticCacheBackend: memory # postgres | pgvector when CLAWQL_INFERENCE_DATABASE_URL set
+
+  # Token-efficiency layers (3–11) — terse/promptCache on by default in code
+  efficiency:
+    terse: true
+    promptCache: true
+    historyCompress: false
+    historyMaxChars: 48000
+    historyKeepRecent: 6
+    promptCompress: false
+    promptCompressMaxChars: 12000
+    httpAutoRoute: true
+    structuredOutput: true
+    tokenBudget: true
+    prefill: false
+    # prefillOpener: ""

--- a/packages/clawql-inference/README.md
+++ b/packages/clawql-inference/README.md
@@ -135,12 +135,24 @@ Use `X-Clawql-Tool` to gate MCP tool names over HTTP (`tool:knowledge_search`).
 
 ## Quick start
 
+**Operator policy example:** [`examples/inference/`](../../examples/inference/) — copy `policy.yaml` to `$CLAWQL_HOME/Inference/` and run `clawql inference serve`.
+
+```bash
+export CLAWQL_HOME="${CLAWQL_HOME:-$HOME/.clawql}"
+mkdir -p "$CLAWQL_HOME/Inference"
+cp examples/inference/policy.yaml "$CLAWQL_HOME/Inference/policy.yaml"
+
+export OPENAI_API_KEY=sk-...
+clawql inference policy show
+clawql inference serve --port 8080
+```
+
 ```bash
 # One-shot completion (requires provider credentials)
 export OPENAI_API_KEY=sk-...
 clawql inference complete --model openai/gpt-4o --message "Summarize this spec"
 
-# OpenAI-compatible HTTP gateway
+# OpenAI-compatible HTTP gateway (uses policy.yaml when present)
 clawql inference serve --port 8080
 curl -s http://127.0.0.1:8080/v1/chat/completions \
   -H 'Content-Type: application/json' \

--- a/website/src/app/quickstart/page.mdx
+++ b/website/src/app/quickstart/page.mdx
@@ -80,8 +80,25 @@ make local-k8s-up
 
 You can open the bundled dashboard at **`http://clawql.localhost`**, bundled docs UI at **`http://docs.localhost`**, and point MCP clients at **`http://clawql-mcp.localhost/mcp`** (**Ingress** — same hostname + **`/mcp`** pattern as production). The script installs **Kyverno** and only admits **Cosign-signed** ClawQL images from **GHCR** (including MCP, website, and dashboard images) — see [Security](/security) and the repo doc **[golden-image-pipeline.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/security/golden-image-pipeline.md)**.
 
+## 6. Inference gateway (optional)
+
+Drop-in **OpenAI-compatible** LLM proxy with operator policy in YAML (`$CLAWQL_HOME/Inference/policy.yaml`):
+
+```bash
+export CLAWQL_HOME="${CLAWQL_HOME:-$HOME/.clawql}"
+mkdir -p "$CLAWQL_HOME/Inference"
+cp examples/inference/policy.yaml "$CLAWQL_HOME/Inference/policy.yaml"
+export OPENAI_API_KEY=sk-...   # and/or OLLAMA_BASE_URL=http://127.0.0.1:11434
+
+clawql inference policy show
+clawql inference serve --port 8080
+```
+
+Set `OPENAI_BASE_URL=http://127.0.0.1:8080/v1` on any OpenAI SDK. Walkthrough: [examples/inference/README.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/examples/inference/README.md) · Reference: [clawql-inference](/inference/clawql-inference).
+
 ## Next steps
 
 - [Install](/install) — binaries, Docker, HTTP transport
+- [Inference gateway](/inference/clawql-inference) — OpenAI-compatible proxy, policy YAML, flywheel
 - [Spec configuration](/spec-configuration) — merge rules and environment variables
 - [Tools](/tools) — **`search`** and **`execute`**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a copy-paste **inference policy example** and updates quickstart docs to use it.

- **`examples/inference/policy.yaml`** — commented operator manifest (escalation, cache, store, pipeline, observability, efficiency layers)
- **`examples/inference/README.md`** — step-by-step quickstart (CLAWQL_HOME, policy show, serve, curl, optional Postgres)
- **`docs/inference/clawql-inference.md`** — new Quick start section linking the example
- **`packages/clawql-inference/README.md`** — policy-first quick start
- **`website/src/app/quickstart/page.mdx`** — optional inference gateway section (§6)
- **`examples/clawql-local-docker-compose/README.md`** — cross-link to inference example

## Testing

Docs-only change; no code paths modified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f526a-09e5-764d-8661-cc263cfe629c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

