### PR TITLE
feat(memory): native Effect.gen stages for memory_ingest pipeline

### DIFF
--- a/docs/design/modularization-implementation-status.md
+++ b/docs/design/modularization-implementation-status.md
@@ -235,16 +235,17 @@ From enablement §5.4 and the Effect plan §8:
 
 ## 7. Effect-TS migration status
 
-| Area                                                                             | Status                                                                                    |
-| -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `effect` dependency                                                              | ✅ Pinned in `clawql-api`                                                                 |
-| `SearchService` / `ExecuteService`                                               | ✅ Live Layers; MCP uses `getClawqlApi().run(Effect…)`                                    |
-| `AuditLive`                                                                      | ✅ Composed in `createClawQLApi()`                                                        |
-| `Plugin` / `PluginRegistry`                                                      | ✅ Effect `register` / `beforeCallTool`                                                   |
-| Extracted packages (`memory`, `documents`, `automation`, `sandbox`, `ouroboros`) | ❌ Still `async` at IO edges; Layer wrappers shipped                                      |
-| `@effect/schema` at boundaries                                                   | ❌ Zod remains at MCP tool registration                                                   |
-| Horizontal `Plugin` Layers                                                       | ✅ All tiers via `composeHorizontalPluginLayers()`                                        |
-| Operator dynamic Layer list from CRD                                             | ✅ `composeHorizontalPluginLayersFromTierSpec()` maps `ClawQLHorizontalTierSpec` → Layers |
+| Area                                                                             | Status                                                                                                                |
+| -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `effect` dependency                                                              | ✅ Pinned in `clawql-api`                                                                                             |
+| `SearchService` / `ExecuteService`                                               | ✅ Live Layers; MCP uses `getClawqlApi().run(Effect…)`                                                                |
+| `AuditLive`                                                                      | ✅ Composed in `createClawQLApi()`                                                                                    |
+| `Plugin` / `PluginRegistry`                                                      | ✅ Effect `register` / `beforeCallTool`                                                                               |
+| Extracted packages (`memory`, `documents`, `automation`, `sandbox`, `ouroboros`) | 🚧 Layer wrappers shipped; memory ingest/recall + ouroboros hot paths use native `Effect.gen` (IO still `tryPromise`) |
+| `@effect/schema` at boundaries                                                   | ❌ Zod remains at MCP tool registration                                                                               |
+| Horizontal `Plugin` Layers                                                       | ✅ All tiers via `composeHorizontalPluginLayers()`                                                                    |
+| Operator dynamic Layer list from CRD                                             | ✅ `composeHorizontalPluginLayersFromTierSpec()` maps `ClawQLHorizontalTierSpec` → Layers                             |
+| `MemoryIngestService` / vault post-sync                                          | ✅ Native `Effect.gen` stages prepare → vault write → `MemoryDbService` sync (no nested `runMemoryEffect`)            |
 
 **Rule for new code in extracted packages:** prefer Effect in `clawql-core` / `clawql-api`; legacy `async` is acceptable at IO edges during migration (`Effect.tryPromise`). See plan §7.
 

--- a/packages/clawql-memory/src/effect/index.ts
+++ b/packages/clawql-memory/src/effect/index.ts
@@ -9,7 +9,11 @@ export {
 } from "./vault-config-service.js";
 export { EmbeddingService, embeddingLiveLayer } from "./embedding-service.js";
 export { MemoryDbService, memoryDbLiveLayer, type MemoryDbDocument } from "./memory-db-service.js";
