### PR TITLE
OpenRouter-first clawql-inference path for existing customers

### DIFF
--- a/.github/workflows/openbench-ab.yml
+++ b/.github/workflows/openbench-ab.yml
@@ -1,9 +1,10 @@
-# OpenBench A/B via clawql-inference (direct BYOK; OpenRouter optional).
+# OpenBench A/B via clawql-inference.
+#
+# OpenRouter-first for teams already on that aggregator (OPENROUTER_API_KEY +
+# openrouter/* models). Direct BYOK (DeepSeek, Groq, …) remains fully supported.
 #
 # - workflow_dispatch: full knobs (manual)
-# - pull_request / push (path-filtered): CI smoke — skip (exit 0) when no BYOK secret
-#
-# Preferred secret: DEEPSEEK_API_KEY. Optional OPENROUTER_API_KEY for openrouter/* models.
+# - pull_request / push (path-filtered): CI smoke — skip (exit 0) when no secret
 
 name: OpenBench A/B (clawql on vs off)
 
@@ -20,10 +21,10 @@ on:
           - multi-provider-api-workflow
         default: memory-dependent-continuation
       model:
-        description: "clawql-inference model (deepseek/… preferred; openrouter/… optional)"
+        description: "clawql-inference model — openrouter/* with OPENROUTER_API_KEY, or direct BYOK ids"
         required: true
         type: string
-        default: deepseek/deepseek-chat
+        default: openrouter/deepseek/deepseek-chat
       trials:
         description: Trials per arm (keep small — each cell spends tokens)
         required: true
@@ -61,6 +62,7 @@ on:
       - "bin/clawql.mjs"
       - ".github/workflows/openbench-ab.yml"
       - "docs/benchmarks/openbench*.md"
+      - "docs/getting-started/inference.md"
   push:
     branches: [main]
     paths:
@@ -71,6 +73,7 @@ on:
       - "bin/clawql.mjs"
       - ".github/workflows/openbench-ab.yml"
       - "docs/benchmarks/openbench*.md"
+      - "docs/getting-started/inference.md"
 
 concurrency:
   group: openbench-ab-${{ github.workflow }}-${{ github.ref }}
@@ -81,7 +84,7 @@ permissions:
 
 jobs:
   ab-compare:
-    name: A/B via clawql-inference (BYOK)
+    name: A/B via clawql-inference (OpenRouter or BYOK)
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
@@ -91,8 +94,9 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       # Defaults for pull_request / push; workflow_dispatch inputs override when set.
+      # OpenRouter-first default model for teams bringing an existing aggregator key.
       OPENBENCH_TASK: ${{ inputs.task || 'memory-dependent-continuation' }}
-      OPENBENCH_MODEL: ${{ inputs.model || 'deepseek/deepseek-chat' }}
+      OPENBENCH_MODEL: ${{ inputs.model || 'openrouter/deepseek/deepseek-chat' }}
       OPENBENCH_TRIALS: ${{ inputs.trials || '1' }}
       OPENBENCH_TIMEOUT_S: ${{ inputs.timeout_s || '180' }}
       OPENBENCH_ARMS: ${{ inputs.arms || 'clawql-on,clawql-off' }}
@@ -113,19 +117,26 @@ jobs:
           run_benchmark=false
           reason=""
 
