### PR TITLE
fix(deps): restore main after Dependabot Effect/TS fallout

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,9 @@
     "": {
       "name": "clawql-mcp",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.1085.0",
-        "@effect/opentelemetry": "^0.63.0",
-        "@effect/platform": "^0.96.0",
+        "@aws-sdk/client-s3": "^3.1090.0",
+        "@effect/opentelemetry": "^0.64.0",
+        "@effect/platform": "^0.97.0",
         "@graphql-mesh/utils": "^0.104.36",
         "@grpc/grpc-js": "^1.14.4",
         "@grpc/proto-loader": "^0.8.1",
@@ -35,7 +35,7 @@
         "clawql-release": "7.1.0",
         "clawql-sandbox": "7.1.0",
         "dotenv": "^17.4.2",
-        "effect": "3.21.4",
+        "effect": "3.22.0",
         "express": "^5.2.1",
         "express-rate-limit": "^8.5.2",
         "graphql": "^16.14.2",
@@ -60,7 +60,7 @@
         "eslint": "^10.7.0",
         "prettier": "^3.9.3",
         "tsx": "^4.23.1",
-        "turbo": "^2.10.3",
+        "turbo": "^2.10.5",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.62.1",
         "vitest": "^4.1.7",
@@ -78,7 +78,7 @@
       },
       "devDependencies": {
         "@types/node": "^26.1.1",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.1",
       },
     },
@@ -107,7 +107,7 @@
       "devDependencies": {
         "@types/node": "^26.1.1",
         "tsup": "^8.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.1",
       },
     },
@@ -122,7 +122,7 @@
       "devDependencies": {
         "@types/node": "^26.1.1",
         "tsup": "^8.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.1",
       },
     },
@@ -144,7 +144,7 @@
         "@types/node": "^26.1.1",
         "@types/sql.js": "^1.4.11",
         "tsup": "^8.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.1",
       },
     },
@@ -173,7 +173,7 @@
       "devDependencies": {
         "@types/node": "^26.1.1",
         "tsup": "^8.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.1",
       },
     },
@@ -191,7 +191,7 @@
       "devDependencies": {
         "@types/node": "^26.1.1",
         "tsup": "^8.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.1",
       },
     },
@@ -221,7 +221,7 @@
         "@types/node": "^26.1.1",
         "@types/pg": "^8.20.0",
         "tsup": "^8.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.1",
       },
     },
@@ -243,7 +243,7 @@
         "@types/pg": "^8.20.0",
         "@types/sql.js": "^1.4.11",
         "tsup": "^8.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.1",
       },
     },
@@ -264,7 +264,7 @@
       "devDependencies": {
         "@types/node": "^26.1.1",
         "tsup": "^8.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.1",
       },
     },
@@ -283,7 +283,7 @@
       "devDependencies": {
         "@types/node": "^26.1.1",
         "tsup": "^8.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.1",
       },
     },
@@ -303,7 +303,7 @@
         "@types/node": "^26.1.1",
         "@types/pg": "^8.20.0",
         "tsup": "^8.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.1",
       },
     },
@@ -316,7 +316,7 @@
       "devDependencies": {
         "@types/node": "^26.1.1",
         "tsup": "^8.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.1",
       },
     },
@@ -338,12 +338,12 @@
       "devDependencies": {
         "@types/node": "^26.1.1",
         "tsup": "^8.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.1",
       },
       "optionalDependencies": {
         "mppx": "^0.8.6",
-        "viem": "^2.55.1",
+        "viem": "^2.55.4",
       },
     },
     "packages/clawql-release": {
@@ -359,7 +359,7 @@
       "devDependencies": {
         "@types/node": "^26.1.1",
         "tsup": "^8.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.1",
       },
     },
@@ -375,7 +375,7 @@
       "devDependencies": {
         "@types/node": "^26.1.1",
         "tsup": "^8.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.1",
       },
     },
@@ -392,7 +392,7 @@
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@types/node": "^26.1.1",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.1",
         "zod": "^3.24.0",
       },
