### PR TITLE
docs: make immutable releases guide inviting for newcomers

### DIFF
--- a/docs/getting-started/clawql-release-mvp.md
+++ b/docs/getting-started/clawql-release-mvp.md
@@ -1,27 +1,22 @@
-# clawql-release reference notes
+# clawql-release — CLI reference
 
-> **Hands-on guide:** [`immutable-releases.md`](./immutable-releases.md) · https://docs.clawql.com/getting-started/immutable-releases  
-> **Vision:** https://docs.clawql.com/vision/immutable-releases
+Friendly walkthrough: **[Immutable releases](./immutable-releases.md)** · https://docs.clawql.com/getting-started/immutable-releases
 
-Short reference for Layer 0 CLI flags, env knobs, and CI. Prefer the getting-started guide for the full end-to-end path.
+This page is a compact cheat sheet for flags and env vars.
 
-## Quick start
+## Commands
 
 ```bash
-clawql release init
-
-clawql-release immutable-volume snapshot --backend git-worktree --name build-local
-clawql-release golden-image build --image-digest clawql-mcp=sha256:YOUR_DIGEST
-
-clawql release publish --tag v7.1.0 \
-  --sbom sbom.cdx.json \
-  --npm-tgz clawql-mcp-7.1.0.tgz \
-  --image-digest clawql-mcp=sha256:YOUR_DIGEST \
-  --stage-ipfs --permanent --github
-
-clawql release verify releases/v7.1.0/manifest.json
-clawql-release pull <arweave-tx-id> --rift
+clawql-release init
+clawql-release immutable-volume snapshot --backend git-worktree|rift --name NAME
+clawql-release immutable-volume list
+clawql-release golden-image build --image-digest NAME=sha256:…
+clawql-release publish --tag vX.Y.Z [--sbom …] [--npm-tgz …] [--stage-ipfs] [--permanent] [--encrypt] [--price "0.50 USDC"] [--github] [--dry-run]
+clawql-release verify <manifest.json|bundle-dir|tx-id>
+clawql-release pull <target> [--rift]
 ```
+
+Same via `clawql release …`.
 
 ## Dry-run / CI
 
@@ -29,24 +24,22 @@ clawql-release pull <arweave-tx-id> --rift
 CLAWQL_RELEASE_DRY_RUN=1 node scripts/release/ci-pipeline-e2e.mjs
 ```
 
-Workflow: [`.github/workflows/clawql-release-pipeline.yml`](../../.github/workflows/clawql-release-pipeline.yml)
-
 Do **not** put spendable Arweave wallets in GitHub Actions secrets for that workflow.
 
-## Env knobs
+## Env
 
-| Env                                                      | Purpose                              |
-| -------------------------------------------------------- | ------------------------------------ |
-| `CLAWQL_RELEASE_DRY_RUN=1` / `CLAWQL_RELEASE_MODE=local` | Force local backends                 |
-| `CLAWQL_ARWEAVE_WALLET_JWK`                              | Enable ar.io / Turbo upload path     |
-| `CLAWQL_ARIO_TURBO_URL`                                  | Turbo endpoint for uploads           |
-| `CLAWQL_IPFS_GATEWAY`                                    | IPFS HTTP gateway                    |
-| `CLAWQL_X402_ENFORCE=1`                                  | Live x402 facilitator verification   |
-| `CLAWQL_LIT_NETWORK`                                     | Lit Protocol network for key release |
+| Env                         | Purpose                   |
+| --------------------------- | ------------------------- |
+| `CLAWQL_RELEASE_DRY_RUN=1`  | Local backends            |
+| `CLAWQL_ARWEAVE_WALLET_JWK` | Live ar.io / Turbo upload |
+| `CLAWQL_ARIO_TURBO_URL`     | Turbo endpoint            |
+| `CLAWQL_IPFS_GATEWAY`       | IPFS gateway              |
+| `CLAWQL_X402_ENFORCE=1`     | Live x402 facilitator     |
+| `CLAWQL_LIT_NETWORK`        | Lit network label         |
 
-## Runtime verify
+## Runtime
 
-- `clawql doctor --smoke` — auto-resolves `releases/v{version}/manifest.json`
-- `CLAWQL_RELEASE_MANIFEST=…` — MCP startup verify; strict with `CLAWQL_RELEASE_MANIFEST_STRICT=1`
+- `clawql doctor --smoke` — checks `releases/v{version}/manifest.json` when present
+- `CLAWQL_RELEASE_MANIFEST=…` — verify at MCP startup
 
-Cosign for containers: [`docs/security/golden-image-pipeline.md`](../security/golden-image-pipeline.md)
+Cosign: [`docs/security/golden-image-pipeline.md`](../security/golden-image-pipeline.md)

--- a/docs/getting-started/immutable-releases.md
+++ b/docs/getting-started/immutable-releases.md
@@ -101,12 +101,12 @@ clawql-release publish --tag v7.1.0 \
 
 ## Stuck?
 
-| You see…                  | Try…                            |
-| ------------------------- | ------------------------------- |
-| Dirty git tree at publish | Commit or stash tracked changes |
-| Rift “no reflinks”        | Stick with `git-worktree`       |
+| You see…                  | Try…                              |
+| ------------------------- | --------------------------------- |
+| Dirty git tree at publish | Commit or stash tracked changes   |
+| Rift “no reflinks”        | Stick with `git-worktree`         |
 | Verify signature failed   | Re-publish; check `.clawql/keys/` |
-| No real Arweave tx        | Expected in dry-run — that’s OK |
+| No real Arweave tx        | Expected in dry-run — that’s OK   |
 
 ---
 

--- a/docs/getting-started/immutable-releases.md
+++ b/docs/getting-started/immutable-releases.md
@@ -1,170 +1,87 @@
-# Getting started: immutable releases (`clawql-release`)
+# Immutable releases
 
-This guide walks through **Layer 0** end to end: parallel workspaces → signed artifacts → IPFS staging → optional Lit/x402 encryption → Arweave permanence → verify and pull.
+Make a release you can **trust forever** — same bytes tomorrow, next year, and after any tag rewrite.
 
-Vision (why): [Immutable releases](https://docs.clawql.com/vision/immutable-releases) · source [`docs/vision/clawql-hybrid-decentralized-github-alternative.md`](../vision/clawql-hybrid-decentralized-github-alternative.md)
+Start on your laptop. No wallets. Go permanent when you want to.
 
-CLI package: [`packages/clawql-release`](../../packages/clawql-release/README.md)
-
----
-
-## What you get
-
-| Step           | Command                            | Outcome                                            |
-| -------------- | ---------------------------------- | -------------------------------------------------- |
-| Init           | `clawql-release init`              | `.clawql/release.json`, signed commits by default  |
-| Workspaces     | `immutable-volume snapshot`        | Parallel `git-worktree` or `rift` CoW checkouts    |
-| Golden image   | `golden-image build`               | Signed attestations (+ cosign/syft when installed) |
-| Publish        | `publish --stage-ipfs --permanent` | Manifest + Merkle root; staged then permanent      |
-| Paid / private | `publish --encrypt --price "…"`    | Lit condition + x402 access metadata               |
-| Consume        | `verify` / `pull`                  | Tamper check; decrypt when paid                    |
-
-Day-to-day collaboration stays on **Radicle** (primary) with **GitHub as a mirror**. Official releases become permanent and verifiable on **Arweave** (via ar.io when configured).
+**Website:** [docs.clawql.com/getting-started/immutable-releases](https://docs.clawql.com/getting-started/immutable-releases) · **Why:** [vision](https://docs.clawql.com/vision/immutable-releases)
 
 ---
 
-## Prerequisites
+## Try it in one command
 
-- Node.js **≥ 22**
-- Git (for worktrees and commit signing)
-- From a ClawQL checkout (or any repo using the CLI):
+From a ClawQL checkout (Node 22+):
 
 ```bash
