### PR TITLE
feat(documents): native Effect.gen stages for external ingest

### DIFF
--- a/docs/design/modularization-implementation-status.md
+++ b/docs/design/modularization-implementation-status.md
@@ -235,18 +235,19 @@ From enablement §5.4 and the Effect plan §8:
 
 ## 7. Effect-TS migration status
 
-| Area                                                                             | Status                                                                                                                                       |
-| -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `effect` dependency                                                              | ✅ Pinned in `clawql-api`                                                                                                                    |
-| `SearchService` / `ExecuteService`                                               | ✅ Live Layers; MCP uses `getClawqlApi().run(Effect…)`                                                                                       |
-| `AuditLive`                                                                      | ✅ Composed in `createClawQLApi()`                                                                                                           |
-| `Plugin` / `PluginRegistry`                                                      | ✅ Effect `register` / `beforeCallTool`                                                                                                      |
-| Extracted packages (`memory`, `documents`, `automation`, `sandbox`, `ouroboros`) | 🚧 Layer wrappers shipped; memory ingest/recall, documents IDP runner, + ouroboros hot paths use native `Effect.gen` (IO still `tryPromise`) |
-| `@effect/schema` at boundaries                                                   | ❌ Zod remains at MCP tool registration                                                                                                      |
-| Horizontal `Plugin` Layers                                                       | ✅ All tiers via `composeHorizontalPluginLayers()`                                                                                           |
-| Operator dynamic Layer list from CRD                                             | ✅ `composeHorizontalPluginLayersFromTierSpec()` maps `ClawQLHorizontalTierSpec` → Layers                                                    |
-| `MemoryIngestService` / vault post-sync                                          | ✅ Native `Effect.gen` stages prepare → vault write → `MemoryDbService` sync (no nested `runMemoryEffect`)                                   |
-| `DocumentsToolsService` IDP runner                                               | ✅ Native `Effect.gen` hop loop (skip/dry-run/execute+retry/Merkle/onHop); Promise façade kept for tests                                     |
+| Area                                                                             | Status                                                                                                                                                  |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `effect` dependency                                                              | ✅ Pinned in `clawql-api`                                                                                                                               |
+| `SearchService` / `ExecuteService`                                               | ✅ Live Layers; MCP uses `getClawqlApi().run(Effect…)`                                                                                                  |
+| `AuditLive`                                                                      | ✅ Composed in `createClawQLApi()`                                                                                                                      |
+| `Plugin` / `PluginRegistry`                                                      | ✅ Effect `register` / `beforeCallTool`                                                                                                                 |
+| Extracted packages (`memory`, `documents`, `automation`, `sandbox`, `ouroboros`) | 🚧 Layer wrappers shipped; memory ingest/recall, documents IDP + external ingest, + ouroboros hot paths use native `Effect.gen` (IO still `tryPromise`) |
+| `@effect/schema` at boundaries                                                   | ❌ Zod remains at MCP tool registration                                                                                                                 |
+| Horizontal `Plugin` Layers                                                       | ✅ All tiers via `composeHorizontalPluginLayers()`                                                                                                      |
+| Operator dynamic Layer list from CRD                                             | ✅ `composeHorizontalPluginLayersFromTierSpec()` maps `ClawQLHorizontalTierSpec` → Layers                                                               |
+| `MemoryIngestService` / vault post-sync                                          | ✅ Native `Effect.gen` stages prepare → vault write → `MemoryDbService` sync (no nested `runMemoryEffect`)                                              |
+| `DocumentsToolsService` IDP runner                                               | ✅ Native `Effect.gen` hop loop (skip/dry-run/execute+retry/Merkle/onHop); Promise façade kept for tests                                                |
+| `DocumentsIngestService` external ingest                                         | ✅ Native `Effect.gen` prelude → prepare/fetch → write → `vaultWritePostSyncEffect` (no nested `runMemoryEffect`)                                       |
 
 **Rule for new code in extracted packages:** prefer Effect in `clawql-core` / `clawql-api`; legacy `async` is acceptable at IO edges during migration (`Effect.tryPromise`). See plan §7.
 

--- a/packages/clawql-documents/src/effect/documents-effect-runtime.ts
+++ b/packages/clawql-documents/src/effect/documents-effect-runtime.ts
@@ -1,5 +1,10 @@
 import { Cause, Effect, Exit, Layer } from "effect";
