### PR TITLE
fix inference GTM: llms.txt link + enterprise framing

### DIFF
--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -61,6 +61,7 @@ jobs:
           test -f out/inference/gtm/index.html
           test -f out/enterprise/gtm/index.html
           grep -qi 'operating system for agents' out/llms.txt
+          grep -q 'inference/gtm' out/llms.txt
           grep -q 'inference/gtm' out/sitemap.xml
           grep -q 'enterprise/gtm' out/sitemap.xml
           # Ensure install script is shell, not HTML

--- a/landing-page/demo/scripts/generate-agent-assets.mjs
+++ b/landing-page/demo/scripts/generate-agent-assets.mjs
@@ -310,6 +310,7 @@ writeText(
 
 - [Docs](${docs})
 - [Getting started](${docs}/getting-started)
+- [Inference-first GTM playbook](${origin}/inference/gtm/)
 - [Enterprise GTM playbook](${origin}/enterprise/gtm/)
 - [MCP Server Card](/.well-known/mcp/server-card.json)
 `,

--- a/landing-page/demo/src/app/inference/gtm/page.tsx
+++ b/landing-page/demo/src/app/inference/gtm/page.tsx
@@ -21,11 +21,12 @@ export default function Page() {
         eyebrow={
           <p className="text-sm/7 font-medium text-mist-600 dark:text-mist-300">Inference-first GTM · July 2026</p>
         }
-        headline="The inference gateway is the razor"
+        headline="Lead with the Unified Gateway"
         subheadline={
           <p>
-            ClawQL’s default go-to-market playbook — from <code>npx clawql-inference</code> and a three-minute install
-            to memory, Flywheel, Virtual Gateway, and the full sovereign platform. Everything else is the blade.
+            ClawQL’s default go-to-market playbook — land with an OpenAI-compatible inference control plane and native{' '}
+            <code>/mcp</code> access, then expand into memory, Flywheel, Virtual Gateway governance, and the full
+            sovereign agent operating system.
           </p>
         }
         cta={

--- a/landing-page/demo/src/components/sections/inference-gtm-playbook.tsx
+++ b/landing-page/demo/src/components/sections/inference-gtm-playbook.tsx
@@ -55,8 +55,8 @@ export function InferenceGtmPlaybook() {
             {[
               {
                 label: 'Primary positioning',
-                value: 'Inference is the razor',
-                sub: 'Everything else is the blade — expand from three minutes of install',
+                value: 'Gateway-first adoption',
+                sub: 'Prove value in minutes, then expand into the sovereign operating system',
               },
               {
                 label: 'Entry binary',
@@ -88,7 +88,7 @@ export function InferenceGtmPlaybook() {
             and asked buyers to evaluate a comprehensive system before experiencing any of it. This playbook documents
             the corrected motion.
           </p>
-          <Callout>The inference gateway is the razor. Everything else is the blade.</Callout>
+          <Callout>The Unified Gateway is the adoption surface. The sovereign platform is the destination.</Callout>
           <p>
             <code>npx clawql-inference</code> and <code>export OPENAI_BASE_URL=http://localhost:8080</code> are the
             lowest-friction entry points in the stack. A developer can be running ClawQL in three minutes without
@@ -456,8 +456,8 @@ clawql sources add https://your-nextcloud-instance/api
               path for engineers and data-sovereignty buyers who will never use managed SaaS.
             </li>
             <li>
-              <strong>Developer ($29/mo):</strong> Inference gateway + vault memory. The “razor” tier — cheap enough
-              that cost is never the reason not to try it.
+              <strong>Developer ($29/mo):</strong> Inference gateway + vault memory. The land-and-expand entry tier —
+              priced so procurement friction never blocks a technical evaluation.
             </li>
             <li>
               <strong>Teams ($99/mo):</strong> Inference + vault memory + Onyx semantic search. Five users. Still below


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #703:

1. **llms.txt** — add Inference-first GTM as the primary link in the generated agent-assets template; assert it in landing deploy verify.
2. **Copy** — remove the “razor / blade” metaphor in favor of enterprise-appropriate framing: Unified Gateway as the **adoption surface**, sovereign platform as the **destination**; hero becomes “Lead with the Unified Gateway.”

## Test plan

- [ ] No “razor” / “blade” on `/inference/gtm`
- [ ] Deploy verify greps `inference/gtm` in `out/llms.txt`
- [ ] Live page + `llms.txt` after merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5923-61ff-77f8-92df-6c4b1fa90953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5923-61ff-77f8-92df-6c4b1fa90953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

