### PR TITLE
feat(ouroboros): EventStore Effect service

### DIFF
--- a/packages/clawql-ouroboros/src/effect/index.ts
+++ b/packages/clawql-ouroboros/src/effect/index.ts
@@ -2,6 +2,10 @@ export { OuroborosError } from "./ouroboros-errors.js";
 export { ouroborosFromPromise } from "./ouroboros-effect-utils.js";
 export { OuroborosContextService, ouroborosContextLiveLayer } from "./ouroboros-context-service.js";
 export {
+  OuroborosEventStoreService,
+  ouroborosEventStoreLiveLayer,
+} from "./ouroboros-event-store-service.js";
+export {
   executeCreateSeedFromDocumentEffect,
   executeGetLineageStatusEffect,
   executeMeasureDriftEffect,

--- a/packages/clawql-ouroboros/src/effect/ouroboros-effect-runtime.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-effect-runtime.ts
@@ -8,14 +8,23 @@ import type {
   RunOuroborosSchema,
 } from "../mcp-hooks.js";
 import { OuroborosContextService, ouroborosContextLiveLayer } from "./ouroboros-context-service.js";
+import {
+  OuroborosEventStoreService,
+  ouroborosEventStoreLiveLayer,
+} from "./ouroboros-event-store-service.js";
 import { OuroborosError } from "./ouroboros-errors.js";
 import { OuroborosToolsService, ouroborosToolsLiveLayer } from "./ouroboros-tools-service.js";
 
-export type OuroborosServices = OuroborosContextService | OuroborosToolsService;
+export type OuroborosServices =
+  OuroborosContextService | OuroborosToolsService | OuroborosEventStoreService;
 
 /** Merged Effect Layer for Ouroboros domain services. */
 export function ouroborosServicesLiveLayer(): Layer.Layer<OuroborosServices> {
-  return Layer.mergeAll(ouroborosContextLiveLayer(), ouroborosToolsLiveLayer());
+  return Layer.mergeAll(
+    ouroborosEventStoreLiveLayer(),
+    ouroborosContextLiveLayer(),
+    ouroborosToolsLiveLayer()
+  );
 }
 
 function throwOuroborosFailure(cause: Cause.Cause<unknown>): never {

--- a/packages/clawql-ouroboros/src/effect/ouroboros-event-store-service.test.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-event-store-service.test.ts
@@ -1,0 +1,39 @@
+import { Effect } from "effect";
+import { InMemoryEventStore } from "../in-memory-event-store.js";
+import { describe, expect, it } from "vitest";
+import { Layer } from "effect";
+import { ouroborosFromPromise } from "./ouroboros-effect-utils.js";
+import { OuroborosEventStoreService } from "./ouroboros-event-store-service.js";
+
+describe("OuroborosEventStoreService", () => {
+  it("append and getLineage round-trip via in-memory store", async () => {
+    const store = new InMemoryEventStore();
+    const layer = Layer.succeed(
+      OuroborosEventStoreService,
+      OuroborosEventStoreService.of({
+        getStore: () => store,
+        append: (event) => ouroborosFromPromise(() => store.append(event)),
+        getLineage: (seedId) => ouroborosFromPromise(() => store.getLineage(seedId)),
+      })
+    );
+    const lineage = await Effect.runPromise(
+      Effect.gen(function* () {
+        const es = yield* OuroborosEventStoreService;
+        yield* es.append({
+          type: "generation_completed",
+          seed_id: "seed-test",
+          data: {
+            generation_number: 1,
+            seed: { metadata: { seed_id: "seed-test" } },
+            execution_output: "out",
+            evaluation_summary: { final_approved: true, score: 1, ac_results: [] },
+            phase: "completed",
+            ontology_schema: { name: "o", description: "d", fields: [] },
+          },
+        });
+        return yield* es.getLineage("seed-test");
+      }).pipe(Effect.provide(layer))
+    );
+    expect(lineage.seed_id).toBe("seed-test");
+  });
+});

--- a/packages/clawql-ouroboros/src/effect/ouroboros-event-store-service.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-event-store-service.ts
@@ -1,0 +1,28 @@
+import { Context, Effect, Layer } from "effect";
+import type { EventStore, StoredEvent } from "../interfaces.js";
+import type { OntologyLineage } from "../lineage.js";
+import { getOrCreateOuroborosEventStore } from "../glue/create-event-store.js";
+import { OuroborosError } from "./ouroboros-errors.js";
+import { ouroborosFromPromise } from "./ouroboros-effect-utils.js";
+
+/** Effect service for durable Ouroboros lineage event storage. */
+export class OuroborosEventStoreService extends Context.Tag("clawql/OuroborosEventStoreService")<
+  OuroborosEventStoreService,
+  {
+    readonly getStore: () => EventStore;
+    readonly append: (event: StoredEvent) => Effect.Effect<void, OuroborosError>;
+    readonly getLineage: (seedId: string) => Effect.Effect<OntologyLineage, OuroborosError>;
+  }
+>() {}
+
+export function ouroborosEventStoreLiveLayer(): Layer.Layer<OuroborosEventStoreService> {
+  const store = getOrCreateOuroborosEventStore();
+  return Layer.succeed(
+    OuroborosEventStoreService,
+    OuroborosEventStoreService.of({
+      getStore: () => store,
+      append: (event) => ouroborosFromPromise(() => store.append(event)),
+      getLineage: (seedId) => ouroborosFromPromise(() => store.getLineage(seedId)),
+    })
+  );
+}

--- a/packages/clawql-ouroboros/src/effect/ouroboros-tools-effect.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-tools-effect.ts
@@ -8,6 +8,7 @@ import type {
   RunOuroborosSchema,
 } from "../mcp-hooks.js";
 import { OuroborosContextService } from "./ouroboros-context-service.js";
+import { OuroborosEventStoreService } from "./ouroboros-event-store-service.js";
 import { OuroborosError } from "./ouroboros-errors.js";
 import { ouroborosFromPromise } from "./ouroboros-effect-utils.js";
 
@@ -54,15 +55,11 @@ export function executeGetLineageStatusEffect(
 ): Effect.Effect<
   Awaited<ReturnType<typeof import("../mcp-hooks.js").ouroborosMcpTools.getLineageStatus.handler>>,
   OuroborosError,
-  OuroborosContextService
+  OuroborosEventStoreService
 > {
   return Effect.gen(function* () {
-    const ctxSvc = yield* OuroborosContextService;
-    const ctx = ctxSvc.getContext();
-    return yield* ouroborosFromPromise(async () => {
-      const { ouroborosMcpTools } = await import("../mcp-hooks.js");
-      return ouroborosMcpTools.getLineageStatus.handler(input, ctx);
-    });
+    const es = yield* OuroborosEventStoreService;
+    return yield* es.getLineage(input.seedId);
   });
 }
 

--- a/packages/clawql-ouroboros/src/effect/ouroboros-tools-service.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-tools-service.ts
@@ -8,6 +8,7 @@ import type {
   RunOuroborosSchema,
 } from "../mcp-hooks.js";
 import { OuroborosContextService } from "./ouroboros-context-service.js";
+import { OuroborosEventStoreService } from "./ouroboros-event-store-service.js";
 import { OuroborosError } from "./ouroboros-errors.js";
 import {
   executeCreateSeedFromDocumentEffect,
@@ -48,7 +49,7 @@ export class OuroborosToolsService extends Context.Tag("clawql/OuroborosToolsSer
         ReturnType<typeof import("../mcp-hooks.js").ouroborosMcpTools.getLineageStatus.handler>
       >,
       OuroborosError,
-      OuroborosContextService
+      OuroborosEventStoreService
     >;
     readonly measureDrift: (
       input: z.infer<typeof MeasureDriftSchema>

--- a/packages/clawql-ouroboros/src/glue/create-event-store.ts
+++ b/packages/clawql-ouroboros/src/glue/create-event-store.ts
@@ -1,0 +1,20 @@
+import { InMemoryEventStore } from "../in-memory-event-store.js";
+import type { EventStore } from "../interfaces.js";
+import { PostgresOuroborosEventStore } from "./postgres-event-store.js";
+import { getOuroborosPgPool } from "./postgres-pool.js";
+
+let sharedEventStore: EventStore | null = null;
+
+/** Shared event store instance (Postgres when configured, else in-memory). */
+export function getOrCreateOuroborosEventStore(): EventStore {
+  if (!sharedEventStore) {
+    const pgPool = getOuroborosPgPool();
+    sharedEventStore = pgPool ? new PostgresOuroborosEventStore(pgPool) : new InMemoryEventStore();
+  }
+  return sharedEventStore;
+}
+
+/** Vitest: reset singleton so env / pool changes apply. */
+export function resetOuroborosEventStoreForTests(): void {
+  sharedEventStore = null;
+}

--- a/packages/clawql-ouroboros/src/plugin/context.ts
+++ b/packages/clawql-ouroboros/src/plugin/context.ts
@@ -1,11 +1,10 @@
-import { EvolutionaryLoop, InMemoryEventStore, type EventStore } from "../index.js";
+import { EvolutionaryLoop } from "../index.js";
 import { createDefaultOuroborosEngines } from "../glue/default-engines.js";
-import { PostgresOuroborosEventStore } from "../glue/postgres-event-store.js";
 import {
-  closeOuroborosPgPool,
-  getOuroborosPgPool,
-  registerOuroborosPoolShutdownHooks,
-} from "../glue/postgres-pool.js";
+  getOrCreateOuroborosEventStore,
+  resetOuroborosEventStoreForTests,
+} from "../glue/create-event-store.js";
+import { closeOuroborosPgPool, registerOuroborosPoolShutdownHooks } from "../glue/postgres-pool.js";
 import type { OuroborosContext } from "../mcp-hooks.js";
 import { getOuroborosPluginDeps } from "./deps.js";
 import { createModelEscalationRouter, loadModelEscalationConfig } from "clawql-inference";
@@ -13,18 +12,10 @@ import { createModelEscalationRouter, loadModelEscalationConfig } from "clawql-i
 let ctxCache: OuroborosContext | null = null;
 let shutdownHooksRegistered = false;
 
-function createEventStore(): EventStore {
-  const pgPool = getOuroborosPgPool();
-  if (pgPool) {
-    return new PostgresOuroborosEventStore(pgPool);
-  }
-  return new InMemoryEventStore();
-}
-
 export function getOuroborosContext(): OuroborosContext {
   if (!ctxCache) {
     const { search, execute } = getOuroborosPluginDeps();
-    const eventStore = createEventStore();
+    const eventStore = getOrCreateOuroborosEventStore();
     const engines = createDefaultOuroborosEngines({
       search: async (query, limit) => {
         const r = await search({ query, limit });
@@ -61,5 +52,6 @@ export function ensureOuroborosPoolShutdownHooks(): void {
 export function resetOuroborosContextForTests(): void {
   ctxCache = null;
   shutdownHooksRegistered = false;
+  resetOuroborosEventStoreForTests();
   void closeOuroborosPgPool();
 }

--- a/packages/clawql-ouroboros/src/plugin/index.ts
+++ b/packages/clawql-ouroboros/src/plugin/index.ts
@@ -14,8 +14,10 @@ export { getOuroborosContext, resetOuroborosContextForTests } from "./context.js
 export {
   OuroborosContextService,
   OuroborosError,
+  OuroborosEventStoreService,
   OuroborosToolsService,
   ouroborosContextLiveLayer,
+  ouroborosEventStoreLiveLayer,
   ouroborosCreateSeedProgram,
   ouroborosLineageProgram,
   ouroborosMeasureDriftProgram,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Introduces `OuroborosEventStoreService` as an Effect service layer for lineage/event-store access in the Ouroboros package.

- Adds shared `getOrCreateOuroborosEventStore` factory in `glue/create-event-store.ts`
- Routes `get_lineage_status` through `OuroborosEventStoreService` instead of direct mcp-hooks handler
- Merges event store layer into `ouroborosServicesLiveLayer`
- Plugin context uses shared factory; test reset helpers updated

Part of the Ouroboros Effect migration (slice 1 of 3).

## Test plan

- [x] `npm run build -w clawql-ouroboros`
- [x] `npx vitest run packages/clawql-ouroboros/src`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