-npm ci
-npm run build -w clawql-core
-npm run build -w clawql-release
-# binary: npx clawql-release …  or  clawql release …
-```
-
-Optional tools (used when present):
-
-| Tool                                                                    | Role                                                      |
-| ----------------------------------------------------------------------- | --------------------------------------------------------- |
-| [`rift-snapshot`](https://www.npmjs.com/package/rift-snapshot) (`rift`) | Fast CoW workspaces (needs btrfs / APFS / XFS reflinks)   |
-| `ipfs` (Kubo)                                                           | Real IPFS CIDs instead of local content-addressed staging |
-| `rad`                                                                   | Radicle push as primary git surface                       |
-| `gh`                                                                    | Attach manifest to a GitHub Release (mirror)              |
-| `cosign` / `syft`                                                       | Container signatures / SBOM generation                    |
-
----
-
-## Path A — dry-run (start here)
-
-No wallets, no daemons. Proves the full control plane locally or in CI.
-
-```bash
-export CLAWQL_RELEASE_DRY_RUN=1
-
-clawql-release init
-
-# Parallel agent-style workspaces
-clawql-release immutable-volume snapshot --backend git-worktree --name agent-a
-clawql-release immutable-volume snapshot --backend git-worktree --name agent-b
-clawql-release immutable-volume snapshot --backend rift --name rift-a
-
-# Fixture artifacts (replace with real SBOM / digests in production)
-printf '%s\n' '{"bomFormat":"CycloneDX","specVersion":"1.5","version":1}' > /tmp/sbom.cdx.json
-
-clawql-release golden-image build \
-  --image-digest clawql-mcp=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-
-clawql-release publish --tag v0.0.0-local \
-  --sbom /tmp/sbom.cdx.json \
-  --image-digest clawql-mcp=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
-  --stage-ipfs --permanent --encrypt --price "0.01 USDC" \
-  --dry-run
-
-# Print tx id from the publish output, then:
-clawql-release verify local_<…>
-clawql-release pull local_<…> --rift
-```
-
-**One-shot CI/local script** (same flow GitHub Actions runs):
-
-```bash
+npm ci && npm run build -w clawql-core && npm run build -w clawql-release
 CLAWQL_RELEASE_DRY_RUN=1 node scripts/release/ci-pipeline-e2e.mjs
 ```
 
-Workflow: [`.github/workflows/clawql-release-pipeline.yml`](../../.github/workflows/clawql-release-pipeline.yml)
-
-Dry-run stores live under `.clawql/` (gitignored):
-
-| Path                    | Purpose                                               |
-| ----------------------- | ----------------------------------------------------- |
-| `.clawql/ipfs-staging/` | Content-addressed staging (`clawql-cid:sha256:…`)     |
-| `.clawql/arweave/<tx>/` | Permanent bundle stand-in                             |
-| `.clawql/escrow/`       | Content-encryption keys for Lit dry-run release       |
-| `.clawql/keys/`         | Ed25519 release signing + optional SSH commit signing |
-| `.clawql/workspaces/`   | Snapshot metadata + git-worktree roots                |
-| `.rifts/`               | Rift CLI or local fallback workspaces                 |
+That dry-run walks the whole pipeline locally: workspaces → signed manifest → stage → permanent store → verify → pull. Nothing spends crypto. Nothing needs IPFS or Arweave online.
 
 ---
 
-## Path B — real workspaces (laptop)
+## Walk through it yourself
 
-### Git worktree (always available)
+Four small steps. You can stop after publish and still have a signed, verifiable release.
+
+### 1. Init
 
 ```bash
-clawql-release immutable-volume snapshot --backend git-worktree --name feature-42
-cd .clawql/workspaces/git-worktree/feature-42
-# edit / test / commit as usual (shared object store with the main repo)
+clawql-release init
+# or: clawql release init
 ```
 
-List / remove:
+Creates `.clawql/release.json` and turns on signed commits when it can.
+
+### 2. Make a workspace (optional)
 
 ```bash
+clawql-release immutable-volume snapshot --backend git-worktree --name my-agent
+cd .clawql/workspaces/git-worktree/my-agent
+```
+
+Prefer `git-worktree` first — it always works. Try `--backend rift` later if you have Rift and a CoW filesystem (APFS / btrfs). If Rift can’t CoW, ClawQL still creates a local fallback.
+
+### 3. Publish (still dry-run)
+
+```bash
+export CLAWQL_RELEASE_DRY_RUN=1
+printf '%s\n' '{"bomFormat":"CycloneDX","specVersion":"1.5","version":1}' > /tmp/sbom.cdx.json
+
+clawql-release publish --tag v0.0.0-local \
+  --sbom /tmp/sbom.cdx.json \
+  --stage-ipfs --permanent --dry-run
+```
+
+Copy the `Arweave tx:` / `local_…` id from the output.
+
+### 4. Verify & pull
+
+```bash
+clawql-release verify local_YOUR_ID
+clawql-release pull local_YOUR_ID
+```
+
+You just finished the core path without leaving your machine.
+
+---
+
+## When you’re ready for more
+
+Skip this section until you need it.
+
+**Parallel agents** — snapshot a few worktrees and work side by side:
+
+```bash
+clawql-release immutable-volume snapshot --backend git-worktree --name agent-a
+clawql-release immutable-volume snapshot --backend git-worktree --name agent-b
 clawql-release immutable-volume list