-export { executeMemoryIngestEffect } from "./memory-ingest-effect.js";
+export {
+  executeMemoryIngestEffect,
+  executeMemoryIngestCoreEffect,
+  type MemoryIngestServices,
+} from "./memory-ingest-effect.js";
 export {
   executeMemoryRecallEffect,
   executeMemoryRecallCoreEffect,

--- a/packages/clawql-memory/src/effect/memory-ingest-effect.test.ts
+++ b/packages/clawql-memory/src/effect/memory-ingest-effect.test.ts
@@ -1,0 +1,113 @@
+import { readFile } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect, Layer } from "effect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { embeddingLiveLayer } from "./embedding-service.js";
+import {
+  executeMemoryIngestCoreEffect,
+  executeMemoryIngestEffect,
+} from "./memory-ingest-effect.js";
+import { memoryDbLiveLayer } from "./memory-db-service.js";
+import { memoryIngestLiveLayer } from "./memory-ingest-service.js";
+import { memoryRecallLiveLayer } from "./memory-recall-service.js";
+import { memoryServicesLiveLayer } from "./memory-effect-runtime.js";
+import { MemoryIngestService } from "./memory-ingest-service.js";
+import { createVaultConfigTestLayer } from "./vault-config-service.js";
+
+describe("executeMemoryIngestCoreEffect", () => {
+  let home: string;
+  let prevVault: string | undefined;
+  let prevMemoryDb: string | undefined;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "clawql-memory-ingest-native-"));
+    prevVault = process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+    prevMemoryDb = process.env.CLAWQL_MEMORY_DB;
+    process.env.CLAWQL_OBSIDIAN_VAULT_PATH = home;
+    process.env.CLAWQL_MEMORY_DB = "0";
+  });
+
+  afterEach(async () => {
+    if (prevVault === undefined) delete process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+    else process.env.CLAWQL_OBSIDIAN_VAULT_PATH = prevVault;
+    if (prevMemoryDb === undefined) delete process.env.CLAWQL_MEMORY_DB;
+    else process.env.CLAWQL_MEMORY_DB = prevMemoryDb;
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("stages prepare → vault write without nested Layer provision", async () => {
+    const layer = memoryServicesLiveLayer();
+    const result = await Effect.runPromise(
+      executeMemoryIngestCoreEffect(home, {
+        title: "Native Effect Ingest",
+        insights: "staged Effect.gen pipeline",
+        rebuild: { embeddings: false },
+      }).pipe(Effect.provide(layer))
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.path).toBe("Memory/native-effect-ingest.md");
+    expect(result.rebuild?.embeddings?.synced).toBe(false);
+    const body = await readFile(join(home, "Memory", "native-effect-ingest.md"), "utf8");
+    expect(body).toContain("staged Effect.gen pipeline");
+  });
+
+  it("skips duplicate payloads by content hash", async () => {
+    const layer = memoryServicesLiveLayer();
+    const input = {
+      title: "Dedup Effect",
+      insights: "same section twice",
+      rebuild: { embeddings: false as const },
+    };
+    const first = await Effect.runPromise(
+      executeMemoryIngestCoreEffect(home, input).pipe(Effect.provide(layer))
+    );
+    const second = await Effect.runPromise(
+      executeMemoryIngestCoreEffect(home, input).pipe(Effect.provide(layer))
+    );
+
+    expect(first.ok).toBe(true);
+    expect(first.skipped).toBeFalsy();
+    expect(second.ok).toBe(true);
+    expect(second.skipped).toBe(true);
+  });
+
+  it("executeMemoryIngestEffect reports missing vault", async () => {
+    const tailored = Layer.mergeAll(
+      createVaultConfigTestLayer({}),
+      memoryDbLiveLayer(),
+      embeddingLiveLayer(),
+      memoryIngestLiveLayer(),
+      memoryRecallLiveLayer()
+    );
+    const result = await Effect.runPromise(
+      executeMemoryIngestEffect({
+        title: "No vault",
+        insights: "should fail",
+      }).pipe(Effect.provide(tailored))
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/vault is not configured/i);
+  });
+
+  it("MemoryIngestService uses native Effect ingest", async () => {
+    const layer = memoryServicesLiveLayer();
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const ingest = yield* MemoryIngestService;
+        return yield* ingest.ingest({
+          title: "Service native",
+          insights: "via MemoryIngestService",
+          rebuild: { embeddings: false },
+          wikilinks: ["Related Note"],
+        });
+      }).pipe(Effect.provide(layer))
+    );
+
+    expect(result.ok).toBe(true);
+    const body = await readFile(join(home, "Memory", "service-native.md"), "utf8");
+    expect(body).toContain("[[Related Note]]");
+  });
+});

--- a/packages/clawql-memory/src/effect/memory-ingest-effect.ts
+++ b/packages/clawql-memory/src/effect/memory-ingest-effect.ts
@@ -1,26 +1,116 @@
 import { Effect } from "effect";
 import {
-  executeMemoryIngestCore,
+  prepareMemoryIngestEffectiveInput,
+  writeMemoryIngestPage,
   type MemoryIngestInput,
   type MemoryIngestResult,
 } from "../ingest/ingest.js";
 import { MemoryError } from "./memory-errors.js";
 import { memoryFromPromise } from "./memory-effect-utils.js";