@@ -425,7 +425,7 @@
     "brace-expansion@1": "1.1.16",
     "brace-expansion@2": "2.1.2",
     "brace-expansion@5": "5.0.8",
-    "effect": "3.21.4",
+    "effect": "3.22.0",
     "esbuild": "0.28.1",
     "fast-uri": "3.1.4",
     "hono": "4.12.31",
@@ -496,9 +496,9 @@
 
     "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
 
-    "@effect/opentelemetry": ["@effect/opentelemetry@0.63.0", "", { "peerDependencies": { "@effect/platform": "^0.96.0", "@opentelemetry/api": "^1.9", "@opentelemetry/resources": "^2.0.0", "@opentelemetry/sdk-logs": ">=0.203.0 <0.300.0", "@opentelemetry/sdk-metrics": "^2.0.0", "@opentelemetry/sdk-trace-base": "^2.0.0", "@opentelemetry/sdk-trace-node": "^2.0.0", "@opentelemetry/sdk-trace-web": "^2.0.0", "@opentelemetry/semantic-conventions": "^1.33.0", "effect": "^3.21.0" } }, "sha512-2yUG2QWNATi1uKP0kwhaP5eLp+c5NDzAL3EOpIcGLBAC0cbXZrx4n9Qw/QwUKxpuV+pbhrBUPCiByyWAFKfuCw=="],
+    "@effect/opentelemetry": ["@effect/opentelemetry@0.64.0", "", { "peerDependencies": { "@effect/platform": "^0.97.0", "@opentelemetry/api": "^1.9", "@opentelemetry/resources": "^2.0.0", "@opentelemetry/sdk-logs": ">=0.203.0 <0.300.0", "@opentelemetry/sdk-metrics": "^2.0.0", "@opentelemetry/sdk-trace-base": "^2.0.0", "@opentelemetry/sdk-trace-node": "^2.0.0", "@opentelemetry/sdk-trace-web": "^2.0.0", "@opentelemetry/semantic-conventions": "^1.33.0", "effect": "^3.22.0" } }, "sha512-fLdsyh/u5ImTyvWUfDQy53PVgHEWO0fOjwKzpmhQzW6CYs8wFBU6pP/VpuRYvCGgpZxk8KW4ySr+fvQ0o74rrA=="],
 
-    "@effect/platform": ["@effect/platform@0.96.3", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.10", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.21.5" } }, "sha512-LzvIj4HYE++TcTv/cVTCI/GRvQTV0ymwRmgjZMzNB5dU4OS05pTN36RKN0npiOm5orLJgw4yjIv1dNZoYGh/vg=="],
+    "@effect/platform": ["@effect/platform@0.97.0", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.10", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.22.0" } }, "sha512-PPSKkQ+QlIbKcf74FZKi3pi2h8hqYjsrUYaFuWXsuHpr8gjUoNNxJBptYzkzy4X9f7EeHhHqDMcj9YxaMygiHg=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -1218,7 +1218,7 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
-    "effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
+    "effect": ["effect@3.22.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-jhYFe0zTlIRqYFrKTS+6luhmS/Tm0f+JLo0K9KUxvtFab1SUGEszQi2ehOP6QzAZvy831lDmTwwzvVDZSPNz3g=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/infra/pulumi/package.json
+++ b/infra/pulumi/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.1",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.1"
   },
   "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
             ],
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.1090.0",
-                "@effect/opentelemetry": "^0.63.0",
+                "@effect/opentelemetry": "^0.64.0",
                 "@effect/platform": "^0.97.0",
                 "@graphql-mesh/utils": "^0.104.36",
                 "@grpc/grpc-js": "^1.14.4",
@@ -43,7 +43,7 @@
                 "clawql-release": "7.1.0",
                 "clawql-sandbox": "7.1.0",
                 "dotenv": "^17.4.2",
-                "effect": "3.21.4",
+                "effect": "3.22.0",
                 "express": "^5.2.1",
                 "express-rate-limit": "^8.5.2",
                 "graphql": "^16.14.2",
@@ -74,8 +74,8 @@
                 "prettier": "^3.9.3",
                 "tsx": "^4.23.1",
                 "turbo": "^2.10.5",