-clawql-release immutable-volume remove --name feature-42
 ```
 
-### Rift CoW (when the filesystem supports it)
+**Real artifacts** — SBOM, `npm pack` tarball, image digests:
 
 ```bash
-npm install --prefix ~/.local/clawql-rift rift-snapshot
-export PATH="$HOME/.local/clawql-rift/node_modules/.bin:$PATH"
-
-rift init    # must succeed on btrfs / APFS / XFS with reflinks
-clawql-release immutable-volume snapshot --backend rift --name agent-42
-```
-
-If `rift init` fails with “copy-on-write cloning unavailable” (typical on ext4 / overlay / many CI runners), `clawql-release` still creates a **local fallback** under `.rifts/` for provenance. True CoW needs a capable volume — use a laptop APFS volume, a btrfs disk, or a self-hosted runner with that FS.
-
----
-
-## Path C — full publish (production-shaped)
-
-### 1. Collect artifacts
-
-Build your SBOM, npm pack, and record image digests (from GHCR / cosign):
-
-```bash
-# examples — adjust to your pipeline
-npm pack
-# syft . -o cyclonedx-json=sbom.cdx.json
-# skopeo inspect … → digests
-```
-
-### 2. Snapshot the build environment
-
-```bash
-clawql-release immutable-volume snapshot --backend rift --name build-$(date -u +%Y%m%d)
-# or: --backend git-worktree
-```
-
-### 3. Golden image attestations
-
-```bash
-clawql-release golden-image build \
-  --version 7.1.0 \
-  --image-digest clawql-mcp=sha256:YOUR_DIGEST
-```
-
-### 4. Publish
-
-**Public release (GitHub mirror + IPFS staging + Arweave):**
-
-```bash
-# Omit CLAWQL_RELEASE_DRY_RUN for live backends when tools/env are set
 clawql-release publish --tag v7.1.0 \
   --sbom sbom.cdx.json \
   --npm-tgz clawql-mcp-7.1.0.tgz \
