### PR TITLE
feat(documents): native Effect.gen IDP pipeline hop loop

### DIFF
--- a/docs/design/modularization-implementation-status.md
+++ b/docs/design/modularization-implementation-status.md
@@ -235,17 +235,18 @@ From enablement §5.4 and the Effect plan §8:
 
 ## 7. Effect-TS migration status
 
-| Area                                                                             | Status                                                                                                                |
-| -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `effect` dependency                                                              | ✅ Pinned in `clawql-api`                                                                                             |
-| `SearchService` / `ExecuteService`                                               | ✅ Live Layers; MCP uses `getClawqlApi().run(Effect…)`                                                                |
-| `AuditLive`                                                                      | ✅ Composed in `createClawQLApi()`                                                                                    |
-| `Plugin` / `PluginRegistry`                                                      | ✅ Effect `register` / `beforeCallTool`                                                                               |
-| Extracted packages (`memory`, `documents`, `automation`, `sandbox`, `ouroboros`) | 🚧 Layer wrappers shipped; memory ingest/recall + ouroboros hot paths use native `Effect.gen` (IO still `tryPromise`) |
-| `@effect/schema` at boundaries                                                   | ❌ Zod remains at MCP tool registration                                                                               |
-| Horizontal `Plugin` Layers                                                       | ✅ All tiers via `composeHorizontalPluginLayers()`                                                                    |
-| Operator dynamic Layer list from CRD                                             | ✅ `composeHorizontalPluginLayersFromTierSpec()` maps `ClawQLHorizontalTierSpec` → Layers                             |
-| `MemoryIngestService` / vault post-sync                                          | ✅ Native `Effect.gen` stages prepare → vault write → `MemoryDbService` sync (no nested `runMemoryEffect`)            |
+| Area                                                                             | Status                                                                                                                                       |
+| -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `effect` dependency                                                              | ✅ Pinned in `clawql-api`                                                                                                                    |
+| `SearchService` / `ExecuteService`                                               | ✅ Live Layers; MCP uses `getClawqlApi().run(Effect…)`                                                                                       |
+| `AuditLive`                                                                      | ✅ Composed in `createClawQLApi()`                                                                                                           |
+| `Plugin` / `PluginRegistry`                                                      | ✅ Effect `register` / `beforeCallTool`                                                                                                      |
+| Extracted packages (`memory`, `documents`, `automation`, `sandbox`, `ouroboros`) | 🚧 Layer wrappers shipped; memory ingest/recall, documents IDP runner, + ouroboros hot paths use native `Effect.gen` (IO still `tryPromise`) |
+| `@effect/schema` at boundaries                                                   | ❌ Zod remains at MCP tool registration                                                                                                      |
+| Horizontal `Plugin` Layers                                                       | ✅ All tiers via `composeHorizontalPluginLayers()`                                                                                           |
+| Operator dynamic Layer list from CRD                                             | ✅ `composeHorizontalPluginLayersFromTierSpec()` maps `ClawQLHorizontalTierSpec` → Layers                                                    |
+| `MemoryIngestService` / vault post-sync                                          | ✅ Native `Effect.gen` stages prepare → vault write → `MemoryDbService` sync (no nested `runMemoryEffect`)                                   |
+| `DocumentsToolsService` IDP runner                                               | ✅ Native `Effect.gen` hop loop (skip/dry-run/execute+retry/Merkle/onHop); Promise façade kept for tests                                     |
 
 **Rule for new code in extracted packages:** prefer Effect in `clawql-core` / `clawql-api`; legacy `async` is acceptable at IO edges during migration (`Effect.tryPromise`). See plan §7.
 

--- a/packages/clawql-documents/src/effect/documents-tools-effect.ts
+++ b/packages/clawql-documents/src/effect/documents-tools-effect.ts
@@ -9,30 +9,33 @@ import {
   type ExtractDocumentInput,
   type ExtractDocumentResult,
 } from "../langextract/extract-document.js";
