### PR TITLE
feat(ouroboros): native Effect createSeed + proposeRevision

### DIFF
--- a/packages/clawql-ouroboros/src/effect/ouroboros-tools-effect.test.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-tools-effect.test.ts
@@ -9,8 +9,11 @@ import { ouroborosFromPromise } from "./ouroboros-effect-utils.js";
 import {
   executeCreateSeedFromDocumentEffect,
   executeMeasureDriftEffect,
+  executeProposeSeedRevisionFromEvalEffect,
 } from "./ouroboros-tools-effect.js";
 import { OuroborosToolsService, ouroborosToolsLiveLayer } from "./ouroboros-tools-service.js";
+
+const toolsOnlyLayer = ouroborosToolsLiveLayer();
 
 const stubContext = {} as OuroborosContext;
 
@@ -19,7 +22,7 @@ const testLayer = Layer.mergeAll(
     OuroborosContextService,
     OuroborosContextService.of({ getContext: () => stubContext })
   ),
-  ouroborosToolsLiveLayer()
+  toolsOnlyLayer
 );
 
 function minimalSeed(seedId: string): Seed {
@@ -88,16 +91,53 @@ describe("executeCreateSeedFromDocumentEffect", () => {
     }
   });
 
-  it("executeCreateSeedFromDocumentEffect uses context service", async () => {
+  it("executeCreateSeedFromDocumentEffect builds seed without context service", async () => {
     const result = await Effect.runPromise(
       executeCreateSeedFromDocumentEffect({
         documentId: "doc-ctx",
         extractedText: "Context service wiring validation text",
         metadata: {},
         taskType: "ingest",
-      }).pipe(Effect.provide(testLayer))
+      }).pipe(Effect.provide(toolsOnlyLayer))
     );
     expect(result).toMatchObject({ success: true });
+  });
+});
+
+describe("executeProposeSeedRevisionFromEvalEffect", () => {
+  it("proposes a dry-run revision via EventStoreService", async () => {
+    const store = new InMemoryEventStore();
+    const base = minimalSeed("seed-propose-effect");
+    base.evaluation_principles = [{ name: "accuracy", description: "score", weight: 1 }];
+
+    const res = await Effect.runPromise(
+      executeProposeSeedRevisionFromEvalEffect({
+        scoreName: "accuracy",
+        scoreValue: 0.95,
+        seedId: "seed-propose-effect",
+        autoApply: false,
+        minScore: 0.8,
+        baseSeed: base,
+      }).pipe(Effect.provide(eventStoreTestLayer(store)))
+    );
+
+    expect(res.ok).toBe(true);
+    expect(res.action).toBe("proposed");
+    expect(res.dryRun).toBe(true);
+    expect(
+      store.snapshot("seed-propose-effect").some((e) => e.type === "langfuse_eval_received")
+    ).toBe(true);
+  });
+
+  it("returns ok:false when eval payload is missing", async () => {
+    const store = new InMemoryEventStore();
+    const res = await Effect.runPromise(
+      executeProposeSeedRevisionFromEvalEffect({}).pipe(Effect.provide(eventStoreTestLayer(store)))
+    );
+    expect(res).toMatchObject({
+      ok: false,
+      error: "Missing eval: provide `payload` or `scoreValue` (+ optional scoreName/seedId)",
+    });
   });
 });
 

--- a/packages/clawql-ouroboros/src/effect/ouroboros-tools-effect.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-tools-effect.ts
@@ -2,6 +2,14 @@ import { Effect } from "effect";
 import type { z } from "zod";
 import { driftReportPayload, measureDrift } from "../drift.js";
 import { resolveBaselineSeed } from "../glue/resolve-baseline-seed.js";