@@ -172,136 +89,30 @@ clawql-release publish --tag v7.1.0 \
   --stage-ipfs --permanent --github
 ```
 
-**Paid / private release:**
+**Paid / private** — add `--encrypt --price "0.50 USDC"` (dry-run works without a wallet).
 
-```bash
-clawql-release publish --tag v7.1.0 \
-  --sbom sbom.cdx.json \
-  --stage-ipfs --permanent \
-  --encrypt --price "0.50 USDC"
-```
+**Live networks** — laptop or self-hosted runner only (keep spendable keys off hosted Actions):
 
-### 5. Verify and pull
-
-```bash
-clawql-release verify releases/v7.1.0/manifest.json
-clawql-release verify <arweave-tx-id>
-
-clawql-release pull <arweave-tx-id> --rift
-# Paid bundles: present PAYMENT-SIGNATURE / dry-run receipt; Lit releases the CEK
-```
-
-`clawql release …` is the same surface via the main ClawQL CLI.
+- IPFS: Kubo (`ipfs` on `PATH`)
+- Arweave: `CLAWQL_ARWEAVE_WALLET_JWK`
+- x402 / Lit: `CLAWQL_X402_ENFORCE=1`, `CLAWQL_LIT_NETWORK`
 
 ---
 
-## Configuration
+## Stuck?
 
-`clawql-release init` writes `.clawql/release.json`. Useful fields:
-
-```json
-{
-  "version": 1,
-  "outputDir": "releases",
-  "requireSignedCommits": true,
-  "workspaceBackend": "git-worktree",
-  "collaboration": {
-    "primary": "radicle",
-    "githubMirrorUrl": "https://github.com/org/repo"
-  },
-  "permanence": {
-    "arweaveGateway": "https://arweave.net",
-    "dryRun": true
-  },
-  "access": {
-    "defaultPrice": "0.50 USDC",
-    "asset": "USDC",
-    "network": "base-sepolia"
-  }
-}
-```
-
-Signed commits: init enables `commit.gpgsign` when a signing identity exists, or configures an SSH key under `.clawql/keys/`. Opt out with `requireSignedCommits: false`.
+| You see…                  | Try…                            |
+| ------------------------- | ------------------------------- |
+| Dirty git tree at publish | Commit or stash tracked changes |
+| Rift “no reflinks”        | Stick with `git-worktree`       |
+| Verify signature failed   | Re-publish; check `.clawql/keys/` |
+| No real Arweave tx        | Expected in dry-run — that’s OK |
 
 ---
 
-## Live network knobs (laptop / self-hosted — not hosted Actions wallets)
+## Keep going
 
-| Env                                                      | Enables                           |
-| -------------------------------------------------------- | --------------------------------- |
-| `CLAWQL_RELEASE_DRY_RUN=1` / `CLAWQL_RELEASE_MODE=local` | Force local backends (CI default) |
-| _(ipfs on PATH)_                                         | Real `ipfs add` CIDs              |
-| `CLAWQL_IPFS_GATEWAY`                                    | HTTP gateway base for IPFS        |
-| `CLAWQL_ARWEAVE_WALLET_JWK`                              | ar.io / Turbo upload path         |
-| `CLAWQL_ARIO_TURBO_URL`                                  | Turbo endpoint                    |
-| `CLAWQL_ARWEAVE_GATEWAY` / `CLAWQL_ARIO_GATEWAY`         | Fetch/verify gateways             |
-| `CLAWQL_X402_ENFORCE=1`                                  | Live facilitator verify           |
-| `CLAWQL_X402_FACILITATOR_URL`                            | Facilitator base URL              |
-| `CLAWQL_X402_WALLET` / `CLAWQL_X402_NETWORK`             | Payment metadata defaults         |
-| `CLAWQL_LIT_NETWORK`                                     | Lit network label for key release |
-
-**Do not** put spendable Arweave wallets in GitHub Actions secrets for the dry-run workflow. Prefer laptop or a self-hosted runner for one small live `--permanent` publish.
-
-### Maturity of live adapters
-
-| Backend                    | Dry-run / local              | Live                                                                 |
-| -------------------------- | ---------------------------- | -------------------------------------------------------------------- |
-| git-worktree               | Full                         | Full                                                                 |
-| rift                       | Fallback under `.rifts/`     | Full when `rift` + CoW FS work                                       |
-| IPFS staging               | `clawql-cid:sha256:…`        | Kubo when `ipfs` is available                                        |
-| Ed25519 manifest/artifacts | Full                         | Full                                                                 |
-| Arweave / ar.io            | `.clawql/arweave/<tx>/`      | Env-gated Turbo path (harden with a real wallet on laptop)           |
-| Lit + x402                 | Escrow CEK + dry-run receipt | Soft facilitator / Lit hooks — validate on testnet before production |
-
----
-
-## What the manifest records
-
-Every publish writes `releases/<tag>/manifest.json` (schema **v0.2**) including:
-
-- `repository.commit` + dirty flag
-- `artifacts.*` / `images.*` with SHA-256 (+ Ed25519 signatures)
-- `merkleRoot` over those leaves
-- `buildEnvironment` (worktree / rift snapshot ancestry when present)
-- `collaboration` (Radicle primary + GitHub mirror banner)
-- `staging.ipfs` · `permanence.arweave` · `access` (public or paid)
-
-Runtime checks:
-
-- `clawql doctor --smoke` resolves `releases/v{version}/manifest.json` when present
-- `CLAWQL_RELEASE_MANIFEST=/path/to/manifest.json` verifies at MCP startup (strict with `CLAWQL_RELEASE_MANIFEST_STRICT=1` or production)
-
-Container digests are also verified with cosign separately — see [`docs/security/golden-image-pipeline.md`](../security/golden-image-pipeline.md).
-
----
-
-## Suggested learning order
-
-1. **Dry-run** — `ci-pipeline-e2e.mjs` or Path A above
-2. **Parallel worktrees** on your laptop — Path B
-3. **Rift CoW** on APFS/btrfs if you run many agents
-4. **Local Kubo** — publish with `--stage-ipfs` without dry-run
-5. **One tiny Arweave publish** with a funded wallet outside CI
-6. **x402 + Lit testnet** for a paid decrypt round-trip
-
----
-
-## Troubleshooting
-
-| Symptom                           | Likely cause                           | Fix                                                                       |
-| --------------------------------- | -------------------------------------- | ------------------------------------------------------------------------- |
-| `Manifest records dirty git tree` | Uncommitted tracked changes at collect | Commit or stash; untracked `.clawql/` / `.rifts/` are ignored             |
-| `rift init` fails (no reflinks)   | ext4 / overlay / cloud VM              | Use git-worktree or a CoW-capable volume                                  |
-| `verify` fails signature          | Wrong key / tampered file              | Re-publish; check `.clawql/keys/`                                         |
-| No Arweave tx on `--permanent`    | Dry-run or missing wallet              | Expected under `CLAWQL_RELEASE_DRY_RUN`; set wallet only on trusted hosts |
-| Pull decrypt fails                | Missing escrow / payment               | Check `.clawql/escrow/<tag>.key` or live Lit+x402 config                  |
-
----
-
-## Related docs
-
-- Vision: [Immutable releases](https://docs.clawql.com/vision/immutable-releases)
-- Short reference (MVP-era notes): [`clawql-release-mvp.md`](./clawql-release-mvp.md)
-- Package README: [`packages/clawql-release/README.md`](../../packages/clawql-release/README.md)
-- Golden images: [`docs/security/golden-image-pipeline.md`](../security/golden-image-pipeline.md)
-- Modularization Layer 0: [`docs/vision/clawql-modularization-v2.md`](../vision/clawql-modularization-v2.md)
+- [Vision — Immutable releases](https://docs.clawql.com/vision/immutable-releases) — architecture & rationale
+- [CLI cheat sheet](./clawql-release-mvp.md) — flags & env vars
+- [Golden image pipeline](../security/golden-image-pipeline.md) — container signing
+- Package: [`clawql-release`](../../packages/clawql-release/README.md)

--- a/website/src/app/getting-started/immutable-releases/page.tsx
+++ b/website/src/app/getting-started/immutable-releases/page.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@/components/Button'
 import { DocProse } from '@/components/DocProse'
 import { Note } from '@/components/mdx'
 import { Tag } from '@/components/Tag'
@@ -5,51 +6,109 @@ import GettingStartedImmutableReleasesBody from '@/generated/getting-started-imm
 import { docsPageMetadata } from '@/lib/seo'
 
 export const metadata = docsPageMetadata({
-  title: 'Immutable releases (clawql-release)',
+  title: 'Immutable releases',
   description:
-    'End-to-end Layer 0 guide: parallel workspaces, signed artifacts, IPFS staging, Lit/x402 access, Arweave permanence, and verify/pull with clawql-release.',
+    'A calm getting-started path for clawql-release: one dry-run command, then publish and verify trusted releases — no wallets required to start.',
   path: '/getting-started/immutable-releases',
   ogType: 'article',
 })
 
 export const dynamic = 'force-static'
 
+const steps = [
+  {
+    n: '1',
+    title: 'Try the dry-run',
+    body: 'One script proves the pipeline on your laptop.',
+  },
+  {
+    n: '2',
+    title: 'Publish locally',
+    body: 'A signed manifest you can verify anytime.',
+  },
+  {
+    n: '3',
+    title: 'Go permanent later',
+    body: 'Add IPFS or Arweave only when you want to.',
+  },
+] as const
+
 export default function GettingStartedImmutableReleasesPage() {
   return (
-    <article className="flex h-full flex-col pt-10 pb-10">
+    <article className="flex h-full flex-col pt-10 pb-16">
       <div className="not-prose mb-6 flex flex-wrap items-center gap-2">
         <Tag color="claw" variant="medium">
           Getting started
         </Tag>
         <Tag color="sky" variant="medium">
-          Layer 0
+          ~5 minutes
         </Tag>
       </div>
 
-      <div className="not-prose mb-8">
+      <header className="not-prose mb-8 max-w-2xl">
+        <h1 className="text-4xl font-semibold tracking-tight text-zinc-950 sm:text-5xl dark:text-white">
+          Immutable releases
+        </h1>
+        <p className="mt-4 text-lg leading-relaxed text-zinc-600 dark:text-zinc-400">
+          Ship something you can verify forever — starting with a safe dry-run.
+          No wallets. No daemons. Just a first win.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <Button href="#try-it-in-one-command" arrow="right">
+            <>Try the dry-run</>
+          </Button>
+          <Button href="/vision/immutable-releases" variant="outline">
+            <>Why this exists</>
+          </Button>
+        </div>
+      </header>
+
+      <div className="not-prose mb-10">
         <Note>
-          <strong>Hands-on pipeline guide.</strong> Generated from{' '}
-          <a
-            href="https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/getting-started/immutable-releases.md"
-            className="font-medium text-inherit underline underline-offset-2"
-          >
-            docs/getting-started/immutable-releases.md
-          </a>{' '}
-          on <code className="font-mono text-xs">main</code>. For the product
-          vision, see{' '}
-          <a
-            href="/vision/immutable-releases"
-            className="font-medium text-inherit underline underline-offset-2"
-          >
-            Immutable releases
-          </a>
-          .
+          <strong>Start here.</strong> The dry-run below is the same flow CI
+          uses. Skip wallets, IPFS, and Arweave until you outgrow local mode.
         </Note>
       </div>
 
-      <DocProse className="flex-auto">
+      <ol className="not-prose mb-12 grid gap-6 sm:grid-cols-3 sm:gap-8">
+        {steps.map((step, index) => (
+          <li key={step.n} className="relative min-w-0">
+            {index < steps.length - 1 ? (
+              <span
+                aria-hidden
+                className="absolute top-4 left-[calc(50%+1.25rem)] hidden h-px w-[calc(100%-1.5rem)] bg-gradient-to-r from-claw-cyan/40 to-transparent sm:block"
+              />
+            ) : null}
+            <div className="flex items-start gap-3 sm:flex-col sm:items-start sm:gap-2">
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-claw-cyan/15 text-sm font-semibold text-[#0e7490] dark:bg-claw-cyan/20 dark:text-claw-cyan">
+                {step.n}
+              </span>
+              <div>
+                <p className="text-base font-semibold text-zinc-950 dark:text-white">
+                  {step.title}
+                </p>
+                <p className="mt-1 text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">
+                  {step.body}
+                </p>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ol>
+
+      <DocProse className="flex-auto [&_h1]:sr-only">
         <GettingStartedImmutableReleasesBody />
       </DocProse>
+
+      <p className="not-prose mt-12 text-sm text-zinc-500 dark:text-zinc-500">
+        Source:{' '}
+        <a
+          href="https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/getting-started/immutable-releases.md"
+          className="underline underline-offset-2 hover:text-zinc-800 dark:hover:text-zinc-300"
+        >
+          docs/getting-started/immutable-releases.md
+        </a>
+      </p>
     </article>
   )
 }

--- a/website/src/app/getting-started/page.mdx
+++ b/website/src/app/getting-started/page.mdx
@@ -44,7 +44,7 @@ You are connecting to ClawQL’s **Agentic Gateway** — the Foundational Platfo
 | **Tier 1 Compose**     | Full local IDP slice                       | [Deployment](/deployment)                                                                        |
 | **Helm full stack**    | Team K8s, IDP pipeline                     | [Kubernetes](/deployment/kubernetes) · [Helm](/helm)                                             |
 | **Teams**              | Shared memory, golden hosts, observability | [For teams](/getting-started/for-teams)                                                          |
-| **Immutable releases** | Layer 0 verify / permanence pipeline       | [Immutable releases](/getting-started/immutable-releases) · [Vision](/vision/immutable-releases) |
+| **Immutable releases** | Verify forever — start with a local dry-run | [Immutable releases](/getting-started/immutable-releases) · [Vision](/vision/immutable-releases) |
 | **Operations**         | Secrets, health, day-2                     | [Operations guide](/deployment/operations-guide)                                                 |
 
 ## Next steps

--- a/website/src/app/getting-started/page.mdx
+++ b/website/src/app/getting-started/page.mdx
@@ -37,15 +37,15 @@ You are connecting to ClawQL’s **Agentic Gateway** — the Foundational Platfo
 
 ## Deployment options
 
-| Path                   | Best for                                   | Start here                                                                                       |
-| ---------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------ |
-| **Local MCP**          | Evaluation, solo dev                       | [Quickstart](/quickstart) · [Agent setup](/agent-setup)                                          |
-| **Inference**          | OpenAI drop-in gateway, BYOK models        | [Inference setup](/getting-started/inference)                                                    |
-| **Tier 1 Compose**     | Full local IDP slice                       | [Deployment](/deployment)                                                                        |
-| **Helm full stack**    | Team K8s, IDP pipeline                     | [Kubernetes](/deployment/kubernetes) · [Helm](/helm)                                             |
-| **Teams**              | Shared memory, golden hosts, observability | [For teams](/getting-started/for-teams)                                                          |
+| Path                   | Best for                                    | Start here                                                                                       |
+| ---------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| **Local MCP**          | Evaluation, solo dev                        | [Quickstart](/quickstart) · [Agent setup](/agent-setup)                                          |
+| **Inference**          | OpenAI drop-in gateway, BYOK models         | [Inference setup](/getting-started/inference)                                                    |
+| **Tier 1 Compose**     | Full local IDP slice                        | [Deployment](/deployment)                                                                        |
+| **Helm full stack**    | Team K8s, IDP pipeline                      | [Kubernetes](/deployment/kubernetes) · [Helm](/helm)                                             |
+| **Teams**              | Shared memory, golden hosts, observability  | [For teams](/getting-started/for-teams)                                                          |
 | **Immutable releases** | Verify forever — start with a local dry-run | [Immutable releases](/getting-started/immutable-releases) · [Vision](/vision/immutable-releases) |
-| **Operations**         | Secrets, health, day-2                     | [Operations guide](/deployment/operations-guide)                                                 |
+| **Operations**         | Secrets, health, day-2                      | [Operations guide](/deployment/operations-guide)                                                 |
 
 ## Next steps
 

--- a/website/src/app/vision/immutable-releases/page.tsx
+++ b/website/src/app/vision/immutable-releases/page.tsx
@@ -35,8 +35,8 @@ export default function ImmutableReleasesPage() {
           >
             docs/vision/clawql-hybrid-decentralized-github-alternative.md
           </a>{' '}
-          on <code className="font-mono text-xs">main</code>. Hands-on
-          walkthrough:{' '}
+          on <code className="font-mono text-xs">main</code>. New here? Start
+          with the calm walkthrough:{' '}
           <a
             href="/getting-started/immutable-releases"
             className="font-medium text-inherit underline underline-offset-2"

--- a/website/src/generated/getting-started-immutable-releases-body.mdx
+++ b/website/src/generated/getting-started-immutable-releases-body.mdx
@@ -1,170 +1,87 @@
-# Getting started: immutable releases (`clawql-release`)
+# Immutable releases
 
-This guide walks through **Layer 0** end to end: parallel workspaces → signed artifacts → IPFS staging → optional Lit/x402 encryption → Arweave permanence → verify and pull.
+Make a release you can **trust forever** — same bytes tomorrow, next year, and after any tag rewrite.
 
-Vision (why): [Immutable releases](https://docs.clawql.com/vision/immutable-releases) · source [`docs/vision/clawql-hybrid-decentralized-github-alternative.md`](/vision/immutable-releases)
+Start on your laptop. No wallets. Go permanent when you want to.
 
-CLI package: [`packages/clawql-release`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/packages/clawql-release/README.md)
-
----
-
-## What you get
-
-| Step           | Command                            | Outcome                                            |
-| -------------- | ---------------------------------- | -------------------------------------------------- |
-| Init           | `clawql-release init`              | `.clawql/release.json`, signed commits by default  |
-| Workspaces     | `immutable-volume snapshot`        | Parallel `git-worktree` or `rift` CoW checkouts    |
-| Golden image   | `golden-image build`               | Signed attestations (+ cosign/syft when installed) |
-| Publish        | `publish --stage-ipfs --permanent` | Manifest + Merkle root; staged then permanent      |
-| Paid / private | `publish --encrypt --price "…"`    | Lit condition + x402 access metadata               |
-| Consume        | `verify` / `pull`                  | Tamper check; decrypt when paid                    |
-
-Day-to-day collaboration stays on **Radicle** (primary) with **GitHub as a mirror**. Official releases become permanent and verifiable on **Arweave** (via ar.io when configured).
+**Website:** [docs.clawql.com/getting-started/immutable-releases](https://docs.clawql.com/getting-started/immutable-releases) · **Why:** [vision](https://docs.clawql.com/vision/immutable-releases)
 
 ---
 
-## Prerequisites
+## Try it in one command
 
-- Node.js **≥ 22**
-- Git (for worktrees and commit signing)
-- From a ClawQL checkout (or any repo using the CLI):
+From a ClawQL checkout (Node 22+):
 
 ```bash
