### PR TITLE
feat(ouroboros): EvolutionaryLoop native Effect.gen + LoopService

### DIFF
--- a/packages/clawql-ouroboros/src/effect/evolutionary-loop-effect.ts
+++ b/packages/clawql-ouroboros/src/effect/evolutionary-loop-effect.ts
@@ -7,10 +7,8 @@ import {
   type ModelEscalationDecision,
 } from "clawql-inference";
 import type { Seed } from "../seed.js";
-import type { Evaluator, Executor, ReflectEngine, WonderEngine } from "../interfaces.js";
 import { ConvergenceCriteria, type ConvergenceConfig } from "../convergence.js";
 import { driftReportPayload, measureDrift } from "../drift.js";
-import type { LoopRoutingOptions } from "../evolutionary-loop.js";
 import type { GenerationSnapshot, LoopResult, EvolutionaryLoopDeps } from "../evolutionary-loop.js";
 import { appendInferenceAuditEvent } from "../glue/routing-audit.js";
 import { buildRoutingCorrelationId, buildRoutingFailureSignals } from "../glue/routing-failures.js";

--- a/packages/clawql-ouroboros/src/effect/evolutionary-loop-effect.ts
+++ b/packages/clawql-ouroboros/src/effect/evolutionary-loop-effect.ts
@@ -1,0 +1,245 @@
+import { v4 as uuidv4 } from "uuid";
+import { Effect } from "effect";
+import {
+  buildModelEscalationAuditEntry,
+  evaluateAgentCoordination,
+  type EngineCallContext,
+  type ModelEscalationDecision,
+} from "clawql-inference";
+import type { Seed } from "../seed.js";
+import type { Evaluator, Executor, ReflectEngine, WonderEngine } from "../interfaces.js";
+import { ConvergenceCriteria, type ConvergenceConfig } from "../convergence.js";
+import { driftReportPayload, measureDrift } from "../drift.js";
+import type { LoopRoutingOptions } from "../evolutionary-loop.js";
+import type { GenerationSnapshot, LoopResult, EvolutionaryLoopDeps } from "../evolutionary-loop.js";
+import { appendInferenceAuditEvent } from "../glue/routing-audit.js";
+import { buildRoutingCorrelationId, buildRoutingFailureSignals } from "../glue/routing-failures.js";
+import { OuroborosError } from "./ouroboros-errors.js";
+import { ouroborosFromPromise } from "./ouroboros-effect-utils.js";
+import type { WonderOutput } from "../interfaces.js";
+
+export function runEvolutionaryLoopBodyEffect(
+  deps: EvolutionaryLoopDeps,
+  seed: Seed,
+  runOverrides?: Partial<ConvergenceConfig>
+): Effect.Effect<LoopResult, OuroborosError> {
+  return Effect.gen(function* () {
+    const convergence = new ConvergenceCriteria({
+      ...deps.convergenceConfig,
+      ...runOverrides,
+    });
+    const maxGenerations = convergence.config.maxGenerations;
+
+    let currentSeed = seed;
+    const generations: GenerationSnapshot[] = [];
+    let generationNumber = 1;
+    let latestWonder: WonderOutput | undefined;
+    let routingDecision: ModelEscalationDecision | undefined;
+
+    while (generationNumber <= maxGenerations) {
+      if (deps.routingOptions.router && routingDecision === undefined) {
+        routingDecision = deps.routingOptions.router.initialTier({
+          isDecomposedChild: deps.routingOptions.isDecomposedChild ?? false,
+          seedId: seed.metadata.seed_id,
+        });
+      }
+
+      const engineCtx: EngineCallContext = {
+        seedId: seed.metadata.seed_id,
+        generationNumber,
+        routing: routingDecision,
+      };
+
+      if (generationNumber > 1) {
+        const prevGen = generations[generations.length - 1]!;
+
+        latestWonder = yield* ouroborosFromPromise(() =>
+          deps.wonderEngine.wonder(currentSeed, prevGen.evaluation, engineCtx)
+        );
+
+        const reflect = yield* ouroborosFromPromise(() =>
+          deps.reflectEngine.reflect(
+            currentSeed,
+            prevGen.executionOutput,
+            prevGen.evaluation,
+            latestWonder!,
+            engineCtx
+          )
+        );
+
+        currentSeed = {
+          ...currentSeed,
+          ...reflect.newSeedData,
+          metadata: {
+            ...currentSeed.metadata,
+            parent_seed_id: currentSeed.metadata.seed_id,
+            seed_id: `seed_${uuidv4().slice(0, 12)}`,
+          },
+        } as Seed;
+      }
+
+      const executionOutput = yield* ouroborosFromPromise(() =>
+        deps.executor.execute(currentSeed, engineCtx)
+      );
+      const evaluation = yield* ouroborosFromPromise(() =>
+        deps.evaluator.evaluate(executionOutput, currentSeed, engineCtx)
+      );
+
+      const snapshot: GenerationSnapshot = {
+        generationNumber,
+        seed: currentSeed,
+        executionOutput,
+        evaluation,
+        wonder: latestWonder,
+        routing: routingDecision,
+      };
+      generations.push(snapshot);
+
+      const failedConstraints = evaluation.ac_results
+        .filter((ac) => !ac.passed)
+        .map((ac) => ac.ac_content);
+      const driftReport = measureDrift({
+        baselineSeed: seed,
+        currentOutput: executionOutput,
+        constraintViolations: failedConstraints,
+        currentConcepts: currentSeed.ontology_schema.fields.map((f) => f.name),
+      });
+
+      yield* ouroborosFromPromise(() =>
+        deps.eventStore.append({
+          type: "drift_measured",
+          seed_id: seed.metadata.seed_id,
+          data: driftReportPayload(driftReport, {
+            generation_number: generationNumber,
+            constraint_violations: failedConstraints,
+            current_concepts: currentSeed.ontology_schema.fields.map((f) => f.name),
+          }),
+          timestamp: new Date(),
+        })
+      );
+
+      yield* ouroborosFromPromise(() =>
+        deps.eventStore.append({
+          type: "generation_completed",
+          seed_id: seed.metadata.seed_id,
+          data: {
+            generation_number: generationNumber,
+            seed: currentSeed,
+            execution_output: executionOutput,
+            evaluation_summary: evaluation,
+            phase: "completed" as const,
+            ontology_schema: currentSeed.ontology_schema,
+            routing_decision: routingDecision,
+          },
+          timestamp: new Date(),
+        })
+      );
+
+      const lineage = yield* ouroborosFromPromise(() =>
+        deps.eventStore.getLineage(seed.metadata.seed_id)
+      );
+
+      const signal = convergence.evaluate(
+        lineage,
+        latestWonder,
+        evaluation,
+        undefined,
+        driftReport
+      );
+
+      if (signal.converged) {
+        yield* ouroborosFromPromise(() =>
+          deps.eventStore.append({
+            type: "ouroboros_finished",
+            seed_id: seed.metadata.seed_id,
+            data: {
+              converged: true,
+              generation_count: generations.length,
+              reason_code: signal.reason_code,
+              reason: signal.reason,
+              ontology_similarity: signal.ontology_similarity,
+            },
+            timestamp: new Date(),
+          })
+        );
+        const finalLineage = yield* ouroborosFromPromise(() =>
+          deps.eventStore.getLineage(seed.metadata.seed_id)
+        );
+        return { lineage: finalLineage, converged: true, finalSeed: currentSeed, generations };
+      }
+
+      const router = deps.routingOptions.router;
+      if (router && routingDecision) {
+        const failureSignals = buildRoutingFailureSignals({
+          generationNumber,
+          evaluation,
+          driftReport,
+          convergenceConfig: convergence.config,
+        });
+        if (failureSignals.length) {
+          const correlationId = buildRoutingCorrelationId(seed.metadata.seed_id, generationNumber);
+          const before = routingDecision;
+          const after = router.escalate(before, failureSignals[0]!);
+          if (
+            after.tier !== before.tier ||
+            after.modelId !== before.modelId ||
+            after.retryAttempt > before.retryAttempt
+          ) {
+            yield* ouroborosFromPromise(() =>
+              appendInferenceAuditEvent(
+                deps.eventStore,
+                seed.metadata.seed_id,
+                buildModelEscalationAuditEntry({
+                  before,
+                  after,
+                  correlationId,
+                })
+              )
+            );
+            routingDecision = after;
+            snapshot.routing = after;
+          }
+
+          const coordination = yield* ouroborosFromPromise(() =>
+            evaluateAgentCoordination({
+              router,
+              decision: routingDecision!,
+              signals: failureSignals,
+              driftCombined: driftReport.combined_drift,
+              correlationId,
+            })
+          );
+          if (coordination.triggered && coordination.auditEntry) {
+            yield* ouroborosFromPromise(() =>
+              appendInferenceAuditEvent(
+                deps.eventStore,
+                seed.metadata.seed_id,
+                coordination.auditEntry!
+              )
+            );
+          }
+        }
+      }
+
+      generationNumber++;
+    }
+
+    yield* ouroborosFromPromise(() =>
+      deps.eventStore.append({
+        type: "ouroboros_finished",
+        seed_id: seed.metadata.seed_id,
+        data: {
+          converged: false,
+          generation_count: generations.length,
+          reason_code: "max_generations",
+          reason: `Exhausted at max generations (${convergence.config.maxGenerations})`,
+        },
+        timestamp: new Date(),
+      })
+    );
+    const lineage = yield* ouroborosFromPromise(() =>
+      deps.eventStore.getLineage(seed.metadata.seed_id)
+    );
+    return { lineage, converged: false, finalSeed: currentSeed, generations };
+  });
+}

