### PR TITLE
chore(deps): consolidate Dependabot updates (July 2026)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,12 +28,12 @@ jobs:
       # actions/checkout@v7.0.0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
-      # github/codeql-action@v4.36.3
-      - uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a
+      # github/codeql-action@v4.37.0
+      - uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9
         with:
           languages: javascript-typescript
           config-file: ./.github/codeql/codeql-config.yml
 
-      - uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a
+      - uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9
 
-      - uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a
+      - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9

--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Download build artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: landing-page-out
           path: landing-page/demo/out

--- a/.github/workflows/packer-publish.yml
+++ b/.github/workflows/packer-publish.yml
@@ -124,12 +124,12 @@ jobs:
           unzip -qo /tmp/packer.zip -d /usr/local/bin
 
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.PACKER_GCP_CREDENTIALS_JSON }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Packer build GCP
         working-directory: packer

--- a/.github/workflows/trufflehog-scheduled.yml
+++ b/.github/workflows/trufflehog-scheduled.yml
@@ -22,9 +22,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      # trufflesecurity/trufflehog@v3.95.8 (tag → commit pin for supply chain)
+      # trufflesecurity/trufflehog@v3.95.9 (tag → commit pin for supply chain)
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f
+        uses: trufflesecurity/trufflehog@27b0417c16317ca9a472a9a8092acce143b49c55
         with:
           path: ./
           extra_args: --exclude-paths=.github/trufflehog-exclude-paths.txt --only-verified

--- a/infra/pulumi/package.json
+++ b/infra/pulumi/package.json
@@ -35,9 +35,9 @@
     "destroy": "pulumi destroy"
   },
   "dependencies": {
-    "@pulumi/aws": "^6.83.0",
+    "@pulumi/aws": "^7.36.0",
     "@pulumi/cloudflare": "^6.4.0",
-    "@pulumi/gcp": "^8.36.0",
+    "@pulumi/gcp": "^9.29.0",
     "@pulumi/pulumi": "^3.210.0",
     "zod": "4.3.6"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "infra/pulumi"
             ],
             "dependencies": {
-                "@aws-sdk/client-s3": "^3.1084.0",
+                "@aws-sdk/client-s3": "^3.1085.0",
                 "@graphql-mesh/utils": "^0.104.36",
                 "@grpc/grpc-js": "^1.14.4",
                 "@grpc/proto-loader": "^0.8.1",
@@ -65,9 +65,9 @@
                 "@types/pg": "^8.20.0",
                 "@types/sql.js": "^1.4.11",
                 "@vitest/coverage-v8": "^4.1.7",
-                "eslint": "^10.6.0",
+                "eslint": "^10.7.0",
                 "prettier": "^3.9.3",
-                "tsx": "^4.23.0",
+                "tsx": "^4.23.1",
                 "turbo": "^2.10.3",
                 "typescript": "^6.0.3",
                 "typescript-eslint": "^8.62.1",
@@ -82,9 +82,9 @@
             "version": "7.0.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@pulumi/aws": "^6.83.0",
+                "@pulumi/aws": "^7.36.0",
                 "@pulumi/cloudflare": "^6.4.0",
-                "@pulumi/gcp": "^8.36.0",
+                "@pulumi/gcp": "^9.29.0",
                 "@pulumi/pulumi": "^3.210.0",
                 "zod": "4.3.6"
             },
