### PR TITLE
feat(ouroboros): native Effect measureDrift via EventStoreService

### DIFF
--- a/packages/clawql-ouroboros/src/effect/ouroboros-tools-effect.test.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-tools-effect.test.ts
@@ -1,8 +1,15 @@
 import { Effect, Layer } from "effect";
 import { describe, expect, it } from "vitest";
+import { InMemoryEventStore } from "../in-memory-event-store.js";
 import type { OuroborosContext } from "../mcp-hooks.js";
+import type { Seed } from "../seed.js";
 import { OuroborosContextService } from "./ouroboros-context-service.js";
-import { executeCreateSeedFromDocumentEffect } from "./ouroboros-tools-effect.js";
+import { OuroborosEventStoreService } from "./ouroboros-event-store-service.js";
+import { ouroborosFromPromise } from "./ouroboros-effect-utils.js";
+import {
+  executeCreateSeedFromDocumentEffect,
+  executeMeasureDriftEffect,
+} from "./ouroboros-tools-effect.js";
 import { OuroborosToolsService, ouroborosToolsLiveLayer } from "./ouroboros-tools-service.js";
 
 const stubContext = {} as OuroborosContext;
@@ -14,6 +21,52 @@ const testLayer = Layer.mergeAll(
   ),
   ouroborosToolsLiveLayer()
 );
+
+function minimalSeed(seedId: string): Seed {
+  return {
+    goal: "Ship secure GitHub release workflow",
+    task_type: "analysis",
+    brownfield_context: {
+      project_type: "greenfield",
+      context_references: [],
+      existing_patterns: [],
+      existing_dependencies: [],
+    },
+    constraints: ["No secrets in git"],
+    acceptance_criteria: [],
+    ontology_schema: {
+      name: "o",
+      description: "d",
+      fields: [
+        { name: "workflow", field_type: "string", description: "Actions workflow", required: true },
+      ],
+    },
+    evaluation_principles: [],
+    exit_conditions: [],
+    metadata: {
+      seed_id: seedId,
+      version: "1.0.0",
+      created_at: new Date(),
+      ambiguity_score: 0.1,
+      interview_id: null,
+      parent_seed_id: null,
+    },
+  };
+}
+
+function eventStoreTestLayer(store: InMemoryEventStore) {
+  return Layer.mergeAll(
+    Layer.succeed(
+      OuroborosEventStoreService,
+      OuroborosEventStoreService.of({
+        getStore: () => store,
+        append: (event) => ouroborosFromPromise(() => store.append(event)),
+        getLineage: (seedId) => ouroborosFromPromise(() => store.getLineage(seedId)),
+      })
+    ),
+    ouroborosToolsLiveLayer()
+  );
+}
 
 describe("executeCreateSeedFromDocumentEffect", () => {
   it("builds a seed via OuroborosToolsService", async () => {
@@ -45,5 +98,96 @@ describe("executeCreateSeedFromDocumentEffect", () => {
       }).pipe(Effect.provide(testLayer))
     );
     expect(result).toMatchObject({ success: true });
+  });
+});
+
+describe("executeMeasureDriftEffect", () => {
+  it("persists drift_measured via OuroborosEventStoreService", async () => {
+    const store = new InMemoryEventStore();
+    const root = minimalSeed("seed-drift-effect");
+    await store.append({
+      type: "generation_completed",
+      seed_id: "seed-drift-effect",
+      data: {
+        generation_number: 1,
+        seed: root,
+        execution_output: "ok",
+        evaluation_summary: {
+          final_approved: true,
+          score: 0.9,
+          ac_results: [{ ac_index: 0, ac_content: "pass", passed: true, evidence: "ok" }],
+        },
+        phase: "completed",
+        ontology_schema: root.ontology_schema,
+      },
+    });
+
+    const res = await Effect.runPromise(
+      executeMeasureDriftEffect({
+        seedId: "seed-drift-effect",
+        currentOutput: "GitHub Actions workflow without secrets in git",
+        constraintViolations: [],
+        currentConcepts: ["workflow"],
+        persistEvent: true,
+      }).pipe(Effect.provide(eventStoreTestLayer(store)))
+    );
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.report.combined_drift).toBeTypeOf("number");
+    }
+    expect(store.snapshot("seed-drift-effect").some((e) => e.type === "drift_measured")).toBe(true);
+  });
+
+  it("skips persist when persistEvent is false", async () => {
+    const store = new InMemoryEventStore();
+    const root = minimalSeed("seed-drift-nopersist");
+    await store.append({
+      type: "generation_completed",
+      seed_id: "seed-drift-nopersist",
+      data: {
+        generation_number: 1,
+        seed: root,
+        execution_output: "ok",
+        evaluation_summary: {
+          final_approved: true,
+          score: 0.9,
+          ac_results: [],
+        },
+        phase: "completed",
+        ontology_schema: root.ontology_schema,
+      },
+    });
+
+    const res = await Effect.runPromise(
+      executeMeasureDriftEffect({
+        seedId: "seed-drift-nopersist",
+        currentOutput: "GitHub Actions workflow",
+        constraintViolations: [],
+        currentConcepts: ["workflow"],
+        persistEvent: false,
+      }).pipe(Effect.provide(eventStoreTestLayer(store)))
+    );
+
+    expect(res.ok).toBe(true);
+    expect(store.snapshot("seed-drift-nopersist").some((e) => e.type === "drift_measured")).toBe(
+      false
+    );
+  });
+
+  it("returns ok:false when baseline cannot be resolved", async () => {
+    const store = new InMemoryEventStore();
+    const res = await Effect.runPromise(
+      executeMeasureDriftEffect({
+        currentOutput: "some output",
+        constraintViolations: [],
+        currentConcepts: [],
+        persistEvent: true,
+      }).pipe(Effect.provide(eventStoreTestLayer(store)))
+    );
+    expect(res).toEqual({
+      ok: false,
+      error: "Provide `seed`, `seedId` with lineage events, or `seedContent`",
+    });
   });
 });