--- a/packages/clawql-ouroboros/src/effect/index.ts
+++ b/packages/clawql-ouroboros/src/effect/index.ts
@@ -6,6 +6,14 @@ export {
   ouroborosEventStoreLiveLayer,
 } from "./ouroboros-event-store-service.js";
 export {
+  OuroborosLoopService,
+  ouroborosLoopLiveLayer,
+  executeRunEvolutionaryLoopFromInputEffect,
+  formatRunEvolutionaryLoopMcpResult,
+  resetOuroborosLoopDepsForTests,
+} from "./ouroboros-loop-service.js";
+export { runEvolutionaryLoopBodyEffect } from "./evolutionary-loop-effect.js";
+export {
   executeCreateSeedFromDocumentEffect,
   executeGetLineageStatusEffect,
   executeMeasureDriftEffect,

--- a/packages/clawql-ouroboros/src/effect/ouroboros-effect-runtime.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-effect-runtime.ts
@@ -13,15 +13,20 @@ import {
   ouroborosEventStoreLiveLayer,
 } from "./ouroboros-event-store-service.js";
 import { OuroborosError } from "./ouroboros-errors.js";
+import { OuroborosLoopService, ouroborosLoopLiveLayer } from "./ouroboros-loop-service.js";
 import { OuroborosToolsService, ouroborosToolsLiveLayer } from "./ouroboros-tools-service.js";
 
 export type OuroborosServices =
-  OuroborosContextService | OuroborosToolsService | OuroborosEventStoreService;
+  | OuroborosContextService
+  | OuroborosToolsService
+  | OuroborosEventStoreService
+  | OuroborosLoopService;
 
 /** Merged Effect Layer for Ouroboros domain services. */
 export function ouroborosServicesLiveLayer(): Layer.Layer<OuroborosServices> {
   return Layer.mergeAll(
     ouroborosEventStoreLiveLayer(),
+    ouroborosLoopLiveLayer(),
     ouroborosContextLiveLayer(),
     ouroborosToolsLiveLayer()
   );

--- a/packages/clawql-ouroboros/src/effect/ouroboros-loop-service.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-loop-service.ts
@@ -1,0 +1,84 @@
+import { Context, Effect, Layer } from "effect";
+import { SeedSchema } from "../seed.js";
+import type { Seed } from "../seed.js";
+import type { ConvergenceConfig } from "../convergence.js";
+import type { LoopResult } from "../evolutionary-loop.js";
+import { buildEvolutionaryLoop } from "../glue/build-evolutionary-loop.js";
+import { OuroborosError } from "./ouroboros-errors.js";
+import { runEvolutionaryLoopBodyEffect } from "./evolutionary-loop-effect.js";
+
+let builtLoopCache: ReturnType<typeof buildEvolutionaryLoop> | null = null;
+
+function getBuiltLoop(): ReturnType<typeof buildEvolutionaryLoop> {
+  if (!builtLoopCache) {
+    builtLoopCache = buildEvolutionaryLoop();
+  }
+  return builtLoopCache;
+}
+
+/** Vitest: clear cached loop bundle. */
+export function resetOuroborosLoopDepsForTests(): void {
+  builtLoopCache = null;
+}
+
+/** Effect service for the Ouroboros evolutionary loop. */
+export class OuroborosLoopService extends Context.Tag("clawql/OuroborosLoopService")<
+  OuroborosLoopService,
+  {
+    readonly run: (
+      seed: Seed,
+      runOverrides?: Partial<ConvergenceConfig>
+    ) => Effect.Effect<LoopResult, OuroborosError>;
+    readonly getLoop: () => ReturnType<typeof buildEvolutionaryLoop>["loop"];
+  }
+>() {}
+
+export function ouroborosLoopLiveLayer(): Layer.Layer<OuroborosLoopService> {
+  return Layer.succeed(
+    OuroborosLoopService,
+    OuroborosLoopService.of({
+      run: (seed, runOverrides) =>
+        runEvolutionaryLoopBodyEffect(getBuiltLoop().loop.loopDeps(), seed, runOverrides),
+      getLoop: () => getBuiltLoop().loop,
+    })
+  );
+}
+
+export type RunOuroborosMcpInput = {
+  seed: unknown;
+  maxGenerations?: number;
+  convergenceThreshold?: number;
+};
+
+/** Map loop result to MCP tool response shape. */
+export function formatRunEvolutionaryLoopMcpResult(result: LoopResult) {
+  return {
+    converged: result.converged,
+    generations: result.generations.length,
+    finalSeed: result.finalSeed,
+    lineageId: result.lineage.seed_id,
+    status: result.lineage.status,
+    summary: result.converged
+      ? `Converged in ${result.generations.length} generation(s)`
+      : `Exhausted ${result.generations.length} generation(s) without convergence`,
+  };
+}
+
+/** MCP run_evolutionary_loop input → Effect program. */
+export function executeRunEvolutionaryLoopFromInputEffect(
+  input: RunOuroborosMcpInput
+): Effect.Effect<
+  ReturnType<typeof formatRunEvolutionaryLoopMcpResult>,
+  OuroborosError,
+  OuroborosLoopService
+> {
+  return Effect.gen(function* () {
+    const loopSvc = yield* OuroborosLoopService;
+    const validatedSeed = SeedSchema.parse(input.seed);
+    const result = yield* loopSvc.run(validatedSeed, {
+      maxGenerations: input.maxGenerations,
+      convergenceThreshold: input.convergenceThreshold,
+    });
+    return formatRunEvolutionaryLoopMcpResult(result);
+  });
+}

--- a/packages/clawql-ouroboros/src/effect/ouroboros-tools-effect.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-tools-effect.ts
@@ -9,8 +9,10 @@ import type {
 } from "../mcp-hooks.js";
 import { OuroborosContextService } from "./ouroboros-context-service.js";
 import { OuroborosEventStoreService } from "./ouroboros-event-store-service.js";
+import { OuroborosLoopService } from "./ouroboros-loop-service.js";
 import { OuroborosError } from "./ouroboros-errors.js";
 import { ouroborosFromPromise } from "./ouroboros-effect-utils.js";
+import { executeRunEvolutionaryLoopFromInputEffect } from "./ouroboros-loop-service.js";
 
 export function executeCreateSeedFromDocumentEffect(
   input: z.infer<typeof CreateSeedFromDocumentSchema>
@@ -38,16 +40,9 @@ export function executeRunEvolutionaryLoopEffect(
     ReturnType<typeof import("../mcp-hooks.js").ouroborosMcpTools.runEvolutionaryLoop.handler>
   >,
   OuroborosError,
-  OuroborosContextService
+  OuroborosLoopService
 > {
-  return Effect.gen(function* () {
-    const ctxSvc = yield* OuroborosContextService;
-    const ctx = ctxSvc.getContext();
-    return yield* ouroborosFromPromise(async () => {
-      const { ouroborosMcpTools } = await import("../mcp-hooks.js");
-      return ouroborosMcpTools.runEvolutionaryLoop.handler(input, ctx);
-    });
-  });
+  return executeRunEvolutionaryLoopFromInputEffect(input);
 }
 
 export function executeGetLineageStatusEffect(

--- a/packages/clawql-ouroboros/src/effect/ouroboros-tools-service.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-tools-service.ts
@@ -9,6 +9,7 @@ import type {
 } from "../mcp-hooks.js";
 import { OuroborosContextService } from "./ouroboros-context-service.js";
 import { OuroborosEventStoreService } from "./ouroboros-event-store-service.js";
+import { OuroborosLoopService } from "./ouroboros-loop-service.js";
 import { OuroborosError } from "./ouroboros-errors.js";
 import {
   executeCreateSeedFromDocumentEffect,
@@ -40,7 +41,7 @@ export class OuroborosToolsService extends Context.Tag("clawql/OuroborosToolsSer
         ReturnType<typeof import("../mcp-hooks.js").ouroborosMcpTools.runEvolutionaryLoop.handler>
       >,
       OuroborosError,
-      OuroborosContextService
+      OuroborosLoopService
     >;
     readonly getLineageStatus: (
       input: z.infer<typeof GetLineageStatusSchema>

--- a/packages/clawql-ouroboros/src/evolutionary-loop.ts
+++ b/packages/clawql-ouroboros/src/evolutionary-loop.ts
@@ -1,11 +1,4 @@
-import { v4 as uuidv4 } from "uuid";
-import {
-  buildModelEscalationAuditEntry,
-  evaluateAgentCoordination,
-  type AdaptiveRouter,
-  type EngineCallContext,
-  type ModelEscalationDecision,
-} from "clawql-inference";
+import type { AdaptiveRouter } from "clawql-inference";
 import type { Seed } from "./seed.js";
 import type {
   EventStore,
@@ -17,10 +10,8 @@ import type {
   WonderOutput,
 } from "./interfaces.js";
 import { ConvergenceCriteria, type ConvergenceConfig } from "./convergence.js";
-import { driftReportPayload, measureDrift } from "./drift.js";
 import type { OntologyLineage } from "./lineage.js";
-import { appendInferenceAuditEvent } from "./glue/routing-audit.js";
-import { buildRoutingCorrelationId, buildRoutingFailureSignals } from "./glue/routing-failures.js";
+import type { ModelEscalationDecision } from "clawql-inference";
 
 export interface LoopResult {
   lineage: OntologyLineage;
@@ -44,6 +35,16 @@ export interface LoopRoutingOptions {
   isDecomposedChild?: boolean;
 }
 
+export type EvolutionaryLoopDeps = {
+  readonly eventStore: EventStore;
+  readonly wonderEngine: WonderEngine;
+  readonly reflectEngine: ReflectEngine;
+  readonly executor: Executor;
+  readonly evaluator: Evaluator;
+  readonly convergenceConfig: ConvergenceConfig;
+  readonly routingOptions: LoopRoutingOptions;
+};
+
 export class EvolutionaryLoop {
   private readonly convergence: ConvergenceCriteria;
 
@@ -59,198 +60,25 @@ export class EvolutionaryLoop {
     this.convergence = new ConvergenceCriteria(config);
   }
 
+  /** Dependencies for native Effect.gen loop body. */
+  loopDeps(): EvolutionaryLoopDeps {
+    return {
+      eventStore: this.eventStore,
+      wonderEngine: this.wonderEngine,
+      reflectEngine: this.reflectEngine,
+      executor: this.executor,
+      evaluator: this.evaluator,
+      convergenceConfig: this.convergence.config,
+      routingOptions: this.routingOptions,
+    };
+  }
+
   /**
    * @param runOverrides Optional per-run limits (e.g. MCP `maxGenerations` / `convergenceThreshold`).
    */
   async run(seed: Seed, runOverrides?: Partial<ConvergenceConfig>): Promise<LoopResult> {
-    const convergence = new ConvergenceCriteria({
-      ...this.convergence.config,
-      ...runOverrides,
-    });
-    const maxGenerations = convergence.config.maxGenerations;
-
-    let currentSeed = seed;
-    const generations: GenerationSnapshot[] = [];
-    let generationNumber = 1;
-    let latestWonder: WonderOutput | undefined;
-    let routingDecision: ModelEscalationDecision | undefined;
-
-    while (generationNumber <= maxGenerations) {
-      if (this.routingOptions.router && routingDecision === undefined) {
-        routingDecision = this.routingOptions.router.initialTier({
-          isDecomposedChild: this.routingOptions.isDecomposedChild ?? false,
-          seedId: seed.metadata.seed_id,
-        });
-      }
-
-      const engineCtx: EngineCallContext = {
-        seedId: seed.metadata.seed_id,
-        generationNumber,
-        routing: routingDecision,
-      };
-
-      if (generationNumber > 1) {
-        const prevGen = generations[generations.length - 1];
-
-        latestWonder = await this.wonderEngine.wonder(currentSeed, prevGen.evaluation, engineCtx);
-
-        const reflect = await this.reflectEngine.reflect(
-          currentSeed,
-          prevGen.executionOutput,
-          prevGen.evaluation,
-          latestWonder,
-          engineCtx
-        );
-
-        currentSeed = {
-          ...currentSeed,
-          ...reflect.newSeedData,
-          metadata: {
-            ...currentSeed.metadata,
-            parent_seed_id: currentSeed.metadata.seed_id,
-            seed_id: `seed_${uuidv4().slice(0, 12)}`,
-          },
-        } as Seed;
-      }
-
-      const executionOutput = await this.executor.execute(currentSeed, engineCtx);
-      const evaluation = await this.evaluator.evaluate(executionOutput, currentSeed, engineCtx);
-
-      const snapshot: GenerationSnapshot = {
-        generationNumber,
-        seed: currentSeed,
-        executionOutput,
-        evaluation,
-        wonder: latestWonder,
-        routing: routingDecision,
-      };
-      generations.push(snapshot);
-
-      const failedConstraints = evaluation.ac_results
-        .filter((ac) => !ac.passed)
-        .map((ac) => ac.ac_content);
-      const driftReport = measureDrift({
-        baselineSeed: seed,
-        currentOutput: executionOutput,
-        constraintViolations: failedConstraints,
-        currentConcepts: currentSeed.ontology_schema.fields.map((f) => f.name),
-      });
-
-      await this.eventStore.append({
-        type: "drift_measured",
-        seed_id: seed.metadata.seed_id,
-        data: driftReportPayload(driftReport, {
-          generation_number: generationNumber,
-          constraint_violations: failedConstraints,
-          current_concepts: currentSeed.ontology_schema.fields.map((f) => f.name),
-        }),
-        timestamp: new Date(),
-      });
-
-      await this.eventStore.append({
-        type: "generation_completed",
-        seed_id: seed.metadata.seed_id,
-        data: {
-          generation_number: generationNumber,
-          seed: currentSeed,
-          execution_output: executionOutput,
-          evaluation_summary: evaluation,
-          phase: "completed" as const,
-          ontology_schema: currentSeed.ontology_schema,
-          routing_decision: routingDecision,
-        },
-        timestamp: new Date(),
-      });
-
-      const lineage = await this.eventStore.getLineage(seed.metadata.seed_id);
-
-      const signal = convergence.evaluate(
-        lineage,
-        latestWonder,
-        evaluation,
-        undefined,
-        driftReport
-      );
-
-      if (signal.converged) {
-        await this.eventStore.append({
-          type: "ouroboros_finished",
-          seed_id: seed.metadata.seed_id,
-          data: {
-            converged: true,
-            generation_count: generations.length,
-            reason_code: signal.reason_code,
-            reason: signal.reason,
-            ontology_similarity: signal.ontology_similarity,
-          },
-          timestamp: new Date(),
-        });
-        const finalLineage = await this.eventStore.getLineage(seed.metadata.seed_id);
-        return { lineage: finalLineage, converged: true, finalSeed: currentSeed, generations };
-      }
-
-      const router = this.routingOptions.router;
-      if (router && routingDecision) {
-        const failureSignals = buildRoutingFailureSignals({
-          generationNumber,
-          evaluation,
-          driftReport,
-          convergenceConfig: convergence.config,
-        });
-        if (failureSignals.length) {
-          const correlationId = buildRoutingCorrelationId(seed.metadata.seed_id, generationNumber);
-          const before = routingDecision;
-          const after = router.escalate(before, failureSignals[0]!);
-          if (
-            after.tier !== before.tier ||
-            after.modelId !== before.modelId ||
-            after.retryAttempt > before.retryAttempt
-          ) {
-            await appendInferenceAuditEvent(
-              this.eventStore,
-              seed.metadata.seed_id,
-              buildModelEscalationAuditEntry({
-                before,
-                after,
-                correlationId,
-              })
-            );
-            routingDecision = after;
-            snapshot.routing = after;
-          }
-
-          const coordination = await evaluateAgentCoordination({
-            router,
-            decision: routingDecision,
-            signals: failureSignals,
-            driftCombined: driftReport.combined_drift,
-            correlationId,
-          });
-          if (coordination.triggered && coordination.auditEntry) {
-            await appendInferenceAuditEvent(
-              this.eventStore,
-              seed.metadata.seed_id,
-              coordination.auditEntry
-            );
-          }
-        }
-      }
-
-      generationNumber++;
-    }
-
-    await this.eventStore.append({
-      type: "ouroboros_finished",
-      seed_id: seed.metadata.seed_id,
-      data: {
-        converged: false,
-        generation_count: generations.length,
-        reason_code: "max_generations",
-        reason: `Exhausted at max generations (${convergence.config.maxGenerations})`,
-      },
-      timestamp: new Date(),
-    });
-    const lineage = await this.eventStore.getLineage(seed.metadata.seed_id);
-    return { lineage, converged: false, finalSeed: currentSeed, generations };
+    const { runEvolutionaryLoopBodyEffect } = await import("./effect/evolutionary-loop-effect.js");
+    const { Effect } = await import("effect");
+    return Effect.runPromise(runEvolutionaryLoopBodyEffect(this.loopDeps(), seed, runOverrides));
   }
 }

--- a/packages/clawql-ouroboros/src/glue/build-evolutionary-loop.ts
+++ b/packages/clawql-ouroboros/src/glue/build-evolutionary-loop.ts
@@ -1,0 +1,35 @@
+import { EvolutionaryLoop } from "../evolutionary-loop.js";
+import { createDefaultOuroborosEngines } from "./default-engines.js";
+import { getOrCreateOuroborosEventStore } from "./create-event-store.js";
+import { getOuroborosPluginDeps } from "../plugin/deps.js";
+import { createModelEscalationRouter, loadModelEscalationConfig } from "clawql-inference";
+
+/** Build loop + shared event store (search/execute deps must be configured). */
+export function buildEvolutionaryLoop(): {
+  loop: EvolutionaryLoop;
+  eventStore: ReturnType<typeof getOrCreateOuroborosEventStore>;
+} {
+  const { search, execute } = getOuroborosPluginDeps();
+  const eventStore = getOrCreateOuroborosEventStore();
+  const engines = createDefaultOuroborosEngines({
+    search: async (query, limit) => {
+      const r = await search({ query, limit });
+      return { content: [...r.content] };
+    },
+    execute: async (params) => {
+      const r = await execute(params);
+      return { content: [...r.content] };
+    },
+  });
+  const router = createModelEscalationRouter(loadModelEscalationConfig());
+  const loop = new EvolutionaryLoop(
+    eventStore,
+    engines.wonder,
+    engines.reflect,
+    engines.execute,
+    engines.evaluate,
+    {},
+    { router }
+  );
+  return { loop, eventStore };
+}

--- a/packages/clawql-ouroboros/src/plugin/context.ts
+++ b/packages/clawql-ouroboros/src/plugin/context.ts
@@ -1,7 +1,4 @@
-import {
-  getOrCreateOuroborosEventStore,
-  resetOuroborosEventStoreForTests,
-} from "../glue/create-event-store.js";
+import { resetOuroborosEventStoreForTests } from "../glue/create-event-store.js";
 import { buildEvolutionaryLoop } from "../glue/build-evolutionary-loop.js";
 import { closeOuroborosPgPool, registerOuroborosPoolShutdownHooks } from "../glue/postgres-pool.js";
 import type { OuroborosContext } from "../mcp-hooks.js";

--- a/packages/clawql-ouroboros/src/plugin/context.ts
+++ b/packages/clawql-ouroboros/src/plugin/context.ts
@@ -1,42 +1,19 @@
-import { EvolutionaryLoop } from "../index.js";
-import { createDefaultOuroborosEngines } from "../glue/default-engines.js";
 import {
   getOrCreateOuroborosEventStore,
   resetOuroborosEventStoreForTests,
 } from "../glue/create-event-store.js";
+import { buildEvolutionaryLoop } from "../glue/build-evolutionary-loop.js";
 import { closeOuroborosPgPool, registerOuroborosPoolShutdownHooks } from "../glue/postgres-pool.js";
 import type { OuroborosContext } from "../mcp-hooks.js";
-import { getOuroborosPluginDeps } from "./deps.js";
-import { createModelEscalationRouter, loadModelEscalationConfig } from "clawql-inference";
+import { resetOuroborosLoopDepsForTests } from "../effect/ouroboros-loop-service.js";
 
 let ctxCache: OuroborosContext | null = null;
 let shutdownHooksRegistered = false;
 
 export function getOuroborosContext(): OuroborosContext {
   if (!ctxCache) {
-    const { search, execute } = getOuroborosPluginDeps();
-    const eventStore = getOrCreateOuroborosEventStore();
-    const engines = createDefaultOuroborosEngines({
-      search: async (query, limit) => {
-        const r = await search({ query, limit });
-        return { content: [...r.content] };
-      },
-      execute: async (params) => {
-        const r = await execute(params);
-        return { content: [...r.content] };
-      },
-    });
-    const router = createModelEscalationRouter(loadModelEscalationConfig());
-    const ouroborosLoop = new EvolutionaryLoop(
-      eventStore,
-      engines.wonder,
-      engines.reflect,
-      engines.execute,
-      engines.evaluate,
-      {},
-      { router }
-    );
-    ctxCache = { ouroborosLoop, eventStore };
+    const { loop, eventStore } = buildEvolutionaryLoop();
+    ctxCache = { ouroborosLoop: loop, eventStore };
   }
   return ctxCache;
 }
@@ -53,5 +30,6 @@ export function resetOuroborosContextForTests(): void {
   ctxCache = null;
   shutdownHooksRegistered = false;
   resetOuroborosEventStoreForTests();
+  resetOuroborosLoopDepsForTests();
   void closeOuroborosPgPool();
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates the Ouroboros evolutionary loop body to native `Effect.gen` and introduces `OuroborosLoopService`.

- Adds `runEvolutionaryLoopBodyEffect` in `effect/evolutionary-loop-effect.ts`
- Adds `OuroborosLoopService` with MCP `run_evolutionary_loop` routing via `executeRunEvolutionaryLoopFromInputEffect`
- Shared `buildEvolutionaryLoop()` factory in `glue/build-evolutionary-loop.ts`
- `EvolutionaryLoop.run()` delegates to the Effect body; plugin context uses shared builder

Part of the Ouroboros Effect migration (slice 2 of 3).

## Test plan

- [x] `npm run build -w clawql-ouroboros`
- [x] `npx vitest run packages/clawql-ouroboros/src`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