-npm ci
-npm run build -w clawql-core
-npm run build -w clawql-release
-# binary: npx clawql-release …  or  clawql release …
-```
-
-Optional tools (used when present):
-
-| Tool                                                                    | Role                                                      |
-| ----------------------------------------------------------------------- | --------------------------------------------------------- |
-| [`rift-snapshot`](https://www.npmjs.com/package/rift-snapshot) (`rift`) | Fast CoW workspaces (needs btrfs / APFS / XFS reflinks)   |
-| `ipfs` (Kubo)                                                           | Real IPFS CIDs instead of local content-addressed staging |
-| `rad`                                                                   | Radicle push as primary git surface                       |
-| `gh`                                                                    | Attach manifest to a GitHub Release (mirror)              |
-| `cosign` / `syft`                                                       | Container signatures / SBOM generation                    |
-
----
-
-## Path A — dry-run (start here)
-
-No wallets, no daemons. Proves the full control plane locally or in CI.
-
-```bash
-export CLAWQL_RELEASE_DRY_RUN=1
-
-clawql-release init
-
-# Parallel agent-style workspaces
-clawql-release immutable-volume snapshot --backend git-worktree --name agent-a
-clawql-release immutable-volume snapshot --backend git-worktree --name agent-b
-clawql-release immutable-volume snapshot --backend rift --name rift-a
-
-# Fixture artifacts (replace with real SBOM / digests in production)
-printf '%s\n' '{"bomFormat":"CycloneDX","specVersion":"1.5","version":1}' > /tmp/sbom.cdx.json
-
-clawql-release golden-image build \
-  --image-digest clawql-mcp=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-
-clawql-release publish --tag v0.0.0-local \
-  --sbom /tmp/sbom.cdx.json \
-  --image-digest clawql-mcp=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
-  --stage-ipfs --permanent --encrypt --price "0.01 USDC" \
-  --dry-run
-
-# Print tx id from the publish output, then:
-clawql-release verify local_<…>
-clawql-release pull local_<…> --rift
-```
-
-**One-shot CI/local script** (same flow GitHub Actions runs):
-
-```bash
+npm ci && npm run build -w clawql-core && npm run build -w clawql-release
 CLAWQL_RELEASE_DRY_RUN=1 node scripts/release/ci-pipeline-e2e.mjs
 ```
 
-Workflow: [`.github/workflows/clawql-release-pipeline.yml`](../../.github/workflows/clawql-release-pipeline.yml)
-
-Dry-run stores live under `.clawql/` (gitignored):
-
-| Path                    | Purpose                                               |
-| ----------------------- | ----------------------------------------------------- |
-| `.clawql/ipfs-staging/` | Content-addressed staging (`clawql-cid:sha256:…`)     |
-| `.clawql/arweave/<tx>/` | Permanent bundle stand-in                             |
-| `.clawql/escrow/`       | Content-encryption keys for Lit dry-run release       |
-| `.clawql/keys/`         | Ed25519 release signing + optional SSH commit signing |
-| `.clawql/workspaces/`   | Snapshot metadata + git-worktree roots                |
-| `.rifts/`               | Rift CLI or local fallback workspaces                 |
+That dry-run walks the whole pipeline locally: workspaces → signed manifest → stage → permanent store → verify → pull. Nothing spends crypto. Nothing needs IPFS or Arweave online.
 
 ---
 
-## Path B — real workspaces (laptop)
+## Walk through it yourself
 
-### Git worktree (always available)
+Four small steps. You can stop after publish and still have a signed, verifiable release.
+
+### 1. Init
 
 ```bash
