### PR TITLE
feat(ouroboros): OuroborosEnginesService + shared engines factory

### DIFF
--- a/packages/clawql-ouroboros/src/effect/index.ts
+++ b/packages/clawql-ouroboros/src/effect/index.ts
@@ -6,6 +6,14 @@ export {
   ouroborosEventStoreLiveLayer,
 } from "./ouroboros-event-store-service.js";
 export {
+  OuroborosEnginesService,
+  ouroborosEnginesLiveLayer,
+  getOrCreateOuroborosEngines,
+  resetOuroborosEnginesForTests,
+  buildOuroborosToolBridgeFromPluginDeps,
+  type OuroborosEngines,
+} from "./ouroboros-engines-service.js";
+export {
   OuroborosLoopService,
   ouroborosLoopLiveLayer,
   executeRunEvolutionaryLoopFromInputEffect,

--- a/packages/clawql-ouroboros/src/effect/ouroboros-effect-runtime.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-effect-runtime.ts
@@ -13,6 +13,7 @@ import {
   ouroborosEventStoreLiveLayer,
 } from "./ouroboros-event-store-service.js";
 import { OuroborosError } from "./ouroboros-errors.js";
+import { OuroborosEnginesService, ouroborosEnginesLiveLayer } from "./ouroboros-engines-service.js";
 import { OuroborosLoopService, ouroborosLoopLiveLayer } from "./ouroboros-loop-service.js";
 import { OuroborosPollerService, ouroborosPollerLiveLayer } from "./ouroboros-poller-service.js";
 import { OuroborosToolsService, ouroborosToolsLiveLayer } from "./ouroboros-tools-service.js";
@@ -21,6 +22,7 @@ export type OuroborosServices =
   | OuroborosContextService
   | OuroborosToolsService
   | OuroborosEventStoreService
+  | OuroborosEnginesService
   | OuroborosLoopService
   | OuroborosPollerService;
 
@@ -28,6 +30,7 @@ export type OuroborosServices =
 export function ouroborosServicesLiveLayer(): Layer.Layer<OuroborosServices> {
   return Layer.mergeAll(
     ouroborosEventStoreLiveLayer(),
+    ouroborosEnginesLiveLayer(),
     ouroborosLoopLiveLayer(),
     ouroborosPollerLiveLayer(),
     ouroborosContextLiveLayer(),

--- a/packages/clawql-ouroboros/src/effect/ouroboros-engines-service.test.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-engines-service.test.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect";
 import { afterEach, describe, expect, it } from "vitest";
 import type { Seed } from "../seed.js";
+import { configureOuroborosPluginDeps, resetOuroborosPluginDepsForTests } from "../plugin/deps.js";
 import {
   OuroborosEnginesService,
   ouroborosEnginesLiveLayer,
@@ -36,9 +37,15 @@ function minimalSeed(seedId: string): Seed {
 describe("OuroborosEnginesService", () => {
   afterEach(() => {
     resetOuroborosEnginesForTests();
+    resetOuroborosPluginDepsForTests();
   });
 
   it("provides default engines and execute/evaluate Effect methods", async () => {
+    configureOuroborosPluginDeps({
+      search: async () => ({ content: [{ type: "text", text: "[]" }] }),
+      execute: async () => ({ content: [{ type: "text", text: '{"ok":true}' }] }),
+    });
+
     const seed = minimalSeed("seed-engines");
     const result = await Effect.runPromise(
       Effect.gen(function* () {

--- a/packages/clawql-ouroboros/src/effect/ouroboros-engines-service.test.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-engines-service.test.ts
@@ -1,0 +1,59 @@
+import { Effect } from "effect";
+import { afterEach, describe, expect, it } from "vitest";
+import type { Seed } from "../seed.js";
+import {
+  OuroborosEnginesService,
+  ouroborosEnginesLiveLayer,
+  resetOuroborosEnginesForTests,
+} from "./ouroboros-engines-service.js";
+
+function minimalSeed(seedId: string): Seed {
+  return {
+    goal: "engines service test",
+    task_type: "analysis",
+    brownfield_context: {
+      project_type: "greenfield",
+      context_references: [],
+      existing_patterns: [],
+      existing_dependencies: [],
+    },
+    constraints: [],
+    acceptance_criteria: ["must produce output"],
+    ontology_schema: { name: "o", description: "d", fields: [] },
+    evaluation_principles: [],
+    exit_conditions: [],
+    metadata: {
+      seed_id: seedId,
+      version: "1.0.0",
+      created_at: new Date(),
+      ambiguity_score: 0.1,
+      interview_id: null,
+      parent_seed_id: null,
+    },
+  };
+}
+
+describe("OuroborosEnginesService", () => {
+  afterEach(() => {
+    resetOuroborosEnginesForTests();
+  });
+
+  it("provides default engines and execute/evaluate Effect methods", async () => {
+    const seed = minimalSeed("seed-engines");
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const engines = yield* OuroborosEnginesService;
+        const output = yield* engines.execute(seed);
+        const evaluation = yield* engines.evaluate(output, seed);
+        return { output, evaluation, bundle: engines.getEngines() };
+      }).pipe(Effect.provide(ouroborosEnginesLiveLayer()))
+    );
+
+    expect(result.output).toContain("clawql-ouroboros-default-execute");
+    expect(result.evaluation.final_approved).toBeTypeOf("boolean");
+    expect(result.bundle.wonder).toBeDefined();
+    expect(result.bundle.reflect).toBeDefined();
+    expect(result.bundle.execute).toBeDefined();
+    expect(result.bundle.evaluate).toBeDefined();
+  });
+});

--- a/packages/clawql-ouroboros/src/effect/ouroboros-engines-service.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-engines-service.ts
@@ -1,0 +1,114 @@
+import { Context, Effect, Layer } from "effect";
+import type {
+  EngineCallContext,
+  EvaluationSummary,
+  Evaluator,
+  Executor,
+  ReflectEngine,
+  ReflectOutput,
+  WonderEngine,
+  WonderOutput,
+} from "../interfaces.js";
+import type { Seed } from "../seed.js";
+import {
+  createDefaultOuroborosEngines,
+  type OuroborosToolBridge,
+} from "../glue/default-engines.js";
+import { getOuroborosPluginDeps } from "../plugin/deps.js";
+import { OuroborosError } from "./ouroboros-errors.js";
+import { ouroborosFromPromise } from "./ouroboros-effect-utils.js";
+
+export type OuroborosEngines = {
+  wonder: WonderEngine;
+  reflect: ReflectEngine;
+  execute: Executor;
+  evaluate: Evaluator;
+};
+
+let enginesCache: OuroborosEngines | null = null;
+
+/** Build tool bridge from plugin Search/Execute deps. */
+export function buildOuroborosToolBridgeFromPluginDeps(): OuroborosToolBridge {
+  const { search, execute } = getOuroborosPluginDeps();
+  return {
+    search: async (query, limit) => {
+      const r = await search({ query, limit });
+      return { content: [...r.content] };
+    },
+    execute: async (params) => {
+      const r = await execute(params);
+      return { content: [...r.content] };
+    },
+  };
+}
+
+/** Shared default engines singleton (search/execute deps must be configured). */
+export function getOrCreateOuroborosEngines(): OuroborosEngines {
+  if (!enginesCache) {
+    enginesCache = createDefaultOuroborosEngines(buildOuroborosToolBridgeFromPluginDeps());
+  }
+  return enginesCache;
+}
+
+/** Vitest: clear cached engines so dep changes apply. */
+export function resetOuroborosEnginesForTests(): void {
+  enginesCache = null;
+}
+
+/** Effect service for Wonder / Reflect / Executor / Evaluator engines. */
+export class OuroborosEnginesService extends Context.Tag("clawql/OuroborosEnginesService")<
+  OuroborosEnginesService,
+  {
+    readonly getEngines: () => OuroborosEngines;
+    readonly wonder: (
+      seed: Seed,
+      previousEvaluation?: EvaluationSummary,
+      ctx?: EngineCallContext
+    ) => Effect.Effect<WonderOutput, OuroborosError>;
+    readonly reflect: (
+      seed: Seed,
+      executionOutput: string,
+      evaluation: EvaluationSummary,
+      wonder: WonderOutput,
+      ctx?: EngineCallContext
+    ) => Effect.Effect<ReflectOutput, OuroborosError>;
+    readonly execute: (
+      seed: Seed,
+      ctx?: EngineCallContext
+    ) => Effect.Effect<string, OuroborosError>;
+    readonly evaluate: (
+      executionOutput: string,
+      seed: Seed,
+      ctx?: EngineCallContext
+    ) => Effect.Effect<EvaluationSummary, OuroborosError>;
+  }
+>() {}
+
+export function ouroborosEnginesLiveLayer(): Layer.Layer<OuroborosEnginesService> {
+  return Layer.succeed(
+    OuroborosEnginesService,
+    OuroborosEnginesService.of({
+      getEngines: () => getOrCreateOuroborosEngines(),
+      wonder: (seed, previousEvaluation, ctx) =>
+        ouroborosFromPromise(() =>
+          getOrCreateOuroborosEngines().wonder.wonder(seed, previousEvaluation, ctx)
+        ),
+      reflect: (seed, executionOutput, evaluation, wonder, ctx) =>
+        ouroborosFromPromise(() =>
+          getOrCreateOuroborosEngines().reflect.reflect(
+            seed,
+            executionOutput,
+            evaluation,
+            wonder,
+            ctx
+          )
+        ),
+      execute: (seed, ctx) =>
+        ouroborosFromPromise(() => getOrCreateOuroborosEngines().execute.execute(seed, ctx)),
+      evaluate: (executionOutput, seed, ctx) =>
+        ouroborosFromPromise(() =>
+          getOrCreateOuroborosEngines().evaluate.evaluate(executionOutput, seed, ctx)
+        ),
+    })
+  );
+}

--- a/packages/clawql-ouroboros/src/glue/build-evolutionary-loop.ts
+++ b/packages/clawql-ouroboros/src/glue/build-evolutionary-loop.ts
@@ -1,7 +1,6 @@
 import { EvolutionaryLoop } from "../evolutionary-loop.js";
-import { createDefaultOuroborosEngines } from "./default-engines.js";
 import { getOrCreateOuroborosEventStore } from "./create-event-store.js";
-import { getOuroborosPluginDeps } from "../plugin/deps.js";
+import { getOrCreateOuroborosEngines } from "../effect/ouroboros-engines-service.js";
 import { createModelEscalationRouter, loadModelEscalationConfig } from "clawql-inference";
 
 /** Build loop + shared event store (search/execute deps must be configured). */
@@ -9,18 +8,8 @@ export function buildEvolutionaryLoop(): {
   loop: EvolutionaryLoop;
   eventStore: ReturnType<typeof getOrCreateOuroborosEventStore>;
 } {
-  const { search, execute } = getOuroborosPluginDeps();
   const eventStore = getOrCreateOuroborosEventStore();
-  const engines = createDefaultOuroborosEngines({
-    search: async (query, limit) => {
-      const r = await search({ query, limit });
-      return { content: [...r.content] };
-    },
-    execute: async (params) => {
-      const r = await execute(params);
-      return { content: [...r.content] };
-    },
-  });
+  const engines = getOrCreateOuroborosEngines();
   const router = createModelEscalationRouter(loadModelEscalationConfig());
   const loop = new EvolutionaryLoop(
     eventStore,

--- a/packages/clawql-ouroboros/src/plugin/context.ts
+++ b/packages/clawql-ouroboros/src/plugin/context.ts
@@ -2,6 +2,7 @@ import { resetOuroborosEventStoreForTests } from "../glue/create-event-store.js"
 import { buildEvolutionaryLoop } from "../glue/build-evolutionary-loop.js";
 import { closeOuroborosPgPool, registerOuroborosPoolShutdownHooks } from "../glue/postgres-pool.js";
 import type { OuroborosContext } from "../mcp-hooks.js";
+import { resetOuroborosEnginesForTests } from "../effect/ouroboros-engines-service.js";
 import { resetOuroborosLoopDepsForTests } from "../effect/ouroboros-loop-service.js";
 
 let ctxCache: OuroborosContext | null = null;
@@ -27,6 +28,7 @@ export function resetOuroborosContextForTests(): void {
   ctxCache = null;
   shutdownHooksRegistered = false;
   resetOuroborosEventStoreForTests();
+  resetOuroborosEnginesForTests();
   resetOuroborosLoopDepsForTests();
   void closeOuroborosPgPool();
 }

--- a/packages/clawql-ouroboros/src/plugin/index.ts
+++ b/packages/clawql-ouroboros/src/plugin/index.ts
@@ -14,11 +14,13 @@ export { getOuroborosContext, resetOuroborosContextForTests } from "./context.js
 export {
   OuroborosContextService,
   OuroborosError,
+  OuroborosEnginesService,
   OuroborosEventStoreService,
   OuroborosLoopService,
   OuroborosPollerService,
   OuroborosToolsService,
   ouroborosContextLiveLayer,
+  ouroborosEnginesLiveLayer,
   ouroborosEventStoreLiveLayer,
   ouroborosLoopLiveLayer,
   ouroborosPollerLiveLayer,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Introduces `OuroborosEnginesService` as an Effect capability Tag for Wonder / Reflect / Executor / Evaluator.

- Shared `getOrCreateOuroborosEngines()` factory (plugin Search/Execute bridge)
- Effect methods wrap engine IO via `ouroborosFromPromise`
- `buildEvolutionaryLoop()` consumes the shared engines cache
- Merged into `ouroborosServicesLiveLayer`; test reset clears engines cache

Part of Ouroboros Effect follow-ups (slice 2 of 3).

## Test plan

- [x] `npm run build -w clawql-ouroboros`
- [x] `npx vitest run packages/clawql-ouroboros/src`
- [x] `npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