+import { createSeedFromDocumentCore } from "../glue/seed-from-document.js";
+import {
+  langfuseEvalAutoApplyEnabled,
+  loadLatestSeedFromLineage,
+  normalizeLangfuseEvalPayload,
+  parseLangfuseMinScore,
+  processLangfuseEval,
+} from "../eval/index.js";
 import type {
   CreateSeedFromDocumentSchema,
   GetLineageStatusSchema,
@@ -9,30 +17,19 @@ import type {
   ProposeSeedRevisionFromEvalSchema,
   RunOuroborosSchema,
 } from "../mcp-hooks.js";
-import { OuroborosContextService } from "./ouroboros-context-service.js";
+import { SeedSchema } from "../seed.js";
 import { OuroborosEventStoreService } from "./ouroboros-event-store-service.js";
 import { OuroborosLoopService } from "./ouroboros-loop-service.js";
 import { OuroborosError } from "./ouroboros-errors.js";
 import { ouroborosFromPromise } from "./ouroboros-effect-utils.js";
 import { executeRunEvolutionaryLoopFromInputEffect } from "./ouroboros-loop-service.js";
 
+export type CreateSeedFromDocumentResult = ReturnType<typeof createSeedFromDocumentCore>;
+
 export function executeCreateSeedFromDocumentEffect(
   input: z.infer<typeof CreateSeedFromDocumentSchema>
-): Effect.Effect<
-  Awaited<
-    ReturnType<typeof import("../mcp-hooks.js").ouroborosMcpTools.createSeedFromDocument.handler>
-  >,
-  OuroborosError,
-  OuroborosContextService
-> {
-  return Effect.gen(function* () {
-    const ctxSvc = yield* OuroborosContextService;
-    const ctx = ctxSvc.getContext();
-    return yield* ouroborosFromPromise(async () => {
-      const { ouroborosMcpTools } = await import("../mcp-hooks.js");
-      return ouroborosMcpTools.createSeedFromDocument.handler(input, ctx);
-    });
-  });
+): Effect.Effect<CreateSeedFromDocumentResult> {
+  return Effect.sync(() => createSeedFromDocumentCore(input));
 }
 
 export function executeRunEvolutionaryLoopEffect(
@@ -64,18 +61,16 @@ export type MeasureDriftResult = Awaited<
   ReturnType<typeof import("../mcp-hooks.js").ouroborosMcpTools.measureDrift.handler>
 >;
 
-function measureDriftFailure(err: unknown): MeasureDriftResult {
+function taggedFailureMessage(err: unknown): string {
   if (err instanceof OuroborosError) {
     const cause = err.cause;
-    return {
-      ok: false,
-      error: cause instanceof Error ? cause.message : cause != null ? String(cause) : err.reason,
-    };
+    return cause instanceof Error ? cause.message : cause != null ? String(cause) : err.reason;
   }
-  return {
-    ok: false,
-    error: err instanceof Error ? err.message : String(err),
-  };
+  return err instanceof Error ? err.message : String(err);
+}
+
+function measureDriftFailure(err: unknown): MeasureDriftResult {
+  return { ok: false, error: taggedFailureMessage(err) };
 }
 
 export function executeMeasureDriftEffect(
@@ -120,23 +115,56 @@ export function executeMeasureDriftEffect(
   }).pipe(Effect.catchAll((err) => Effect.succeed(measureDriftFailure(err))));
 }
 
+export type ProposeSeedRevisionResult = Awaited<
+  ReturnType<typeof import("../mcp-hooks.js").ouroborosMcpTools.proposeSeedRevisionFromEval.handler>
+>;
+
 export function executeProposeSeedRevisionFromEvalEffect(
   input: z.infer<typeof ProposeSeedRevisionFromEvalSchema>
-): Effect.Effect<
-  Awaited<
-    ReturnType<
-      typeof import("../mcp-hooks.js").ouroborosMcpTools.proposeSeedRevisionFromEval.handler
-    >
-  >,
-  OuroborosError,
-  OuroborosContextService
-> {
+): Effect.Effect<ProposeSeedRevisionResult, never, OuroborosEventStoreService> {
   return Effect.gen(function* () {
-    const ctxSvc = yield* OuroborosContextService;
-    const ctx = ctxSvc.getContext();
-    return yield* ouroborosFromPromise(async () => {
-      const { ouroborosMcpTools } = await import("../mcp-hooks.js");
-      return ouroborosMcpTools.proposeSeedRevisionFromEval.handler(input, ctx);
-    });
-  });
+    const es = yield* OuroborosEventStoreService;
+
+    let evalEvent =
+      input.payload !== undefined ? normalizeLangfuseEvalPayload(input.payload) : null;
+    if (!evalEvent && input.scoreValue !== undefined) {
+      evalEvent = {
+        scoreName: input.scoreName?.trim() || "langfuse_score",
+        scoreValue: input.scoreValue,
+        traceId: input.traceId,
+        seedId: input.seedId,
+        correlationId: input.correlationId,
+        comment: input.comment,
+        metadata: {},
+      };
+    }
+    if (!evalEvent) {
+      return {
+        ok: false as const,
+        error: "Missing eval: provide `payload` or `scoreValue` (+ optional scoreName/seedId)",
+      };
+    }
+
+    const minScore = input.minScore ?? parseLangfuseMinScore(process.env);
+    const autoApply = input.autoApply ?? langfuseEvalAutoApplyEnabled(process.env);
+    const baseSeed = input.baseSeed !== undefined ? SeedSchema.parse(input.baseSeed) : undefined;
+    const store = es.getStore();
+
+    return yield* ouroborosFromPromise(() =>
+      processLangfuseEval(evalEvent!, {
+        minScore,
+        autoApply,
+        eventStore: store,
+        baseSeed,
+        loadSeedByLineageId: async (seedId) => loadLatestSeedFromLineage(store, seedId),
+      })
+    );
+  }).pipe(
+    Effect.catchAll((err) =>
+      Effect.succeed({
+        ok: false as const,
+        error: taggedFailureMessage(err),
+      })
+    )
+  );
 }

