### PR TITLE
fix(ci): unblock clawql.com landing deploy verify step

### DIFF
--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -58,7 +58,9 @@ jobs:
           test -f out/favicon.ico
           test -f out/robots.txt
           test -f out/sitemap.xml
-          grep -q 'operating system for agents' out/llms.txt
+          test -f out/enterprise/gtm/index.html
+          grep -qi 'operating system for agents' out/llms.txt
+          grep -q 'enterprise/gtm' out/sitemap.xml
           # Ensure install script is shell, not HTML
           head -1 out/install | grep -q '^#!/usr/bin/env bash'
       - name: Upload Pages artifact


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`Deploy landing page` has been failing since #696 (and again on #700), so clawql.com never received the SEO fixes or `/enterprise/gtm`.

Failure was in **Verify SEO/agent static assets**:

```bash
grep -q 'operating system for agents' out/llms.txt
```

`llms.txt` contains `Operating system for agents` — case-sensitive `grep` exits 1 and aborts the deploy before Pages upload.

## Fix

- Use `grep -qi` for the tagline check
- Also assert `out/enterprise/gtm/index.html` and sitemap entry exist

## Test plan

- [x] Local reproduce: case-sensitive grep fails; `-i` passes
- [ ] CI green
- [ ] After merge: Deploy landing page succeeds; `https://clawql.com/enterprise/gtm/` returns 200

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5923-61ff-77f8-92df-6c4b1fa90953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5923-61ff-77f8-92df-6c4b1fa90953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