-clawql-release immutable-volume snapshot --backend git-worktree --name feature-42
-cd .clawql/workspaces/git-worktree/feature-42
-# edit / test / commit as usual (shared object store with the main repo)
+clawql-release init
+# or: clawql release init
 ```
 
-List / remove:
+Creates `.clawql/release.json` and turns on signed commits when it can.
+
+### 2. Make a workspace (optional)
 
 ```bash
+clawql-release immutable-volume snapshot --backend git-worktree --name my-agent
+cd .clawql/workspaces/git-worktree/my-agent
+```
+
+Prefer `git-worktree` first — it always works. Try `--backend rift` later if you have Rift and a CoW filesystem (APFS / btrfs). If Rift can’t CoW, ClawQL still creates a local fallback.
+
+### 3. Publish (still dry-run)
+
+```bash
+export CLAWQL_RELEASE_DRY_RUN=1
+printf '%s\n' '{"bomFormat":"CycloneDX","specVersion":"1.5","version":1}' > /tmp/sbom.cdx.json
+
+clawql-release publish --tag v0.0.0-local \
+  --sbom /tmp/sbom.cdx.json \
+  --stage-ipfs --permanent --dry-run
+```
+
+Copy the `Arweave tx:` / `local_…` id from the output.
+
+### 4. Verify & pull
+
+```bash
+clawql-release verify local_YOUR_ID
+clawql-release pull local_YOUR_ID
+```
+
+You just finished the core path without leaving your machine.
+
+---
+
+## When you’re ready for more
+
+Skip this section until you need it.
+
+**Parallel agents** — snapshot a few worktrees and work side by side:
+
+```bash
+clawql-release immutable-volume snapshot --backend git-worktree --name agent-a
+clawql-release immutable-volume snapshot --backend git-worktree --name agent-b
 clawql-release immutable-volume list