-import { vaultConfigLiveLayer, VaultConfigService } from "clawql-memory/plugin";
+import {
+  memoryDbLiveLayer,
+  MemoryDbService,
+  vaultConfigLiveLayer,
+  VaultConfigService,
+} from "clawql-memory/plugin";
 import type { ExternalIngestInput, ExternalIngestResult } from "../ingest/external-ingest.js";
 import type {
   ClassifyDocumentInput,
@@ -13,12 +18,14 @@ import type { RunIdpPipelineInput, RunIdpPipelineResult } from "../pipeline/runn
 import { DocumentsIngestService, documentsIngestLiveLayer } from "./documents-ingest-service.js";
 import { DocumentsToolsService, documentsToolsLiveLayer } from "./documents-tools-service.js";
 
-export type DocumentsServices = VaultConfigService | DocumentsIngestService | DocumentsToolsService;
+export type DocumentsServices =
+  VaultConfigService | MemoryDbService | DocumentsIngestService | DocumentsToolsService;
 
-/** Merged Effect Layer for clawql-documents domain services + memory vault config. */
+/** Merged Effect Layer for clawql-documents domain services + memory vault/db. */
 export function documentsServicesLiveLayer(): Layer.Layer<DocumentsServices> {
   return Layer.mergeAll(
     vaultConfigLiveLayer(),
+    memoryDbLiveLayer(),
     documentsIngestLiveLayer(),
     documentsToolsLiveLayer()
   );

--- a/packages/clawql-documents/src/effect/documents-ingest-service.ts
+++ b/packages/clawql-documents/src/effect/documents-ingest-service.ts
@@ -1,5 +1,5 @@
 import { Context, Effect, Layer } from "effect";
-import { VaultConfigService } from "clawql-memory/plugin";
+import { MemoryDbService, VaultConfigService } from "clawql-memory/plugin";
 import type { ExternalIngestInput, ExternalIngestResult } from "../ingest/external-ingest.js";
 import { executeExternalIngestEffect } from "./external-ingest-effect.js";
 import { DocumentsError } from "./documents-errors.js";
@@ -10,7 +10,7 @@ export class DocumentsIngestService extends Context.Tag("clawql/DocumentsIngestS
   {
     readonly ingest: (
       input: ExternalIngestInput
-    ) => Effect.Effect<ExternalIngestResult, DocumentsError, VaultConfigService>;
+    ) => Effect.Effect<ExternalIngestResult, DocumentsError, VaultConfigService | MemoryDbService>;
   }
 >() {}
 

--- a/packages/clawql-documents/src/effect/external-ingest-effect.test.ts
+++ b/packages/clawql-documents/src/effect/external-ingest-effect.test.ts
@@ -1,7 +1,13 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Effect } from "effect";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { documentsServicesLiveLayer } from "./documents-effect-runtime.js";
-import { executeExternalIngestEffect } from "./external-ingest-effect.js";
+import {
+  executeExternalIngestCoreEffect,
+  executeExternalIngestEffect,
+} from "./external-ingest-effect.js";
 
 describe("executeExternalIngestEffect", () => {
   it("returns disabled stub when CLAWQL_EXTERNAL_INGEST is unset", async () => {
@@ -20,5 +26,71 @@ describe("executeExternalIngestEffect", () => {
       if (saved === undefined) delete process.env.CLAWQL_EXTERNAL_INGEST;
       else process.env.CLAWQL_EXTERNAL_INGEST = saved;
     }
+  });
+});
+
+describe("executeExternalIngestCoreEffect", () => {
+  let home: string;
+  let prevVault: string | undefined;
+  let prevIngest: string | undefined;
+  let prevMemoryDb: string | undefined;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "clawql-docs-ingest-native-"));
+    prevVault = process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+    prevIngest = process.env.CLAWQL_EXTERNAL_INGEST;
+    prevMemoryDb = process.env.CLAWQL_MEMORY_DB;
+    process.env.CLAWQL_OBSIDIAN_VAULT_PATH = home;
+    process.env.CLAWQL_EXTERNAL_INGEST = "1";
+    process.env.CLAWQL_MEMORY_DB = "0";
+  });
+
+  afterEach(async () => {
+    if (prevVault === undefined) delete process.env.CLAWQL_OBSIDIAN_VAULT_PATH;
+    else process.env.CLAWQL_OBSIDIAN_VAULT_PATH = prevVault;
+    if (prevIngest === undefined) delete process.env.CLAWQL_EXTERNAL_INGEST;
+    else process.env.CLAWQL_EXTERNAL_INGEST = prevIngest;
+    if (prevMemoryDb === undefined) delete process.env.CLAWQL_MEMORY_DB;
+    else process.env.CLAWQL_MEMORY_DB = prevMemoryDb;
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("stages prepare → vault write without nested runMemoryEffect", async () => {
+    const result = await Effect.runPromise(
+      executeExternalIngestCoreEffect(home, {
+        dryRun: false,
+        documents: [
+          {
+            path: "Memory/external/native-effect.md",
+            markdown: "# Native Effect ingest\n\nstaged pipeline\n",
+          },
+        ],
+      }).pipe(Effect.provide(documentsServicesLiveLayer()))
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.dryRun).toBe(false);
+    expect(result.importedPaths).toEqual(["Memory/external/native-effect.md"]);
+    const body = await readFile(join(home, "Memory", "external", "native-effect.md"), "utf8");
+    expect(body).toContain("staged pipeline");
+  });
+
+  it("dry-run skips vault writes", async () => {
+    const result = await Effect.runPromise(
+      executeExternalIngestCoreEffect(home, {
+        dryRun: true,
+        documents: [
+          {
+            path: "Memory/external/dry.md",
+            markdown: "would write",
+          },
+        ],
+      }).pipe(Effect.provide(documentsServicesLiveLayer()))
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.dryRun).toBe(true);
+    expect(result.importedPaths).toEqual(["Memory/external/dry.md"]);
+    await expect(readFile(join(home, "Memory", "external", "dry.md"), "utf8")).rejects.toThrow();
   });
 });