--- a/packages/clawql-ouroboros/src/effect/ouroboros-tools-service.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-tools-service.ts
@@ -7,7 +7,6 @@ import type {
   ProposeSeedRevisionFromEvalSchema,
   RunOuroborosSchema,
 } from "../mcp-hooks.js";
-import { OuroborosContextService } from "./ouroboros-context-service.js";
 import { OuroborosEventStoreService } from "./ouroboros-event-store-service.js";
 import { OuroborosLoopService } from "./ouroboros-loop-service.js";
 import { OuroborosError } from "./ouroboros-errors.js";
@@ -30,9 +29,7 @@ export class OuroborosToolsService extends Context.Tag("clawql/OuroborosToolsSer
         ReturnType<
           typeof import("../mcp-hooks.js").ouroborosMcpTools.createSeedFromDocument.handler
         >
-      >,
-      OuroborosError,
-      OuroborosContextService
+      >
     >;
     readonly runEvolutionaryLoop: (
       input: z.infer<typeof RunOuroborosSchema>
@@ -67,8 +64,8 @@ export class OuroborosToolsService extends Context.Tag("clawql/OuroborosToolsSer
           typeof import("../mcp-hooks.js").ouroborosMcpTools.proposeSeedRevisionFromEval.handler
         >
       >,
-      OuroborosError,
-      OuroborosContextService
+      never,
+      OuroborosEventStoreService
     >;
   }
 >() {}

--- a/packages/clawql-ouroboros/src/glue/seed-from-document.ts
+++ b/packages/clawql-ouroboros/src/glue/seed-from-document.ts
@@ -1,0 +1,197 @@
+import { v4 as uuidv4 } from "uuid";
+import { SeedSchema, type Seed } from "../seed.js";
+
+export type CreateSeedFromDocumentInput = {
+  documentId: string;
+  extractedText: string;
+  metadata: Record<string, unknown>;
+  goalHint?: string;
+  taskType: "code" | "research" | "analysis" | "ingest";
+};
+
+export type CreateSeedFromDocumentResult =
+  { success: true; seed: Seed } | { success: false; error: string };
+
+export function deriveGoal(
+  documentId: string,
+  metadata: Record<string, unknown>,
+  goalHint?: string
+): string {
+  if (goalHint) return goalHint;
+  const title =
+    (metadata["title"] as string | undefined) ??
+    (metadata["filename"] as string | undefined) ??
+    (metadata["subject"] as string | undefined);
+  if (title) return `Extract and evolve structured knowledge from: ${title}`;
+  return `Process and evolve knowledge from document ${documentId}`;
+}
+
+const STOP_WORDS = new Set([
+  "the",
+  "a",
+  "an",
+  "and",
+  "or",
+  "but",
+  "in",
+  "on",
+  "at",
+  "to",
+  "for",
+  "of",
+  "with",
+  "by",
+  "from",
+  "is",
+  "are",
+  "was",
+  "were",
+  "be",
+  "been",
+  "have",
+  "has",
+  "had",
+  "do",
+  "does",
+  "did",
+  "will",
+  "would",
+  "could",
+  "should",
+  "may",
+  "might",
+  "can",
+  "this",
+  "that",
+  "these",
+  "those",
+  "it",
+  "its",
+  "as",
+  "if",
+  "then",
+  "than",
+  "so",
+  "not",
+  "no",
+  "yes",
+  "all",
+  "any",
+  "each",
+  "some",
+  "such",
+  "other",
+  "also",
+  "into",
+  "about",
+  "up",
+  "out",
+  "over",
+  "after",
+  "before",
+  "between",
+  "through",
+  "during",
+]);
+
+export function inferOntologyFields(
+  text: string,
+  maxFields = 8
+): Array<{ name: string; field_type: string; description: string; required: boolean }> {
+  const freq = new Map<string, number>();
+
+  for (const token of text.toLowerCase().split(/\W+/)) {
+    if (token.length < 4) continue;
+    if (STOP_WORDS.has(token)) continue;
+    freq.set(token, (freq.get(token) ?? 0) + 1);
+  }
+
+  const candidates = [...freq.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, maxFields)
+    .map(([name]) => ({
+      name,
+      field_type: "string",
+      description: `Extracted concept: ${name}`,
+      required: false,
+    }));
+
+  return [
+    {
+      name: "content_summary",
+      field_type: "string",
+      description: "Summary of document content",
+      required: true,
+    },
+    {
+      name: "document_id",
+      field_type: "string",
+      description: "Source document identifier",
+      required: true,
+    },
+    ...candidates,
+  ];
+}
+
+/** Build a Seed from extracted document text (pure; no EventStore). */
+export function createSeedFromDocumentCore(
+  input: CreateSeedFromDocumentInput
+): CreateSeedFromDocumentResult {
+  try {
+    const goal = deriveGoal(input.documentId, input.metadata, input.goalHint);
+    const fields = inferOntologyFields(input.extractedText);
+
+    const raw = {
+      goal,
+      task_type: input.taskType,
+      brownfield_context: {
+        project_type: "brownfield" as const,
+        context_references: [input.documentId],
+        existing_patterns: [],
+        existing_dependencies: [],
+      },
+      constraints: ["Preserve semantic fidelity to source document"],
+      acceptance_criteria: [
+        "Ontology fields cover main topics of the document",
+        "Ontology similarity convergence >= 0.92",
+      ],
+      ontology_schema: {
+        name: `DocumentOntology_${input.documentId}`,
+        description: `Knowledge ontology extracted from document ${input.documentId}`,
+        fields,
+      },
+      evaluation_principles: [
+        {
+          name: "Semantic fidelity",
+          description: "Output faithfully represents source content",
+          weight: 0.6,
+        },
+        {
+          name: "Ontology completeness",
+          description: "Key entities and relations captured",
+          weight: 0.4,
+        },
+      ],
+      exit_conditions: [
+        {
+          name: "High similarity",
+          description: "Ontology stable across generations",
+          evaluation_criteria: "Similarity >= 0.95 for 2+ generations",
+        },
+      ],
+      metadata: {
+        seed_id: `docseed_${input.documentId}_${uuidv4().slice(0, 8)}`,
+        version: "1.0.0",
+        created_at: new Date(),
+        ambiguity_score: Math.min(0.8, 500 / Math.max(input.extractedText.length, 1)),
+        interview_id: null,
+        parent_seed_id: null,
+      },
+    };
+
+    const parsed = SeedSchema.parse(raw);
+    return { success: true, seed: parsed };
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/packages/clawql-ouroboros/src/mcp-hooks.ts
+++ b/packages/clawql-ouroboros/src/mcp-hooks.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
-import { v4 as uuidv4 } from "uuid";
 import { SeedSchema, type Seed } from "./seed.js";
 import { EvolutionaryLoop } from "./evolutionary-loop.js";
 import type { EventStore } from "./interfaces.js";
 import { driftReportPayload, measureDrift } from "./drift.js";
 import { resolveBaselineSeed } from "./glue/resolve-baseline-seed.js";
+import { createSeedFromDocumentCore } from "./glue/seed-from-document.js";
 import {
   langfuseEvalAutoApplyEnabled,
   loadLatestSeedFromLineage,
@@ -76,129 +76,6 @@ export const ProposeSeedRevisionFromEvalSchema = z.object({
   baseSeed: z.unknown().optional(),
 });
 
-// ---------------------------------------------------------------------------
-
-function deriveGoal(
-  documentId: string,
-  metadata: Record<string, unknown>,
-  goalHint?: string
-): string {
-  if (goalHint) return goalHint;
-  const title =
-    (metadata["title"] as string | undefined) ??
-    (metadata["filename"] as string | undefined) ??
-    (metadata["subject"] as string | undefined);
-  if (title) return `Extract and evolve structured knowledge from: ${title}`;
-  return `Process and evolve knowledge from document ${documentId}`;
-}
-
-const STOP_WORDS = new Set([
-  "the",
-  "a",
-  "an",
-  "and",
-  "or",
-  "but",
-  "in",
-  "on",
-  "at",
-  "to",
-  "for",
-  "of",
-  "with",
-  "by",
-  "from",
-  "is",
-  "are",
-  "was",
-  "were",
-  "be",
-  "been",
-  "have",
-  "has",
-  "had",
-  "do",
-  "does",
-  "did",
-  "will",
-  "would",
-  "could",
-  "should",
-  "may",
-  "might",
-  "can",
-  "this",
-  "that",
-  "these",
-  "those",
-  "it",
-  "its",
-  "as",
-  "if",
-  "then",
-  "than",
-  "so",
-  "not",
-  "no",
-  "yes",
-  "all",
-  "any",
-  "each",
-  "some",
-  "such",
-  "other",
-  "also",
-  "into",
-  "about",
-  "up",
-  "out",
-  "over",
-  "after",
-  "before",
-  "between",
-  "through",
-  "during",
-]);
-
-function inferOntologyFields(
-  text: string,
-  maxFields = 8
-): Array<{ name: string; field_type: string; description: string; required: boolean }> {
-  const freq = new Map<string, number>();
-
-  for (const token of text.toLowerCase().split(/\W+/)) {
-    if (token.length < 4) continue;
-    if (STOP_WORDS.has(token)) continue;
-    freq.set(token, (freq.get(token) ?? 0) + 1);
-  }
-
-  const candidates = [...freq.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, maxFields)
-    .map(([name]) => ({
-      name,
-      field_type: "string",
-      description: `Extracted concept: ${name}`,
-      required: false,
-    }));
-
-  return [
-    {
-      name: "content_summary",
-      field_type: "string",
-      description: "Summary of document content",
-      required: true,
-    },
-    {
-      name: "document_id",
-      field_type: "string",
-      description: "Source document identifier",
-      required: true,
-    },
-    ...candidates,
-  ];
-}
-
 export const ouroborosMcpTools = {
   createSeedFromDocument: {
     name: "ouroboros_create_seed_from_document" as const,
@@ -210,63 +87,7 @@ export const ouroborosMcpTools = {
       input: z.infer<typeof CreateSeedFromDocumentSchema>,
       _context: OuroborosContext
     ): Promise<{ success: true; seed: Seed } | { success: false; error: string }> => {
-      try {
-        const goal = deriveGoal(input.documentId, input.metadata, input.goalHint);
-        const fields = inferOntologyFields(input.extractedText);
-
-        const raw = {
-          goal,
-          task_type: input.taskType,
-          brownfield_context: {
-            project_type: "brownfield" as const,
-            context_references: [input.documentId],
-            existing_patterns: [],
-            existing_dependencies: [],
-          },
-          constraints: ["Preserve semantic fidelity to source document"],
-          acceptance_criteria: [
-            "Ontology fields cover main topics of the document",
-            "Ontology similarity convergence >= 0.92",
-          ],
-          ontology_schema: {
-            name: `DocumentOntology_${input.documentId}`,
-            description: `Knowledge ontology extracted from document ${input.documentId}`,
-            fields,
-          },
-          evaluation_principles: [
-            {
-              name: "Semantic fidelity",
-              description: "Output faithfully represents source content",
-              weight: 0.6,
-            },
-            {
-              name: "Ontology completeness",
-              description: "Key entities and relations captured",
-              weight: 0.4,
-            },
-          ],
-          exit_conditions: [
-            {
-              name: "High similarity",
-              description: "Ontology stable across generations",
-              evaluation_criteria: "Similarity >= 0.95 for 2+ generations",
-            },
-          ],
-          metadata: {
-            seed_id: `docseed_${input.documentId}_${uuidv4().slice(0, 8)}`,
-            version: "1.0.0",
-            created_at: new Date(),
-            ambiguity_score: Math.min(0.8, 500 / Math.max(input.extractedText.length, 1)),
-            interview_id: null,
-            parent_seed_id: null,
-          },
-        };
-
-        const parsed = SeedSchema.parse(raw);
-        return { success: true, seed: parsed };
-      } catch (err) {
-        return { success: false, error: err instanceof Error ? err.message : String(err) };
-      }
+      return createSeedFromDocumentCore(input);
     },
   },
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the remaining Ouroboros Effect → mcp-hooks reverse bridges for `createSeedFromDocument` and `proposeSeedRevisionFromEval`.

- Extracts `createSeedFromDocumentCore` / ontology helpers to `glue/seed-from-document.ts`
- `executeCreateSeedFromDocumentEffect` is pure `Effect.sync` (no ContextService)
- `executeProposeSeedRevisionFromEvalEffect` uses `OuroborosEventStoreService` + `processLangfuseEval` at the IO edge
- MCP handlers remain Promise facades over shared cores / store

Part of EffectTS follow-ups after engines/measureDrift.

## Test plan

- [x] `npm run build -w clawql-ouroboros`
- [x] `npx vitest run` ouroboros tools/effect + mcp-hooks + eval
- [x] `npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

