### PR TITLE
feat(effect): fiber-based schedule, ouroboros, and inference workers

### DIFF
--- a/docs/design/effect-ts-modularization-rearchitecture-plan.md
+++ b/docs/design/effect-ts-modularization-rearchitecture-plan.md
@@ -289,9 +289,9 @@ Label cross-cutting PRs with both `effect-foundation` and `modularization-platfo
 1. **Docs:** keep [`modularization-implementation-status.md`](./modularization-implementation-status.md) updated as features merge.
 2. **Transport:** continue slim toward transport-only `clawql-mcp` packaging.
 3. **Third-party plugins:** document npm package template + `CLAWQL_PLUGINS` / Operator toggle.
-4. **Optional later:** `@effect/schema` at boundaries; Effect fibers for schedule / ouroboros / inference pollers (not required for migration-complete).
+4. **Optional later:** `@effect/schema` at boundaries; NATS consumer / Postgres pools as `Layer.scoped`; `Effect.withSpan` on pipeline stages; ManagedRuntime dispose on server shutdown.
 
-**Completed:** Turborepo scaffold; `clawql-core` + `AuditService`; execute/search Effect services; `PanguardProxyPlugin`; extraction **phases 1–9**; horizontal Plugin Layers; **Effect hot-path migration** for memory/documents/automation/sandbox/ouroboros + opt-in tools (pageindex, Onyx, HITL) + MCP audit bridge (IO remains `tryPromise`). Ouroboros Effect rewrite landed on the `effect-ouroboros` track.
+**Completed:** Turborepo scaffold; `clawql-core` + `AuditService`; execute/search Effect services; `PanguardProxyPlugin`; extraction **phases 1–9**; horizontal Plugin Layers; **Effect hot-path migration** for memory/documents/automation/sandbox/ouroboros + opt-in tools (pageindex, Onyx, HITL) + MCP audit bridge; **fiber workers** for schedule / ouroboros seeds poller / inference pipeline (IO remains `tryPromise`). Ouroboros Effect rewrite landed on the `effect-ouroboros` track.
 ---
 
 ## 14. References

--- a/docs/design/modularization-implementation-status.md
+++ b/docs/design/modularization-implementation-status.md
@@ -260,7 +260,7 @@ From enablement §5.4 and the Effect plan §8:
 | `AutomationToolsService` argocd                                                  | ✅ Native `Effect.gen` enabled → soft Zod → K8s CRD list/get/sync                                                                               |
 | `hitl_enqueue_label_studio`                                                      | ✅ Native `Effect.gen` config/validate → HTTP import → NATS publish hook                                                                        |
 | `SandboxExecService` sandbox_exec                                                | ✅ Native `Effect.gen` (parse backend → resolve probes → dispatch Kata/Docker/Seatbelt/bridge → shape); Promise façade kept                     |
-| Background workers (schedule / ouroboros poller / inference pipeline)            | ✅ Daemon fibers + `Effect.sleep` loops (skip-if-busy `Ref`); interruptible `stop()`; TestClock-covered                                                                                           |
+| Background workers (schedule / ouroboros poller / inference pipeline)            | ✅ Daemon fibers + `Effect.sleep` loops (skip-if-busy `Ref`); interruptible `stop()`; TestClock-covered                                         |
 
 **Rule for new code in extracted packages:** prefer Effect in `clawql-core` / `clawql-api`; legacy `async` is acceptable **only** at IO edges (`Effect.tryPromise`). See plan §7.
 

--- a/docs/design/modularization-implementation-status.md
+++ b/docs/design/modularization-implementation-status.md
@@ -235,7 +235,9 @@ From enablement §5.4 and the Effect plan §8:
 
 ## 7. Effect-TS migration status
 
-**Migration complete (July 2026):** registered MCP tool hot paths use native `Effect.gen` staging + Layers. External IO (fs, fetch, sql.js, K8s, embeddings, sandbox backends) remains behind `Effect.tryPromise` / `*FromPromise` by design. Zod stays at MCP registration; Promise façades bridge the SDK. `setInterval` workers (schedule / ouroboros poller / inference) remain imperative unless a future fibers track is opened.
+**Migration complete (July 2026):** registered MCP tool hot paths use native `Effect.gen` staging + Layers. External IO (fs, fetch, sql.js, K8s, embeddings, sandbox backends) remains behind `Effect.tryPromise` / `*FromPromise` by design. Zod stays at MCP registration; Promise façades bridge the SDK.
+
+**Workers / fibers:** schedule, Ouroboros seeds poller, and inference pipeline workers use daemon fibers + interruptible sleep (skip-if-busy `Ref`) instead of `setInterval`. Nested `Effect.runPromise` inside poller Effect.gen is removed (`OuroborosLoopService.run` is invoked as an Effect).
 
 | Area                                                                             | Status                                                                                                                                          |
 | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -258,6 +260,7 @@ From enablement §5.4 and the Effect plan §8:
 | `AutomationToolsService` argocd                                                  | ✅ Native `Effect.gen` enabled → soft Zod → K8s CRD list/get/sync                                                                               |
 | `hitl_enqueue_label_studio`                                                      | ✅ Native `Effect.gen` config/validate → HTTP import → NATS publish hook                                                                        |
 | `SandboxExecService` sandbox_exec                                                | ✅ Native `Effect.gen` (parse backend → resolve probes → dispatch Kata/Docker/Seatbelt/bridge → shape); Promise façade kept                     |
+| Background workers (schedule / ouroboros poller / inference pipeline)            | ✅ Daemon fibers + `Effect.sleep` loops (skip-if-busy `Ref`); interruptible `stop()`; TestClock-covered                                                                                           |
 
 **Rule for new code in extracted packages:** prefer Effect in `clawql-core` / `clawql-api`; legacy `async` is acceptable **only** at IO edges (`Effect.tryPromise`). See plan §7.
 

--- a/packages/clawql-automation/src/effect/index.ts
+++ b/packages/clawql-automation/src/effect/index.ts
@@ -1,4 +1,5 @@
 export { executeHitlEnqueueLabelStudioEffect } from "./hitl-enqueue-effect.js";
+export { startScheduleWorkerFiberEffect } from "./schedule-worker-effect.js";
 export { AutomationError } from "./automation-errors.js";
 export { automationFromPromise, type McpTextResult } from "./automation-effect-utils.js";
 export {

--- a/packages/clawql-automation/src/effect/schedule-worker-effect.test.ts
+++ b/packages/clawql-automation/src/effect/schedule-worker-effect.test.ts
@@ -1,0 +1,71 @@
+import { Deferred, Duration, Effect, Fiber, Ref, TestClock, TestContext } from "effect";
+import { describe, expect, it } from "vitest";
+import { startScheduleWorkerFiberEffect } from "./schedule-worker-effect.js";
+
+describe("startScheduleWorkerFiberEffect", () => {
+  it("ticks after poll interval with TestClock", async () => {
+    const ticks = { n: 0 };
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const handle = yield* startScheduleWorkerFiberEffect(async () => {
+          ticks.n += 1;
+          return 0;
+        }, 10);
+        yield* TestClock.adjust(Duration.millis(12));
+        expect(ticks.n).toBe(1);
+        yield* Fiber.interrupt(handle.fiber);
+      }).pipe(Effect.provide(TestContext.TestContext))
+    );
+  });
+
+  it("skips overlapping ticks while busy", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const started = yield* Ref.make(0);
+        const latch = yield* Deferred.make<void>();
+
+        const handle = yield* startScheduleWorkerFiberEffect(
+          () =>
+            Effect.runPromise(
+              Effect.gen(function* () {
+                yield* Ref.update(started, (n) => n + 1);
+                yield* Deferred.await(latch);
+                return 0;
+              })
+            ),
+          10
+        );
+
+        yield* TestClock.adjust(Duration.millis(12));
+        expect(yield* Ref.get(started)).toBe(1);
+
+        yield* TestClock.adjust(Duration.millis(40));
+        expect(yield* Ref.get(started)).toBe(1);
+
+        yield* Deferred.succeed(latch, undefined);
+        yield* TestClock.adjust(Duration.millis(12));
+        expect(yield* Ref.get(started)).toBe(2);
+
+        yield* Fiber.interrupt(handle.fiber);
+      }).pipe(Effect.provide(TestContext.TestContext))
+    );
+  });
+
+  it("reports tick errors via callback", async () => {
+    const errors: string[] = [];
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const handle = yield* startScheduleWorkerFiberEffect(
+          async () => {
+            throw new Error("tick boom");
+          },
+          10,
+          (msg) => errors.push(msg)
+        );
+        yield* TestClock.adjust(Duration.millis(12));
+        expect(errors.some((e) => e.includes("tick boom"))).toBe(true);
+        yield* Fiber.interrupt(handle.fiber);
+      }).pipe(Effect.provide(TestContext.TestContext))
+    );
+  });
+});

--- a/packages/clawql-automation/src/effect/schedule-worker-effect.ts
+++ b/packages/clawql-automation/src/effect/schedule-worker-effect.ts
@@ -1,0 +1,72 @@
+/**
+ * Effect-native schedule worker: daemon fiber + skip-if-busy Ref.
+ * Replaces setInterval in {@link startScheduleWorker}.
+ */
+
+import { Cause, Duration, Effect, Fiber, Ref } from "effect";
+import { AutomationError } from "./automation-errors.js";
+import { automationFromPromise } from "./automation-effect-utils.js";
+
+export type ScheduleWorkerTick = () => Promise<number>;
+
+export type ScheduleWorkerHandle = {
+  readonly stop: () => void;
+  readonly fiber: Fiber.RuntimeFiber<never, never>;
+};
+
+/**
+ * Fork a daemon loop: sleep pollMs → tick (skip if busy) → forever.
+ * First tick fires after the first interval (same as setInterval).
+ */
+export function startScheduleWorkerFiberEffect(
+  tick: ScheduleWorkerTick,
+  pollMs: number,
+  onTickError?: (message: string) => void
+): Effect.Effect<ScheduleWorkerHandle> {
+  return Effect.gen(function* () {
+    const busy = yield* Ref.make(false);
+
+    const maybeTick = Effect.gen(function* () {
+      if (yield* Ref.get(busy)) {
+        return;
+      }
+      yield* Ref.set(busy, true);
+      yield* automationFromPromise(() => tick()).pipe(
+        Effect.catchAllCause((cause) =>
+          Effect.sync(() => {
+            const squashed = Cause.squash(cause);
+            let msg: string;
+            if (squashed instanceof AutomationError) {
+              const nested = squashed.cause;
+              msg =
+                nested instanceof Error
+                  ? nested.message
+                  : nested != null
+                    ? String(nested)
+                    : squashed.reason;
+            } else if (squashed instanceof Error) {
+              msg = squashed.message;
+            } else {
+              msg = String(squashed);
+            }
+            (onTickError ?? ((m) => console.error(`[clawql-schedule] worker tick failed: ${m}`)))(
+              msg
+            );
+          })
+        ),
+        Effect.ensuring(Ref.set(busy, false))
+      );
+    });
+
+    const loop = Effect.forever(
+      Effect.sleep(Duration.millis(pollMs)).pipe(Effect.zipRight(maybeTick))
+    );
+    const fiber = yield* Effect.forkDaemon(loop);
+    return {
+      fiber,
+      stop: () => {
+        Effect.runFork(Fiber.interrupt(fiber));
+      },
+    };
+  });
+}

--- a/packages/clawql-automation/src/schedule/schedule.ts
+++ b/packages/clawql-automation/src/schedule/schedule.ts
@@ -8,8 +8,10 @@ import { randomUUID } from "node:crypto";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { dirname, isAbsolute, resolve as resolvePath } from "node:path";
+import { Effect } from "effect";
 import initSqlJs, { type Database } from "sql.js";
 import { z } from "zod";
+import { startScheduleWorkerFiberEffect } from "../effect/schedule-worker-effect.js";
 import { executeNotifySlackCore } from "../notify/notify.js";
 
 type Frequency =
@@ -73,8 +75,7 @@ type TriggerOutcome = {
 
 const SCHEMA_VERSION = 1;
 let sqlJsPromise: ReturnType<typeof initSqlJs> | null = null;
-let scheduleWorkerTimer: NodeJS.Timeout | null = null;
-let scheduleWorkerBusy = false;
+let scheduleWorkerStop: (() => void) | null = null;
 const cronMinuteRunCache = new Map<string, string>();
 
 async function loadSqlJs(): Promise<ReturnType<typeof initSqlJs>> {
@@ -867,26 +868,18 @@ export async function runScheduleWorkerTick(now = new Date()): Promise<number> {
 }
 
 export function startScheduleWorker(): void {
-  if (scheduleWorkerTimer) return;
+  if (scheduleWorkerStop) return;
   const pollMs = getSchedulePollMs();
-  scheduleWorkerTimer = setInterval(async () => {
-    if (scheduleWorkerBusy) return;
-    scheduleWorkerBusy = true;
-    try {
-      await runScheduleWorkerTick();
-    } catch (error: unknown) {
-      const msg = error instanceof Error ? error.message : String(error);
-      console.error(`[clawql-schedule] worker tick failed: ${msg}`);
-    } finally {
-      scheduleWorkerBusy = false;
-    }
-  }, pollMs);
+  const handle = Effect.runSync(
+    startScheduleWorkerFiberEffect(() => runScheduleWorkerTick(), pollMs)
+  );
+  scheduleWorkerStop = handle.stop;
 }
 
 export function stopScheduleWorker(): void {
-  if (!scheduleWorkerTimer) return;
-  clearInterval(scheduleWorkerTimer);
-  scheduleWorkerTimer = null;
+  if (!scheduleWorkerStop) return;
+  scheduleWorkerStop();
+  scheduleWorkerStop = null;
 }
 
 export function registerScheduleWorkerShutdownHooks(): void {
@@ -1043,7 +1036,6 @@ export async function handleScheduleToolInput(
 export function resetScheduleSqlJsForTests(): void {
   sqlJsPromise = null;
   stopScheduleWorker();
-  scheduleWorkerBusy = false;
   cronMinuteRunCache.clear();
 }
 

--- a/packages/clawql-inference/src/pipeline/pipeline-worker-effect.test.ts
+++ b/packages/clawql-inference/src/pipeline/pipeline-worker-effect.test.ts
@@ -1,0 +1,23 @@
+import { Duration, Effect, Fiber, TestClock, TestContext } from "effect";
+import { describe, expect, it } from "vitest";
+import { startPipelineWorkerFiberEffect } from "./pipeline-worker-effect.js";
+
+describe("startPipelineWorkerFiberEffect", () => {
+  it("runs an immediate first tick then spaced polls", async () => {
+    const ticks = { n: 0 };
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const handle = yield* startPipelineWorkerFiberEffect(async () => {
+          ticks.n += 1;
+        }, 10);
+        // first iteration runs tick before sleep
+        yield* TestClock.adjust(Duration.millis(1));
+        expect(ticks.n).toBeGreaterThanOrEqual(1);
+        const afterFirst = ticks.n;
+        yield* TestClock.adjust(Duration.millis(12));
+        expect(ticks.n).toBeGreaterThan(afterFirst);
+        yield* Fiber.interrupt(handle.fiber);
+      }).pipe(Effect.provide(TestContext.TestContext))
+    );
+  });
+});

--- a/packages/clawql-inference/src/pipeline/pipeline-worker-effect.ts
+++ b/packages/clawql-inference/src/pipeline/pipeline-worker-effect.ts
@@ -1,0 +1,47 @@
+/**
+ * Effect-native inference pipeline worker: daemon fiber + spaced poll.
+ * Replaces setInterval; keeps advisory-lock tick IO behind tryPromise.
+ */
+
+import { Duration, Effect, Fiber, Ref } from "effect";
+
+export type PipelineWorkerTick = () => Promise<void>;
+
+export type PipelineWorkerHandle = {
+  readonly stop: () => void;
+  readonly fiber: Fiber.RuntimeFiber<never, never>;
+};
+
+/**
+ * Immediate first tick, then sleep pollMs forever (matches prior setInterval + eager void tick).
+ */
+export function startPipelineWorkerFiberEffect(
+  tick: PipelineWorkerTick,
+  pollMs: number
+): Effect.Effect<PipelineWorkerHandle> {
+  return Effect.gen(function* () {
+    const busy = yield* Ref.make(false);
+
+    const maybeTick = Effect.gen(function* () {
+      if (yield* Ref.get(busy)) {
+        return;
+      }
+      yield* Ref.set(busy, true);
+      yield* Effect.tryPromise({
+        try: () => tick(),
+        catch: () => undefined as void,
+      }).pipe(Effect.ensuring(Ref.set(busy, false)));
+    });
+
+    const loop = Effect.forever(
+      maybeTick.pipe(Effect.zipRight(Effect.sleep(Duration.millis(pollMs))))
+    );
+    const fiber = yield* Effect.forkDaemon(loop);
+    return {
+      fiber,
+      stop: () => {
+        Effect.runFork(Fiber.interrupt(fiber));
+      },
+    };
+  });
+}

--- a/packages/clawql-inference/src/pipeline/worker.ts
+++ b/packages/clawql-inference/src/pipeline/worker.ts
@@ -1,10 +1,12 @@
+import { Effect } from "effect";
 import { buildPipelineRunLockKey, tryAcquirePipelineAdvisoryLock } from "./advisory-lock.js";
 import { loadPipelineConfig, savePipelineConfig } from "./config.js";
 import { cronMatchesUtc, toMinuteKey } from "./cron.js";
+import { startPipelineWorkerFiberEffect } from "./pipeline-worker-effect.js";
 import { runPipelineOnce } from "./run.js";
 import type { InferencePipelineConfig } from "./types.js";
 
-let workerTimer: ReturnType<typeof setInterval> | null = null;
+let pipelineWorkerStop: (() => void) | null = null;
 const minuteRunCache = new Set<string>();
 
 export type PipelineWorkerOptions = {
@@ -57,21 +59,22 @@ async function pipelineWorkerTick(env: NodeJS.ProcessEnv): Promise<void> {
   }
 }
 
+/** Start Effect daemon fiber for inference pipeline cron ticks. */
 export function startPipelineWorker(options: PipelineWorkerOptions = {}): void {
-  if (workerTimer) return;
+  if (pipelineWorkerStop) return;
   const env = options.env ?? process.env;
   const pollMs =
     options.pollMs ?? Number.parseInt(env.CLAWQL_INFERENCE_PIPELINE_POLL_MS?.trim() || "60000", 10);
-  workerTimer = setInterval(() => {
-    void pipelineWorkerTick(env).catch(() => {});
-  }, pollMs);
-  void pipelineWorkerTick(env).catch(() => {});
+  const handle = Effect.runSync(
+    startPipelineWorkerFiberEffect(() => pipelineWorkerTick(env), pollMs)
+  );
+  pipelineWorkerStop = handle.stop;
 }
 
 export function stopPipelineWorker(): void {
-  if (workerTimer) {
-    clearInterval(workerTimer);
-    workerTimer = null;
+  if (pipelineWorkerStop) {
+    pipelineWorkerStop();
+    pipelineWorkerStop = null;
   }
   minuteRunCache.clear();
 }

--- a/packages/clawql-ouroboros/README.md
+++ b/packages/clawql-ouroboros/README.md
@@ -45,7 +45,7 @@ Installing the **root** repo with `npm install github:danielsmithdevelopment/Cla
 | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **`clawql-ouroboros`**           | `SeedSchema`, types, `EvolutionaryLoop`, `ConvergenceCriteria`, `RegressionDetector`, `InMemoryEventStore`, interfaces                                                                                           |
 | **`clawql-ouroboros/mcp-hooks`** | `ouroborosMcpTools` — Zod input schemas + async handlers for seed-from-document, run loop, lineage query (wire to [@modelcontextprotocol/sdk](https://www.npmjs.com/package/@modelcontextprotocol/sdk) yourself) |
-| **`clawql-ouroboros/poller`**    | `startSeedsPoller` — Effect daemon-fiber worker (interruptible); you supply `fetchPending(): Promise<Seed[]>` and `markFailed(seedId, err)`                                                                                                  |
+| **`clawql-ouroboros/poller`**    | `startSeedsPoller` — Effect daemon-fiber worker (interruptible); you supply `fetchPending(): Promise<Seed[]>` and `markFailed(seedId, err)`                                                                      |
 
 **Runtime dependencies:** `zod` ^4, `uuid` ^11 (declared in this package’s `package.json`).
 

--- a/packages/clawql-ouroboros/README.md
+++ b/packages/clawql-ouroboros/README.md
@@ -45,7 +45,7 @@ Installing the **root** repo with `npm install github:danielsmithdevelopment/Cla
 | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **`clawql-ouroboros`**           | `SeedSchema`, types, `EvolutionaryLoop`, `ConvergenceCriteria`, `RegressionDetector`, `InMemoryEventStore`, interfaces                                                                                           |
 | **`clawql-ouroboros/mcp-hooks`** | `ouroborosMcpTools` — Zod input schemas + async handlers for seed-from-document, run loop, lineage query (wire to [@modelcontextprotocol/sdk](https://www.npmjs.com/package/@modelcontextprotocol/sdk) yourself) |
-| **`clawql-ouroboros/poller`**    | `startSeedsPoller` — `setInterval` worker; you supply `fetchPending(): Promise<Seed[]>` and `markFailed(seedId, err)`                                                                                            |
+| **`clawql-ouroboros/poller`**    | `startSeedsPoller` — Effect daemon-fiber worker (interruptible); you supply `fetchPending(): Promise<Seed[]>` and `markFailed(seedId, err)`                                                                                                  |
 
 **Runtime dependencies:** `zod` ^4, `uuid` ^11 (declared in this package’s `package.json`).
 

--- a/packages/clawql-ouroboros/src/effect/ouroboros-poller-service.ts
+++ b/packages/clawql-ouroboros/src/effect/ouroboros-poller-service.ts
@@ -1,7 +1,13 @@
+/**
+ * Effect service for the Ouroboros seeds background poller.
+ * Runs {@link OuroborosLoopService.run} directly (no nested Effect.runPromise).
+ */
+
 import { Context, Effect, Layer } from "effect";
 import type { Seed } from "../seed.js";
-import { startSeedsPollerCore, type SeedPollerOptions } from "../glue/seeds-poller-core.js";
+import { startSeedsPollerFiberEffect, type SeedPollerOptions } from "../glue/seeds-poller-core.js";
 import { OuroborosLoopService } from "./ouroboros-loop-service.js";
+import { ouroborosFromPromise } from "./ouroboros-effect-utils.js";
 
 /** Effect service for the Ouroboros seeds background poller. */
 export class OuroborosPollerService extends Context.Tag("clawql/OuroborosPollerService")<
@@ -22,14 +28,13 @@ export function ouroborosPollerLiveLayer(): Layer.Layer<OuroborosPollerService> 
       start: (fetchPending, markFailed, options) =>
         Effect.gen(function* () {
           const loopSvc = yield* OuroborosLoopService;
-          return startSeedsPollerCore(
-            async (seed) => {
-              await Effect.runPromise(loopSvc.run(seed));
-            },
-            fetchPending,
-            markFailed,
+          const handle = yield* startSeedsPollerFiberEffect(
+            (seed) => loopSvc.run(seed).pipe(Effect.asVoid),
+            ouroborosFromPromise(() => fetchPending()),
+            (seedId, error) => ouroborosFromPromise(() => markFailed(seedId, error)),
             options
           );
+          return { stop: handle.stop };
         }),
     })
   );

--- a/packages/clawql-ouroboros/src/glue/seeds-poller-core.ts
+++ b/packages/clawql-ouroboros/src/glue/seeds-poller-core.ts
@@ -1,3 +1,9 @@
+/**
+ * Effect-native seeds poller: spaced ticks + skip-if-busy {@link Ref},
+ * forked as a daemon fiber (interruptible). Replaces `setInterval`.
+ */
+
+import { Cause, Duration, Effect, Fiber, Ref } from "effect";
 import type { Seed } from "../seed.js";
 
 export interface SeedPollerOptions {
@@ -7,42 +13,116 @@ export interface SeedPollerOptions {
 
 export type SeedRunFn = (seed: Seed) => Promise<void>;
 
-function createSkipMutex() {
-  let locked = false;
-  return async function withLock<T>(fn: () => Promise<T>): Promise<T | undefined> {
-    if (locked) return undefined;
-    locked = true;
-    try {
-      return await fn();
-    } finally {
-      locked = false;
-    }
-  };
+/** Seed runner Effect — failures are soft-caught per seed in the tick. */
+export type SeedRunEffect = (seed: Seed) => Effect.Effect<void, unknown>;
+
+function asUnknownError(cause: Cause.Cause<unknown>): unknown {
+  return Cause.squash(cause);
 }
 
-/** Core interval poller for pending seeds (caller supplies `run` / `fetchPending` / `markFailed`). */
+/** One poll cycle: fetch pending seeds and run each (soft-fail → markFailed / onError). */
+export function seedsPollTickEffect(
+  run: SeedRunEffect,
+  fetchPending: Effect.Effect<Seed[], unknown>,
+  markFailed: (seedId: string, error: unknown) => Effect.Effect<void, unknown>,
+  onError?: (seed: Seed, error: unknown) => Effect.Effect<void, unknown>
+): Effect.Effect<void> {
+  return Effect.gen(function* () {
+    const pending = yield* fetchPending.pipe(Effect.orDie);
+    for (const seed of pending) {
+      yield* run(seed).pipe(
+        Effect.catchAllCause((cause) =>
+          Effect.gen(function* () {
+            const err = asUnknownError(cause);
+            yield* markFailed(seed.metadata.seed_id, err).pipe(Effect.orDie);
+            if (onError) {
+              yield* onError(seed, err).pipe(Effect.orDie);
+            }
+          })
+        )
+      );
+    }
+  });
+}
+
+export type SeedsPollerHandle = {
+  readonly stop: () => void;
+  readonly fiber: Fiber.RuntimeFiber<never, never>;
+};
+
+/**
+ * Daemon fiber: sleep `pollIntervalMs` → tick (skip if busy) → forever.
+ * Matches prior setInterval + skip-mutex semantics (first tick after first interval).
+ */
+export function startSeedsPollerFiberEffect(
+  run: SeedRunEffect,
+  fetchPending: Effect.Effect<Seed[], unknown>,
+  markFailed: (seedId: string, error: unknown) => Effect.Effect<void, unknown>,
+  options: SeedPollerOptions = {}
+): Effect.Effect<SeedsPollerHandle> {
+  const pollIntervalMs = options.pollIntervalMs ?? 5_000;
+  const onErrorEffect = options.onError
+    ? (seed: Seed, error: unknown) =>
+        Effect.tryPromise({
+          try: async () => {
+            await options.onError?.(seed, error);
+          },
+          catch: () => undefined as void,
+        }).pipe(Effect.asVoid)
+    : undefined;
+
+  return Effect.gen(function* () {
+    const busy = yield* Ref.make(false);
+
+    const maybeTick = Effect.gen(function* () {
+      if (yield* Ref.get(busy)) {
+        return;
+      }
+      yield* Ref.set(busy, true);
+      yield* seedsPollTickEffect(run, fetchPending, markFailed, onErrorEffect).pipe(
+        Effect.ensuring(Ref.set(busy, false))
+      );
+    });
+
+    const loop = Effect.forever(
+      Effect.sleep(Duration.millis(pollIntervalMs)).pipe(Effect.zipRight(maybeTick))
+    );
+
+    const fiber = yield* Effect.forkDaemon(loop);
+
+    return {
+      fiber,
+      stop: () => {
+        Effect.runFork(Fiber.interrupt(fiber));
+      },
+    };
+  });
+}
+
+function promiseAsEffect<A>(tryFn: () => Promise<A>): Effect.Effect<A, unknown> {
+  return Effect.tryPromise({
+    try: tryFn,
+    catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+  });
+}
+
+/**
+ * Promise façade (same shape as the historical setInterval helper).
+ * Prefer {@link startSeedsPollerFiberEffect} inside Effect programs.
+ */
 export function startSeedsPollerCore(
   run: SeedRunFn,
   fetchPending: () => Promise<Seed[]>,
   markFailed: (seedId: string, error: unknown) => Promise<void>,
   options: SeedPollerOptions = {}
 ): { stop: () => void } {
-  const { pollIntervalMs = 5_000, onError } = options;
-  const withLock = createSkipMutex();
-
-  const handle = setInterval(() => {
-    void withLock(async () => {
-      const pending = await fetchPending();
-      for (const seed of pending) {
-        try {
-          await run(seed);
-        } catch (err) {
-          await markFailed(seed.metadata.seed_id, err);
-          await onError?.(seed, err);
-        }
-      }
-    });
-  }, pollIntervalMs);
-
-  return { stop: () => clearInterval(handle) };
+  const handle = Effect.runSync(
+    startSeedsPollerFiberEffect(
+      (seed) => promiseAsEffect(() => run(seed)),
+      promiseAsEffect(() => fetchPending()),
+      (seedId, error) => promiseAsEffect(() => markFailed(seedId, error)),
+      options
+    )
+  );
+  return { stop: handle.stop };
 }

--- a/packages/clawql-ouroboros/src/poller.test.ts
+++ b/packages/clawql-ouroboros/src/poller.test.ts
@@ -1,5 +1,7 @@
+import { Deferred, Duration, Effect, Fiber, Ref, TestClock, TestContext } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { startSeedsPoller } from "./poller.js";
+import { startSeedsPollerFiberEffect, type SeedRunEffect } from "./glue/seeds-poller-core.js";
 import type { Seed } from "./seed.js";
 
 function makeSeed(seedId: string): Seed {
@@ -28,64 +30,103 @@ function makeSeed(seedId: string): Seed {
   };
 }
 
-describe("startSeedsPoller", () => {
+describe("startSeedsPollerFiberEffect (TestClock)", () => {
+  it("runs pending seeds and soft-fails failures", async () => {
+    const okSeed = makeSeed("ok-seed");
+    const badSeed = makeSeed("bad-seed");
+    const runs: string[] = [];
+    const failed: Array<{ id: string; err: unknown }> = [];
+    const errors: Seed[] = [];
+
+    const run: SeedRunEffect = (seed) =>
+      Effect.gen(function* () {
+        runs.push(seed.metadata.seed_id);
+        if (seed.metadata.seed_id === "bad-seed") {
+          yield* Effect.fail(new Error("boom"));
+        }
+      });
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const handle = yield* startSeedsPollerFiberEffect(
+          run,
+          Effect.succeed([okSeed, badSeed]),
+          (seedId, error) =>
+            Effect.sync(() => {
+              failed.push({ id: seedId, err: error });
+            }),
+          {
+            pollIntervalMs: 10,
+            onError: async (seed) => {
+              errors.push(seed);
+            },
+          }
+        );
+        yield* TestClock.adjust(Duration.millis(12));
+        expect(runs).toEqual(["ok-seed", "bad-seed"]);
+        expect(failed).toHaveLength(1);
+        expect(failed[0]?.id).toBe("bad-seed");
+        expect(errors).toHaveLength(1);
+        yield* Fiber.interrupt(handle.fiber);
+      }).pipe(Effect.provide(TestContext.TestContext))
+    );
+  });
+
+  it("skips overlapping polls while prior run is in flight", async () => {
+    const seed = makeSeed("slow-seed");
+    const fetchCount = { n: 0 };
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const latch = yield* Deferred.make<void>();
+        const runCount = yield* Ref.make(0);
+
+        const handle = yield* startSeedsPollerFiberEffect(
+          () =>
+            Effect.gen(function* () {
+              yield* Ref.update(runCount, (n) => n + 1);
+              yield* Deferred.await(latch);
+            }),
+          Effect.sync(() => {
+            fetchCount.n += 1;
+            return [seed];
+          }),
+          () => Effect.void,
+          { pollIntervalMs: 10 }
+        );
+
+        yield* TestClock.adjust(Duration.millis(12));
+        expect(fetchCount.n).toBe(1);
+        expect(yield* Ref.get(runCount)).toBe(1);
+
+        yield* TestClock.adjust(Duration.millis(30));
+        expect(fetchCount.n).toBe(1);
+        expect(yield* Ref.get(runCount)).toBe(1);
+
+        yield* Deferred.succeed(latch, undefined);
+        yield* TestClock.adjust(Duration.millis(12));
+        expect(fetchCount.n).toBe(2);
+        expect(yield* Ref.get(runCount)).toBe(2);
+
+        yield* Fiber.interrupt(handle.fiber);
+      }).pipe(Effect.provide(TestContext.TestContext))
+    );
+  });
+});
+
+describe("startSeedsPoller Promise façade", () => {
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it("runs pending seeds and marks failures", async () => {
-    vi.useFakeTimers();
-    const okSeed = makeSeed("ok-seed");
-    const badSeed = makeSeed("bad-seed");
-    const run = vi.fn(async (seed: Seed) => {
-      if (seed.metadata.seed_id === "bad-seed") throw new Error("boom");
-    });
-    const fetchPending = vi.fn(async () => [okSeed, badSeed]);
-    const markFailed = vi.fn(async () => {});
-    const onError = vi.fn(async () => {});
-
-    const poller = startSeedsPoller({ run } as never, fetchPending, markFailed, {
-      pollIntervalMs: 10,
-      onError,
-    });
-
-    await vi.advanceTimersByTimeAsync(12);
-
-    expect(fetchPending).toHaveBeenCalledTimes(1);
-    expect(run).toHaveBeenCalledTimes(2);
-    expect(markFailed).toHaveBeenCalledWith("bad-seed", expect.any(Error));
-    expect(onError).toHaveBeenCalledWith(badSeed, expect.any(Error));
-
-    poller.stop();
-  });
-
-  it("skips overlapping polls while prior run is in flight", async () => {
-    vi.useFakeTimers();
-    const seed = makeSeed("slow-seed");
-    let resolveRun: (() => void) | null = null;
-    const run = vi.fn(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveRun = resolve;
-        })
+  it("exposes stop() without throwing", () => {
+    const poller = startSeedsPoller(
+      { run: async () => undefined } as never,
+      async () => [],
+      async () => {},
+      { pollIntervalMs: 60_000 }
     );
-    const fetchPending = vi.fn(async () => [seed]);
-    const markFailed = vi.fn(async () => {});
-    const poller = startSeedsPoller({ run } as never, fetchPending, markFailed, {
-      pollIntervalMs: 10,
-    });
-
-    await vi.advanceTimersByTimeAsync(12);
-    await vi.advanceTimersByTimeAsync(25);
-    expect(fetchPending).toHaveBeenCalledTimes(1);
-    expect(run).toHaveBeenCalledTimes(1);
-
-    resolveRun?.();
-    await Promise.resolve();
-    await vi.advanceTimersByTimeAsync(12);
-
-    expect(fetchPending).toHaveBeenCalledTimes(2);
-    expect(run).toHaveBeenCalledTimes(2);
+    expect(typeof poller.stop).toBe("function");
     poller.stop();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves remaining `setInterval` workers onto Effect best-practice concurrency:

### Changes
- **Ouroboros seeds poller** — daemon fiber + `Effect.sleep` + skip-if-busy `Ref`; `OuroborosLoopService.run` invoked as Effect (**no nested `Effect.runPromise`**)
- **Schedule worker** — same fiber pattern; Promise tick IO stays behind `automationFromPromise`
- **Inference pipeline worker** — daemon fiber with immediate first tick then spaced sleep
- **Tests** — Effect `TestClock` / `TestContext` for tick + overlap semantics
- **Docs** — modularization §7 + rearchitecture plan next steps updated

### Out of scope (next PRs)
- NATS consumer / Postgres pools as `Layer.scoped`
- ManagedRuntime dispose on server shutdown
- `Effect.withSpan`
- Zod → Schema
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