-                "typescript": "^7.0.2",
-                "typescript-eslint": "^8.62.1",
+                "typescript": "^6.0.3",
+                "typescript-eslint": "^8.65.0",
                 "vitest": "^4.1.7"
             },
             "engines": {
@@ -95,7 +95,7 @@
             },
             "devDependencies": {
                 "@types/node": "^26.1.1",
-                "typescript": "^7.0.2",
+                "typescript": "^6.0.3",
                 "vitest": "^4.1.1"
             },
             "engines": {
@@ -566,12 +566,12 @@
             "optional": true
         },
         "node_modules/@effect/opentelemetry": {
-            "version": "0.63.0",
-            "resolved": "https://registry.npmjs.org/@effect/opentelemetry/-/opentelemetry-0.63.0.tgz",
-            "integrity": "sha512-2yUG2QWNATi1uKP0kwhaP5eLp+c5NDzAL3EOpIcGLBAC0cbXZrx4n9Qw/QwUKxpuV+pbhrBUPCiByyWAFKfuCw==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@effect/opentelemetry/-/opentelemetry-0.64.0.tgz",
+            "integrity": "sha512-fLdsyh/u5ImTyvWUfDQy53PVgHEWO0fOjwKzpmhQzW6CYs8wFBU6pP/VpuRYvCGgpZxk8KW4ySr+fvQ0o74rrA==",
             "license": "MIT",
             "peerDependencies": {
-                "@effect/platform": "^0.96.0",
+                "@effect/platform": "^0.97.0",
                 "@opentelemetry/api": "^1.9",
                 "@opentelemetry/resources": "^2.0.0",
                 "@opentelemetry/sdk-logs": ">=0.203.0 <0.300.0",
@@ -580,7 +580,7 @@
                 "@opentelemetry/sdk-trace-node": "^2.0.0",
                 "@opentelemetry/sdk-trace-web": "^2.0.0",
                 "@opentelemetry/semantic-conventions": "^1.33.0",
-                "effect": "^3.21.0"
+                "effect": "^3.22.0"
             }
         },
         "node_modules/@effect/platform": {
@@ -4926,326 +4926,6 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "node_modules/@typescript/typescript-aix-ppc64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
-            "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
-            "cpu": [
-                "ppc64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "aix"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-darwin-arm64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
-            "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-darwin-x64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
-            "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-freebsd-arm64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
-            "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-freebsd-x64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
-            "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-linux-arm": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
-            "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-linux-arm64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
-            "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-linux-loong64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
-            "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
-            "cpu": [
-                "loong64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-linux-mips64el": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
-            "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
-            "cpu": [
-                "mips64el"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-linux-ppc64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
-            "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
-            "cpu": [
-                "ppc64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-linux-riscv64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
-            "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
-            "cpu": [
-                "riscv64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-linux-s390x": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
-            "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
-            "cpu": [
-                "s390x"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-linux-x64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
-            "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-netbsd-arm64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
-            "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-netbsd-x64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
-            "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-openbsd-arm64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
-            "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-openbsd-x64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
-            "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-sunos-x64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
-            "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-win32-arm64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
-            "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-win32-x64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
-            "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
         "node_modules/@vitest/coverage-v8": {
             "version": "4.1.10",
             "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
@@ -6513,9 +6193,9 @@
             "license": "MIT"
         },
         "node_modules/effect": {
-            "version": "3.21.4",
-            "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.4.tgz",
-            "integrity": "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ==",
+            "version": "3.22.0",
+            "resolved": "https://registry.npmjs.org/effect/-/effect-3.22.0.tgz",
+            "integrity": "sha512-jhYFe0zTlIRqYFrKTS+6luhmS/Tm0f+JLo0K9KUxvtFab1SUGEszQi2ehOP6QzAZvy831lDmTwwzvVDZSPNz3g==",
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
@@ -11774,37 +11454,16 @@
             }
         },
         "node_modules/typescript": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-            "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "license": "Apache-2.0",
             "bin": {
-                "tsc": "bin/tsc"
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=16.20.0"
-            },
-            "optionalDependencies": {
-                "@typescript/typescript-aix-ppc64": "7.0.2",
-                "@typescript/typescript-darwin-arm64": "7.0.2",
-                "@typescript/typescript-darwin-x64": "7.0.2",
-                "@typescript/typescript-freebsd-arm64": "7.0.2",
-                "@typescript/typescript-freebsd-x64": "7.0.2",
-                "@typescript/typescript-linux-arm": "7.0.2",
-                "@typescript/typescript-linux-arm64": "7.0.2",
-                "@typescript/typescript-linux-loong64": "7.0.2",
-                "@typescript/typescript-linux-mips64el": "7.0.2",
-                "@typescript/typescript-linux-ppc64": "7.0.2",
-                "@typescript/typescript-linux-riscv64": "7.0.2",
-                "@typescript/typescript-linux-s390x": "7.0.2",
-                "@typescript/typescript-linux-x64": "7.0.2",
-                "@typescript/typescript-netbsd-arm64": "7.0.2",
-                "@typescript/typescript-netbsd-x64": "7.0.2",
-                "@typescript/typescript-openbsd-arm64": "7.0.2",
-                "@typescript/typescript-openbsd-x64": "7.0.2",
-                "@typescript/typescript-sunos-x64": "7.0.2",
-                "@typescript/typescript-win32-arm64": "7.0.2",
-                "@typescript/typescript-win32-x64": "7.0.2"
+                "node": ">=14.17"
             }
         },
         "node_modules/typescript-eslint": {
@@ -12693,7 +12352,7 @@
             "devDependencies": {
                 "@types/node": "^26.1.1",
                 "tsup": "^8.3.0",
-                "typescript": "^7.0.2",
+                "typescript": "^6.0.3",
                 "vitest": "^4.1.1"
             },
             "engines": {
@@ -12724,7 +12383,7 @@
             "devDependencies": {
                 "@types/node": "^26.1.1",
                 "tsup": "^8.3.0",
-                "typescript": "^7.0.2",
+                "typescript": "^6.0.3",
                 "vitest": "^4.1.1"
             },
             "engines": {
@@ -12762,7 +12421,7 @@
                 "@types/node": "^26.1.1",
                 "@types/sql.js": "^1.4.11",
                 "tsup": "^8.3.0",
-                "typescript": "^7.0.2",
+                "typescript": "^6.0.3",
                 "vitest": "^4.1.1"
             },
             "engines": {
@@ -12775,7 +12434,7 @@
             "dependencies": {
                 "effect": "^3.21.4",
                 "tree-sitter-wasms": "^0.1.13",
-                "typescript": "^7.0.2",
+                "typescript": "^6.0.3",
                 "web-tree-sitter": "^0.25.6",
                 "zod": "4.3.6"
             },
@@ -12797,7 +12456,7 @@
             "devDependencies": {
                 "@types/node": "^26.1.1",
                 "tsup": "^8.3.0",
-                "typescript": "^7.0.2",
+                "typescript": "^6.0.3",
                 "vitest": "^4.1.1"
             },
             "engines": {
@@ -12818,7 +12477,7 @@
             "devDependencies": {
                 "@types/node": "^26.1.1",
                 "tsup": "^8.3.0",
-                "typescript": "^7.0.2",
+                "typescript": "^6.0.3",
                 "vitest": "^4.1.1"
             },
             "engines": {
@@ -12851,7 +12510,7 @@
                 "@types/node": "^26.1.1",
                 "@types/pg": "^8.20.0",
                 "tsup": "^8.3.0",
-                "typescript": "^7.0.2",
+                "typescript": "^6.0.3",
                 "vitest": "^4.1.1"
             },
             "engines": {
@@ -12876,7 +12535,7 @@
                 "@types/pg": "^8.20.0",
                 "@types/sql.js": "^1.4.11",
                 "tsup": "^8.3.0",
-                "typescript": "^7.0.2",
+                "typescript": "^6.0.3",
                 "vitest": "^4.1.1"
             },
             "engines": {
@@ -12900,7 +12559,7 @@
             "devDependencies": {
                 "@types/node": "^26.1.1",
                 "tsup": "^8.3.0",
-                "typescript": "^7.0.2",
+                "typescript": "^6.0.3",
                 "vitest": "^4.1.1"
             },
             "engines": {
@@ -12922,7 +12581,7 @@
             "devDependencies": {
                 "@types/node": "^26.1.1",
                 "tsup": "^8.3.0",
-                "typescript": "^7.0.2",
+                "typescript": "^6.0.3",
                 "vitest": "^4.1.1"
             },
             "engines": {
@@ -12945,7 +12604,7 @@
                 "@types/node": "^26.1.1",
                 "@types/pg": "^8.20.0",
                 "tsup": "^8.3.0",
-                "typescript": "^7.0.2",
+                "typescript": "^6.0.3",
                 "vitest": "^4.1.1"
             },
             "engines": {
@@ -12961,7 +12620,7 @@
             "devDependencies": {
                 "@types/node": "^26.1.1",
                 "tsup": "^8.3.0",
-                "typescript": "^7.0.2",
+                "typescript": "^6.0.3",
                 "vitest": "^4.1.1"
             },
             "engines": {
@@ -12986,7 +12645,7 @@
             "devDependencies": {
                 "@types/node": "^26.1.1",
                 "tsup": "^8.3.0",
-                "typescript": "^7.0.2",
+                "typescript": "^6.0.3",
                 "vitest": "^4.1.1"
             },
             "engines": {
@@ -13027,7 +12686,7 @@
             "devDependencies": {
                 "@types/node": "^26.1.1",
                 "tsup": "^8.3.0",
-                "typescript": "^7.0.2",
+                "typescript": "^6.0.3",
                 "vitest": "^4.1.1"
             },
             "engines": {
@@ -13046,7 +12705,7 @@
             "devDependencies": {
                 "@types/node": "^26.1.1",
                 "tsup": "^8.3.0",
-                "typescript": "^7.0.2",
+                "typescript": "^6.0.3",
                 "vitest": "^4.1.1"
             },
             "engines": {
@@ -13066,7 +12725,7 @@
             "devDependencies": {
                 "@modelcontextprotocol/sdk": "^1.27.1",
                 "@types/node": "^26.1.1",
-                "typescript": "^7.0.2",
+                "typescript": "^6.0.3",
                 "vitest": "^4.1.1",
                 "zod": "^3.24.0"
             },

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.1090.0",
-        "@effect/opentelemetry": "^0.63.0",
+        "@effect/opentelemetry": "^0.64.0",
         "@effect/platform": "^0.97.0",
         "@graphql-mesh/utils": "^0.104.36",
         "@grpc/grpc-js": "^1.14.4",
@@ -147,7 +147,7 @@
         "clawql-release": "7.1.0",
         "clawql-sandbox": "7.1.0",
         "dotenv": "^17.4.2",
-        "effect": "3.21.4",
+        "effect": "3.22.0",
         "express": "^5.2.1",
         "express-rate-limit": "^8.5.2",
         "graphql": "^16.14.2",
@@ -173,8 +173,8 @@
         "prettier": "^3.9.3",
         "tsx": "^4.23.1",
         "turbo": "^2.10.5",
-        "typescript": "^7.0.2",
-        "typescript-eslint": "^8.62.1",
+        "typescript": "^6.0.3",
+        "typescript-eslint": "^8.65.0",
         "vitest": "^4.1.7"
     },
     "overrides": {
@@ -211,6 +211,6 @@
         "brace-expansion@1": "1.1.16",
         "brace-expansion@2": "2.1.2",
         "brace-expansion@5": "5.0.8",
-        "effect": "3.21.4"
+        "effect": "3.22.0"
     }
 }

--- a/packages/clawql-api/package.json
+++ b/packages/clawql-api/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@types/node": "^26.1.1",
     "tsup": "^8.3.0",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.1"
   },
   "files": [

--- a/packages/clawql-auth/package.json
+++ b/packages/clawql-auth/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@types/node": "^26.1.1",
     "tsup": "^8.3.0",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.1"
   },
   "files": [

--- a/packages/clawql-automation/package.json
+++ b/packages/clawql-automation/package.json
@@ -102,7 +102,7 @@
     "@types/node": "^26.1.1",
     "@types/sql.js": "^1.4.11",
     "tsup": "^8.3.0",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.1"
   },
   "files": [

--- a/packages/clawql-codegraph/package.json
+++ b/packages/clawql-codegraph/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "effect": "^3.21.4",
     "tree-sitter-wasms": "^0.1.13",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "web-tree-sitter": "^0.25.6",
     "zod": "4.3.6"
   },

--- a/packages/clawql-core/package.json
+++ b/packages/clawql-core/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@types/node": "^26.1.1",
     "tsup": "^8.3.0",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.1"
   },
   "files": [

--- a/packages/clawql-documents/package.json
+++ b/packages/clawql-documents/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@types/node": "^26.1.1",
     "tsup": "^8.3.0",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.1"
   },
   "files": [

--- a/packages/clawql-inference/package.json
+++ b/packages/clawql-inference/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^26.1.1",
     "@types/pg": "^8.20.0",
     "tsup": "^8.3.0",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.1"
   },
   "files": [

--- a/packages/clawql-memory/package.json
+++ b/packages/clawql-memory/package.json
@@ -127,7 +127,7 @@
     "@types/pg": "^8.20.0",
     "@types/sql.js": "^1.4.11",
     "tsup": "^8.3.0",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.1"
   },
   "files": [

--- a/packages/clawql-ontology/package.json
+++ b/packages/clawql-ontology/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^26.1.1",
     "tsup": "^8.3.0",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.1"
   },
   "files": [

--- a/packages/clawql-operator/package.json
+++ b/packages/clawql-operator/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@types/node": "^26.1.1",
     "tsup": "^8.3.0",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.1"
   },
   "files": [

--- a/packages/clawql-ouroboros/package.json
+++ b/packages/clawql-ouroboros/package.json
@@ -55,7 +55,7 @@
     "@types/node": "^26.1.1",
     "@types/pg": "^8.20.0",
     "tsup": "^8.3.0",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.1"
   },
   "files": [

--- a/packages/clawql-pageindex/package.json
+++ b/packages/clawql-pageindex/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@types/node": "^26.1.1",
     "tsup": "^8.3.0",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.1"
   },
   "files": [

--- a/packages/clawql-payments/package.json
+++ b/packages/clawql-payments/package.json
@@ -121,7 +121,7 @@
   "devDependencies": {
     "@types/node": "^26.1.1",
     "tsup": "^8.3.0",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.1"
   },
   "files": [

--- a/packages/clawql-release/package.json
+++ b/packages/clawql-release/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@types/node": "^26.1.1",
     "tsup": "^8.3.0",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.1"
   },
   "files": [

--- a/packages/clawql-sandbox/package.json
+++ b/packages/clawql-sandbox/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^26.1.1",
     "tsup": "^8.3.0",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.1"
   },
   "files": [

--- a/packages/mcp-grpc-transport/package.json
+++ b/packages/mcp-grpc-transport/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@types/node": "^26.1.1",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.1",
     "zod": "^3.24.0"
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Main broke after a Dependabot merge batch (`npm ci` ERESOLVE + premature TypeScript 7).

### Cause
- `#730` raised `@effect/platform` to **0.97** while `@effect/opentelemetry` stayed on **0.63** (peer wants `^0.96`)
- `#651` raised **TypeScript to 7.0.2** across workspaces despite prior unstable CI

### Fix
- Revert workspace `typescript` to **^6.0.3**
- Bump `@effect/opentelemetry` → **^0.64.0** and `effect` → **3.22.0** (dep + override) to match platform 0.97
- Refresh `package-lock.json` / `bun.lock`
- Align `typescript-eslint` range to **^8.65.0**

### Verification
- `npm ci` OK
- OSV scan: no issues
- `npm run build` OK

Remaining Dependabot PRs that conflict should be rebased after this lands — do not merge unstable majors without green CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8c5f-3427-7f47-befd-9ee7d3470e2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8c5f-3427-7f47-befd-9ee7d3470e2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