@@ -95,6 +95,72 @@
             },
             "engines": {
                 "node": ">=22"
+            }
+        },
+        "infra/pulumi/node_modules/@pulumi/aws": {
+            "version": "7.36.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/aws/-/aws-7.36.0.tgz",
+            "integrity": "sha512-ba90eMECkq76+l3qNPZFpqtfUR36UwZifb7ELx2Gj0edYkNo3P4eSaDAd15Cc41oIiX6p4C/KcaaeNTu3eawVw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@pulumi/pulumi": "^3.142.0",
+                "mime": "^2.0.0"
+            }
+        },
+        "infra/pulumi/node_modules/@pulumi/gcp": {
+            "version": "9.30.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/gcp/-/gcp-9.30.0.tgz",
+            "integrity": "sha512-FIPD7QKHEMv7qnrMe6mkL3pAWynKvIGqb77RbvOTL30S0yFY7Q+/O+qOl/eauMzOGxwc9H/Q8pX+XzxsW6coqg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@npmcli/package-json": "^6.2.0",
+                "@pulumi/pulumi": "^3.142.0",
+                "@types/express": "^4.16.0"
+            }
+        },
+        "infra/pulumi/node_modules/@types/express": {
+            "version": "4.17.25",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+            "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/body-parser": "*",
+                "@types/express-serve-static-core": "^4.17.33",
+                "@types/qs": "*",
+                "@types/serve-static": "^1"
+            }
+        },
+        "infra/pulumi/node_modules/@types/express-serve-static-core": {
+            "version": "4.19.9",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
+            "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*",
+                "@types/send": "*"
+            }
+        },
+        "infra/pulumi/node_modules/@types/send": {
+            "version": "0.17.6",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+            "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mime": "^1",
+                "@types/node": "*"
+            }
+        },
+        "infra/pulumi/node_modules/@types/serve-static": {
+            "version": "1.15.10",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+            "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/http-errors": "*",
+                "@types/node": "*",
+                "@types/send": "<1"
             }
         },
         "node_modules/@adraffy/ens-normalize": {
@@ -146,9 +212,9 @@
             }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.1084.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1084.0.tgz",
-            "integrity": "sha512-W8KZlbU3vL4N0rZnXqryH5Ft3fkBnGypaorZmFxBoZRMGkwtvRBGiSnNXu1/1a/j/qZNwwt6LLNBWQQysB/pRg==",
+            "version": "3.1085.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1085.0.tgz",
+            "integrity": "sha512-O0xe8sR50AYkwxlvRRsV0qytEO2dtXQTQ1CF3YBBdE5xtVkbu27H0vGa1mjQi1/+fbYM80AWEIPai5jZmXyubw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/checksums": "^3.1000.16",
@@ -1611,6 +1677,18 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/@grpc/proto-loader/node_modules/protobufjs": {
+            "version": "8.7.1",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.1.tgz",
+            "integrity": "sha512-agdGHrXNTv0IrYscJPDou/PlEJk1c/hBZ9o/B5NH2i/nSPtPqacNxzgwf1CebXxFMjMrZH5sqv9uQuw96aGt/A==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "long": "^5.3.2"
+            },
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/@grpc/reflection": {
@@ -3665,16 +3743,6 @@
                 "node": ">=14"
             }
         },