--- a/packages/clawql-ouroboros/src/effect/ouroboros-tools-effect.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-tools-effect.ts
@@ -1,5 +1,7 @@
 import { Effect } from "effect";
 import type { z } from "zod";
+import { driftReportPayload, measureDrift } from "../drift.js";
+import { resolveBaselineSeed } from "../glue/resolve-baseline-seed.js";
 import type {
   CreateSeedFromDocumentSchema,
   GetLineageStatusSchema,
@@ -58,21 +60,64 @@ export function executeGetLineageStatusEffect(
   });
 }
 
+export type MeasureDriftResult = Awaited<
+  ReturnType<typeof import("../mcp-hooks.js").ouroborosMcpTools.measureDrift.handler>
+>;
+
+function measureDriftFailure(err: unknown): MeasureDriftResult {
+  if (err instanceof OuroborosError) {
+    const cause = err.cause;
+    return {
+      ok: false,
+      error: cause instanceof Error ? cause.message : cause != null ? String(cause) : err.reason,
+    };
+  }
+  return {
+    ok: false,
+    error: err instanceof Error ? err.message : String(err),
+  };
+}
+
 export function executeMeasureDriftEffect(
   input: z.infer<typeof MeasureDriftSchema>
-): Effect.Effect<
-  Awaited<ReturnType<typeof import("../mcp-hooks.js").ouroborosMcpTools.measureDrift.handler>>,
-  OuroborosError,
-  OuroborosContextService
-> {
+): Effect.Effect<MeasureDriftResult, never, OuroborosEventStoreService> {
   return Effect.gen(function* () {
-    const ctxSvc = yield* OuroborosContextService;
-    const ctx = ctxSvc.getContext();
-    return yield* ouroborosFromPromise(async () => {
-      const { ouroborosMcpTools } = await import("../mcp-hooks.js");
-      return ouroborosMcpTools.measureDrift.handler(input, ctx);
+    const es = yield* OuroborosEventStoreService;
+    const baselineSeed = yield* ouroborosFromPromise(() =>
+      resolveBaselineSeed(input, es.getStore())
+    );
+    if (!baselineSeed) {
+      return {
+        ok: false as const,
+        error: "Provide `seed`, `seedId` with lineage events, or `seedContent`",
+      };
+    }
+
+    const report = measureDrift({
+      baselineSeed,
+      currentOutput: input.currentOutput,
+      constraintViolations: input.constraintViolations,
+      currentConcepts: input.currentConcepts,
     });
-  });
+
+    const rootSeedId = input.seedId ?? baselineSeed.metadata.seed_id;
+    const payload = driftReportPayload(report, {
+      generation_number: input.generationNumber ?? null,
+      constraint_violations: input.constraintViolations ?? [],
+      current_concepts: input.currentConcepts ?? [],
+    });
+
+    if (input.persistEvent !== false && input.seedId) {
+      yield* es.append({
+        type: "drift_measured",
+        seed_id: input.seedId,
+        data: payload,
+        timestamp: new Date(),
+      });
+    }
+
+    return { ok: true as const, report: payload, seedId: rootSeedId };
+  }).pipe(Effect.catchAll((err) => Effect.succeed(measureDriftFailure(err))));
 }
 
 export function executeProposeSeedRevisionFromEvalEffect(

--- a/packages/clawql-ouroboros/src/effect/ouroboros-tools-service.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-tools-service.ts
@@ -56,8 +56,8 @@ export class OuroborosToolsService extends Context.Tag("clawql/OuroborosToolsSer
       input: z.infer<typeof MeasureDriftSchema>
     ) => Effect.Effect<
       Awaited<ReturnType<typeof import("../mcp-hooks.js").ouroborosMcpTools.measureDrift.handler>>,
-      OuroborosError,
-      OuroborosContextService
+      never,
+      OuroborosEventStoreService
     >;
     readonly proposeSeedRevisionFromEval: (
       input: z.infer<typeof ProposeSeedRevisionFromEvalSchema>

--- a/packages/clawql-ouroboros/src/glue/resolve-baseline-seed.ts
+++ b/packages/clawql-ouroboros/src/glue/resolve-baseline-seed.ts
@@ -1,0 +1,56 @@
+import { v4 as uuidv4 } from "uuid";
+import type { EventStore } from "../interfaces.js";
+import { SeedSchema, type Seed } from "../seed.js";
+
+export type ResolveBaselineSeedInput = {
+  seed?: unknown;
+  seedId?: string;
+  seedContent?: string;
+};
+
+/** Resolve baseline Seed for drift measurement from inline seed, lineage, or free-form content. */
+export async function resolveBaselineSeed(
+  input: ResolveBaselineSeedInput,
+  eventStore: EventStore
+): Promise<Seed | null> {
+  if (input.seed !== undefined) {
+    return SeedSchema.parse(input.seed);
+  }
+
+  if (input.seedId) {
+    const lineage = await eventStore.getLineage(input.seedId);
+    if (lineage.generations.length > 0) {
+      return lineage.generations[0]!.seed;
+    }
+  }
+
+  if (input.seedContent?.trim()) {
+    const goalMatch = input.seedContent.match(/goal:\s*["']?([^\n"']+)/i);
+    const goal = goalMatch?.[1]?.trim() || "Unspecified goal from seedContent";
+    return SeedSchema.parse({
+      goal,
+      task_type: "analysis",
+      brownfield_context: {
+        project_type: "brownfield",
+        context_references: [],
+        existing_patterns: [],
+        existing_dependencies: [],
+      },
+      constraints: [],
+      acceptance_criteria: [],
+      ontology_schema: { name: "InlineSeed", description: goal, fields: [] },
+      evaluation_principles: [],
+      exit_conditions: [],
+      metadata: {
+        seed_id: input.seedId ?? `seed_inline_${uuidv4().slice(0, 8)}`,
+        version: "1.0.0",
+        created_at: new Date(),
+        ambiguity_score: 0.15,
+        interview_id: null,
+        parent_seed_id: null,
+      },
+    });
+  }
+
+  return null;
+}

--- a/packages/clawql-ouroboros/src/mcp-hooks.ts
+++ b/packages/clawql-ouroboros/src/mcp-hooks.ts
@@ -4,6 +4,7 @@ import { SeedSchema, type Seed } from "./seed.js";
 import { EvolutionaryLoop } from "./evolutionary-loop.js";
 import type { EventStore } from "./interfaces.js";
 import { driftReportPayload, measureDrift } from "./drift.js";
+import { resolveBaselineSeed } from "./glue/resolve-baseline-seed.js";
 import {
   langfuseEvalAutoApplyEnabled,
   loadLatestSeedFromLineage,
@@ -197,54 +198,6 @@ function inferOntologyFields(
     ...candidates,
   ];
 }
-
-async function resolveBaselineSeed(
-  input: z.infer<typeof MeasureDriftSchema>,
-  eventStore: EventStore
-): Promise<Seed | null> {
-  if (input.seed !== undefined) {
-    return SeedSchema.parse(input.seed);
-  }
-
-  if (input.seedId) {
-    const lineage = await eventStore.getLineage(input.seedId);
-    if (lineage.generations.length > 0) {
-      return lineage.generations[0].seed;
-    }
-  }
-
-  if (input.seedContent?.trim()) {
-    const goalMatch = input.seedContent.match(/goal:\s*["']?([^\n"']+)/i);
-    const goal = goalMatch?.[1]?.trim() || "Unspecified goal from seedContent";
-    return SeedSchema.parse({
-      goal,
-      task_type: "analysis",
-      brownfield_context: {
-        project_type: "brownfield",
-        context_references: [],
-        existing_patterns: [],
-        existing_dependencies: [],
-      },
-      constraints: [],
-      acceptance_criteria: [],
-      ontology_schema: { name: "InlineSeed", description: goal, fields: [] },
-      evaluation_principles: [],
-      exit_conditions: [],
-      metadata: {
-        seed_id: input.seedId ?? `seed_inline_${uuidv4().slice(0, 8)}`,
-        version: "1.0.0",
-        created_at: new Date(),
-        ambiguity_score: 0.15,
-        interview_id: null,
-        parent_seed_id: null,
-      },
-    });
-  }
-
-  return null;
-}
-
-// ---------------------------------------------------------------------------
 
 export const ouroborosMcpTools = {
   createSeedFromDocument: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Natively implements `ouroboros_measure_drift` on Effect services instead of bridging through the mcp-hooks Promise handler.

- Extracts `resolveBaselineSeed` to `glue/resolve-baseline-seed.ts` (shared by mcp-hooks + Effect)
- `executeMeasureDriftEffect` uses `OuroborosEventStoreService` for baseline lineage lookup and optional `drift_measured` append
- Preserves MCP result shape (`ok` / `report` / `seedId` or `error`)
- Adds Effect unit tests for persist / no-persist / missing baseline

Part of Ouroboros Effect follow-ups (slice 1 of 3).

## Test plan

- [x] `npm run build -w clawql-ouroboros`
- [x] `npx vitest run packages/clawql-ouroboros/src/effect/ouroboros-tools-effect.test.ts packages/clawql-ouroboros/src/mcp-hooks.test.ts`
- [x] `npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