+import { MemoryDbService } from "./memory-db-service.js";
+import {
+  memoryIngestPostSyncExtrasEffect,
+  vaultProviderIndexEffect,
+} from "./memory-vault-post-sync-effect.js";
 import { VaultConfigService } from "./vault-config-service.js";
 
 const VAULT_NOT_CONFIGURED =
   "Obsidian vault is not configured. Set CLAWQL_OBSIDIAN_VAULT_PATH to a writable directory.";
 
+export type MemoryIngestServices = VaultConfigService | MemoryDbService;
+
+function wantEmbeddingsRebuild(effective: MemoryIngestInput): boolean {
+  return (
+    effective.rebuild?.embeddings !== false &&
+    (effective.rebuild?.embeddings === true || process.env.CLAWQL_MEMORY_DB?.trim() !== "0")
+  );
+}
+
+function wantPageIndexRebuild(effective: MemoryIngestInput): boolean {
+  return (
+    effective.rebuild?.pageindex === true ||
+    process.env.CLAWQL_MEMORY_INGEST_REBUILD_PAGEINDEX?.trim() === "1"
+  );
+}
+
+/**
+ * Vault write + post-sync / rebuild as Effect.gen.
+ * fs / Presidio stay behind {@link memoryFromPromise}; db sync via {@link MemoryDbService}.
+ */
+export function executeMemoryIngestCoreEffect(
+  vault: string,
+  input: MemoryIngestInput
+): Effect.Effect<MemoryIngestResult, MemoryError, MemoryDbService> {
+  return Effect.gen(function* () {
+    const prepared = yield* memoryFromPromise(() => prepareMemoryIngestEffectiveInput(input));
+    if (!prepared.ok) {
+      return { ok: false, error: prepared.error };
+    }
+
+    const { title, effective, fileProvenance } = prepared;
+    const result = yield* memoryFromPromise(() =>
+      writeMemoryIngestPage(vault, title, effective, fileProvenance)
+    );
+
+    if (!result.ok || result.skipped) {
+      return result;
+    }
+
+    const rebuild: NonNullable<MemoryIngestResult["rebuild"]> = {};
+    let extras: Partial<MemoryIngestResult> = {};
+
+    if (wantEmbeddingsRebuild(effective)) {
+      extras = yield* memoryIngestPostSyncExtrasEffect(vault);
+      rebuild.embeddings = { synced: true };
+    } else if (effective.rebuild?.embeddings === false) {
+      rebuild.embeddings = {
+        synced: false,
+        skipped: "rebuild.embeddings=false; memory.db / embedding sync skipped",
+      };
+    }
+
+    yield* vaultProviderIndexEffect(vault);
+
+    if (wantPageIndexRebuild(effective) && result.path) {
+      rebuild.pageindex = yield* memoryFromPromise(async () => {
+        try {
+          const { pageindexBuildFromVaultPath } = await import("../recall/pageindex-recall.js");
+          const docId = result.path!.replace(/^Memory\//, "").replace(/\.md$/i, "");
+          return await pageindexBuildFromVaultPath({
+            docId,
+            vaultRelativePath: result.path!,
+          });
+        } catch (e) {
+          return {
+            error: e instanceof Error ? e.message : String(e),
+          };
+        }
+      });
+    }
+
+    yield* memoryFromPromise(async () => {
+      const { runAfterIngestVaultSync } = await import("../sync/vault-sync-hooks.js");
+      await runAfterIngestVaultSync();
+    });
+
+    return {
+      ...result,
+      ...extras,
+      rebuild: Object.keys(rebuild).length > 0 ? rebuild : undefined,
+    };
+  });
+}
+
 /** Ingest pipeline as Effect.gen — vault path via {@link VaultConfigService}. */
 export function executeMemoryIngestEffect(
   input: MemoryIngestInput
-): Effect.Effect<MemoryIngestResult, MemoryError, VaultConfigService> {
+): Effect.Effect<MemoryIngestResult, MemoryError, MemoryIngestServices> {
   return Effect.gen(function* () {
     const vaultConfig = yield* VaultConfigService;
     const vault = vaultConfig.getObsidianVaultPath();
     if (!vault) {
       return { ok: false, error: VAULT_NOT_CONFIGURED };
     }
-    return yield* memoryFromPromise(() => executeMemoryIngestCore(vault, input));
+    return yield* executeMemoryIngestCoreEffect(vault, input);
   });
 }

--- a/packages/clawql-memory/src/effect/memory-ingest-service.ts
+++ b/packages/clawql-memory/src/effect/memory-ingest-service.ts
@@ -1,8 +1,7 @@
 import { Context, Effect, Layer } from "effect";
 import type { MemoryIngestInput, MemoryIngestResult } from "../ingest/ingest.js";
-import { executeMemoryIngestEffect } from "./memory-ingest-effect.js";
+import { executeMemoryIngestEffect, type MemoryIngestServices } from "./memory-ingest-effect.js";
 import { MemoryError } from "./memory-errors.js";
-import { VaultConfigService } from "./vault-config-service.js";
 
 /** Effect service for vault memory ingest (`memory_ingest`). */
 export class MemoryIngestService extends Context.Tag("clawql/MemoryIngestService")<
@@ -10,7 +9,7 @@ export class MemoryIngestService extends Context.Tag("clawql/MemoryIngestService
   {
     readonly ingest: (
       input: MemoryIngestInput
-    ) => Effect.Effect<MemoryIngestResult, MemoryError, VaultConfigService>;
+    ) => Effect.Effect<MemoryIngestResult, MemoryError, MemoryIngestServices>;
   }
 >() {}
 

--- a/packages/clawql-memory/src/ingest/ingest.ts
+++ b/packages/clawql-memory/src/ingest/ingest.ts
@@ -186,23 +186,22 @@ function buildFrontmatter(title: string): string {
   ].join("\n");
 }
 