-        "node_modules/@pulumi/aws": {
-            "version": "6.83.4",
-            "resolved": "https://registry.npmjs.org/@pulumi/aws/-/aws-6.83.4.tgz",
-            "integrity": "sha512-mk3LhRJF6BdOq7VAWtrZpv+loLdaPxvbOVTESommiYXlSX87xXA8mytQCaeIXaivtpdj+xcBOJ8vz0A0Ktmw9g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@pulumi/pulumi": "^3.142.0",
-                "mime": "^2.0.0"
-            }
-        },
         "node_modules/@pulumi/cloudflare": {
             "version": "6.17.0",
             "resolved": "https://registry.npmjs.org/@pulumi/cloudflare/-/cloudflare-6.17.0.tgz",
@@ -3682,62 +3750,6 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@pulumi/pulumi": "^3.142.0"
-            }
-        },
-        "node_modules/@pulumi/gcp": {
-            "version": "8.41.1",
-            "resolved": "https://registry.npmjs.org/@pulumi/gcp/-/gcp-8.41.1.tgz",
-            "integrity": "sha512-cEuhyrys+h2HMMdAKIXT6QDjjMzQRDUDV9CytIw146lpXp2bACUr4NwMefX7LgzUW+ebs7t7YClU/sNbI3OaDw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@npmcli/package-json": "^6.2.0",
-                "@pulumi/pulumi": "^3.142.0",
-                "@types/express": "^4.16.0"
-            }
-        },
-        "node_modules/@pulumi/gcp/node_modules/@types/express": {
-            "version": "4.17.25",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
-            "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/body-parser": "*",
-                "@types/express-serve-static-core": "^4.17.33",
-                "@types/qs": "*",
-                "@types/serve-static": "^1"
-            }
-        },
-        "node_modules/@pulumi/gcp/node_modules/@types/express-serve-static-core": {
-            "version": "4.19.9",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
-            "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "@types/qs": "*",
-                "@types/range-parser": "*",
-                "@types/send": "*"
-            }
-        },
-        "node_modules/@pulumi/gcp/node_modules/@types/send": {
-            "version": "0.17.6",
-            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
-            "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/mime": "^1",
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@pulumi/gcp/node_modules/@types/serve-static": {
-            "version": "1.15.10",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
-            "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/http-errors": "*",
-                "@types/node": "*",
-                "@types/send": "<1"
             }
         },
         "node_modules/@pulumi/pulumi": {
@@ -4682,19 +4694,6 @@
             "dependencies": {
                 "@smithy/core": "^3.29.2",
                 "@smithy/types": "^4.16.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/protocol-http": {
-            "version": "5.5.7",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.5.7.tgz",
-            "integrity": "sha512-l14/j6NWpfxt5lKJnyLK3DbCVf3jSOk3wjeIVAhQBFB/35G5SRcZ4urnrhUcOh0elK9SlyyeJ7poguJnk+ux2g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/core": "^3.29.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6807,9 +6806,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.6.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
-            "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+            "version": "10.7.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
+            "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
             "dev": true,
             "license": "MIT",
             "workspaces": [
@@ -8062,7 +8061,6 @@
             ],
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "peerDependencies": {
                 "ws": "*"
             }
@@ -11381,26 +11379,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/stripe": {
-            "version": "18.5.0",
-            "resolved": "https://registry.npmjs.org/stripe/-/stripe-18.5.0.tgz",
-            "integrity": "sha512-Hp+wFiEQtCB0LlNgcFh5uVyKznpDjzyUZ+CNVEf+I3fhlYvh7rZruIg+jOwzJRCpy0ZTPMjlzm7J2/M2N6d+DA==",
-            "license": "MIT",
-            "dependencies": {
-                "qs": "^6.11.0"
-            },
-            "engines": {
-                "node": ">=12.*"
-            },
-            "peerDependencies": {
-                "@types/node": ">=12.x.x"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/sucrase": {
             "version": "3.35.1",
             "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -11791,9 +11769,9 @@
             "license": "MIT"
         },
         "node_modules/tsx": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
-            "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+            "version": "4.23.1",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+            "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12069,7 +12047,6 @@
             ],
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "@noble/curves": "1.9.1",
                 "@noble/hashes": "1.8.0",
@@ -12095,7 +12072,6 @@
             "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/wevm"
             },
@@ -12124,7 +12100,6 @@
             ],
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "@adraffy/ens-normalize": "^1.11.0",
                 "@noble/ciphers": "^1.3.0",
@@ -12593,8 +12568,8 @@
                 "@grpc/proto-loader": "^0.8.1",
                 "@modelcontextprotocol/sdk": "^1.29.0",
                 "@omnigraph/openapi": "^0.109.51",
-                "@smithy/protocol-http": "^5.1.2",
-                "@smithy/signature-v4": "^5.1.2",
+                "@smithy/protocol-http": "^5.5.8",
+                "@smithy/signature-v4": "^5.6.4",
                 "clawql-auth": "7.0.0",
                 "clawql-core": "7.0.0",
                 "effect": "^3.21.4",
@@ -12615,13 +12590,65 @@
                 "node": ">=22"
             }
         },