+          has_byok=false
+          if [ -n "${DEEPSEEK_API_KEY:-}" ] || [ -n "${GROQ_API_KEY:-}" ] \
+            || [ -n "${OPENAI_API_KEY:-}" ] || [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+            has_byok=true
+          fi
+
           if [[ "$MODEL" == openrouter/* ]]; then
             if [ -n "${OPENROUTER_API_KEY:-}" ]; then
               run_benchmark=true
-              reason="OpenRouter escape hatch for $MODEL"
+              reason="OpenRouter key for $MODEL (bring-your-aggregator path)"
             else
-              reason="Model '$MODEL' needs OPENROUTER_API_KEY (optional escape hatch)."
+              reason="Model '$MODEL' needs repository secret OPENROUTER_API_KEY. Add it under Settings → Secrets, or switch to a direct BYOK model + DEEPSEEK_API_KEY / etc."
             fi
-          elif [ -n "${DEEPSEEK_API_KEY:-}" ] || [ -n "${GROQ_API_KEY:-}" ] \
-            || [ -n "${OPENAI_API_KEY:-}" ] || [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+          elif [ "$has_byok" = true ]; then
             run_benchmark=true
             reason="Direct BYOK credentials for clawql-inference ($MODEL)"
+          elif [ -n "${OPENROUTER_API_KEY:-}" ]; then
+            reason="OPENROUTER_API_KEY is set, but model '$MODEL' is a direct BYOK id. Use an openrouter/* model (default: openrouter/deepseek/deepseek-chat) or add the matching vendor secret."
           else
-            reason="No DEEPSEEK_API_KEY (preferred) or other vendor BYOK secret. OpenRouter remains optional via OPENROUTER_API_KEY + openrouter/* models."
+            reason="Add OPENROUTER_API_KEY (OpenRouter-first) or a vendor BYOK secret (DEEPSEEK_API_KEY, …). Models: openrouter/<vendor>/<model> or deepseek/… with the matching key."
           fi
 
           echo "run_benchmark=${run_benchmark}" >> "$GITHUB_OUTPUT"
@@ -178,7 +189,7 @@ jobs:
           command -v opencode
           opencode --version || true
 
-      - name: Start clawql-inference (BYOK upstreams)
+      - name: Start clawql-inference (OpenRouter and/or BYOK)
         if: steps.preflight.outputs.run_benchmark == 'true'
         run: |
           mkdir -p artifacts/openbench-ab
@@ -190,14 +201,20 @@ jobs:
           for i in $(seq 1 60); do
             if curl -sf "http://127.0.0.1:${PORT}/healthz" >/dev/null; then
               echo "clawql-inference healthy after ${i}s"
-              # Fail fast if catalog is empty (secret present but unused / wrong).
               models="$(curl -sf "http://127.0.0.1:${PORT}/v1/models" || true)"
               echo "$models" | head -c 400
               echo ""
               if ! echo "$models" | grep -q '"id"'; then
-                echo "::error::/v1/models has no credentialed models — check BYOK secrets"
+                echo "::error::/v1/models has no credentialed models — check OPENROUTER_API_KEY or BYOK secrets"
                 tail -n 120 artifacts/openbench-ab/inference.log || true
                 exit 1
+              fi
+              # Ensure the requested model appears when OpenRouter-first.
+              if [[ "${OPENBENCH_MODEL}" == openrouter/* ]]; then
+                if ! echo "$models" | grep -Fq "\"id\":\"${OPENBENCH_MODEL}\"" \
+                  && ! echo "$models" | grep -Fq "\"id\": \"${OPENBENCH_MODEL}\""; then
+                  echo "::warning::Model ${OPENBENCH_MODEL} not listed in /v1/models (catalog may still route it)"
+                fi
               fi
               exit 0
             fi
@@ -226,10 +243,10 @@ jobs:
             --out "$OUT" \
             --summary-md "$SUM"
           {
-            echo "## OpenBench A/B (clawql-inference BYOK)"
+            echo "## OpenBench A/B (clawql-inference)"
             echo ""
             echo "- Run: [\`${{ github.run_id }}\`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-            echo "- Inference: \`clawql-inference\` (direct BYOK; OpenRouter optional)"
+            echo "- Inference: \`clawql-inference\` (OpenRouter-first or direct BYOK)"
             echo "- Agent: OpenCode"
             echo "- Task: \`${OPENBENCH_TASK}\`"
             echo "- Model: \`${OPENBENCH_MODEL}\`"

--- a/docs/benchmarks/openbench-github-actions.md
+++ b/docs/benchmarks/openbench-github-actions.md
@@ -52,12 +52,12 @@ clawql inference serve
 1. Actions → **OpenBench A/B (clawql on vs off)** → **Run workflow**
 2. Suggested first try (OpenRouter key only):
 
-| Input    | Value                              |
-| -------- | ---------------------------------- |
-| `task`   | `memory-dependent-continuation`    |
+| Input    | Value                               |
+| -------- | ----------------------------------- |
+| `task`   | `memory-dependent-continuation`     |
 | `model`  | `openrouter/deepseek/deepseek-chat` |
-| `trials` | `1`                                |
-| `arms`   | `clawql-on,clawql-off`             |
+| `trials` | `1`                                 |
+| `arms`   | `clawql-on,clawql-off`              |
 
 OpenRouter examples:
 

--- a/docs/benchmarks/openbench-github-actions.md
+++ b/docs/benchmarks/openbench-github-actions.md
@@ -2,18 +2,19 @@
 
 Workflow: [`.github/workflows/openbench-ab.yml`](../../.github/workflows/openbench-ab.yml)
 
-Spins up **clawql-inference** with **direct BYOK** providers (DeepSeek, Groq, …),
-runs the same model with and without ClawQL MCP (via OpenCode), posts a Step
-Summary, uploads JSON, tears down.
+Spins up **clawql-inference**, runs the same model with and without ClawQL MCP
+(via OpenCode), posts a Step Summary, uploads JSON, tears down.
 
-OpenRouter remains an **optional escape hatch** (`openrouter/*` +
-`OPENROUTER_API_KEY`) — not required to benchmark ClawQL.
+**OpenRouter-first:** if you already have an OpenRouter key and do not yet have
+per-provider Anthropic/OpenAI/DeepSeek keys, set **`OPENROUTER_API_KEY`** and
+keep the default `openrouter/*` model. Direct BYOK remains fully supported when
+you add vendor secrets later.
 
 ## When it runs
 
 | Trigger                                               | Behavior                                                                                                          |
 | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| **`workflow_dispatch`**                               | Manual knobs (task / model / trials / arms). **Fails** if no matching BYOK / OpenRouter secret                    |
+| **`workflow_dispatch`**                               | Manual knobs (task / model / trials / arms). **Fails** if no matching OpenRouter / BYOK secret                    |
 | **`pull_request` / `push` to `main`** (path-filtered) | CI smoke with defaults. **Skips live A/B (exit 0)** when secrets are missing; always runs offline task validation |
 | Main **CI** workflow                                  | Always runs `python3 openbench/validate_tasks.py` (offline checkers only)                                         |
 
@@ -21,10 +22,11 @@ Path filters include `openbench/**`, `packages/clawql-inference/**`, and the wor
 
 ## Prerequisites (live A/B)
 
-1. Repository secret **`DEEPSEEK_API_KEY`** (preferred for the default model),
-   **or** another vendor BYOK secret (`GROQ_API_KEY`, `OPENAI_API_KEY`, …)
-2. Optional: **`OPENROUTER_API_KEY`** only when you choose an `openrouter/*` model
-3. Branch containing `openbench/` + `.github/workflows/openbench-ab.yml`
+1. Repository secret **`OPENROUTER_API_KEY`** (recommended start — default model
+   is `openrouter/deepseek/deepseek-chat`), **or** a direct vendor BYOK secret
+   (`DEEPSEEK_API_KEY`, `GROQ_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, …)
+   when you choose a non-`openrouter/*` model
+2. Branch containing `openbench/` + `.github/workflows/openbench-ab.yml`
 
 Fork PRs cannot read these secrets — live A/B is skipped; offline validation still runs.
 
@@ -36,8 +38,8 @@ OpenCode (clawql-on | clawql-off)
         ▼
 clawql inference serve
         │
-        ├── deepseek / groq / fireworks / …   (direct BYOK — default)
-        └── openrouter/*                      (optional escape hatch)
+        ├── openrouter/*                      (OpenRouter-first — existing aggregator key)
+        └── deepseek / groq / openai / …      (direct BYOK when you have vendor keys)
 ```
 
 | Arm            | Difference                                                            |
@@ -48,25 +50,26 @@ clawql inference serve
 ## How to run (manual)
 
 1. Actions → **OpenBench A/B (clawql on vs off)** → **Run workflow**
-2. Suggested first try:
+2. Suggested first try (OpenRouter key only):
 
-| Input    | Value                           |
-| -------- | ------------------------------- |
-| `task`   | `memory-dependent-continuation` |
-| `model`  | `deepseek/deepseek-chat`        |
-| `trials` | `1`                             |
-| `arms`   | `clawql-on,clawql-off`          |
+| Input    | Value                              |
+| -------- | ---------------------------------- |
+| `task`   | `memory-dependent-continuation`    |
+| `model`  | `openrouter/deepseek/deepseek-chat` |
+| `trials` | `1`                                |
+| `arms`   | `clawql-on,clawql-off`             |
 
-Direct BYOK examples:
+OpenRouter examples:
+
+- `openrouter/deepseek/deepseek-chat`
+- `openrouter/qwen/qwen3.6-plus`
+
+Direct BYOK (when you have vendor keys):
 
 - `deepseek/deepseek-chat`
 - `clawql/cheap-chat` (alias → DeepSeek)
 - `groq/llama-3.3-70b-versatile`
-
-Optional OpenRouter escape hatch:
-
-- `openrouter/qwen/qwen3.6-plus`
-- `openrouter/deepseek/deepseek-chat`
+- `anthropic/claude-sonnet-4-6`
 
 Via `gh`:
 
@@ -74,25 +77,25 @@ Via `gh`:
 gh workflow run openbench-ab.yml \
   --ref main \
   -f task=memory-dependent-continuation \
-  -f model=deepseek/deepseek-chat \
+  -f model=openrouter/deepseek/deepseek-chat \
   -f trials=1
 ```
 
 ## Local equivalent
 
 ```bash
-export DEEPSEEK_API_KEY=sk-…
+export OPENROUTER_API_KEY=sk-or-…
 npm ci && npm run build
 npm install -g opencode-ai@latest   # or your OpenCode install path
 
-# terminal 1 — inference gateway (all BYOK builtins; OpenRouter optional)
+# terminal 1 — inference gateway (OpenRouter and/or BYOK)
 node bin/clawql.mjs inference serve --port 8080
 
 # terminal 2 — A/B
 export CLAWQL_BIN="$PWD/bin/clawql.mjs"
 python3 openbench/scripts/run-ab-compare.py \
   --task memory-dependent-continuation \
-  --model deepseek/deepseek-chat \
+  --model openrouter/deepseek/deepseek-chat \
   --inference-url http://127.0.0.1:8080/v1 \
   --trials 1 \
   --out /tmp/ab-results.json \
@@ -104,4 +107,4 @@ python3 openbench/scripts/run-ab-compare.py \
 - Workflow: [`.github/workflows/openbench-ab.yml`](../../.github/workflows/openbench-ab.yml)
 - Runner: [`openbench/scripts/run-ab-compare.py`](../../openbench/scripts/run-ab-compare.py)
 - Offline validate: [`openbench/validate_tasks.py`](../../openbench/validate_tasks.py) (`npm run openbench:validate`)
-- Providers / catalog: `packages/clawql-inference` (BYOK builtins + optional `openrouter`)
+- Providers / catalog: `packages/clawql-inference` (BYOK builtins + `openrouter`)

--- a/docs/benchmarks/openbench.md
+++ b/docs/benchmarks/openbench.md
@@ -48,8 +48,10 @@ python3 openbench/validate_tasks.py
 ## GitHub Actions A/B (CI + manual)
 
 - **Offline:** main CI always runs `python3 openbench/validate_tasks.py`.
-- **Live A/B:** [`.github/workflows/openbench-ab.yml`](../../.github/workflows/openbench-ab.yml) runs on path-filtered PR/push to `main` and via `workflow_dispatch`. Preferred secret: `DEEPSEEK_API_KEY`. Missing secrets → live A/B **skipped** on PR/push (exit 0); manual dispatch still fails closed.
-- OpenRouter (`OPENROUTER_API_KEY` + `openrouter/*`) is optional.
+- **Live A/B:** [`.github/workflows/openbench-ab.yml`](../../.github/workflows/openbench-ab.yml) runs on path-filtered PR/push to `main` and via `workflow_dispatch`.
+- **Default model:** `openrouter/deepseek/deepseek-chat` — preferred secret: **`OPENROUTER_API_KEY`** (bring your existing aggregator key; no per-provider BYOK required).
+- Missing secrets → live A/B **skipped** on PR/push (exit 0); manual dispatch still fails closed.
+- Optional later: switch `model` to direct BYOK ids (`deepseek/*`, `anthropic/*`, …) when you add vendor keys.
 
 See [`openbench-github-actions.md`](openbench-github-actions.md).
 
@@ -58,7 +60,7 @@ See [`openbench-github-actions.md`](openbench-github-actions.md).
 See [`openbench/README.md`](../../openbench/README.md) and
 [`openbench/scripts/run-with-openbench.sh`](../../openbench/scripts/run-with-openbench.sh).
 
-Live runs need agent CLI credentials plus a BYOK inference secret in CI.
+Live runs need agent CLI credentials plus an OpenRouter or BYOK inference secret in CI.
 
 ## Relation to planning-context benchmarks
 

--- a/docs/getting-started/inference.md
+++ b/docs/getting-started/inference.md
@@ -242,8 +242,8 @@ GTM narrative: [Inference-first GTM](https://clawql.com/inference/gtm) · Archit
 
 ## Troubleshooting
 
-| Symptom                          | Fix                                                                                |
-| -------------------------------- | ---------------------------------------------------------------------------------- |
+| Symptom                          | Fix                                                                                         |
+| -------------------------------- | ------------------------------------------------------------------------------------------- |
 | Empty `/v1/models`               | Set `OPENROUTER_API_KEY` and/or a vendor BYOK key; catalog lists **credentialed** providers |
 | OpenRouter model 401 / missing   | Export `OPENROUTER_API_KEY` in the **same shell** as `inference serve`                      |
 | Want direct BYOK later           | Set `DEEPSEEK_API_KEY` (etc.) and use `deepseek/…` / `anthropic/…` model ids                |

--- a/docs/getting-started/inference.md
+++ b/docs/getting-started/inference.md
@@ -1,10 +1,22 @@
 # Get started with clawql-inference
 
-Spin up ClawQL’s **Agentic Gateway** inference control plane in minutes: OpenAI-compatible `/v1`, direct BYOK providers, optional OpenRouter escape hatch, and a clear path to pair MCP + vault memory.
+Spin up ClawQL’s **Agentic Gateway** inference control plane in minutes: OpenAI-compatible `/v1`, bring-your-OpenRouter **or** direct BYOK providers, and a clear path to pair MCP + vault memory.
 
 **Website:** [docs.clawql.com/getting-started/inference](https://docs.clawql.com/getting-started/inference)
 
 **Deep reference:** [clawql-inference](/inference/clawql-inference) · **Providers:** [Inference providers](/plugins/inference-providers) · **Fabric:** [Zero-Trust Agentic Fabric](/architecture/agentic-fabric)
+
+## Already on OpenRouter?
+
+If you already pay OpenRouter and **do not** have Anthropic/OpenAI/DeepSeek keys in ClawQL yet, start with the key you have:
+
+1. Set `OPENROUTER_API_KEY` (local `.env`, GitHub Actions secret, or Vault).
+2. Use catalog models such as `openrouter/deepseek/deepseek-chat` or `openrouter/qwen/qwen3.6-plus`.
+3. Point clients at clawql-inference (`OPENAI_BASE_URL` / gateway `/v1`) — same OpenAI-compatible API, with ClawQL memory and policy in front.
+
+That path is intentional: **bring your aggregator key first**, then add direct BYOK (`deepseek/*`, `anthropic/*`, `openai/*`, …) when you want to disintermediate OpenRouter for cost, latency, or residency.
+
+OpenBench CI defaults to this OpenRouter-first model so live benchmarks work with a single secret. See [OpenBench GitHub Actions](../benchmarks/openbench-github-actions.md).
 
 ## What you get
 
@@ -12,8 +24,8 @@ Spin up ClawQL’s **Agentic Gateway** inference control plane in minutes: OpenA
 | -------------------------- | ------------------------------------------------------------------------------------ |
 | **`/v1/chat/completions`** | Drop-in OpenAI SDK / curl / coding-agent base URL                                    |
 | **`/v1/models`**           | Credentialed catalog + `clawql/*` aliases                                            |
+| **OpenRouter (day-one)**   | Use your existing `OPENROUTER_API_KEY` + `openrouter/*` models                       |
 | **Direct BYOK**            | DeepSeek, Groq, Fireworks, Together, Mistral, xAI, Google, OpenAI, Anthropic, Ollama |
-| **OpenRouter (optional)**  | Keep `openrouter/*` if you prefer that aggregator — never required                   |
 | **Control plane**          | Tier escalation, semantic cache, fallback, virtual keys, audit / spend               |
 
 On a laptop this is your **Edge Agentic Gateway**. Later you can grow into a Managed Gateway or Dedicated Virtual Gateway without changing the client contract (`OPENAI_BASE_URL` + key).
@@ -33,11 +45,11 @@ On a laptop this is your **Edge Agentic Gateway**. Later you can grow into a Man
               │
      ┌────────┼────────────────────────────┐
      ▼        ▼                            ▼
-  DeepSeek  Groq / OpenAI / …     openrouter/* (optional)
-  (your keys — default path)      (escape hatch only)
+  openrouter/*                 DeepSeek / Groq / OpenAI / …
+  (existing aggregator key)    (direct BYOK when ready)
 ```
 
-**Default posture:** bring **your** vendor keys. ClawQL routes `provider/model` directly. OpenRouter is an opt-in upstream, not the product.
+**Day-one posture for OpenRouter customers:** bring the aggregator key you already have. Add direct vendor keys later when you want to skip OpenRouter for production traffic. ClawQL routes `provider/model` the same either way.
 
 Pair with MCP when you want agents to **search / execute / remember** against your APIs and vault:
 
@@ -52,6 +64,7 @@ Today those are often two local processes; the **product** is one Agentic Gatewa
 
 | You want…                                    | Jump to                                            |
 | -------------------------------------------- | -------------------------------------------------- |
+| Keep using your existing OpenRouter key      | [Already on OpenRouter?](#already-on-openrouter)   |
 | First completion in under 5 minutes          | [Five-minute start](#five-minute-start)            |
 | Managed Edge Gateway (`/mcp` + `/v1`)        | [Managed Edge Gateway](#what-good-looks-like-next) |
 | Point OpenCode / OpenAI SDK at the gateway   | [Point a client](#point-a-client)                  |
@@ -81,15 +94,21 @@ cp examples/inference/policy.yaml "$CLAWQL_HOME/Inference/policy.yaml"
 # export CLAWQL_INFERENCE_POLICY_MANIFEST=/path/to/policy.yaml
 ```
 
-### 3. Bring a provider key (BYOK)
+### 3. Bring a provider key
 
-Prefer a direct vendor key:
+**Already on OpenRouter?** Use that key only:
 
 ```bash
-export DEEPSEEK_API_KEY=sk-…          # recommended first key
+export OPENROUTER_API_KEY=sk-or-…     # recommended if you already have OpenRouter
+```
+
+Direct BYOK (when you have per-provider keys and want to skip the aggregator):
+
+```bash
+# export DEEPSEEK_API_KEY=sk-…        # direct DeepSeek
 # export GROQ_API_KEY=…               # or another BYOK provider
 # export OPENAI_API_KEY=…             # OpenAI / embeddings
-# export OPENROUTER_API_KEY=sk-or-…   # optional escape hatch only
+# export ANTHROPIC_API_KEY=…          # Anthropic
 ```
 
 Never commit keys. Local secrets belong in your shell / secret manager — not in git or MCP JSON.
@@ -109,20 +128,21 @@ curl -s http://127.0.0.1:8080/healthz
 
 curl -s http://127.0.0.1:8080/v1/models | head
 
+# OpenRouter-first (when OPENROUTER_API_KEY is set)
 curl -s http://127.0.0.1:8080/v1/chat/completions \
   -H 'Content-Type: application/json' \
-  -d '{"model":"deepseek/deepseek-chat","messages":[{"role":"user","content":"Say hi in one sentence."}]}'
+  -d '{"model":"openrouter/deepseek/deepseek-chat","messages":[{"role":"user","content":"Say hi in one sentence."}]}'
 
-# Catalog alias (same upstream when DeepSeek is keyed)
-curl -s http://127.0.0.1:8080/v1/chat/completions \
-  -H 'Content-Type: application/json' \
-  -d '{"model":"clawql/cheap-chat","messages":[{"role":"user","content":"hi"}]}'
+# Direct BYOK example (when DEEPSEEK_API_KEY is set)
+# curl -s http://127.0.0.1:8080/v1/chat/completions \
+#   -H 'Content-Type: application/json' \
+#   -d '{"model":"deepseek/deepseek-chat","messages":[{"role":"user","content":"Say hi in one sentence."}]}'
 ```
 
 One-shot without HTTP:
 
 ```bash
-clawql inference complete --model deepseek/deepseek-chat --message "hello"
+clawql inference complete --model openrouter/deepseek/deepseek-chat --message "hello"
 ```
 
 ---
@@ -142,11 +162,11 @@ Model ids use `provider/model` (e.g. `deepseek/deepseek-chat`, `groq/llama-3.3-7
 
 ```bash
 # terminal 1
-DEEPSEEK_API_KEY=sk-… clawql inference serve --port 8080
+OPENROUTER_API_KEY=sk-or-… clawql inference serve --port 8080
 
 # terminal 2
 CLAWQL_OPENBENCH=1 clawql opencode --non-interactive \
-  --model clawql/deepseek/deepseek-chat \
+  --model clawql/openrouter/deepseek/deepseek-chat \
   --inference-url http://127.0.0.1:8080/v1 \
   --message "Say hello" \
   --workdir /tmp/demo
@@ -186,7 +206,7 @@ Start local; harden before sharing a URL:
 
 | Practice                              | Why                                                                 |
 | ------------------------------------- | ------------------------------------------------------------------- |
-| **BYOK by default**                   | You own vendor keys; OpenRouter is optional                         |
+| **Your keys**                         | OpenRouter aggregator key and/or direct vendor BYOK — you own them  |
 | **Virtual keys for shared gateways**  | Per-team budgets / rate limits; secrets stored hashed               |
 | **No `noAuth` on anything networked** | Require Bearer / virtual key on `/v1/*`                             |
 | **Tenant from the token**             | Do not trust client-supplied tenant headers on shared hosts         |
@@ -203,7 +223,7 @@ Defense-in-depth narrative: [MCP proxy JWT ATR](https://github.com/danielsmithde
 2. **Managed Edge Gateway (go-live)** — one hostname for `/v1` + `/mcp` + memory:
 
 ```bash
-export DEEPSEEK_API_KEY=sk-…   # or another BYOK key
+export OPENROUTER_API_KEY=sk-or-…   # or DEEPSEEK_API_KEY / other BYOK
 clawql gateway create --profile process --team demo
 # → MCP URL, Inference URL, virtual key (shown once)
 ```
@@ -224,18 +244,18 @@ GTM narrative: [Inference-first GTM](https://clawql.com/inference/gtm) · Archit
 
 | Symptom                          | Fix                                                                                |
 | -------------------------------- | ---------------------------------------------------------------------------------- |
-| Empty `/v1/models`               | Set a vendor key (`DEEPSEEK_API_KEY`, …); catalog lists **credentialed** providers |
-| `DEEPSEEK_API_KEY is required`   | Export the key in the **same shell** as `inference serve`                          |
-| Want OpenRouter long-tail        | `OPENROUTER_API_KEY=…` and model `openrouter/<vendor>/<model>`                     |
-| Client still hits api.openai.com | Set `OPENAI_BASE_URL=http://127.0.0.1:8080/v1` (include `/v1`)                     |
-| Policy looks wrong               | `clawql inference policy show --json` — env overrides YAML                         |
+| Empty `/v1/models`               | Set `OPENROUTER_API_KEY` and/or a vendor BYOK key; catalog lists **credentialed** providers |
+| OpenRouter model 401 / missing   | Export `OPENROUTER_API_KEY` in the **same shell** as `inference serve`                      |
+| Want direct BYOK later           | Set `DEEPSEEK_API_KEY` (etc.) and use `deepseek/…` / `anthropic/…` model ids                |
+| Client still hits api.openai.com | Set `OPENAI_BASE_URL=http://127.0.0.1:8080/v1` (include `/v1`)                              |
+| Policy looks wrong               | `clawql inference policy show --json` — env overrides YAML                                  |
 
 ---
 
 ## Next reading
 
 - [clawql-inference reference](/inference/clawql-inference) — policy schema, cache, flywheel, entitlements
-- [Inference providers](/plugins/inference-providers) — BYOK builtins + OpenRouter escape hatch
+- [Inference providers](/plugins/inference-providers) — OpenRouter + BYOK builtins
 - [Agent setup](/agent-setup) — MCP + memory onboarding
 - [Token efficiency](/architecture/token-efficiency) — twelve compounding layers
 - [Getting started overview](/getting-started)

--- a/openbench/README.md
+++ b/openbench/README.md
@@ -27,8 +27,9 @@ openbench/
 ## Prerequisites
 
 1. ClawQL CLI on `PATH` (`npm i -g clawql-mcp` or repo `bin/clawql.mjs`).
-2. **clawql-inference** with a **direct BYOK** key (preferred: `DEEPSEEK_API_KEY`)
-   for the default A/B path. `OPENROUTER_API_KEY` is optional for `openrouter/*`.
+2. **clawql-inference** with an inference key. **OpenRouter-first:** set
+   `OPENROUTER_API_KEY` and use `openrouter/*` models (default CI path). Direct
+   BYOK (`DEEPSEEK_API_KEY`, …) is optional when you have vendor keys.
 3. OpenCode CLI for the coding-agent harness (`opencode`).
 4. Optional: clone OpenBench for matrix runs against stock harnesses.
 
@@ -38,15 +39,15 @@ git clone https://github.com/minghinmatthewlam/openbench.git
 
 ## Track A — ClawQL as a harness
 
-Headless launch through clawql-inference (direct BYOK):
+Headless launch through clawql-inference (OpenRouter-first):
 
 ```bash
 # terminal 1
-DEEPSEEK_API_KEY=sk-… clawql inference serve --port 8080
+OPENROUTER_API_KEY=sk-or-… clawql inference serve --port 8080
 
 # terminal 2
 CLAWQL_OPENBENCH=1 clawql opencode --non-interactive \
-  --model clawql/deepseek/deepseek-chat \
+  --model clawql/openrouter/deepseek/deepseek-chat \
   --inference-url http://127.0.0.1:8080/v1 \
   --task-file /path/to/instruction.md \
   --workdir /path/to/disposable/workspace \
@@ -106,22 +107,22 @@ To contribute these upstream, copy `tasks/<name>/` into OpenBench's `tasks/`
 |----------|---------|
 | `CLAWQL_OPENBENCH=1` | Allow unsandboxed harness on Linux CI; mark bench mode |
 | `CLAWQL_HARNESS_ALLOW_UNSANDBOXED=1` | Same soft-fail for Seatbelt gate |
-| `CLAWQL_OPENBENCH_HARNESS` | Underlying CLI (`opencode` for BYOK A/B) |
+| `CLAWQL_OPENBENCH_HARNESS` | Underlying CLI (`opencode` for A/B) |
 | `CLAWQL_INFERENCE_URL` / `OPENBENCH_INFERENCE_URL` | clawql-inference OpenAI-compat base |
-| `DEEPSEEK_API_KEY` (preferred) | Direct BYOK for default `deepseek/*` models |
-| `OPENROUTER_API_KEY` | Optional escape hatch for `openrouter/*` models |
+| `OPENROUTER_API_KEY` (preferred start) | Aggregator key for default `openrouter/*` models |
+| `DEEPSEEK_API_KEY` (etc.) | Direct BYOK when you skip OpenRouter |
 
 ## One-off GitHub Actions A/B
 
 Manual workflow **OpenBench A/B (clawql on vs off)** — starts
-**clawql-inference** with direct BYOK, runs OpenCode on/off, preferred secret
-`DEEPSEEK_API_KEY`. See
+**clawql-inference**, runs OpenCode on/off. Preferred secret:
+`OPENROUTER_API_KEY` with default model `openrouter/deepseek/deepseek-chat`. See
 [`docs/benchmarks/openbench-github-actions.md`](../docs/benchmarks/openbench-github-actions.md).
 
 ```bash
 gh workflow run openbench-ab.yml \
   -f task=memory-dependent-continuation \
-  -f model=deepseek/deepseek-chat \
+  -f model=openrouter/deepseek/deepseek-chat \
   -f trials=1
 ```
 

--- a/openbench/adapters/clawql.py
+++ b/openbench/adapters/clawql.py
@@ -29,7 +29,7 @@ from pathlib import Path
 NAME = "clawql"
 
 # Which underlying agent CLI ClawQL should launch. Override with CLAWQL_OPENBENCH_HARNESS.
-# Default is OpenCode (pairs with clawql-inference direct BYOK / optional OpenRouter).
+# Default is OpenCode (pairs with clawql-inference OpenRouter-first or direct BYOK).
 _DEFAULT_HARNESS = os.environ.get("CLAWQL_OPENBENCH_HARNESS", "opencode").strip() or "opencode"
 
 # Canonical OpenBench model pin -> CLI model id for the default (opencode) harness.

--- a/openbench/candidates/clawql-opencode-openrouter.toml
+++ b/openbench/candidates/clawql-opencode-openrouter.toml
@@ -2,8 +2,9 @@ kind = "manifest"
 name = "clawql-opencode-openrouter"
 isolate_home = false
 inherit_env = true
-# Optional OpenRouter escape hatch — prefer clawql-opencode-deepseek.toml for
-# direct BYOK. Assumes CLAWQL_INFERENCE_URL / OPENCODE_CONFIG_CONTENT are set.
+# OpenRouter-first day-one path (existing aggregator key). Prefer
+# clawql-opencode-deepseek.toml later when you have direct BYOK.
+# Assumes CLAWQL_INFERENCE_URL / OPENCODE_CONFIG_CONTENT are set.
 command = [
   "clawql", "opencode",
   "--non-interactive",

--- a/openbench/scripts/run-ab-compare.py
+++ b/openbench/scripts/run-ab-compare.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
-"""One-off A/B: clawql-on vs clawql-off through clawql-inference (BYOK).
+"""One-off A/B: clawql-on vs clawql-off through clawql-inference.
 
 Architecture (same model for both arms)::
 
   coding agent (OpenCode)
         │  OPENAI-compatible
         ▼
-  clawql inference serve   ←── DEEPSEEK_API_KEY / GROQ_API_KEY / …
+  clawql inference serve   ←── OPENROUTER_API_KEY and/or BYOK keys
         │
-        ├── direct BYOK (default): deepseek, groq, fireworks, …
-        └── optional escape hatch: OpenRouter (OPENROUTER_API_KEY)
+        ├── openrouter/* (OpenRouter-first — existing aggregator key)
+        └── direct BYOK: deepseek, groq, openai, …
 
 clawql-on  = OpenCode via ``clawql opencode --non-interactive`` + ClawQL MCP
 clawql-off = raw OpenCode pointed at the same inference URL (no ClawQL MCP)
@@ -19,18 +19,18 @@ Requires:
   - ``opencode`` on PATH
   - ``clawql`` / ``bin/clawql.mjs`` for the on-arm
   - A running ``clawql inference serve`` (or let Actions start it)
-  - Vendor BYOK key(s) on the inference process (preferred), or OpenRouter
+  - ``OPENROUTER_API_KEY`` (day-one) and/or vendor BYOK key(s)
 
 Example::
 
-  # terminal 1 — direct DeepSeek (disintermediated)
-  DEEPSEEK_API_KEY=sk-… \\
+  # terminal 1 — OpenRouter-first (existing aggregator key)
+  OPENROUTER_API_KEY=sk-or-… \\
     clawql inference serve --port 8080
 
   # terminal 2
   python3 openbench/scripts/run-ab-compare.py \\
     --task memory-dependent-continuation \\
-    --model deepseek/deepseek-chat \\
+    --model openrouter/deepseek/deepseek-chat \\
     --inference-url http://127.0.0.1:8080/v1 \\
     --trials 1 \\
     --out /tmp/ab-results.json
@@ -59,7 +59,7 @@ KNOWN_TASKS = (
     "multi-provider-api-workflow",
 )
 DEFAULT_HARNESS = "opencode"
-DEFAULT_MODEL = os.environ.get("OPENBENCH_MODEL", "deepseek/deepseek-chat")
+DEFAULT_MODEL = os.environ.get("OPENBENCH_MODEL", "openrouter/deepseek/deepseek-chat")
 DEFAULT_INFERENCE_URL = os.environ.get(
     "CLAWQL_INFERENCE_URL",
     os.environ.get("OPENBENCH_INFERENCE_URL", "http://127.0.0.1:8080/v1"),
@@ -268,7 +268,7 @@ def _dec_timeout_output(exc) -> str:
 def run_arm_off(
     instruction: str, workdir: Path, model: str, timeout_s: int, inference_url: str
 ) -> dict:
-    """Raw OpenCode → clawql-inference (BYOK / optional OpenRouter; no ClawQL MCP)."""
+    """Raw OpenCode → clawql-inference (OpenRouter and/or BYOK; no ClawQL MCP)."""
     exe = resolve_opencode()
     gateway_model = normalize_model_id(model)
     opencode_model = f"clawql/{gateway_model}"
@@ -595,8 +595,8 @@ def main(argv=None) -> int:
         print(
             f"ERROR: clawql-inference not reachable at {inference_url} "
             f"(expected /healthz). Start with:\n"
-            f"  DEEPSEEK_API_KEY=… clawql inference serve --port 8080\n"
-            f"  # or OPENROUTER_API_KEY=… for the optional openrouter/* escape hatch",
+            f"  OPENROUTER_API_KEY=… clawql inference serve --port 8080\n"
+            f"  # or DEEPSEEK_API_KEY=… (direct BYOK) when you skip OpenRouter",
             file=sys.stderr,
         )
         return 2

--- a/website/src/generated/getting-started-inference-body.mdx
+++ b/website/src/generated/getting-started-inference-body.mdx
@@ -1,10 +1,22 @@
 # Get started with clawql-inference
 
-Spin up ClawQL’s **Agentic Gateway** inference control plane in minutes: OpenAI-compatible `/v1`, direct BYOK providers, optional OpenRouter escape hatch, and a clear path to pair MCP + vault memory.
+Spin up ClawQL’s **Agentic Gateway** inference control plane in minutes: OpenAI-compatible `/v1`, bring-your-OpenRouter **or** direct BYOK providers, and a clear path to pair MCP + vault memory.
 
 **Website:** [docs.clawql.com/getting-started/inference](https://docs.clawql.com/getting-started/inference)
 
 **Deep reference:** [clawql-inference](/inference/clawql-inference) · **Providers:** [Inference providers](/plugins/inference-providers) · **Fabric:** [Zero-Trust Agentic Fabric](/architecture/agentic-fabric)
+
+## Already on OpenRouter?
+
+If you already pay OpenRouter and **do not** have Anthropic/OpenAI/DeepSeek keys in ClawQL yet, start with the key you have:
+
+1. Set `OPENROUTER_API_KEY` (local `.env`, GitHub Actions secret, or Vault).
+2. Use catalog models such as `openrouter/deepseek/deepseek-chat` or `openrouter/qwen/qwen3.6-plus`.
+3. Point clients at clawql-inference (`OPENAI_BASE_URL` / gateway `/v1`) — same OpenAI-compatible API, with ClawQL memory and policy in front.
+
+That path is intentional: **bring your aggregator key first**, then add direct BYOK (`deepseek/*`, `anthropic/*`, `openai/*`, …) when you want to disintermediate OpenRouter for cost, latency, or residency.
+
+OpenBench CI defaults to this OpenRouter-first model so live benchmarks work with a single secret. See [OpenBench GitHub Actions](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/benchmarks/openbench-github-actions.md).
 
 ## What you get
 
@@ -12,8 +24,8 @@ Spin up ClawQL’s **Agentic Gateway** inference control plane in minutes: OpenA
 | -------------------------- | ------------------------------------------------------------------------------------ |
 | **`/v1/chat/completions`** | Drop-in OpenAI SDK / curl / coding-agent base URL                                    |
 | **`/v1/models`**           | Credentialed catalog + `clawql/*` aliases                                            |
+| **OpenRouter (day-one)**   | Use your existing `OPENROUTER_API_KEY` + `openrouter/*` models                       |
 | **Direct BYOK**            | DeepSeek, Groq, Fireworks, Together, Mistral, xAI, Google, OpenAI, Anthropic, Ollama |
-| **OpenRouter (optional)**  | Keep `openrouter/*` if you prefer that aggregator — never required                   |
 | **Control plane**          | Tier escalation, semantic cache, fallback, virtual keys, audit / spend               |
 
 On a laptop this is your **Edge Agentic Gateway**. Later you can grow into a Managed Gateway or Dedicated Virtual Gateway without changing the client contract (`OPENAI_BASE_URL` + key).
@@ -33,11 +45,11 @@ On a laptop this is your **Edge Agentic Gateway**. Later you can grow into a Man
               │
      ┌────────┼────────────────────────────┐
      ▼        ▼                            ▼
-  DeepSeek  Groq / OpenAI / …     openrouter/* (optional)
-  (your keys — default path)      (escape hatch only)
+  openrouter/*                 DeepSeek / Groq / OpenAI / …
+  (existing aggregator key)    (direct BYOK when ready)
 ```
 
-**Default posture:** bring **your** vendor keys. ClawQL routes `provider/model` directly. OpenRouter is an opt-in upstream, not the product.
+**Day-one posture for OpenRouter customers:** bring the aggregator key you already have. Add direct vendor keys later when you want to skip OpenRouter for production traffic. ClawQL routes `provider/model` the same either way.
 
 Pair with MCP when you want agents to **search / execute / remember** against your APIs and vault:
 
@@ -52,6 +64,7 @@ Today those are often two local processes; the **product** is one Agentic Gatewa
 
 | You want…                                    | Jump to                                            |
 | -------------------------------------------- | -------------------------------------------------- |
+| Keep using your existing OpenRouter key      | [Already on OpenRouter?](#already-on-openrouter)   |
 | First completion in under 5 minutes          | [Five-minute start](#five-minute-start)            |
 | Managed Edge Gateway (`/mcp` + `/v1`)        | [Managed Edge Gateway](#what-good-looks-like-next) |
 | Point OpenCode / OpenAI SDK at the gateway   | [Point a client](#point-a-client)                  |
@@ -81,15 +94,21 @@ cp examples/inference/policy.yaml "$CLAWQL_HOME/Inference/policy.yaml"
 # export CLAWQL_INFERENCE_POLICY_MANIFEST=/path/to/policy.yaml
 ```
 
-### 3. Bring a provider key (BYOK)
+### 3. Bring a provider key
 
-Prefer a direct vendor key:
+**Already on OpenRouter?** Use that key only:
 
 ```bash
-export DEEPSEEK_API_KEY=sk-…          # recommended first key
+export OPENROUTER_API_KEY=sk-or-…     # recommended if you already have OpenRouter
+```
+
+Direct BYOK (when you have per-provider keys and want to skip the aggregator):
+
+```bash
+# export DEEPSEEK_API_KEY=sk-…        # direct DeepSeek
 # export GROQ_API_KEY=…               # or another BYOK provider
 # export OPENAI_API_KEY=…             # OpenAI / embeddings
-# export OPENROUTER_API_KEY=sk-or-…   # optional escape hatch only
+# export ANTHROPIC_API_KEY=…          # Anthropic
 ```
 
 Never commit keys. Local secrets belong in your shell / secret manager — not in git or MCP JSON.
@@ -109,20 +128,21 @@ curl -s http://127.0.0.1:8080/healthz
 
 curl -s http://127.0.0.1:8080/v1/models | head
 
+# OpenRouter-first (when OPENROUTER_API_KEY is set)
 curl -s http://127.0.0.1:8080/v1/chat/completions \
   -H 'Content-Type: application/json' \
-  -d '{"model":"deepseek/deepseek-chat","messages":[{"role":"user","content":"Say hi in one sentence."}]}'
+  -d '{"model":"openrouter/deepseek/deepseek-chat","messages":[{"role":"user","content":"Say hi in one sentence."}]}'
 
-# Catalog alias (same upstream when DeepSeek is keyed)
-curl -s http://127.0.0.1:8080/v1/chat/completions \
-  -H 'Content-Type: application/json' \
-  -d '{"model":"clawql/cheap-chat","messages":[{"role":"user","content":"hi"}]}'
+# Direct BYOK example (when DEEPSEEK_API_KEY is set)
+# curl -s http://127.0.0.1:8080/v1/chat/completions \
+#   -H 'Content-Type: application/json' \
+#   -d '{"model":"deepseek/deepseek-chat","messages":[{"role":"user","content":"Say hi in one sentence."}]}'
 ```
 
 One-shot without HTTP:
 
 ```bash
-clawql inference complete --model deepseek/deepseek-chat --message "hello"
+clawql inference complete --model openrouter/deepseek/deepseek-chat --message "hello"
 ```
 
 ---
@@ -142,11 +162,11 @@ Model ids use `provider/model` (e.g. `deepseek/deepseek-chat`, `groq/llama-3.3-7
 
 ```bash
 # terminal 1
-DEEPSEEK_API_KEY=sk-… clawql inference serve --port 8080
+OPENROUTER_API_KEY=sk-or-… clawql inference serve --port 8080
 
 # terminal 2
 CLAWQL_OPENBENCH=1 clawql opencode --non-interactive \
-  --model clawql/deepseek/deepseek-chat \
+  --model clawql/openrouter/deepseek/deepseek-chat \
   --inference-url http://127.0.0.1:8080/v1 \
   --message "Say hello" \
   --workdir /tmp/demo
@@ -186,7 +206,7 @@ Start local; harden before sharing a URL:
 
 | Practice                              | Why                                                                 |
 | ------------------------------------- | ------------------------------------------------------------------- |
-| **BYOK by default**                   | You own vendor keys; OpenRouter is optional                         |
+| **Your keys**                         | OpenRouter aggregator key and/or direct vendor BYOK — you own them  |
 | **Virtual keys for shared gateways**  | Per-team budgets / rate limits; secrets stored hashed               |
 | **No `noAuth` on anything networked** | Require Bearer / virtual key on `/v1/*`                             |
 | **Tenant from the token**             | Do not trust client-supplied tenant headers on shared hosts         |
@@ -203,7 +223,7 @@ Defense-in-depth narrative: [MCP proxy JWT ATR](https://github.com/danielsmithde
 2. **Managed Edge Gateway (go-live)** — one hostname for `/v1` + `/mcp` + memory:
 
 ```bash
-export DEEPSEEK_API_KEY=sk-…   # or another BYOK key
+export OPENROUTER_API_KEY=sk-or-…   # or DEEPSEEK_API_KEY / other BYOK
 clawql gateway create --profile process --team demo
 # → MCP URL, Inference URL, virtual key (shown once)
 ```
@@ -222,20 +242,20 @@ GTM narrative: [Inference-first GTM](https://clawql.com/inference/gtm) · Archit
 
 ## Troubleshooting
 
-| Symptom                          | Fix                                                                                |
-| -------------------------------- | ---------------------------------------------------------------------------------- |
-| Empty `/v1/models`               | Set a vendor key (`DEEPSEEK_API_KEY`, …); catalog lists **credentialed** providers |
-| `DEEPSEEK_API_KEY is required`   | Export the key in the **same shell** as `inference serve`                          |
-| Want OpenRouter long-tail        | `OPENROUTER_API_KEY=…` and model `openrouter/<vendor>/<model>`                     |
-| Client still hits api.openai.com | Set `OPENAI_BASE_URL=http://127.0.0.1:8080/v1` (include `/v1`)                     |
-| Policy looks wrong               | `clawql inference policy show --json` — env overrides YAML                         |
+| Symptom                          | Fix                                                                                         |
+| -------------------------------- | ------------------------------------------------------------------------------------------- |
+| Empty `/v1/models`               | Set `OPENROUTER_API_KEY` and/or a vendor BYOK key; catalog lists **credentialed** providers |
+| OpenRouter model 401 / missing   | Export `OPENROUTER_API_KEY` in the **same shell** as `inference serve`                      |
+| Want direct BYOK later           | Set `DEEPSEEK_API_KEY` (etc.) and use `deepseek/…` / `anthropic/…` model ids                |
+| Client still hits api.openai.com | Set `OPENAI_BASE_URL=http://127.0.0.1:8080/v1` (include `/v1`)                              |
+| Policy looks wrong               | `clawql inference policy show --json` — env overrides YAML                                  |
 
 ---
 
 ## Next reading
 
 - [clawql-inference reference](/inference/clawql-inference) — policy schema, cache, flywheel, entitlements
-- [Inference providers](/plugins/inference-providers) — BYOK builtins + OpenRouter escape hatch
+- [Inference providers](/plugins/inference-providers) — OpenRouter + BYOK builtins
 - [Agent setup](/agent-setup) — MCP + memory onboarding
 - [Token efficiency](/architecture/token-efficiency) — twelve compounding layers
 - [Getting started overview](/getting-started)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes **OpenRouter the day-one path** for OpenBench / clawql-inference when teams already have an aggregator key and no per-provider BYOK yet.

## Changes

- OpenBench CI defaults to `openrouter/deepseek/deepseek-chat`
- Prefight treats `OPENROUTER_API_KEY` as first-class
- Docs: Already on OpenRouter? + OpenBench Actions guide OpenRouter-first

## Operator

Repo secret **`OPENROUTER_API_KEY`** is set. After merge, live A/B:

```bash
gh workflow run openbench-ab.yml --ref main \
  -f task=memory-dependent-continuation \
  -f model=openrouter/deepseek/deepseek-chat \
  -f trials=1
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

