### PR TITLE
fix(website): restore docs search dialog open behavior

### DIFF
--- a/website/src/components/Search.tsx
+++ b/website/src/components/Search.tsx
@@ -85,18 +85,23 @@ function useAutocomplete({ onNavigate }: { onNavigate: () => void }) {
         navigate,
       },
       getSources({ query }) {
-        return search(query, { limit: 5 }).then((results) => [
-          {
-            sourceId: 'documentation',
-            getItems() {
-              return results
+        if (!query) {
+          return []
+        }
+        return search(query, { limit: 5 })
+          .then((results) => [
+            {
+              sourceId: 'documentation',
+              getItems() {
+                return results
+              },
+              getItemUrl({ item }: { item: Result }) {
+                return item.url
+              },
+              onSelect: navigate,
             },
-            getItemUrl({ item }: { item: Result }) {
-              return item.url
-            },
-            onSelect: navigate,
-          },
-        ])
+          ])
+          .catch(() => [])
       },
     }),
   )
@@ -346,10 +351,18 @@ function SearchDialog({
   })
   let pathname = usePathname()
   let searchParams = useSearchParams()
+  // Close on client navigations only — not on mount. Dialog mounts when `open`
+  // becomes true; an unconditional effect would close it immediately (broken search).
+  let routeKey = `${pathname}?${searchParams.toString()}`
+  let previousRouteKey = useRef(routeKey)
 
   useEffect(() => {
+    if (previousRouteKey.current === routeKey) {
+      return
+    }
+    previousRouteKey.current = routeKey
     setOpen(false)
-  }, [pathname, searchParams, setOpen])
+  }, [routeKey, setOpen])
 
   return (
     <Dialog
@@ -389,13 +402,14 @@ function SearchDialog({
                 className="border-t border-zinc-200 bg-white empty:hidden dark:border-zinc-100/5 dark:bg-white/2.5"
                 {...autocomplete.getPanelProps({})}
               >
-                {autocompleteState.isOpen && (
-                  <SearchResults
-                    autocomplete={autocomplete}
-                    query={autocompleteState.query}
-                    collection={autocompleteState.collections[0]}
-                  />
-                )}
+                {autocompleteState.isOpen &&
+                  autocompleteState.collections[0] && (
+                    <SearchResults
+                      autocomplete={autocomplete}
+                      query={autocompleteState.query}
+                      collection={autocompleteState.collections[0]}
+                    />
+                  )}
               </div>
             </form>
           </div>

--- a/website/src/mdx/search-runtime.ts
+++ b/website/src/mdx/search-runtime.ts
@@ -91,7 +91,10 @@ async function loadSearchIndex(): Promise<Document> {
 
 function getSearchIndex(): Promise<Document> {
   if (!indexPromise) {
-    indexPromise = loadSearchIndex()
+    indexPromise = loadSearchIndex().catch((error) => {
+      indexPromise = null
+      throw error
+    })
   }
   return indexPromise
 }
@@ -100,25 +103,41 @@ export async function search(
   query: string,
   options: SearchOptions = {},
 ): Promise<Array<Result>> {
-  const sectionIndex = await getSearchIndex()
-  const result = sectionIndex.search(query, {
-    ...options,
-    enrich: true,
-  })
+  try {
+    const sectionIndex = await getSearchIndex()
+    const result = sectionIndex.search(query, {
+      ...options,
+      enrich: true,
+    })
 
-  if (!result.length) {
+    if (!result.length) {
+      return []
+    }
+
+    const first = result[0] as {
+      result: Array<{
+        id: string
+        doc: { title: string; pageTitle?: string } | null
+      }>
+    }
+
+    return (first.result ?? [])
+      .filter(
+        (
+          item,
+        ): item is {
+          id: string
+          doc: { title: string; pageTitle?: string }
+        } => Boolean(item?.doc),
+      )
+      .map((item) => ({
+        url: item.id,
+        title: item.doc.title,
+        pageTitle: item.doc.pageTitle,
+      }))
+  } catch {
     return []
   }
-
-  const first = result[0] as {
-    result: Array<{ id: string; doc: { title: string; pageTitle?: string } }>
-  }
-
-  return first.result.map((item) => ({
-    url: item.id,
-    title: item.doc.title,
-    pageTitle: item.doc.pageTitle,
-  }))
 }
 
 /** Preload index during idle time (optional — search dialog may call this). */

--- a/website/tests/search.spec.ts
+++ b/website/tests/search.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test'
+
+test('docs search opens and returns results', async ({ page }) => {
+  await page.setViewportSize({ width: 1400, height: 900 })
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+
+  await page.getByRole('button', { name: /Search documentation/i }).click()
+
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toBeVisible()
+
+  const input = dialog.getByPlaceholder(/Search documentation/i)
+  await expect(input).toBeFocused()
+  await input.fill('helm')
+
+  await expect(dialog.locator('li').first()).toBeVisible({ timeout: 15_000 })
+  await expect(dialog.getByText(/helm/i).first()).toBeVisible()
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Docs search on [docs.clawql.com](https://docs.clawql.com) never opened a usable dialog. Clicking **Search documentation…** or using ⌘/Ctrl+K left `aria-expanded="false"` with no results panel.

## Root cause

In the Lighthouse perf pass, `SearchDialog` was mounted only while `open` was true. It still had:

```ts
useEffect(() => {
  setOpen(false)
}, [pathname, searchParams, setOpen])
```

That effect runs on **mount**, so every open immediately closed the dialog again (including `defaultOpen` from the deferred-search placeholder).

## Fix

- Close the dialog only when the route key actually changes, not on first mount.
- Guard empty Autocomplete collections and swallow search-index fetch/build failures so a bad index load does not crash the UI.
- Add a Playwright smoke test that opens search and expects Helm results.

## Test plan

- [x] Local reasoning + Playwright repro against production (dialog never stayed open)
- [ ] `npx playwright test tests/search.spec.ts`
- [ ] After deploy: ⌘K → type `helm` → results appear

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5923-61ff-77f8-92df-6c4b1fa90953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5923-61ff-77f8-92df-6c4b1fa90953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