-import {
-  runIdpPipeline,
-  type RunIdpPipelineInput,
-  type RunIdpPipelineResult,
-} from "../pipeline/runner.js";
+import type { RunIdpPipelineInput, RunIdpPipelineResult } from "../pipeline/runner.js";
 import { getDocumentsPluginDeps } from "../plugin/deps.js";
 import { DocumentsError } from "./documents-errors.js";
 import { documentsFromPromise } from "./documents-effect-utils.js";
+import { runIdpPipelineEffect } from "./idp-pipeline-effect.js";
 
-/** IDP pipeline body (deps resolved at call time). */
-export async function executeRunIdpPipelineCore(
-  input: RunIdpPipelineInput
-): Promise<RunIdpPipelineResult> {
-  const deps = getDocumentsPluginDeps();
-  return runIdpPipeline(input, {
-    execute: (p) => deps.execute(p),
-    onHop: deps.onPipelineHop,
-  });
-}
-
+/**
+ * Resolve plugin deps then run native Effect.gen IDP hop loop
+ * (no nested {@link runDocumentsEffect} / single-shot tryPromise wrapper).
+ */
 export function executeRunIdpPipelineEffect(
   input: RunIdpPipelineInput
 ): Effect.Effect<RunIdpPipelineResult, DocumentsError> {
-  return documentsFromPromise(() => executeRunIdpPipelineCore(input));
+  return Effect.gen(function* () {
+    const deps = getDocumentsPluginDeps();
+    return yield* runIdpPipelineEffect(input, {
+      execute: (p) => deps.execute(p),
+      onHop: deps.onPipelineHop,
+    });
+  });
+}
+
+/** @deprecated Prefer {@link executeRunIdpPipelineEffect}; kept for Promise callers. */
+export async function executeRunIdpPipelineCore(
+  input: RunIdpPipelineInput
+): Promise<RunIdpPipelineResult> {
+  return Effect.runPromise(executeRunIdpPipelineEffect(input));
 }
 
 export function executeClassifyDocumentEffect(

--- a/packages/clawql-documents/src/effect/idp-pipeline-effect.test.ts
+++ b/packages/clawql-documents/src/effect/idp-pipeline-effect.test.ts
@@ -1,0 +1,70 @@
+import { Effect } from "effect";
+import { describe, expect, it, vi } from "vitest";
+import { runIdpPipelineEffect } from "./idp-pipeline-effect.js";
+
+const miniPipeline = [
+  {
+    stage: "tika" as const,
+    operationId: "tika::tika_parse_put",
+    label: "Extract text (Tika)",
+  },
+  {
+    stage: "gotenberg" as const,
+    operationId: "gotenberg::post_forms_libreoffice_convert",
+    label: "Normalize PDF (Gotenberg)",
+  },
+];
+
+describe("runIdpPipelineEffect", () => {
+  it("stages dry-run hops without nested Layer provision", async () => {
+    const execute = vi.fn();
+    const result = await Effect.runPromise(
+      runIdpPipelineEffect({ dry_run: true, pipeline: miniPipeline }, { execute })
+    );
+    expect(execute).not.toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    expect(result.hops).toHaveLength(2);
+    expect(result.hops[0]?.response_excerpt).toContain("dry run");
+  });
+
+  it("retries execute failures then succeeds", async () => {
+    const execute = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce({ content: [{ type: "text", text: '{"ok":true}' }] });
+    const result = await Effect.runPromise(
+      runIdpPipelineEffect(
+        {
+          dry_run: false,
+          pipeline: [miniPipeline[0]!],
+          max_retries: 2,
+        },
+        { execute }
+      )
+    );
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(result.hops[0]?.attempts).toBe(2);
+    expect(result.ok).toBe(true);
+  });
+
+  it("halts on error when stop_on_error is true", async () => {
+    const execute = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: '{"error":"bad request"}' }],
+    });
+    const result = await Effect.runPromise(
+      runIdpPipelineEffect(
+        {
+          dry_run: false,
+          pipeline: miniPipeline,
+          stop_on_error: true,
+          max_retries: 0,
+        },
+        { execute }
+      )
+    );
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(result.ok).toBe(false);
+    expect(result.halted_at_operation_id).toBe("tika::tika_parse_put");
+    expect(result.hops).toHaveLength(1);
+  });
+});

