### PR TITLE
feat(effect): ManagedRuntime dispose and scoped pool/NATS helpers

### DIFF
--- a/docs/design/effect-ts-modularization-rearchitecture-plan.md
+++ b/docs/design/effect-ts-modularization-rearchitecture-plan.md
@@ -289,9 +289,9 @@ Label cross-cutting PRs with both `effect-foundation` and `modularization-platfo
 1. **Docs:** keep [`modularization-implementation-status.md`](./modularization-implementation-status.md) updated as features merge.
 2. **Transport:** continue slim toward transport-only `clawql-mcp` packaging.
 3. **Third-party plugins:** document npm package template + `CLAWQL_PLUGINS` / Operator toggle.
-4. **Optional later:** `@effect/schema` at boundaries; NATS consumer / Postgres pools as `Layer.scoped`; `Effect.withSpan` on pipeline stages; ManagedRuntime dispose on server shutdown.
+4. **Optional later:** `@effect/schema` at boundaries; `Effect.withSpan` on pipeline stages; deeper Scope ownership of long-lived plugin Layers (replace throwaway `Effect.scoped(Layer.build)`).
 
-**Completed:** Turborepo scaffold; `clawql-core` + `AuditService`; execute/search Effect services; `PanguardProxyPlugin`; extraction **phases 1–9**; horizontal Plugin Layers; **Effect hot-path migration** for memory/documents/automation/sandbox/ouroboros + opt-in tools (pageindex, Onyx, HITL) + MCP audit bridge; **fiber workers** for schedule / ouroboros seeds poller / inference pipeline (IO remains `tryPromise`). Ouroboros Effect rewrite landed on the `effect-ouroboros` track.
+**Completed:** Turborepo scaffold; `clawql-core` + `AuditService`; execute/search Effect services; `PanguardProxyPlugin`; extraction **phases 1–9**; horizontal Plugin Layers; **Effect hot-path migration** for memory/documents/automation/sandbox/ouroboros + opt-in tools (pageindex, Onyx, HITL) + MCP audit bridge; **fiber workers** for schedule / ouroboros seeds poller / inference pipeline; **ManagedRuntime dispose** + pool/NATS `acquireRelease` helpers (IO remains `tryPromise`). Ouroboros Effect rewrite landed on the `effect-ouroboros` track.
 ---
 
 ## 14. References

--- a/docs/design/modularization-implementation-status.md
+++ b/docs/design/modularization-implementation-status.md
@@ -261,6 +261,8 @@ From enablement §5.4 and the Effect plan §8:
 | `hitl_enqueue_label_studio`                                                      | ✅ Native `Effect.gen` config/validate → HTTP import → NATS publish hook                                                                        |
 | `SandboxExecService` sandbox_exec                                                | ✅ Native `Effect.gen` (parse backend → resolve probes → dispatch Kata/Docker/Seatbelt/bridge → shape); Promise façade kept                     |
 | Background workers (schedule / ouroboros poller / inference pipeline)            | ✅ Daemon fibers + `Effect.sleep` loops (skip-if-busy `Ref`); interruptible `stop()`; TestClock-covered                                         |
+| ManagedRuntime `dispose` + process shutdown                                      | ✅ `ClawQLApiHandle.dispose` → plugin `teardownAll` + `runtime.dispose`; MCP registers `disposeClawqlApi` on SIGINT/SIGTERM                     |
+| Postgres / NATS `acquireRelease`                                                 | ✅ Scoped Effect helpers for Ouroboros + pgvector pools and NATS HITL consumer (singleton façades retained)                                     |
 
 **Rule for new code in extracted packages:** prefer Effect in `clawql-core` / `clawql-api`; legacy `async` is acceptable **only** at IO edges (`Effect.tryPromise`). See plan §7.
 

--- a/packages/clawql-api/src/create-api.test.ts
+++ b/packages/clawql-api/src/create-api.test.ts
@@ -50,14 +50,16 @@ describe("createClawQLApi", () => {
     ).rejects.toThrow();
   });
 
-  it("registers plugins from pluginLayers at runtime init", () => {
-    const api = createClawQLApi({
-      plugins: [],
-      pluginLayers: [makeMemoryLayer()],
-    });
-    expect(api.registry.list().some((p) => p.id === MEMORY_PLUGIN_ID)).toBe(true);
-    const names = api.listMcpTools().map((t) => t.name);
-    expect(names).toContain("memory_ingest");
-    expect(names).toContain("memory_recall");
+  it("dispose tears down plugins and ManagedRuntime", async () => {
+    const api = createClawQLApi({ plugins: [] });
+    await api.run(
+      Effect.gen(function* () {
+        const claw = yield* ClawQLApi;
+        yield* claw.registerPlugin({ id: "demo-dispose", version: "0.0.1" });
+      })
+    );
+    expect(api.registry.list().some((p) => p.id === "demo-dispose")).toBe(true);
+    await api.dispose();
+    expect(api.registry.list()).toHaveLength(0);
   });
 });

--- a/packages/clawql-api/src/create-api.test.ts
+++ b/packages/clawql-api/src/create-api.test.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 import { describe, expect, it } from "vitest";
-import { makeMemoryLayer, MEMORY_PLUGIN_ID } from "clawql-memory/plugin";
+import { MEMORY_PLUGIN_ID } from "clawql-memory/plugin";
 import { ClawQLApi, createClawQLApi } from "./index.js";
 import { PANGUARD_PROXY_PLUGIN_ID } from "./plugins/panguard-proxy-plugin.js";
 

--- a/packages/clawql-api/src/create-api.ts
+++ b/packages/clawql-api/src/create-api.ts
@@ -47,6 +47,8 @@ export type ClawQLApiHandle = {
   readonly run: <A, E extends ClawQLApiRuntimeError>(
     program: Effect.Effect<A, E, ClawQLApiRuntimeServices>
   ) => Promise<A>;
+  /** Tear down plugins then dispose the ManagedRuntime (call on process shutdown). */
+  readonly dispose: () => Promise<void>;
 };
 
 /**
@@ -81,5 +83,9 @@ export function createClawQLApi(options: CreateClawQLApiOptions = {}): ClawQLApi
     runtime,
     listMcpTools,
     run: (program) => runtime.runPromise(program),
+    dispose: async () => {
+      await Effect.runPromise(registry.teardownAll());
+      await runtime.dispose();
+    },
   };
 }

--- a/packages/clawql-automation/src/nats/nats-consumer-effect.test.ts
+++ b/packages/clawql-automation/src/nats/nats-consumer-effect.test.ts
@@ -1,0 +1,18 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { natsHitlConsumerScopedEffect } from "./nats-consumer-effect.js";
+import { resetNatsClientForTests } from "./client.js";
+
+describe("natsHitlConsumerScopedEffect", () => {
+  it("acquireRelease no-ops when NATS is not configured", async () => {
+    resetNatsClientForTests();
+    delete process.env.CLAWQL_NATS_URL;
+    delete process.env.CLAWQL_NATS_JETSTREAM;
+    await Effect.runPromise(
+      Effect.scoped(
+        natsHitlConsumerScopedEffect(async () => ({ ok: true }))
+      )
+    );
+    expect(true).toBe(true);
+  });
+});

--- a/packages/clawql-automation/src/nats/nats-consumer-effect.test.ts
+++ b/packages/clawql-automation/src/nats/nats-consumer-effect.test.ts
@@ -9,9 +9,7 @@ describe("natsHitlConsumerScopedEffect", () => {
     delete process.env.CLAWQL_NATS_URL;
     delete process.env.CLAWQL_NATS_JETSTREAM;
     await Effect.runPromise(
-      Effect.scoped(
-        natsHitlConsumerScopedEffect(async () => ({ ok: true }))
-      )
+      Effect.scoped(natsHitlConsumerScopedEffect(async () => ({ ok: true })))
     );
     expect(true).toBe(true);
   });

--- a/packages/clawql-automation/src/nats/nats-consumer-effect.ts
+++ b/packages/clawql-automation/src/nats/nats-consumer-effect.ts
@@ -2,7 +2,7 @@
  * Effect acquire/release for the NATS HITL resume consumer (plan §7 lifecycle).
  */
 
-import { Effect, type Scope } from "effect";
+import { Effect, Scope } from "effect";
 import {
   startHitlCompletedConsumer,
   stopNatsClient,
@@ -16,7 +16,7 @@ import {
  */
 export function natsHitlConsumerScopedEffect(
   handler: HitlCompletedConsumerHandler
-): Effect.Effect<void, never, Scope> {
+): Effect.Effect<void, never, Scope.Scope> {
   return Effect.acquireRelease(
     Effect.promise(async () => {
       await startHitlCompletedConsumer(handler);

--- a/packages/clawql-automation/src/nats/nats-consumer-effect.ts
+++ b/packages/clawql-automation/src/nats/nats-consumer-effect.ts
@@ -1,0 +1,26 @@
+/**
+ * Effect acquire/release for the NATS HITL resume consumer (plan §7 lifecycle).
+ */
+
+import { Effect, type Scope } from "effect";
+import {
+  startHitlCompletedConsumer,
+  stopNatsClient,
+  type HitlCompletedConsumerHandler,
+} from "./client.js";
+
+/**
+ * Start HITL completed consumer; on Scope close → drain/close NATS client.
+ * Prefer this from long-lived Effect Scopes; MCP plugin onRegister still uses
+ * the Promise façade via {@link startNatsWorkflowWorker}.
+ */
+export function natsHitlConsumerScopedEffect(
+  handler: HitlCompletedConsumerHandler
+): Effect.Effect<void, never, Scope> {
+  return Effect.acquireRelease(
+    Effect.promise(async () => {
+      await startHitlCompletedConsumer(handler);
+    }),
+    () => Effect.promise(() => stopNatsClient())
+  );
+}

--- a/packages/clawql-memory/src/vector/pgvector-pool-effect.ts
+++ b/packages/clawql-memory/src/vector/pgvector-pool-effect.ts
@@ -2,12 +2,16 @@
  * Effect acquire/release for vault pgvector pool (plan §7 resources).
  */
 
-import { Effect, type Scope } from "effect";
+import { Effect, Scope } from "effect";
 import type pg from "pg";
 import { closePostgresVectorPool, getPostgresVectorPool } from "./pgvector.js";
 
 /** Acquire shared vector pool (or null); release → {@link closePostgresVectorPool}. */
-export function postgresVectorPoolScopedEffect(): Effect.Effect<pg.Pool | null, never, Scope> {
+export function postgresVectorPoolScopedEffect(): Effect.Effect<
+  pg.Pool | null,
+  never,
+  Scope.Scope
+> {
   return Effect.acquireRelease(
     Effect.sync(() => getPostgresVectorPool()),
     () => Effect.promise(() => closePostgresVectorPool())

--- a/packages/clawql-memory/src/vector/pgvector-pool-effect.ts
+++ b/packages/clawql-memory/src/vector/pgvector-pool-effect.ts
@@ -1,0 +1,15 @@
+/**
+ * Effect acquire/release for vault pgvector pool (plan §7 resources).
+ */
+
+import { Effect, type Scope } from "effect";
+import type pg from "pg";
+import { closePostgresVectorPool, getPostgresVectorPool } from "./pgvector.js";
+
+/** Acquire shared vector pool (or null); release → {@link closePostgresVectorPool}. */
+export function postgresVectorPoolScopedEffect(): Effect.Effect<pg.Pool | null, never, Scope> {
+  return Effect.acquireRelease(
+    Effect.sync(() => getPostgresVectorPool()),
+    () => Effect.promise(() => closePostgresVectorPool())
+  );
+}

--- a/packages/clawql-ouroboros/src/glue/postgres-pool-effect.test.ts
+++ b/packages/clawql-ouroboros/src/glue/postgres-pool-effect.test.ts
@@ -1,0 +1,12 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { ouroborosPgPoolScopedEffect } from "./postgres-pool-effect.js";
+
+describe("ouroborosPgPoolScopedEffect", () => {
+  it("acquires null and releases when Ouroboros DB env is unset", async () => {
+    delete process.env.CLAWQL_OUROBOROS_DATABASE_URL;
+    delete process.env.CLAWQL_OUROBOROS_DB_HOST;
+    const pool = await Effect.runPromise(Effect.scoped(ouroborosPgPoolScopedEffect()));
+    expect(pool).toBeNull();
+  });
+});

--- a/packages/clawql-ouroboros/src/glue/postgres-pool-effect.ts
+++ b/packages/clawql-ouroboros/src/glue/postgres-pool-effect.ts
@@ -1,0 +1,17 @@
+/**
+ * Effect acquire/release for Ouroboros Postgres pool (plan §7 resources).
+ * Module singleton {@link getOuroborosPgPool} remains for Promise-era call sites;
+ * Scope-aware programs should use this helper inside `Effect.scoped`.
+ */
+
+import { Effect, type Scope } from "effect";
+import type pg from "pg";
+import { closeOuroborosPgPool, getOuroborosPgPool } from "./postgres-pool.js";
+
+/** Acquire the shared Ouroboros pool (or null when unset); release → {@link closeOuroborosPgPool}. */
+export function ouroborosPgPoolScopedEffect(): Effect.Effect<pg.Pool | null, never, Scope> {
+  return Effect.acquireRelease(
+    Effect.sync(() => getOuroborosPgPool()),
+    () => Effect.promise(() => closeOuroborosPgPool())
+  );
+}

--- a/packages/clawql-ouroboros/src/glue/postgres-pool-effect.ts
+++ b/packages/clawql-ouroboros/src/glue/postgres-pool-effect.ts
@@ -4,12 +4,12 @@
  * Scope-aware programs should use this helper inside `Effect.scoped`.
  */
 
-import { Effect, type Scope } from "effect";
+import { Effect, Scope } from "effect";
 import type pg from "pg";
 import { closeOuroborosPgPool, getOuroborosPgPool } from "./postgres-pool.js";
 
 /** Acquire the shared Ouroboros pool (or null when unset); release → {@link closeOuroborosPgPool}. */
-export function ouroborosPgPoolScopedEffect(): Effect.Effect<pg.Pool | null, never, Scope> {
+export function ouroborosPgPoolScopedEffect(): Effect.Effect<pg.Pool | null, never, Scope.Scope> {
   return Effect.acquireRelease(
     Effect.sync(() => getOuroborosPgPool()),
     () => Effect.promise(() => closeOuroborosPgPool())

--- a/packages/clawql-ouroboros/src/plugin/index.ts
+++ b/packages/clawql-ouroboros/src/plugin/index.ts
@@ -11,6 +11,9 @@ export { createOuroborosPlugin, OUROBOROS_PLUGIN_ID } from "./ouroboros-plugin.j
 
 export { getOuroborosContext, resetOuroborosContextForTests } from "./context.js";
 
+export { closeOuroborosPgPool, getOuroborosPgPool } from "../glue/postgres-pool.js";
+export { ouroborosPgPoolScopedEffect } from "../glue/postgres-pool-effect.js";
+
 export {
   OuroborosContextService,
   OuroborosError,

--- a/src/clawql-api-adapters.ts
+++ b/src/clawql-api-adapters.ts
@@ -12,11 +12,14 @@ import {
   type LoadSpecFn,
 } from "clawql-api";
 import { defaultPaymentsProxyPlugins } from "clawql-payments/plugin";
+import { closeOuroborosPgPool } from "clawql-ouroboros/plugin";
+import { closePostgresVectorPool } from "clawql-memory/vector/pgvector";
 import { Effect, Layer } from "effect";
 import { composeHorizontalPluginLayers } from "./compose-horizontal-plugin-layers.js";
 import { resolvePluginCompositionFlags } from "./resolve-plugin-flags.js";
 
 let loadSpecOverride: LoadSpecFn | undefined;
+let shutdownHooksRegistered = false;
 
 /** Test hook — inject mock loadSpec for search/execute handlers. */
 export function setLoadSpecForTests(fn: LoadSpecFn | undefined): void {
@@ -51,11 +54,38 @@ export function getClawqlApi(): ClawQLApiHandle {
   return apiHandle;
 }
 
+/**
+ * Dispose plugins, ManagedRuntime, and shared IO pools.
+ * Safe to call multiple times; next {@link getClawqlApi} rebuilds a fresh runtime.
+ */
+export async function disposeClawqlApi(): Promise<void> {
+  const handle = apiHandle;
+  apiHandle = undefined;
+  if (handle) {
+    await handle.dispose().catch(() => undefined);
+  }
+  await Promise.all([
+    closePostgresVectorPool().catch(() => undefined),
+    closeOuroborosPgPool().catch(() => undefined),
+  ]);
+}
+
 /** Test helper — next getClawqlApi() builds a fresh runtime. */
 export function resetClawqlApiForTests(): void {
   if (!apiHandle) return;
   Effect.runSync(apiHandle.registry.teardownAll());
   apiHandle = undefined;
+}
+
+/** Register SIGINT/SIGTERM → {@link disposeClawqlApi} once per process. */
+export function registerClawqlApiShutdownHooks(): void {
+  if (shutdownHooksRegistered) return;
+  shutdownHooksRegistered = true;
+  const once = (): void => {
+    void disposeClawqlApi().catch(() => undefined);
+  };
+  process.once("SIGINT", once);
+  process.once("SIGTERM", once);
 }
 
 /** Run mcp-proxy `beforeCallTool` hooks (Panguard policy, x402 payment gates, …). */

--- a/src/server-http.ts
+++ b/src/server-http.ts
@@ -385,6 +385,8 @@ async function main() {
   await maybeVerifyReleaseManifestAtStartup();
   registerSpecCacheShutdownHooks();
   registerPostgresPoolShutdownHooks();
+  const { registerClawqlApiShutdownHooks } = await import("./clawql-api-adapters.js");
+  registerClawqlApiShutdownHooks();
   const app = await createMcpHttpApp();
   const { logStartupSummary } = await import("./startup-summary.js");
   await logStartupSummary();

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import { createRegisteredMcpServer } from "./mcp-server-factory.js";
 import { preloadSchemaFieldCacheFromDisk } from "./tools.js";
 import { validateOrDegradeObsidianVaultAtStartup } from "./vault-config.js";
 import { registerPostgresPoolShutdownHooks } from "clawql-memory/vector/pgvector";
+import { registerClawqlApiShutdownHooks } from "./clawql-api-adapters.js";
 import { maybeInitOtelTracing } from "./otel-tracing.js";
 import { maybeVerifyReleaseManifestAtStartup } from "./release-manifest-startup.js";
 
@@ -25,6 +26,7 @@ async function main() {
   await maybeVerifyReleaseManifestAtStartup();
   registerSpecCacheShutdownHooks();
   registerPostgresPoolShutdownHooks();
+  registerClawqlApiShutdownHooks();
   // Pre-warm the spec cache on startup so the first search call is fast
   await loadSpec();
   const { logStartupSummary } = await import("./startup-summary.js");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes Effect scoped-resource / dispose patterns for ClawQL runtime (rebased onto main after #686; supersedes #687):

- **`ClawQLApiHandle.dispose`** — tears down plugins via `teardownAll` then disposes the `ManagedRuntime`
- **`disposeClawqlApi` / `registerClawqlApiShutdownHooks`** — adapters wired from `server.ts` and `server-http.ts`
- **`Effect.acquireRelease` helpers** for Ouroboros/pgvector Postgres pools and NATS HITL consumer (`Scope.Scope` requirement type)
- Re-exports from `clawql-ouroboros/plugin`
- Docs: union fiber workers + dispose/`acquireRelease` status rows

## Test plan

- [x] Unit coverage for `dispose` on `createClawQLApi`
- [x] Lint/format (unused import fix)
- [x] Pool/NATS scoped Effect unit tests
- [ ] CI green (fix DTS `Scope` typing) → merge-after-green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