+        "packages/clawql-api/node_modules/@smithy/core": {
+            "version": "3.29.3",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
+            "integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/clawql-api/node_modules/@smithy/protocol-http": {
+            "version": "5.5.8",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.5.8.tgz",
+            "integrity": "sha512-SyFyL/ajuzJ79W+BpseFFbSz8/Rwj+QGqUlayeZE0jS2aCcjzV5tJBcbHgfypvSHpe7s2JmUHZmfpICaxwEs5g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.29.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/clawql-api/node_modules/@smithy/signature-v4": {
+            "version": "5.6.4",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.4.tgz",
+            "integrity": "sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.29.3",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/clawql-api/node_modules/@smithy/types": {
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+            "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "packages/clawql-auth": {
             "version": "7.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-js": "^5.2.0",
-                "@smithy/protocol-http": "^5.1.2",
-                "@smithy/signature-v4": "^5.1.2"
+                "@smithy/protocol-http": "^5.5.8",
+                "@smithy/signature-v4": "^5.6.4"
             },
             "devDependencies": {
                 "@types/node": "^26.1.1",
@@ -12631,6 +12658,58 @@
             },
             "engines": {
                 "node": ">=22"
+            }
+        },
+        "packages/clawql-auth/node_modules/@smithy/core": {
+            "version": "3.29.3",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
+            "integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/clawql-auth/node_modules/@smithy/protocol-http": {
+            "version": "5.5.8",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.5.8.tgz",
+            "integrity": "sha512-SyFyL/ajuzJ79W+BpseFFbSz8/Rwj+QGqUlayeZE0jS2aCcjzV5tJBcbHgfypvSHpe7s2JmUHZmfpICaxwEs5g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.29.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/clawql-auth/node_modules/@smithy/signature-v4": {
+            "version": "5.6.4",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.4.tgz",
+            "integrity": "sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.29.3",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/clawql-auth/node_modules/@smithy/types": {
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+            "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "packages/clawql-automation": {
@@ -12821,7 +12900,8 @@
                 "clawql-core": "7.0.0",
                 "effect": "^3.21.4",
                 "pg": "^8.21.0",
-                "stripe": "^18.5.0",
+                "stripe": "^22.3.1",
+                "viem": "^2.54.0",
                 "zod": "^4.3.6"
             },
             "bin": {
@@ -12837,7 +12917,25 @@
                 "node": ">=22"
             },
             "optionalDependencies": {
-                "mppx": "^0.8.6"
+                "mppx": "^0.8.6",
+                "viem": "^2.55.1"
+            }
+        },
+        "packages/clawql-payments/node_modules/stripe": {
+            "version": "22.3.1",
+            "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.3.1.tgz",
+            "integrity": "sha512-6XSLN0KK0IdfXqDHqMg6CDoO3eO62ye9dhzw0fZp55AUOzHR1YRJOqYHTsuCi4QJ4Ni/usEmXtq69c9ghKDmYw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
             }
         },
         "packages/clawql-release": {
@@ -12887,7 +12985,7 @@
                 "@grpc/proto-loader": "^0.8.1",
                 "@grpc/reflection": "^1.0.4",
                 "google-proto-files": "^5.0.2",
-                "protobufjs": "^8.7.0"
+                "protobufjs": "^8.7.1"
             },
             "devDependencies": {
                 "@modelcontextprotocol/sdk": "^1.27.1",
@@ -12909,6 +13007,18 @@
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
+            }
+        },
+        "packages/mcp-grpc-transport/node_modules/protobufjs": {
+            "version": "8.7.1",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.1.tgz",
+            "integrity": "sha512-agdGHrXNTv0IrYscJPDou/PlEJk1c/hBZ9o/B5NH2i/nSPtPqacNxzgwf1CebXxFMjMrZH5sqv9uQuw96aGt/A==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "long": "^5.3.2"
+            },
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "packages/mcp-grpc-transport/node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
         "release:manifest": "node scripts/release/build-release-manifest.mjs"
     },
     "dependencies": {
-        "@aws-sdk/client-s3": "^3.1084.0",
+        "@aws-sdk/client-s3": "^3.1085.0",
         "@graphql-mesh/utils": "^0.104.36",
         "@grpc/grpc-js": "^1.14.4",
         "@grpc/proto-loader": "^0.8.1",
@@ -162,9 +162,9 @@
         "@types/pg": "^8.20.0",
         "@types/sql.js": "^1.4.11",
         "@vitest/coverage-v8": "^4.1.7",
-        "eslint": "^10.6.0",
+        "eslint": "^10.7.0",
         "prettier": "^3.9.3",
-        "tsx": "^4.23.0",
+        "tsx": "^4.23.1",
         "turbo": "^2.10.3",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.62.1",
@@ -184,13 +184,13 @@
         "picomatch": "4.0.4",
         "postcss": "8.5.10",
         "qs": "6.15.2",
-        "protobufjs": "8.7.0",
+        "protobufjs": "8.7.1",
         "google-proto-files": {
-            "protobufjs": "8.7.0"
+            "protobufjs": "8.7.1"
         },
         "mcp-grpc-transport": {
             "google-proto-files": {
-                "protobufjs": "8.7.0"
+                "protobufjs": "8.7.1"
             }
         },
         "ws": "8.21.0",

--- a/packages/clawql-api/package.json
+++ b/packages/clawql-api/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "@aws-crypto/sha256-js": "^5.2.0",
     "@graphql-mesh/utils": "^0.104.36",
-    "@smithy/protocol-http": "^5.1.2",
-    "@smithy/signature-v4": "^5.1.2",
+    "@smithy/protocol-http": "^5.5.8",
+    "@smithy/signature-v4": "^5.6.4",
     "@grpc/grpc-js": "^1.14.4",
     "@grpc/proto-loader": "^0.8.1",
     "@omnigraph/openapi": "^0.109.51",

--- a/packages/clawql-auth/package.json
+++ b/packages/clawql-auth/package.json
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "@aws-crypto/sha256-js": "^5.2.0",
-    "@smithy/protocol-http": "^5.1.2",
-    "@smithy/signature-v4": "^5.1.2"
+    "@smithy/protocol-http": "^5.5.8",
+    "@smithy/signature-v4": "^5.6.4"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/packages/clawql-payments/package.json
+++ b/packages/clawql-payments/package.json
@@ -64,12 +64,13 @@
     "clawql-api": "7.0.0",
     "clawql-core": "7.0.0",
     "effect": "^3.21.4",
-    "stripe": "^18.5.0",
     "pg": "^8.21.0",
+    "stripe": "^22.3.1",
     "zod": "^4.3.6"
   },
   "optionalDependencies": {
-    "mppx": "^0.8.6"
+    "mppx": "^0.8.6",
+    "viem": "^2.55.1"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/packages/mcp-grpc-transport/package.json
+++ b/packages/mcp-grpc-transport/package.json
@@ -45,7 +45,7 @@
     "@grpc/proto-loader": "^0.8.1",
     "@grpc/reflection": "^1.0.4",
     "google-proto-files": "^5.0.2",
-    "protobufjs": "^8.7.0"
+    "protobufjs": "^8.7.1"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
@@ -56,7 +56,7 @@
   },
   "overrides": {
     "google-proto-files": {
-      "protobufjs": "8.7.0"
+      "protobufjs": "8.7.1"
     }
   },
   "scripts": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pulled latest `main` and consolidated **16 of 17** open Dependabot PRs into a single branch (same approach as #466).

Build, lint, and tests run locally after the merge (`694` passed; `1` failure in `server.test.ts` also reproduces on current `main` — ouroboros tool gating, unrelated to deps).

## npm updates

| Package | From → To | Dependabot |
|---------|-----------|------------|
| `@aws-sdk/client-s3` | 3.1084.0 → 3.1085.0 | #645 |
| `@smithy/protocol-http` | 5.5.7 → 5.5.8 | #652 |
| `@smithy/signature-v4` | 5.6.3 → 5.6.4 | #650 |
| `protobufjs` | 8.7.0 → 8.7.1 | #637 |
| `stripe` | 18.5.0 → 22.3.1 | #647 |
| `@pulumi/aws` | 6.83.x → 7.36.0 | #640 |
| `@pulumi/gcp` | 8.41.x → 9.29.0 | #648 |
| `eslint` | 10.6.0 → 10.7.0 | #649 |
| `tsx` | 4.23.0 → 4.23.1 | #642 |

**Follow-up for stripe 22 / mppx:** added `viem` as an optional dependency in `clawql-payments` so `mppx` peer resolution stays stable in the consolidated lockfile.

## GitHub Actions updates

| Action | From → To | Dependabot |
|--------|-----------|------------|
| `github/codeql-action/*` | 4.36.3 → 4.37.0 | #641, #643, #646 |
| `trufflesecurity/trufflehog` | 3.95.8 → 3.95.9 | #644 |
| `google-github-actions/auth` | v2 → v3 | #639 |
| `google-github-actions/setup-gcloud` | v2 → v3 | #636 |
| `actions/download-artifact` | v7 → v8 | #638 |

## Deferred (not included)

- **#651 `typescript` 6.0.3 → 7.0.2** — breaks `tsup` DTS generation and conflicts with `typescript-eslint` / `@pulumi/pulumi` peer ranges. Leave open until toolchain catches up.

## Supersedes

#636, #637, #638, #639, #640, #641, #642, #643, #644, #645, #646, #647, #648, #649, #650, #652

## Test plan

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test` (694 passed; 1 pre-existing `server.test.ts` failure on `main`)
- [ ] CI green on this PR
- [ ] Close superseded Dependabot PRs after merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f208b-fa18-751b-afb0-9f88ff2c39c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f208b-fa18-751b-afb0-9f88ff2c39c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