--- a/packages/clawql-documents/src/effect/idp-pipeline-effect.ts
+++ b/packages/clawql-documents/src/effect/idp-pipeline-effect.ts
@@ -1,0 +1,265 @@
+/**
+ * Native Effect.gen staging for {@link runIdpPipeline}:
+ * prep → per-hop skip/dry-run/execute (+retry) → Merkle → onHop.
+ * IO (execute, sleep, Merkle, hooks) stays behind {@link documentsFromPromise} / Effect.sleep.
+ */
+
+import { Duration, Effect, Either } from "effect";
+import type { McpToolResult } from "clawql-core";
+import {
+  DEFAULT_IDP_PIPELINE,
+  pipelineStepsForDashboard,
+  type IdpPipelineStep,
+} from "../pipeline/idp-pipeline.js";
+import {
+  idpPipelineMaxRetries,
+  idpPipelineRetryDelayMs,
+  merklePerHopEnabled,
+} from "../pipeline/env.js";
+import { resolveArgsTemplate, type ArgsTemplateContext } from "../pipeline/args-template.js";
+import type {
+  PipelineHopMerkleSnapshot,
+  PipelineHopResult,
+  RunIdpPipelineInput,
+  RunIdpPipelineOptions,
+  RunIdpPipelineResult,
+} from "../pipeline/runner.js";
+import { DocumentsError } from "./documents-errors.js";
+import { documentsFromPromise } from "./documents-effect-utils.js";
+
+export function sleepMs(ms: number): Effect.Effect<void> {
+  return ms > 0 ? Effect.sleep(Duration.millis(ms)) : Effect.void;
+}
+
+export function parseExecuteText(text: string): { ok: boolean; error?: string; excerpt: string } {
+  const excerpt = text.length > 4000 ? `${text.slice(0, 4000)}…` : text;
+  try {
+    const parsed = JSON.parse(text) as Record<string, unknown>;
+    if (parsed && typeof parsed === "object" && "error" in parsed && parsed.error) {
+      return { ok: false, error: String(parsed.error), excerpt };
+    }
+  } catch {
+    /* non-JSON bodies may still be success for binary-ish providers */
+  }
+  return { ok: true, excerpt };
+}
+
+export function loadMerkleSnapshotEffect(): Effect.Effect<
+  PipelineHopMerkleSnapshot | null | undefined,
+  DocumentsError
+> {
+  return documentsFromPromise(async () => {
+    if (!merklePerHopEnabled()) return undefined;
+    try {
+      const { getObsidianVaultPath } = await import("clawql-memory/vault/config");
+      const vault = getObsidianVaultPath();
+      if (!vault) return null;
+      const { loadVaultMerkleSnapshotFromDb, memoryDbSyncEnabled } =
+        await import("clawql-memory/db/memory-db");
+      if (!memoryDbSyncEnabled()) return null;
+      const snap = await loadVaultMerkleSnapshotFromDb(vault);
+      return snap ?? null;
+    } catch {
+      return null;
+    }
+  });
+}
+
+function resolveStepArgs(
+  step: IdpPipelineStep,
+  input: RunIdpPipelineInput,
+  ctx: ArgsTemplateContext
+): Record<string, unknown> {
+  const explicit = input.step_args?.[step.operationId];
+  if (explicit) {
+    return resolveArgsTemplate(explicit, ctx) as Record<string, unknown>;
+  }
+  if (step.argsTemplate) {
+    return resolveArgsTemplate(step.argsTemplate, ctx) as Record<string, unknown>;
+  }
+  return {};
+}
+
+function slicePipeline(
+  pipeline: IdpPipelineStep[],
+  fromStep?: number,
+  toStep?: number
+): IdpPipelineStep[] {
+  const from = Math.max(0, fromStep ?? 0);
+  const to = toStep !== undefined ? Math.min(pipeline.length, toStep + 1) : pipeline.length;
+  return pipeline.slice(from, to);
+}
+
+function mcpResultText(result: McpToolResult): string {
+  return result.content.map((c) => ("text" in c ? c.text : "")).join("\n");
+}
+
+function invokeOnHop(
+  options: RunIdpPipelineOptions,
+  input: RunIdpPipelineInput,
+  hop: PipelineHopResult,
+  pipeline: IdpPipelineStep[]
+): Effect.Effect<void, DocumentsError> {
+  if (!options.onHop) return Effect.void;
+  const onHop = options.onHop;
+  return documentsFromPromise(async () => {
+    await onHop({ correlation_id: input.correlation_id, hop, pipeline });
+  });
+}
+
+/**
+ * IDP hop loop as Effect.gen. Hop execute failures are caught and retried;
+ * the Effect succeeds with {@link RunIdpPipelineResult} (including `ok: false`).
+ */
+export function runIdpPipelineEffect(
+  input: RunIdpPipelineInput,
+  options: RunIdpPipelineOptions
+): Effect.Effect<RunIdpPipelineResult, DocumentsError> {
+  return Effect.gen(function* () {
+    const pipeline = slicePipeline(
+      input.pipeline ?? DEFAULT_IDP_PIPELINE,
+      input.from_step,
+      input.to_step
+    );
+    const skip = new Set((input.skip_stages ?? []).map((s) => s.toLowerCase()));
+    const dryRun = input.dry_run !== false;
+    const stopOnError = input.stop_on_error !== false;
+    const maxRetries = input.max_retries ?? idpPipelineMaxRetries();
+    const retryDelayMs = idpPipelineRetryDelayMs();
+    const ctx: ArgsTemplateContext = {
+      document_path: input.document_path,
+      processed_path: input.processed_path,
+      document_url: input.document_url,
+    };
+
+    const hops: PipelineHopResult[] = [];
+    let completedThrough = -1;
+    let haltedAt: string | undefined;
+    let fatalError: string | undefined;
+
+    for (let index = 0; index < pipeline.length; index++) {
+      const step = pipeline[index]!;
+      const skipped = skip.has(step.stage);
+      const args = resolveStepArgs(step, input, ctx);
+
+      if (skipped) {
+        const hop: PipelineHopResult = {
+          index,
+          stage: step.stage,
+          operationId: step.operationId,
+          label: step.label,
+          ok: true,
+          skipped: true,
+          attempts: 0,
+          latency_ms: 0,
+          args,
+        };
+        hops.push(hop);
+        completedThrough = index;
+        yield* invokeOnHop(options, input, hop, pipeline);
+        continue;
+      }
+
+      if (dryRun) {
+        const hop: PipelineHopResult = {
+          index,
+          stage: step.stage,
+          operationId: step.operationId,
+          label: step.label,
+          ok: true,
+          skipped: false,
+          attempts: 0,
+          latency_ms: 0,
+          args,
+          response_excerpt: "(dry run — execute not called)",
+        };
+        hops.push(hop);
+        completedThrough = index;
+        yield* invokeOnHop(options, input, hop, pipeline);
+        continue;
+      }
+
+      let attempts = 0;
+      let ok = false;
+      let error: string | undefined;
+      let excerpt: string | undefined;
+      const started = Date.now();
+
+      while (attempts <= maxRetries) {
+        attempts++;
+        const execEither = yield* Effect.either(
+          documentsFromPromise(() =>
+            options.execute({
+              operationId: step.operationId,
+              args,
+            })
+          )
+        );
+
+        if (Either.isRight(execEither)) {
+          const text = mcpResultText(execEither.right);
+          const parsed = parseExecuteText(text);
+          if (parsed.ok) {
+            ok = true;
+            excerpt = parsed.excerpt;
+            break;
+          }
+          error = parsed.error ?? "execute returned error payload";
+          excerpt = parsed.excerpt;
+        } else {
+          const cause = execEither.left.cause;
+          error = cause instanceof Error ? cause.message : String(cause ?? execEither.left.reason);
+        }
+
+        if (attempts <= maxRetries && retryDelayMs > 0) {
+          yield* sleepMs(retryDelayMs * attempts);
+        }
+      }
+
+      const merkle_snapshot = ok ? yield* loadMerkleSnapshotEffect() : undefined;
+      const hop: PipelineHopResult = {
+        index,
+        stage: step.stage,
+        operationId: step.operationId,
+        label: step.label,
+        ok,
+        skipped: false,
+        attempts,
+        latency_ms: Date.now() - started,
+        args,
+        error,
+        response_excerpt: excerpt,
+        merkle_snapshot,
+      };
+      hops.push(hop);
+      yield* invokeOnHop(options, input, hop, pipeline);
+
+      if (ok) {
+        completedThrough = index;
+        continue;
+      }
+
+      haltedAt = step.operationId;
+      fatalError = error ?? `step failed: ${step.operationId}`;
+      if (stopOnError) break;
+    }
+
+    const allHopsOk = hops.length === pipeline.length && hops.every((h) => h.ok);
+    const pipelineSucceeded = allHopsOk && !haltedAt;
+    const dashboardCompletedThrough = pipelineSucceeded
+      ? pipeline.length
+      : Math.max(0, completedThrough);
+    const dashboard_steps = pipelineStepsForDashboard(pipeline, dashboardCompletedThrough);
+
+    return {
+      ok: pipelineSucceeded,
+      dry_run: dryRun,
+      correlation_id: input.correlation_id,
+      completed_through: completedThrough,
+      halted_at_operation_id: haltedAt,
+      error: fatalError,
+      hops,
+      dashboard_steps,
+    } satisfies RunIdpPipelineResult;
+  });
+}