--- a/packages/clawql-documents/src/effect/external-ingest-effect.ts
+++ b/packages/clawql-documents/src/effect/external-ingest-effect.ts
@@ -1,20 +1,176 @@
-import { Effect } from "effect";
-import { VaultConfigService } from "clawql-memory/plugin";
+/**
+ * Native Effect.gen staging for ingest_external_knowledge:
+ * prelude → prepare/fetch → vault write → MemoryDb post-sync / artifact hints.
+ * No nested {@link runMemoryEffect} / {@link runDocumentsEffect}.
+ */
+
+import { Effect, Either } from "effect";
 import {
-  executeExternalIngestCore,
+  MemoryDbService,
+  VaultConfigService,
+  vaultArtifactHintsEffect,
+  vaultWritePostSyncEffect,
+} from "clawql-memory/plugin";
+import {
+  evaluateExternalIngestPrelude,
+  fetchUrlResource,
+  prepareMarkdownDocuments,
+  writePlannedMarkdownDocuments,
+  writeUrlIngestNote,
   type ExternalIngestInput,
   type ExternalIngestResult,
 } from "../ingest/external-ingest.js";
 import { DocumentsError } from "./documents-errors.js";
 import { documentsFromPromise } from "./documents-effect-utils.js";
 
+export type ExternalIngestCoreServices = MemoryDbService;
+
+/**
+ * Vault write + post-sync as Effect.gen.
+ * fs / fetch / Presidio stay behind {@link documentsFromPromise}; db sync via {@link MemoryDbService}.
+ */
+export function executeExternalIngestCoreEffect(
+  vault: string | null,
+  input: ExternalIngestInput
+): Effect.Effect<ExternalIngestResult, DocumentsError, ExternalIngestCoreServices> {
+  return Effect.gen(function* () {
+    const prelude = evaluateExternalIngestPrelude(vault, input);
+    if (prelude.kind === "result") {
+      return prelude.result;
+    }
+
+    if (prelude.kind === "stub") {
+      const hints = yield* vaultArtifactHintsEffect(prelude.vault);
+      return {
+        ok: true,
+        stub: true,
+        enabled: true,
+        vaultConfigured: true,
+        message:
+          `No import payload. Pass documents: [{ path, markdown }] for Markdown import, or url + source "url" with CLAWQL_EXTERNAL_INGEST_FETCH=1. ` +
+          `Preview: source=${JSON.stringify(prelude.srcLabel)}, dryRun=${prelude.dryRun}.`,
+        roadmap: [
+          "Markdown: pass documents[] with vault-relative .md paths (dryRun defaults true).",
+          'URL: set source to "url", pass url (https), scope as optional target path, and CLAWQL_EXTERNAL_INGEST_FETCH=1.',
+          "Secrets: per-provider env vars for future Notion/Confluence/GitHub plugins; never logged.",
+          "Orchestration: writes use the vault lock; syncMemoryDbForVaultScanRoot + _INDEX_ page after import.",
+        ],
+        relatedIssues: [40, 24, 25, 27],
+        ...hints,
+      } satisfies ExternalIngestResult;
+    }
+
+    if (prelude.kind === "url") {
+      if (prelude.dryRun) {
+        const hints = yield* vaultArtifactHintsEffect(prelude.vault);
+        return {
+          ok: true,
+          enabled: true,
+          vaultConfigured: true,
+          dryRun: true,
+          message: `Would fetch ${JSON.stringify(prelude.url)} → ${JSON.stringify(prelude.targetRel)}`,
+          importedPaths: [prelude.targetRel],
+          ...hints,
+        } satisfies ExternalIngestResult;
+      }
+
+      const fetchEither = yield* Effect.either(
+        documentsFromPromise(() => fetchUrlResource(prelude.url))
+      );
+      if (Either.isLeft(fetchEither)) {
+        const cause = fetchEither.left.cause;
+        const msg =
+          cause instanceof Error ? cause.message : String(cause ?? fetchEither.left.reason);
+        return {
+          ok: false,
+          enabled: true,
+          vaultConfigured: true,
+          message: `Fetch failed: ${msg}`,
+          error: "fetch_failed",
+        } satisfies ExternalIngestResult;
+      }
+
+      const resource = fetchEither.right;
+      yield* documentsFromPromise(() =>
+        writeUrlIngestNote(
+          prelude.vault,
+          prelude.targetRel,
+          resource.finalUrl,
+          resource.body,
+          resource.contentType
+        )
+      );
+      yield* vaultWritePostSyncEffect(prelude.vault);
+      const hints = yield* vaultArtifactHintsEffect(prelude.vault);
+      return {
+        ok: true,
+        enabled: true,
+        vaultConfigured: true,
+        dryRun: false,
+        message: `Fetched and wrote ${prelude.targetRel}`,
+        importedPaths: [prelude.targetRel],
+        ...hints,
+      } satisfies ExternalIngestResult;
+    }
+
+    // markdown
+    const prepared = yield* documentsFromPromise(() =>
+      prepareMarkdownDocuments(prelude.documents, prelude.vault)
+    );
+    if (prepared.planned.length === 0) {
+      return {
+        ok: false,
+        enabled: true,
+        vaultConfigured: true,
+        message: "No valid documents to import.",
+        documentErrors: prepared.docErrors,
+        error: "no_valid_documents",
+      } satisfies ExternalIngestResult;
+    }
+
+    if (prelude.dryRun) {
+      const hints = yield* vaultArtifactHintsEffect(prelude.vault);
+      return {
+        ok: true,
+        enabled: true,
+        vaultConfigured: true,
+        dryRun: true,
+        message: `Would import ${prepared.planned.length} Markdown file(s).`,
+        importedPaths: prepared.planned.map((p) => p.rel),
+        documentErrors: prepared.docErrors.length > 0 ? prepared.docErrors : undefined,
+        ...hints,
+      } satisfies ExternalIngestResult;
+    }
+
+    yield* documentsFromPromise(() =>
+      writePlannedMarkdownDocuments(prelude.vault, prepared.planned)
+    );
+    yield* vaultWritePostSyncEffect(prelude.vault);
+    const hints = yield* vaultArtifactHintsEffect(prelude.vault);
+    return {
+      ok: true,
+      enabled: true,
+      vaultConfigured: true,
+      dryRun: false,
+      message: `Imported ${prepared.planned.length} Markdown file(s).`,
+      importedPaths: prepared.planned.map((p) => p.rel),
+      documentErrors: prepared.docErrors.length > 0 ? prepared.docErrors : undefined,
+      ...hints,
+    } satisfies ExternalIngestResult;
+  });
+}
+
 /** External ingest pipeline as Effect.gen — vault path via {@link VaultConfigService}. */
 export function executeExternalIngestEffect(
   input: ExternalIngestInput
-): Effect.Effect<ExternalIngestResult, DocumentsError, VaultConfigService> {
+): Effect.Effect<
+  ExternalIngestResult,
+  DocumentsError,
+  VaultConfigService | ExternalIngestCoreServices
+> {
   return Effect.gen(function* () {
     const vaultConfig = yield* VaultConfigService;
     const vault = vaultConfig.getObsidianVaultPath();
-    return yield* documentsFromPromise(() => executeExternalIngestCore(vault, input));
+    return yield* executeExternalIngestCoreEffect(vault, input);
   });
 }

