### PR TITLE
feat(sandbox): Effect services + sandbox_exec Promise facade

### DIFF
--- a/packages/clawql-sandbox/src/effect/index.ts
+++ b/packages/clawql-sandbox/src/effect/index.ts
@@ -1,0 +1,10 @@
+export { SandboxError } from "./sandbox-errors.js";
+export { sandboxFromPromise } from "./sandbox-effect-utils.js";
+export { executeSandboxExecEffect, type SandboxExecResult } from "./sandbox-exec-effect.js";
+export { SandboxExecService, sandboxExecLiveLayer } from "./sandbox-exec-service.js";
+export {
+  sandboxExecProgram,
+  sandboxServicesLiveLayer,
+  runSandboxEffect,
+  type SandboxServices,
+} from "./sandbox-effect-runtime.js";

--- a/packages/clawql-sandbox/src/effect/sandbox-effect-runtime.ts
+++ b/packages/clawql-sandbox/src/effect/sandbox-effect-runtime.ts
@@ -1,0 +1,44 @@
+import { Cause, Effect, Exit, Layer } from "effect";
+import type { SandboxCodeToolInput } from "../bridge-client.js";
+import { SandboxError } from "./sandbox-errors.js";
+import { SandboxExecService, sandboxExecLiveLayer } from "./sandbox-exec-service.js";
+import type { SandboxExecResult } from "./sandbox-exec-effect.js";
+
+export type SandboxServices = SandboxExecService;
+
+/** Merged Effect Layer for clawql-sandbox domain services. */
+export function sandboxServicesLiveLayer(): Layer.Layer<SandboxServices> {
+  return sandboxExecLiveLayer();
+}
+
+function throwSandboxFailure(cause: Cause.Cause<unknown>): never {
+  const squashed = Cause.squash(cause);
+  if (squashed instanceof SandboxError && squashed.cause != null) {
+    if (squashed.cause instanceof Error) throw squashed.cause;
+    throw new Error(String(squashed.cause));
+  }
+  throw squashed;
+}
+
+/** Run a sandbox Effect program with default services Layer. */
+export async function runSandboxEffect<A, E>(
+  program: Effect.Effect<A, E, SandboxServices>
+): Promise<A> {
+  const exit = await Effect.runPromiseExit(
+    program.pipe(Effect.provide(sandboxServicesLiveLayer()))
+  );
+  if (Exit.isSuccess(exit)) {
+    return exit.value;
+  }
+  throwSandboxFailure(exit.cause);
+}
+
+/** `sandbox_exec` via Effect services. */
+export function sandboxExecProgram(
+  input: SandboxCodeToolInput
+): Effect.Effect<SandboxExecResult, unknown, SandboxServices> {
+  return Effect.gen(function* () {
+    const svc = yield* SandboxExecService;
+    return yield* svc.exec(input);
+  });
+}

--- a/packages/clawql-sandbox/src/effect/sandbox-effect-utils.ts
+++ b/packages/clawql-sandbox/src/effect/sandbox-effect-utils.ts
@@ -1,0 +1,14 @@
+import { Effect } from "effect";
+import { SandboxError } from "./sandbox-errors.js";
+
+/** Lift a Promise into Effect with {@link SandboxError} on failure. */
+export function sandboxFromPromise<A>(tryFn: () => Promise<A>): Effect.Effect<A, SandboxError> {
+  return Effect.tryPromise({
+    try: tryFn,
+    catch: (cause) =>
+      new SandboxError({
+        reason: "sandbox async operation failed",
+        cause,
+      }),
+  });
+}

--- a/packages/clawql-sandbox/src/effect/sandbox-errors.ts
+++ b/packages/clawql-sandbox/src/effect/sandbox-errors.ts
@@ -1,0 +1,7 @@
+import { Data } from "effect";
+
+/** Unexpected failure in a sandbox Effect pipeline. */
+export class SandboxError extends Data.TaggedError("SandboxError")<{
+  readonly reason: string;
+  readonly cause?: unknown;
+}> {}

--- a/packages/clawql-sandbox/src/effect/sandbox-exec-effect.test.ts
+++ b/packages/clawql-sandbox/src/effect/sandbox-exec-effect.test.ts
@@ -1,0 +1,59 @@
+import { Effect } from "effect";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SandboxCodeToolInput } from "../bridge-client.js";
+import { executeSandboxExecEffect } from "./sandbox-exec-effect.js";
+import { SandboxExecService, sandboxExecLiveLayer } from "./sandbox-exec-service.js";
+import { runSandboxEffect, sandboxExecProgram } from "./sandbox-effect-runtime.js";
+
+vi.mock("../bridge-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../bridge-client.js")>();
+  return {
+    ...actual,
+    handleClawqlCodeToolInput: vi.fn(async (params: SandboxCodeToolInput) => ({
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            success: true,
+            backend: "bridge",
+            stdout: `ran:${params.language}`,
+            stderr: "",
+            exitCode: 0,
+          }),
+        },
+      ],
+    })),
+  };
+});
+
+describe("SandboxExecService", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("executes via Effect service layer", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* SandboxExecService;
+        return yield* svc.exec({ code: "1+1", language: "javascript" });
+      }).pipe(Effect.provide(sandboxExecLiveLayer()))
+    );
+
+    expect(result.content[0]?.text).toContain("ran:javascript");
+  });
+
+  it("runSandboxEffect / sandboxExecProgram facade works", async () => {
+    const result = await runSandboxEffect(
+      sandboxExecProgram({ code: "print(1)", language: "python" })
+    );
+    expect(result.content[0]?.text).toContain("ran:python");
+  });
+
+  it("executeSandboxExecEffect returns tool-shaped content", async () => {
+    const result = await Effect.runPromise(
+      executeSandboxExecEffect({ code: "echo hi", language: "shell" })
+    );
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]?.type).toBe("text");
+  });
+});