-clawql-release immutable-volume remove --name feature-42
 ```
 
-### Rift CoW (when the filesystem supports it)
+**Real artifacts** — SBOM, `npm pack` tarball, image digests:
 
 ```bash
-npm install --prefix ~/.local/clawql-rift rift-snapshot
-export PATH="$HOME/.local/clawql-rift/node_modules/.bin:$PATH"
-
-rift init    # must succeed on btrfs / APFS / XFS with reflinks
-clawql-release immutable-volume snapshot --backend rift --name agent-42
-```
-
-If `rift init` fails with “copy-on-write cloning unavailable” (typical on ext4 / overlay / many CI runners), `clawql-release` still creates a **local fallback** under `.rifts/` for provenance. True CoW needs a capable volume — use a laptop APFS volume, a btrfs disk, or a self-hosted runner with that FS.
-
----
-
-## Path C — full publish (production-shaped)
-
-### 1. Collect artifacts
-
-Build your SBOM, npm pack, and record image digests (from GHCR / cosign):
-
-```bash
-# examples — adjust to your pipeline
-npm pack
-# syft . -o cyclonedx-json=sbom.cdx.json
-# skopeo inspect … → digests
-```
-
-### 2. Snapshot the build environment
-
-```bash
-clawql-release immutable-volume snapshot --backend rift --name build-$(date -u +%Y%m%d)
-# or: --backend git-worktree
-```
-
-### 3. Golden image attestations
-
-```bash
-clawql-release golden-image build \
-  --version 7.1.0 \
-  --image-digest clawql-mcp=sha256:YOUR_DIGEST
-```
-
-### 4. Publish
-
-**Public release (GitHub mirror + IPFS staging + Arweave):**
-
-```bash
-# Omit CLAWQL_RELEASE_DRY_RUN for live backends when tools/env are set
 clawql-release publish --tag v7.1.0 \
   --sbom sbom.cdx.json \
   --npm-tgz clawql-mcp-7.1.0.tgz \