--- a/packages/clawql-documents/src/effect/index.ts
+++ b/packages/clawql-documents/src/effect/index.ts
@@ -1,6 +1,10 @@
 export { DocumentsError } from "./documents-errors.js";
 export { documentsFromPromise, documentsSync } from "./documents-effect-utils.js";
-export { executeExternalIngestEffect } from "./external-ingest-effect.js";
+export {
+  executeExternalIngestCoreEffect,
+  executeExternalIngestEffect,
+  type ExternalIngestCoreServices,
+} from "./external-ingest-effect.js";
 export { DocumentsIngestService, documentsIngestLiveLayer } from "./documents-ingest-service.js";
 export {
   executeClassifyDocumentEffect,

--- a/packages/clawql-documents/src/ingest/external-ingest.ts
+++ b/packages/clawql-documents/src/ingest/external-ingest.ts
@@ -4,10 +4,14 @@
  * - **`source: "markdown"`** + **`documents[]`**: write vault-relative `.md` files (same pipeline as `memory_ingest`).
  * - **`source: "url"`** + **`url`**: fetch HTTPS content when **`CLAWQL_EXTERNAL_INGEST_FETCH=1`** (opt-in network).
  * - No payload: legacy **stub** roadmap JSON (still no writes).
+ *
+ * Orchestration: native Effect.gen in {@link executeExternalIngestCoreEffect}.
  */
 
 import { getClawqlOptionalToolFlags } from "clawql-api";
 import { maybePresidioRedactText, presidioEnabled } from "clawql-api";
+import { Effect } from "effect";
+import { memoryDbLiveLayer } from "clawql-memory/plugin";
 import { buildUrlIngestNote, formatUrlResponseAsMarkdown } from "./url-format.js";
 import { slugifyTitle } from "clawql-memory/ingest/slug";
 import {
@@ -73,15 +77,15 @@ export function externalIngestFeatureEnabled(): boolean {
   return getClawqlOptionalToolFlags().externalIngestPreview;
 }
 
-function envFetchAllowed(): boolean {
+export function envFetchAllowed(): boolean {
   return process.env.CLAWQL_EXTERNAL_INGEST_FETCH?.trim() === "1";
 }
 
-function normalizeRelPath(p: string): string {
+export function normalizeRelPath(p: string): string {
   return p.replace(/\\/g, "/").replace(/^\/+/, "");
 }
 
-function validateMarkdownPath(rel: string): string | null {
+export function validateMarkdownPath(rel: string): string | null {
   const n = normalizeRelPath(rel);
   if (!n.toLowerCase().endsWith(".md")) {
     return "path must end with .md";
@@ -92,11 +96,11 @@ function validateMarkdownPath(rel: string): string | null {
   return null;
 }
 
-function isoNow(): string {
+export function isoNow(): string {
   return new Date().toISOString();
 }
 
-function defaultPathForUrl(urlStr: string): string {
+export function defaultPathForUrl(urlStr: string): string {
   let pathname = "/fetched";
   try {
     pathname = new URL(urlStr).pathname || "/";
@@ -110,19 +114,7 @@ function defaultPathForUrl(urlStr: string): string {
   return `Memory/external/${slug}.md`;
 }
 
-async function loadOptionalArtifactHints(
-  vault: string
-): Promise<Pick<ExternalIngestResult, "merkleSnapshot" | "cuckooMembershipReady">> {
-  const { runMemoryEffect, vaultArtifactHintsEffect } = await import("clawql-memory/plugin");
-  return runMemoryEffect(vaultArtifactHintsEffect(vault));
-}
-
-async function afterImportSync(vault: string): Promise<void> {
-  const { runMemoryEffect, vaultWritePostSyncEffect } = await import("clawql-memory/plugin");
-  await runMemoryEffect(vaultWritePostSyncEffect(vault));
-}
-
-async function fetchUrlResource(urlStr: string): Promise<{
+export async function fetchUrlResource(urlStr: string): Promise<{
   body: string;
   contentType: string | null;
   finalUrl: string;
@@ -165,25 +157,115 @@ async function fetchUrlResource(urlStr: string): Promise<{
   return { body, contentType, finalUrl: res.url };
 }
 
+export type PlannedMarkdownDoc = { rel: string; markdown: string };
+
+/** Validate + optional Presidio redact for Markdown documents. */
+export async function prepareMarkdownDocuments(
+  documents: ExternalIngestDocumentInput[],
+  vault: string
+): Promise<{
+  planned: PlannedMarkdownDoc[];
+  docErrors: { path: string; error: string }[];
+}> {
+  const docErrors: { path: string; error: string }[] = [];
+  const planned: PlannedMarkdownDoc[] = [];
+
+  for (const d of documents) {
+    const rel = normalizeRelPath(d.path);
+    const pe = validateMarkdownPath(rel);
+    if (pe) {
+      docErrors.push({ path: d.path, error: pe });
+      continue;
+    }
+    if (Buffer.byteLength(d.markdown ?? "", "utf8") > MAX_MARKDOWN_BYTES) {
+      docErrors.push({ path: d.path, error: "markdown exceeds size cap" });
+      continue;
+    }
+    try {
+      resolveVaultPath(vault, rel);
+    } catch (e: unknown) {
+      docErrors.push({ path: d.path, error: e instanceof Error ? e.message : String(e) });
+      continue;
+    }
+    let markdown = d.markdown ?? "";
+    if (presidioEnabled()) {
+      markdown = await maybePresidioRedactText(markdown);
+    }
+    planned.push({ rel, markdown });
+  }
+
+  return { planned, docErrors };
+}
+
+export async function writePlannedMarkdownDocuments(
+  vault: string,
+  planned: PlannedMarkdownDoc[]
+): Promise<void> {
+  await withVaultWriteLock(vault, async () => {
+    for (const p of planned) {
+      await writeVaultTextFileAtomic(vault, p.rel, p.markdown);
+    }
+  });
+}
+
+export async function writeUrlIngestNote(
+  vault: string,
+  targetRel: string,
+  finalUrl: string,
+  body: string,
+  contentType: string | null
+): Promise<void> {
+  const formatted = formatUrlResponseAsMarkdown(body, contentType, finalUrl);
+  const note = buildUrlIngestNote(finalUrl, formatted, isoNow());
+  await withVaultWriteLock(vault, async () => {
+    await writeVaultTextFileAtomic(vault, targetRel, note);
+  });
+}
+
 /**
- * Run external ingest: Markdown documents and/or (opt-in) URL fetch.
- * Vault path is resolved by the caller (Effect layer or tests).
+ * Sync gate / payload classification (no IO). Early {@link ExternalIngestResult}
+ * or a plan for Effect stages.
  */
-export async function executeExternalIngestCore(
+export type ExternalIngestPrelude =
+  | { kind: "result"; result: ExternalIngestResult }
+  | {
+      kind: "url";
+      vault: string;
+      url: string;
+      targetRel: string;
+      dryRun: boolean;
+    }
+  | {
+      kind: "markdown";
+      vault: string;
+      documents: ExternalIngestDocumentInput[];
+      dryRun: boolean;
+    }
+  | {
+      kind: "stub";
+      vault: string;
+      dryRun: boolean;
+      srcLabel: string;
+    };
+
+export function evaluateExternalIngestPrelude(
   vault: string | null,
   input: ExternalIngestInput
-): Promise<ExternalIngestResult> {
+): ExternalIngestPrelude {
   const vaultConfigured = vault !== null;
   if (!getClawqlOptionalToolFlags().enableDocuments) {
     return {
-      ok: false,
-      stub: true,
-      enabled: false,
-      vaultConfigured,
-      hint: "Set CLAWQL_ENABLE_DOCUMENTS=1 (or unset) for document tools. See docs/mcp/mcp-tools.md.",
-      message: "Document tools are disabled (CLAWQL_ENABLE_DOCUMENTS=0).",
-      roadmap: [],
-      relatedIssues: [40],
+      kind: "result",
+      result: {
+        ok: false,
+        stub: true,
+        enabled: false,
+        vaultConfigured,
+        hint: "Set CLAWQL_ENABLE_DOCUMENTS=1 (or unset) for document tools. See docs/mcp/mcp-tools.md.",
+        message: "Document tools are disabled (CLAWQL_ENABLE_DOCUMENTS=0).",
+        roadmap: [],
+        relatedIssues: [40],
+      },
     };
   }
   const enabled = externalIngestFeatureEnabled();
@@ -191,15 +273,18 @@ export async function executeExternalIngestCore(
 
   if (!enabled) {
     return {
-      ok: false,
-      stub: true,
-      enabled: false,
-      vaultConfigured,
-      hint: "External bulk ingest is not enabled. Set CLAWQL_EXTERNAL_INGEST=1. See docs/mcp/external-ingest.md.",
-      message:
-        "Feature disabled. Set CLAWQL_EXTERNAL_INGEST=1 to import Markdown or (with CLAWQL_EXTERNAL_INGEST_FETCH=1) fetch a URL.",
-      roadmap: [],
-      relatedIssues: [40, 24, 25, 27],
+      kind: "result",
+      result: {
+        ok: false,
+        stub: true,
+        enabled: false,
+        vaultConfigured,
+        hint: "External bulk ingest is not enabled. Set CLAWQL_EXTERNAL_INGEST=1. See docs/mcp/external-ingest.md.",
+        message:
+          "Feature disabled. Set CLAWQL_EXTERNAL_INGEST=1 to import Markdown or (with CLAWQL_EXTERNAL_INGEST_FETCH=1) fetch a URL.",
+        roadmap: [],
+        relatedIssues: [40, 24, 25, 27],
+      },
     };
   }
 
@@ -212,61 +297,76 @@ export async function executeExternalIngestCore(
 
   if (hasImportPayload && (!vaultConfigured || !vault)) {
     return {
-      ok: false,
-      enabled: true,
-      vaultConfigured: false,
-      message: "Obsidian vault is not configured. Set CLAWQL_OBSIDIAN_VAULT_PATH.",
-      error: "vault_missing",
+      kind: "result",
+      result: {
+        ok: false,
+        enabled: true,
+        vaultConfigured: false,
+        message: "Obsidian vault is not configured. Set CLAWQL_OBSIDIAN_VAULT_PATH.",
+        error: "vault_missing",
+      },
     };
   }
 
   if (!vault) {
     return {
-      ok: true,
-      stub: true,
-      enabled: true,
-      vaultConfigured: false,
-      message:
-        "No import payload. Configure CLAWQL_OBSIDIAN_VAULT_PATH to import Markdown or fetch URLs. " +
-        "Pass documents[] or url + source url (with CLAWQL_EXTERNAL_INGEST_FETCH=1).",
-      roadmap: [
-        "Markdown: pass documents[] with vault-relative .md paths (dryRun defaults true).",
-        'URL: set source to "url", pass url (https), scope as optional target path, and CLAWQL_EXTERNAL_INGEST_FETCH=1.',
-        "Secrets: per-provider env vars for future Notion/Confluence/GitHub plugins; never logged.",
-        "Orchestration: writes use the vault lock; syncMemoryDbForVaultScanRoot + _INDEX_ page after import.",
-      ],
-      relatedIssues: [40, 24, 25, 27],
+      kind: "result",
+      result: {
+        ok: true,
+        stub: true,
+        enabled: true,
+        vaultConfigured: false,
+        message:
+          "No import payload. Configure CLAWQL_OBSIDIAN_VAULT_PATH to import Markdown or fetch URLs. " +
+          "Pass documents[] or url + source url (with CLAWQL_EXTERNAL_INGEST_FETCH=1).",
+        roadmap: [
+          "Markdown: pass documents[] with vault-relative .md paths (dryRun defaults true).",
+          'URL: set source to "url", pass url (https), scope as optional target path, and CLAWQL_EXTERNAL_INGEST_FETCH=1.',
+          "Secrets: per-provider env vars for future Notion/Confluence/GitHub plugins; never logged.",
+          "Orchestration: writes use the vault lock; syncMemoryDbForVaultScanRoot + _INDEX_ page after import.",
+        ],
+        relatedIssues: [40, 24, 25, 27],
+      },
     };
   }
 
   if (documents?.length && urlRaw) {
     return {
-      ok: false,
-      enabled: true,
-      vaultConfigured: true,
-      message: "Pass only one of documents[] or url, not both.",
-      error: "conflicting_payload",
+      kind: "result",
+      result: {
+        ok: false,
+        enabled: true,
+        vaultConfigured: true,
+        message: "Pass only one of documents[] or url, not both.",
+        error: "conflicting_payload",
+      },
     };
   }
 
   if (urlRaw || src === "url") {
     if (!urlRaw) {
       return {
-        ok: false,
-        enabled: true,
-        vaultConfigured: true,
-        message: 'source "url" requires a non-empty url string.',
-        error: "url_required",
+        kind: "result",
+        result: {
+          ok: false,
+          enabled: true,
+          vaultConfigured: true,
+          message: 'source "url" requires a non-empty url string.',
+          error: "url_required",
+        },
       };
     }
     if (!envFetchAllowed()) {
       return {
-        ok: false,
-        enabled: true,
-        vaultConfigured: true,
-        message:
-          "URL fetch is disabled. Set CLAWQL_EXTERNAL_INGEST_FETCH=1 to allow HTTPS fetch from this tool.",
-        error: "fetch_disabled",
+        kind: "result",
+        result: {
+          ok: false,
+          enabled: true,
+          vaultConfigured: true,
+          message:
+            "URL fetch is disabled. Set CLAWQL_EXTERNAL_INGEST_FETCH=1 to allow HTTPS fetch from this tool.",
+          error: "fetch_disabled",
+        },
       };
     }
     const targetRel = input.scope?.trim()
@@ -275,11 +375,14 @@ export async function executeExternalIngestCore(
     const pathErr = validateMarkdownPath(targetRel);
     if (pathErr) {
       return {
-        ok: false,
-        enabled: true,
-        vaultConfigured: true,
-        message: `Invalid target path: ${pathErr}`,
-        error: "invalid_path",
+        kind: "result",
+        result: {
+          ok: false,
+          enabled: true,
+          vaultConfigured: true,
+          message: `Invalid target path: ${pathErr}`,
+          error: "invalid_path",
+        },
       };
     }
     try {
@@ -287,164 +390,55 @@ export async function executeExternalIngestCore(
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
       return {
-        ok: false,
-        enabled: true,
-        vaultConfigured: true,
-        message: msg,
-        error: "invalid_path",
+        kind: "result",
+        result: {
+          ok: false,
+          enabled: true,
+          vaultConfigured: true,
+          message: msg,
+          error: "invalid_path",
+        },
       };
     }
-
-    if (dryRun) {
-      return {
-        ok: true,
-        enabled: true,
-        vaultConfigured: true,
-        dryRun: true,
-        message: `Would fetch ${JSON.stringify(urlRaw)} → ${JSON.stringify(targetRel)}`,
-        importedPaths: [targetRel],
-        ...(await loadOptionalArtifactHints(vault)),
-      };
-    }
-
-    let resource: { body: string; contentType: string | null; finalUrl: string };
-    try {
-      resource = await fetchUrlResource(urlRaw);
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      return {
-        ok: false,
-        enabled: true,
-        vaultConfigured: true,
-        message: `Fetch failed: ${msg}`,
-        error: "fetch_failed",
-      };
-    }
-
-    const formatted = formatUrlResponseAsMarkdown(
-      resource.body,
-      resource.contentType,
-      resource.finalUrl
-    );
-    const note = buildUrlIngestNote(resource.finalUrl, formatted, isoNow());
-    await withVaultWriteLock(vault, async () => {
-      await writeVaultTextFileAtomic(vault, targetRel, note);
-    });
-    await afterImportSync(vault);
-
-    const hints = await loadOptionalArtifactHints(vault);
-    return {
-      ok: true,
-      enabled: true,
-      vaultConfigured: true,
-      dryRun: false,
-      message: `Fetched and wrote ${targetRel}`,
-      importedPaths: [targetRel],
-      ...hints,
-    };
+    return { kind: "url", vault, url: urlRaw, targetRel, dryRun };
   }
 
   if (documents !== undefined && documents.length > 0) {
     if (documents.length > MAX_DOCUMENTS) {
       return {
-        ok: false,
-        enabled: true,
-        vaultConfigured: true,
-        message: `At most ${MAX_DOCUMENTS} documents per call.`,
-        error: "too_many_documents",
+        kind: "result",
+        result: {
+          ok: false,
+          enabled: true,
+          vaultConfigured: true,
+          message: `At most ${MAX_DOCUMENTS} documents per call.`,
+          error: "too_many_documents",
+        },
       };
     }
-
-    const docErrors: { path: string; error: string }[] = [];
-    const planned: { rel: string; markdown: string }[] = [];
-
-    for (const d of documents) {
-      const rel = normalizeRelPath(d.path);
-      const pe = validateMarkdownPath(rel);
-      if (pe) {
-        docErrors.push({ path: d.path, error: pe });
-        continue;
-      }
-      if (Buffer.byteLength(d.markdown ?? "", "utf8") > MAX_MARKDOWN_BYTES) {
-        docErrors.push({ path: d.path, error: "markdown exceeds size cap" });
-        continue;
-      }
-      try {
-        resolveVaultPath(vault, rel);
-      } catch (e: unknown) {
-        docErrors.push({ path: d.path, error: e instanceof Error ? e.message : String(e) });
-        continue;
-      }
-      let markdown = d.markdown ?? "";
-      if (presidioEnabled()) {
-        markdown = await maybePresidioRedactText(markdown);
-      }
-      planned.push({ rel, markdown });
-    }
-
-    if (planned.length === 0) {
-      return {
-        ok: false,
-        enabled: true,
-        vaultConfigured: true,
-        message: "No valid documents to import.",
-        documentErrors: docErrors,
-        error: "no_valid_documents",
-      };
-    }
-
-    if (dryRun) {
-      return {
-        ok: true,
-        enabled: true,
-        vaultConfigured: true,
-        dryRun: true,
-        message: `Would import ${planned.length} Markdown file(s).`,
-        importedPaths: planned.map((p) => p.rel),
-        documentErrors: docErrors.length > 0 ? docErrors : undefined,
-        ...(await loadOptionalArtifactHints(vault)),
-      };
-    }
-
-    await withVaultWriteLock(vault, async () => {
-      for (const p of planned) {
-        await writeVaultTextFileAtomic(vault, p.rel, p.markdown);
-      }
-    });
-    await afterImportSync(vault);
-
-    const hints = await loadOptionalArtifactHints(vault);
-    return {
-      ok: true,
-      enabled: true,
-      vaultConfigured: true,
-      dryRun: false,
-      message: `Imported ${planned.length} Markdown file(s).`,
-      importedPaths: planned.map((p) => p.rel),
-      documentErrors: docErrors.length > 0 ? docErrors : undefined,
-      ...hints,
-    };
+    return { kind: "markdown", vault, documents, dryRun };
   }
 
-  const srcLabel = input.source?.trim() || "unspecified";
-  const hints = await loadOptionalArtifactHints(vault);
   return {
-    ok: true,
-    stub: true,
-    enabled: true,
-    vaultConfigured: true,
-    message:
-      `No import payload. Pass documents: [{ path, markdown }] for Markdown import, or url + source "url" with CLAWQL_EXTERNAL_INGEST_FETCH=1. ` +
-      `Preview: source=${JSON.stringify(srcLabel)}, dryRun=${dryRun}.`,
-    roadmap: [
-      "Markdown: pass documents[] with vault-relative .md paths (dryRun defaults true).",
-      'URL: set source to "url", pass url (https), scope as optional target path, and CLAWQL_EXTERNAL_INGEST_FETCH=1.',
-      "Secrets: per-provider env vars for future Notion/Confluence/GitHub plugins; never logged.",
-      "Orchestration: writes use the vault lock; syncMemoryDbForVaultScanRoot + _INDEX_ page after import.",
-    ],
-    relatedIssues: [40, 24, 25, 27],
-    ...hints,
+    kind: "stub",
+    vault,
+    dryRun,
+    srcLabel: input.source?.trim() || "unspecified",
   };
+}
+
+/**
+ * Run external ingest: Markdown documents and/or (opt-in) URL fetch.
+ * Promise façade over native Effect.gen staging (dynamic import avoids cycle).
+ */
+export async function executeExternalIngestCore(
+  vault: string | null,
+  input: ExternalIngestInput
+): Promise<ExternalIngestResult> {
+  const { executeExternalIngestCoreEffect } = await import("../effect/external-ingest-effect.js");
+  return Effect.runPromise(
+    executeExternalIngestCoreEffect(vault, input).pipe(Effect.provide(memoryDbLiveLayer()))
+  );
 }
 
 /** Public async facade for external ingest (MCP tools, scripts). */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Deepens `ingest_external_knowledge` to native **`Effect.gen`** staging (same pattern as memory ingest / IDP runner).

### Changes

- Prelude classification (flags, payload, path gates) then staged prepare/fetch → vault write → `vaultWritePostSyncEffect` / `vaultArtifactHintsEffect`
- **No nested `runMemoryEffect`** on the hot path — uses `MemoryDbService` via documents live Layer
- Promise façades (`executeExternalIngestCore`, `runIngestExternalKnowledge`) unchanged for MCP/callers
- Tests: dry-run + real Markdown write without nested Layer provision issues

### Out of scope

- Classify/extract native Effect deepen
- Automation package Effect staging
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