--- a/packages/clawql-sandbox/src/effect/sandbox-exec-effect.ts
+++ b/packages/clawql-sandbox/src/effect/sandbox-exec-effect.ts
@@ -1,0 +1,13 @@
+import { Effect } from "effect";
+import { handleClawqlCodeToolInput, type SandboxCodeToolInput } from "../bridge-client.js";
+import { SandboxError } from "./sandbox-errors.js";
+import { sandboxFromPromise } from "./sandbox-effect-utils.js";
+
+export type SandboxExecResult = Awaited<ReturnType<typeof handleClawqlCodeToolInput>>;
+
+/** Effect program for `sandbox_exec` (backend resolve + execute at IO edge). */
+export function executeSandboxExecEffect(
+  input: SandboxCodeToolInput
+): Effect.Effect<SandboxExecResult, SandboxError> {
+  return sandboxFromPromise(() => handleClawqlCodeToolInput(input));
+}

--- a/packages/clawql-sandbox/src/effect/sandbox-exec-service.ts
+++ b/packages/clawql-sandbox/src/effect/sandbox-exec-service.ts
@@ -1,0 +1,21 @@
+import { Context, Effect, Layer } from "effect";
+import type { SandboxCodeToolInput } from "../bridge-client.js";
+import { SandboxError } from "./sandbox-errors.js";
+import { executeSandboxExecEffect, type SandboxExecResult } from "./sandbox-exec-effect.js";
+
+/** Effect service for `sandbox_exec` tool body. */
+export class SandboxExecService extends Context.Tag("clawql/SandboxExecService")<
+  SandboxExecService,
+  {
+    readonly exec: (input: SandboxCodeToolInput) => Effect.Effect<SandboxExecResult, SandboxError>;
+  }
+>() {}
+
+export function sandboxExecLiveLayer(): Layer.Layer<SandboxExecService> {
+  return Layer.succeed(
+    SandboxExecService,
+    SandboxExecService.of({
+      exec: executeSandboxExecEffect,
+    })
+  );
+}

--- a/packages/clawql-sandbox/src/plugin/index.ts
+++ b/packages/clawql-sandbox/src/plugin/index.ts
@@ -15,3 +15,15 @@ export {
   type SandboxPersistenceMode,
   type SandboxExecBackendKind,
 } from "../bridge-client.js";
+
+export {
+  SandboxError,
+  SandboxExecService,
+  executeSandboxExecEffect,
+  sandboxExecLiveLayer,
+  sandboxExecProgram,
+  sandboxServicesLiveLayer,
+  runSandboxEffect,
+  type SandboxExecResult,
+  type SandboxServices,
+} from "../effect/index.js";

--- a/packages/clawql-sandbox/src/plugin/sandbox-plugin.ts
+++ b/packages/clawql-sandbox/src/plugin/sandbox-plugin.ts
@@ -2,7 +2,8 @@ import { logMcpToolShape } from "clawql-api/mcp/tool-shape-log";
 import type { Plugin } from "clawql-core";
 import { Effect } from "effect";
 import { z } from "zod";
-import { handleClawqlCodeToolInput, type SandboxCodeToolInput } from "../bridge-client.js";
+import type { SandboxCodeToolInput } from "../bridge-client.js";
+import { runSandboxEffect, sandboxExecProgram } from "../effect/sandbox-effect-runtime.js";
 
 export const SANDBOX_PLUGIN_ID = "clawql-sandbox";
 
@@ -36,6 +37,7 @@ export const sandboxCodeSchema = {
     .describe("Optional wall-clock limit in ms (capped by CLAWQL_SANDBOX_TIMEOUT_MS_MAX)."),
 };
 
+/** Promise facade for `sandbox_exec` (Effect services underneath). */
 export async function handleSandboxExecToolInput(
   params: SandboxCodeToolInput
 ): Promise<{ content: { type: "text"; text: string }[] }> {
@@ -45,7 +47,7 @@ export async function handleSandboxExecToolInput(
     persistenceMode: params.persistenceMode,
     timeoutMs: params.timeoutMs,
   });
-  return handleClawqlCodeToolInput(params);
+  return runSandboxEffect(sandboxExecProgram(params));
 }
 
 export function createSandboxPlugin(): Plugin {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the first Effect services layer for `clawql-sandbox`, matching documents/automation/ouroboros patterns.

- New `packages/clawql-sandbox/src/effect/` — `SandboxError`, `sandboxFromPromise`, `SandboxExecService`, `runSandboxEffect`
- `handleSandboxExecToolInput` / plugin registration use Effect runtime with Promise facade at the MCP edge
- Backend resolution (Kata/Docker/Seatbelt/bridge) remains Promise IO behind `sandboxFromPromise`

Part of EffectTS follow-ups after finishing Ouroboros tool bridges.

## Test plan

- [x] `npm run build -w clawql-sandbox`
- [x] `npx vitest run packages/clawql-sandbox/src` (38 tests)
- [x] `npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