--- a/packages/clawql-documents/src/effect/index.ts
+++ b/packages/clawql-documents/src/effect/index.ts
@@ -8,6 +8,11 @@ export {
   executeRunIdpPipelineCore,
   executeRunIdpPipelineEffect,
 } from "./documents-tools-effect.js";
+export {
+  runIdpPipelineEffect,
+  parseExecuteText,
+  loadMerkleSnapshotEffect,
+} from "./idp-pipeline-effect.js";
 export { DocumentsToolsService, documentsToolsLiveLayer } from "./documents-tools-service.js";
 export {
   documentsClassifyProgram,

--- a/packages/clawql-documents/src/pipeline/runner.ts
+++ b/packages/clawql-documents/src/pipeline/runner.ts
@@ -1,18 +1,13 @@
 /**
  * Automated multi-hop IDP pipeline runner ([#307](https://github.com/danielsmithdevelopment/ClawQL/issues/307)).
- * Executes `DEFAULT_IDP_PIPELINE` (or a custom step list) via injected `execute`, with per-hop retries and Merkle snapshots.
+ * Public Promise API; orchestration is native Effect.gen in {@link runIdpPipelineEffect}.
  */
 
+import { Effect } from "effect";
 import type { McpToolResult } from "clawql-core";
 import type { DocumentsPluginExecuteParams } from "../plugin/deps.js";
-import { resolveArgsTemplate, type ArgsTemplateContext } from "./args-template.js";
-import { idpPipelineMaxRetries, idpPipelineRetryDelayMs, merklePerHopEnabled } from "./env.js";
-import {
-  DEFAULT_IDP_PIPELINE,
-  pipelineStepsForDashboard,
-  type IdpPipelineStage,
-  type IdpPipelineStep,
-} from "./idp-pipeline.js";
+import { runIdpPipelineEffect } from "../effect/idp-pipeline-effect.js";
+import type { IdpPipelineStage, IdpPipelineStep } from "./idp-pipeline.js";
 
 export type PipelineExecuteFn = (params: DocumentsPluginExecuteParams) => Promise<McpToolResult>;
 
@@ -75,210 +70,10 @@ export type RunIdpPipelineOptions = {
   onHop?: (event: PipelineHopHookEvent) => void | Promise<void>;
 };
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function parseExecuteText(text: string): { ok: boolean; error?: string; excerpt: string } {
-  const excerpt = text.length > 4000 ? `${text.slice(0, 4000)}…` : text;
-  try {
-    const parsed = JSON.parse(text) as Record<string, unknown>;
-    if (parsed && typeof parsed === "object" && "error" in parsed && parsed.error) {
-      return { ok: false, error: String(parsed.error), excerpt };
-    }
-  } catch {
-    /* non-JSON bodies may still be success for binary-ish providers */
-  }
-  return { ok: true, excerpt };
-}
-
-async function loadMerkleSnapshot(): Promise<PipelineHopMerkleSnapshot | null | undefined> {
-  if (!merklePerHopEnabled()) return undefined;
-  try {
-    const { getObsidianVaultPath } = await import("clawql-memory/vault/config");
-    const vault = getObsidianVaultPath();
-    if (!vault) return null;
-    const { loadVaultMerkleSnapshotFromDb, memoryDbSyncEnabled } =
-      await import("clawql-memory/db/memory-db");
-    if (!memoryDbSyncEnabled()) return null;
-    const snap = await loadVaultMerkleSnapshotFromDb(vault);
-    return snap ?? null;
-  } catch {
-    return null;
-  }
-}
-
-function resolveStepArgs(
-  step: IdpPipelineStep,
-  input: RunIdpPipelineInput,
-  ctx: ArgsTemplateContext
-): Record<string, unknown> {
-  const explicit = input.step_args?.[step.operationId];
-  if (explicit) {
-    return resolveArgsTemplate(explicit, ctx) as Record<string, unknown>;
-  }
-  if (step.argsTemplate) {
-    return resolveArgsTemplate(step.argsTemplate, ctx) as Record<string, unknown>;
-  }
-  return {};
-}
-
-function slicePipeline(
-  pipeline: IdpPipelineStep[],
-  fromStep?: number,
-  toStep?: number
-): IdpPipelineStep[] {
-  const from = Math.max(0, fromStep ?? 0);
-  const to = toStep !== undefined ? Math.min(pipeline.length, toStep + 1) : pipeline.length;
-  return pipeline.slice(from, to);
-}
-
+/** Promise façade over {@link runIdpPipelineEffect} (tests + legacy callers). */
 export async function runIdpPipeline(
   input: RunIdpPipelineInput,
   options: RunIdpPipelineOptions
 ): Promise<RunIdpPipelineResult> {
-  const pipeline = slicePipeline(
-    input.pipeline ?? DEFAULT_IDP_PIPELINE,
-    input.from_step,
-    input.to_step
-  );
-  const skip = new Set((input.skip_stages ?? []).map((s) => s.toLowerCase()));
-  const dryRun = input.dry_run !== false;
-  const stopOnError = input.stop_on_error !== false;
-  const maxRetries = input.max_retries ?? idpPipelineMaxRetries();
-  const retryDelayMs = idpPipelineRetryDelayMs();
-  const ctx: ArgsTemplateContext = {
-    document_path: input.document_path,
-    processed_path: input.processed_path,
-    document_url: input.document_url,
-  };
-
-  const hops: PipelineHopResult[] = [];
-  let completedThrough = -1;
-  let haltedAt: string | undefined;
-  let fatalError: string | undefined;
-
-  for (let index = 0; index < pipeline.length; index++) {
-    const step = pipeline[index]!;
-    const skipped = skip.has(step.stage);
-    const args = resolveStepArgs(step, input, ctx);
-
-    if (skipped) {
-      const hop: PipelineHopResult = {
-        index,
-        stage: step.stage,
-        operationId: step.operationId,
-        label: step.label,
-        ok: true,
-        skipped: true,
-        attempts: 0,
-        latency_ms: 0,
-        args,
-      };
-      hops.push(hop);
-      completedThrough = index;
-      if (options.onHop) {
-        await options.onHop({ correlation_id: input.correlation_id, hop, pipeline });
-      }
-      continue;
-    }
-
-    if (dryRun) {
-      const hop: PipelineHopResult = {
-        index,
-        stage: step.stage,
-        operationId: step.operationId,
-        label: step.label,
-        ok: true,
-        skipped: false,
-        attempts: 0,
-        latency_ms: 0,
-        args,
-        response_excerpt: "(dry run — execute not called)",
-      };
-      hops.push(hop);
-      completedThrough = index;
-      if (options.onHop) {
-        await options.onHop({ correlation_id: input.correlation_id, hop, pipeline });
-      }
-      continue;
-    }
-
-    let attempts = 0;
-    let ok = false;
-    let error: string | undefined;
-    let excerpt: string | undefined;
-    const started = Date.now();
-
-    while (attempts <= maxRetries) {
-      attempts++;
-      try {
-        const result = await options.execute({
-          operationId: step.operationId,
-          args,
-        });
-        const text = result.content.map((c) => ("text" in c ? c.text : "")).join("\n");
-        const parsed = parseExecuteText(text);
-        if (parsed.ok) {
-          ok = true;
-          excerpt = parsed.excerpt;
-          break;
-        }
-        error = parsed.error ?? "execute returned error payload";
-        excerpt = parsed.excerpt;
-      } catch (e: unknown) {
-        error = e instanceof Error ? e.message : String(e);
-      }
-      if (attempts <= maxRetries && retryDelayMs > 0) {
-        await sleep(retryDelayMs * attempts);
-      }
-    }
-
-    const merkle_snapshot = ok ? await loadMerkleSnapshot() : undefined;
-    const hop: PipelineHopResult = {
-      index,
-      stage: step.stage,
-      operationId: step.operationId,
-      label: step.label,
-      ok,
-      skipped: false,
-      attempts,
-      latency_ms: Date.now() - started,
-      args,
-      error,
-      response_excerpt: excerpt,
-      merkle_snapshot,
-    };
-    hops.push(hop);
-    if (options.onHop) {
-      await options.onHop({ correlation_id: input.correlation_id, hop, pipeline });
-    }
-
-    if (ok) {
-      completedThrough = index;
-      continue;
-    }
-
-    haltedAt = step.operationId;
-    fatalError = error ?? `step failed: ${step.operationId}`;
-    if (stopOnError) break;
-  }
-
-  const allHopsOk = hops.length === pipeline.length && hops.every((h) => h.ok);
-  const pipelineSucceeded = allHopsOk && !haltedAt;
-  const dashboardCompletedThrough = pipelineSucceeded
-    ? pipeline.length
-    : Math.max(0, completedThrough);
-  const dashboard_steps = pipelineStepsForDashboard(pipeline, dashboardCompletedThrough);
-
-  return {
-    ok: pipelineSucceeded,
-    dry_run: dryRun,
-    correlation_id: input.correlation_id,
-    completed_through: completedThrough,
-    halted_at_operation_id: haltedAt,
-    error: fatalError,
-    hops,
-    dashboard_steps,
-  };
+  return Effect.runPromise(runIdpPipelineEffect(input, options));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Deepens `clawql-documents` IDP orchestration to native **`Effect.gen`**, matching the memory ingest staging pattern (prepare → IO edges via `tryPromise` / `Effect.sleep`, no nested `runDocumentsEffect`).

### Changes

- New `runIdpPipelineEffect` — hop loop stages: skip / dry-run / execute+retry / Merkle / `onHop`
- `runIdpPipeline` kept as a thin Promise façade (`Effect.runPromise`) for existing tests/callers
- `executeRunIdpPipelineEffect` calls the staged Effect directly (no single monolithic `documentsFromPromise` wrapper)
- Effect status doc updated in modularization implementation status

### Tests

- Existing `runner.test.ts` parity (façade)
- New `idp-pipeline-effect.test.ts` (dry-run / retry / halt, no nested Layer provision)
- `npx vitest run packages/clawql-documents/src` — 31 passed

### Out of scope (follow-ons)

- External ingest staged Effect.gen
- Classify/extract native Effect (still thin `tryPromise`)
- Inject `ExecuteService` into documents (drop module deps singleton)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