-/** Public async facade for vault ingest (MCP tools, scripts, automation). */
-export async function runMemoryIngest(input: MemoryIngestInput): Promise<MemoryIngestResult> {
-  const { runMemoryEffect, memoryIngestProgram } =
-    await import("../effect/memory-effect-runtime.js");
-  return runMemoryEffect(memoryIngestProgram(input));
-}
+export type PreparedMemoryIngest =
+  | {
+      ok: true;
+      title: string;
+      effective: MemoryIngestInput;
+      fileProvenance?: string;
+    }
+  | { ok: false; error: string };
 
-/** @deprecated Prefer {@link runMemoryIngest} — routes through Effect services. */
-export async function executeMemoryIngest(input: MemoryIngestInput): Promise<MemoryIngestResult> {
-  return runMemoryIngest(input);
-}
-
-/** Vault write + index sync body (vault path already resolved). */
-export async function executeMemoryIngestCore(
-  vault: string,
+/**
+ * Resolve toolOutputs file, normalize citations, and optional Presidio redact.
+ * Pure orchestration helpers for the Effect ingest pipeline (IO at the edges).
+ */
+export async function prepareMemoryIngestEffectiveInput(
   input: MemoryIngestInput
-): Promise<MemoryIngestResult> {
+): Promise<PreparedMemoryIngest> {
   const title = input.title?.trim();
   if (!title) {
     return { ok: false, error: "title is required" };
@@ -229,14 +228,23 @@ export async function executeMemoryIngestCore(
   };
 
   effective = await presidioRedactMemoryIngestInput(effective);
+  return { ok: true, title, effective, fileProvenance };
+}
 
+/** Vault Markdown write only (under write lock). No index / embedding post-sync. */
+export async function writeMemoryIngestPage(
+  vault: string,
+  title: string,
+  effective: MemoryIngestInput,
+  fileProvenance?: string
+): Promise<MemoryIngestResult> {
   const slug = slugifyTitle(title);
   const rel = `${MEMORY_DIR}/${slug}.md`;
   const append = effective.append !== false;
   const hash = hashIngestSection(effective);
   const when = new Date().toISOString();
 
-  const result = await withVaultWriteLock(vault, async () => {
+  return withVaultWriteLock(vault, async () => {
     let existing = "";
     try {
       existing = await readVaultTextFile(vault, rel);
@@ -258,22 +266,7 @@ export async function executeMemoryIngestCore(
     });
     const related = buildRelatedLinks(effective.wikilinks);
 
-    if (!existing) {
-      const body = [
-        buildFrontmatter(title),
-        `# ${title}`,
-        "",
-        related,
-        "---",
-        "",
-        section,
-        "",
-      ].join("\n");
-      await writeVaultTextFileAtomic(vault, rel, body);
-      return { ok: true, path: rel };
-    }
-
-    if (!append) {
+    if (!existing || !append) {
       const body = [
         buildFrontmatter(title),
         `# ${title}`,
@@ -292,57 +285,29 @@ export async function executeMemoryIngestCore(
     await writeVaultTextFileAtomic(vault, rel, next);
     return { ok: true, path: rel };
   });
+}
 
-  if (result.ok && !result.skipped) {
-    const { runMemoryEffect } = await import("../effect/memory-effect-runtime.js");
-    const { memoryIngestPostSyncExtrasEffect, vaultProviderIndexEffect } =
-      await import("../effect/memory-vault-post-sync-effect.js");
+/** Public async facade for vault ingest (MCP tools, scripts, automation). */
+export async function runMemoryIngest(input: MemoryIngestInput): Promise<MemoryIngestResult> {
+  const { runMemoryEffect, memoryIngestProgram } =
+    await import("../effect/memory-effect-runtime.js");
+  return runMemoryEffect(memoryIngestProgram(input));
+}
 
-    const wantEmbeddings =
-      effective.rebuild?.embeddings !== false &&
-      (effective.rebuild?.embeddings === true || process.env.CLAWQL_MEMORY_DB?.trim() !== "0");
-    const wantPageIndex =
-      effective.rebuild?.pageindex === true ||
-      process.env.CLAWQL_MEMORY_INGEST_REBUILD_PAGEINDEX?.trim() === "1";
+/** @deprecated Prefer {@link runMemoryIngest} — routes through Effect services. */
+export async function executeMemoryIngest(input: MemoryIngestInput): Promise<MemoryIngestResult> {
+  return runMemoryIngest(input);
+}
 
-    const rebuild: NonNullable<MemoryIngestResult["rebuild"]> = {};
-
-    if (wantEmbeddings) {
-      const indexExtras = await runMemoryEffect(memoryIngestPostSyncExtrasEffect(vault));
-      Object.assign(result, indexExtras);
-      rebuild.embeddings = { synced: true };
-    } else if (effective.rebuild?.embeddings === false) {
-      rebuild.embeddings = {
-        synced: false,
-        skipped: "rebuild.embeddings=false; memory.db / embedding sync skipped",
-      };
-    }
-
-    await runMemoryEffect(vaultProviderIndexEffect(vault));
-
-    if (wantPageIndex && result.path) {
-      try {
-        const { pageindexBuildFromVaultPath } = await import("../recall/pageindex-recall.js");
-        const docId = result.path.replace(/^Memory\//, "").replace(/\.md$/i, "");
-        const built = await pageindexBuildFromVaultPath({
-          docId,
-          vaultRelativePath: result.path,
-        });
-        rebuild.pageindex = built;
-      } catch (e) {
-        rebuild.pageindex = {
-          error: e instanceof Error ? e.message : String(e),
-        };
-      }
-    }
-
-    const { runAfterIngestVaultSync } = await import("../sync/vault-sync-hooks.js");
-    await runAfterIngestVaultSync();
-    return {
-      ...result,
-      rebuild: Object.keys(rebuild).length > 0 ? rebuild : undefined,
-    };
-  }
-
-  return result;
+/**
+ * Vault write + index sync body (vault path already resolved).
+ * Routes through native Effect.gen (`executeMemoryIngestCoreEffect`) with live Layers.
+ */
+export async function executeMemoryIngestCore(
+  vault: string,
+  input: MemoryIngestInput
+): Promise<MemoryIngestResult> {
+  const { runMemoryEffect } = await import("../effect/memory-effect-runtime.js");
+  const { executeMemoryIngestCoreEffect } = await import("../effect/memory-ingest-effect.js");
+  return runMemoryEffect(executeMemoryIngestCoreEffect(vault, input));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Deepens `memory_ingest` beyond a single `memoryFromPromise(() => executeMemoryIngestCore(...))` wrapper: the Effect pipeline now stages **prepare → vault write → MemoryDbService post-sync / provider index / optional PageIndex / vault hooks**, matching the recall Effect.gen pattern.

## Changes

- `prepareMemoryIngestEffectiveInput` + `writeMemoryIngestPage` helpers in `ingest.ts` (IO-edge async)
- `executeMemoryIngestCoreEffect` — native `Effect.gen` yields `memoryIngestPostSyncExtrasEffect` / `vaultProviderIndexEffect` (no nested `runMemoryEffect`)
- `MemoryIngestService` requirements include `MemoryDbService`
- Unit tests for staged write, dedup skip, missing vault, service path
- Modularization status note for MemoryIngest native Effect

## Test plan

- [x] `npm test -w clawql-memory -- --run src/effect/memory-ingest-effect.test.ts src/effect/memory-services.test.ts`
- [x] `npx vitest run src/memory-ingest.test.ts src/memory-provider-index.test.ts`
- [x] `npm run typecheck -w clawql-memory`
- [ ] CI green on this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