@@ -172,139 +89,33 @@ clawql-release publish --tag v7.1.0 \
   --stage-ipfs --permanent --github
 ```
 
-**Paid / private release:**
+**Paid / private** — add `--encrypt --price "0.50 USDC"` (dry-run works without a wallet).
 
-```bash
-clawql-release publish --tag v7.1.0 \
-  --sbom sbom.cdx.json \
-  --stage-ipfs --permanent \
-  --encrypt --price "0.50 USDC"
-```
+**Live networks** — laptop or self-hosted runner only (keep spendable keys off hosted Actions):
 
-### 5. Verify and pull
-
-```bash
-clawql-release verify releases/v7.1.0/manifest.json
-clawql-release verify <arweave-tx-id>
-
-clawql-release pull <arweave-tx-id> --rift
-# Paid bundles: present PAYMENT-SIGNATURE / dry-run receipt; Lit releases the CEK
-```
-
-`clawql release …` is the same surface via the main ClawQL CLI.
+- IPFS: Kubo (`ipfs` on `PATH`)
+- Arweave: `CLAWQL_ARWEAVE_WALLET_JWK`
+- x402 / Lit: `CLAWQL_X402_ENFORCE=1`, `CLAWQL_LIT_NETWORK`
 
 ---
 
-## Configuration
+## Stuck?
 
-`clawql-release init` writes `.clawql/release.json`. Useful fields:
-
-```json
-{
-  "version": 1,
-  "outputDir": "releases",
-  "requireSignedCommits": true,
-  "workspaceBackend": "git-worktree",
-  "collaboration": {
-    "primary": "radicle",
-    "githubMirrorUrl": "https://github.com/org/repo"
-  },
-  "permanence": {
-    "arweaveGateway": "https://arweave.net",
-    "dryRun": true
-  },
-  "access": {
-    "defaultPrice": "0.50 USDC",
-    "asset": "USDC",
-    "network": "base-sepolia"
-  }
-}
-```
-
-Signed commits: init enables `commit.gpgsign` when a signing identity exists, or configures an SSH key under `.clawql/keys/`. Opt out with `requireSignedCommits: false`.
+| You see…                  | Try…                              |
+| ------------------------- | --------------------------------- |
+| Dirty git tree at publish | Commit or stash tracked changes   |
+| Rift “no reflinks”        | Stick with `git-worktree`         |
+| Verify signature failed   | Re-publish; check `.clawql/keys/` |
+| No real Arweave tx        | Expected in dry-run — that’s OK   |
 
 ---
 
-## Live network knobs (laptop / self-hosted — not hosted Actions wallets)
+## Keep going
 
-| Env                                                      | Enables                           |
-| -------------------------------------------------------- | --------------------------------- |
-| `CLAWQL_RELEASE_DRY_RUN=1` / `CLAWQL_RELEASE_MODE=local` | Force local backends (CI default) |
-| _(ipfs on PATH)_                                         | Real `ipfs add` CIDs              |
-| `CLAWQL_IPFS_GATEWAY`                                    | HTTP gateway base for IPFS        |
-| `CLAWQL_ARWEAVE_WALLET_JWK`                              | ar.io / Turbo upload path         |
-| `CLAWQL_ARIO_TURBO_URL`                                  | Turbo endpoint                    |
-| `CLAWQL_ARWEAVE_GATEWAY` / `CLAWQL_ARIO_GATEWAY`         | Fetch/verify gateways             |
-| `CLAWQL_X402_ENFORCE=1`                                  | Live facilitator verify           |
-| `CLAWQL_X402_FACILITATOR_URL`                            | Facilitator base URL              |
-| `CLAWQL_X402_WALLET` / `CLAWQL_X402_NETWORK`             | Payment metadata defaults         |
-| `CLAWQL_LIT_NETWORK`                                     | Lit network label for key release |
-
-**Do not** put spendable Arweave wallets in GitHub Actions secrets for the dry-run workflow. Prefer laptop or a self-hosted runner for one small live `--permanent` publish.
-
-### Maturity of live adapters
-
-| Backend                    | Dry-run / local              | Live                                                                 |
-| -------------------------- | ---------------------------- | -------------------------------------------------------------------- |
-| git-worktree               | Full                         | Full                                                                 |
-| rift                       | Fallback under `.rifts/`     | Full when `rift` + CoW FS work                                       |
-| IPFS staging               | `clawql-cid:sha256:…`        | Kubo when `ipfs` is available                                        |
-| Ed25519 manifest/artifacts | Full                         | Full                                                                 |
-| Arweave / ar.io            | `.clawql/arweave/<tx>/`      | Env-gated Turbo path (harden with a real wallet on laptop)           |
-| Lit + x402                 | Escrow CEK + dry-run receipt | Soft facilitator / Lit hooks — validate on testnet before production |
-
----
-
-## What the manifest records
-
-Every publish writes `releases/<tag>/manifest.json` (schema **v0.2**) including:
-
-- `repository.commit` + dirty flag
-- `artifacts.*` / `images.*` with SHA-256 (+ Ed25519 signatures)
-- `merkleRoot` over those leaves
-- `buildEnvironment` (worktree / rift snapshot ancestry when present)
-- `collaboration` (Radicle primary + GitHub mirror banner)
-- `staging.ipfs` · `permanence.arweave` · `access` (public or paid)
-
-Runtime checks:
-
-- `clawql doctor --smoke` resolves `releases/v\{version\}/manifest.json` when present
-- `CLAWQL_RELEASE_MANIFEST=/path/to/manifest.json` verifies at MCP startup (strict with `CLAWQL_RELEASE_MANIFEST_STRICT=1` or production)
-
-Container digests are also verified with cosign separately — see [`docs/security/golden-image-pipeline.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/security/golden-image-pipeline.md).
-
----
-
-## Suggested learning order
-
-1. **Dry-run** — `ci-pipeline-e2e.mjs` or Path A above
-2. **Parallel worktrees** on your laptop — Path B
-3. **Rift CoW** on APFS/btrfs if you run many agents
-4. **Local Kubo** — publish with `--stage-ipfs` without dry-run
-5. **One tiny Arweave publish** with a funded wallet outside CI
-6. **x402 + Lit testnet** for a paid decrypt round-trip
-
----
-
-## Troubleshooting
-
-| Symptom                           | Likely cause                           | Fix                                                                       |
-| --------------------------------- | -------------------------------------- | ------------------------------------------------------------------------- |
-| `Manifest records dirty git tree` | Uncommitted tracked changes at collect | Commit or stash; untracked `.clawql/` / `.rifts/` are ignored             |
-| `rift init` fails (no reflinks)   | ext4 / overlay / cloud VM              | Use git-worktree or a CoW-capable volume                                  |
-| `verify` fails signature          | Wrong key / tampered file              | Re-publish; check `.clawql/keys/`                                         |
-| No Arweave tx on `--permanent`    | Dry-run or missing wallet              | Expected under `CLAWQL_RELEASE_DRY_RUN`; set wallet only on trusted hosts |
-| Pull decrypt fails                | Missing escrow / payment               | Check `.clawql/escrow/<tag>.key` or live Lit+x402 config                  |
-
----
-
-## Related docs
-
-- Vision: [Immutable releases](https://docs.clawql.com/vision/immutable-releases)
-- Short reference (MVP-era notes): [`clawql-release-mvp.md`](/getting-started/immutable-releases)
-- Package README: [`packages/clawql-release/README.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/packages/clawql-release/README.md)
-- Golden images: [`docs/security/golden-image-pipeline.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/security/golden-image-pipeline.md)
-- Modularization Layer 0: [`docs/vision/clawql-modularization-v2.md`](/architecture)
+- [Vision — Immutable releases](https://docs.clawql.com/vision/immutable-releases) — architecture & rationale
+- [CLI cheat sheet](/getting-started/immutable-releases) — flags & env vars
+- [Golden image pipeline](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/security/golden-image-pipeline.md) — container signing
+- Package: [`clawql-release`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/packages/clawql-release/README.md)
 
 export function wrapper({ children }) {
   return children

--- a/website/src/lib/docs-hub-data.ts
+++ b/website/src/lib/docs-hub-data.ts
@@ -131,9 +131,9 @@ export const architectureHubCards: Array<ReferenceCard> = [
   }),
   card({
     href: '/getting-started/immutable-releases',
-    name: 'Immutable releases (Layer 0)',
+    name: 'Immutable releases',
     description:
-      'Hands-on clawql-release pipeline: workspaces, IPFS, Lit/x402, Arweave — plus the vision doc.',
+      'Friendly dry-run first: publish, verify, and pull a release you can trust — permanence optional.',
     icon: LinkIcon,
   }),
   card({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The immutable-releases getting-started guide was dense and jargon-heavy for first-time readers. This rewrites it into a calm, progressive path.

## Changes

- **Guide** (`docs/getting-started/immutable-releases.md`): lead with one dry-run command, then a short four-step walkthrough; push advanced / live-network detail into “when you’re ready”
- **Docs page**: welcoming hero, “~5 minutes” tag, soft numbered path (no card wall), start-here note; hide duplicate H1 from synced MDX
- **Cheat sheet** (`clawql-release-mvp.md`): compact CLI reference pointing at the friendly guide
- **Hub / getting-started / vision**: softer copy so newcomers aren’t hit with “Layer 0 / Lit/x402” first

## Test plan

- [ ] Open `/getting-started/immutable-releases` locally or on preview — hero + steps feel light, dry-run CTA anchors correctly
- [ ] Confirm docs hub card and getting-started table read approachably
- [ ] Spot-check GitHub-rendered markdown still has a clear title and path

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8f57-601a-7ec1-bff0-d35011fef4ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8f57-601a-7ec1-bff0-d35011fef4ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

