### PR TITLE
docs(gtm): add standalone ClawQL IDP GTM playbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ This directory is organized by purpose so operational guides, product docs, and 
 - **ClawQL Master enablement guide** (v2.1 — historical unified index; public hub is Architecture): [`vision/clawql-master-enablement-guide.md`](vision/clawql-master-enablement-guide.md) — redirects to [`/architecture`](https://docs.clawql.com/architecture)
 - **ClawQL Modularization v2.1** (package boundaries companion; public hub is Architecture): [`vision/clawql-modularization-v2.md`](vision/clawql-modularization-v2.md) — redirects to [`/architecture`](https://docs.clawql.com/architecture)
 - **ClawQL IDP Platform** (July 2026 — eight-vendor pipeline, umbrella Helm, observability, OpenClaw runbooks): [`vision/clawql-idp-platform.md`](vision/clawql-idp-platform.md) — [`/vision/idp-platform`](https://docs.clawql.com/vision/idp-platform)
+- **ClawQL IDP GTM** (standalone IDP motion — market, positioning, landing brief, sales tables): [`vision/clawql-idp-gtm.md`](vision/clawql-idp-gtm.md) — [`clawql.com/idp/gtm`](https://clawql.com/idp/gtm)
 - **Immutable releases — hybrid decentralized GitHub alternative** (Layer 0: `clawql-release`, Arweave, Radicle, Rift, release manifest): [`vision/clawql-hybrid-decentralized-github-alternative.md`](vision/clawql-hybrid-decentralized-github-alternative.md) — [`/vision/immutable-releases`](https://docs.clawql.com/vision/immutable-releases)
 
 ## Contributing

--- a/docs/vision/clawql-idp-gtm.md
+++ b/docs/vision/clawql-idp-gtm.md
@@ -1,0 +1,246 @@
+# ClawQL IDP — Standalone GTM Strategy, Landing Page Brief & Positioning
+
+**July 2026 · Compiled from competitive research and product docs**
+
+**Audience:** Internal GTM, sales, product marketing  
+**Related:** [IDP platform](./clawql-idp-platform.md) · [IDP pipeline](../providers/idp-pipeline.md) · [Plugins](https://docs.clawql.com/plugins) · Public playbook: [clawql.com/idp/gtm](https://clawql.com/idp/gtm) · Inference GTM: [clawql.com/inference/gtm](https://clawql.com/inference/gtm)
+
+> Internal strategy document. Do not distribute without review.
+
+---
+
+## Part 1: The Market Reality That Creates the Opportunity
+
+### What the 2026 IDP Market Actually Looks Like
+
+The IDP category was formally recognized by Gartner in September 2025 — the first-ever Magic Quadrant for Intelligent Document Processing Solutions evaluated 18 vendors and named five as Leaders: ABBYY, Hyperscience, Infrrd, Tungsten Automation, and UiPath.
+
+What the Magic Quadrant also revealed: extraction accuracy has converged. By 2026, the top platforms all advertise 90–99% accuracy on common document formats, with differences increasingly invisible in production. The traditional moat — "our extraction model is more accurate" — is disappearing. The battleground has shifted to **integration depth**, **deployment model**, and **total cost of ownership**.
+
+ClawQL wins all three. Decisively. On verifiable numbers.
+
+### The Pricing Chasm
+
+| Vendor                   | Pricing model               | Real cost                                                                              |
+| ------------------------ | --------------------------- | -------------------------------------------------------------------------------------- |
+| ABBYY Vantage            | Per-page, custom quote      | $0.02–$0.10/page; median enterprise contract ~$150,000/year + $20–$150K implementation |
+| Hyperscience             | Custom quote, not disclosed | Up to $1.50/page; $30,000–$100,000+ to start                                           |
+| Kofax TotalAgility       | Custom quote                | Mid-five to seven figures annually                                                     |
+| Rossum                   | Tiered, from $18,000/year   | $18,000+ entry; SAP/Coupa-focused                                                      |
+| Intralinks VDR           | Per-page, $0.40–$0.85/page  | $15,000–$200,000+ per M&A deal                                                         |
+| Datasite VDR             | Custom quote                | Up to $720,000/year for large implementations                                          |
+| **ClawQL IDP (Starter)** | **Flat, $299/mo**           | **$3,588/year. Unlimited documents. VDR included.**                                    |
+
+This is not a marginal price advantage. It is a category gap. A team that would pay $150,000/year for ABBYY pays $3,588/year for ClawQL at the Starter tier — for a platform that does more, deploys faster, and doesn't require a dedicated implementation team.
+
+### The Integration Gap No Incumbent Fills
+
+Every incumbent IDP platform stops at extraction and delivery. They extract data from documents and hand it off. What happens next — querying that data, cross-referencing it against institutional knowledge, triggering downstream API actions, archiving with cryptographic provenance, distributing securely to counterparties — is left to the team to build.
+
+ClawQL doesn't stop at extraction. The pipeline runs from document ingestion through to secure external distribution, with every step orchestrated by AI agents through the same MCP endpoint, with Merkle-chained audit trails at every step.
+
+No incumbent can bolt this on. The integration is structural, not additive.
+
+### The Three Buyer Problems Nobody Is Solving
+
+**Problem 1: The SaaS sprawl tax.** A typical document-heavy team in legal, lending, or M&A runs 5–10 disconnected SaaS tools: an OCR vendor, a PDF processor, a document management system, a knowledge search tool, a VDR, and a set of manual handoffs between them. Each tool has separate billing, separate compliance postures, and a separate API contract. Each handoff is a potential breach vector and a guaranteed latency cost.
+
+**Problem 2: The implementation tax.** Enterprise IDP vendors require 3–12 months for full deployment, dedicated implementation teams, and professional services that can add $20,000–$150,000 on top of license fees. A team that needs document processing in Q3 cannot start evaluating ABBYY in Q1 and expect results by Q4.
+
+**Problem 3: The pipeline-VDR gap.** VDR incumbents (Intralinks, Datasite, Ansarada) charge $0.40–$0.85 per page with no pipeline integration. DocSend has engagement analytics but no processing. The documents that end up in a VDR arrived there via a completely separate process — OCR'd by one tool, redacted by another, archived by a third, then manually uploaded to the VDR. There is no platform that closes this loop natively.
+
+ClawQL closes all three gaps simultaneously.
+
+---
+
+## Part 2: The Honest Positioning
+
+### What ClawQL IDP Is
+
+A sovereign, modular Intelligent Document Processing platform that closes the full document lifecycle in a single system:
+
+**Ingest → Classify → Convert → OCR → Redact → Archive → Semantically index → Distribute securely**
+
+Available self-hosted (Apache 2.0 core, free forever) or managed hosted (Starter at $299/mo).
+
+AI agents — accessed via a single MCP endpoint or natural language in Cursor/Claude Code — orchestrate the entire pipeline without custom integration code.
+
+### What ClawQL IDP Is Not (Honest Scope)
+
+- **Not a replacement for ABBYY or Hyperscience at millions-of-documents-per-month enterprise scale.** At that volume, the managed infrastructure investment and vertical-specific extraction model depth of Hyperscience may justify the cost. ClawQL targets teams processing hundreds to tens of thousands of documents per month who need pipeline integration, sovereignty, and price efficiency more than they need a vendor with a 40-year history.
+- **Not yet FedRAMP authorized.** Tungsten Automation achieved FedRAMP High ATO in March 2026. ClawQL does not have this. US federal government procurement requires FedRAMP; ClawQL is not in scope for that buyer today.
+- **Not a forms-automation RPA platform.** Kofax TotalAgility and UiPath Document Understanding integrate deeply with RPA bot orchestration. ClawQL's agent model is different — AI agents, not RPA bots. For teams already standardized on UiPath RPA, Document Understanding integrates natively in a way ClawQL doesn't.
+
+### The Honest Differentiator Claims
+
+These are claimable now, on verifiable evidence:
+
+1. **Most affordable full-pipeline IDP with VDR on the market.** Starter ($299/mo, $3,588/year) includes unlimited documents, full pipeline (Tika + Gotenberg + Stirling + archive layer + Onyx), ConeShare VDR, Merkle audit trails, MCP-native access, and no per-page or per-document meter.
+2. **The only IDP platform that is also an inference gateway and MCP server.** The IDP buyer can start with documents and expand to inference, memory, and agent governance without changing their endpoint or their vendor.
+3. **The only IDP with native MCP access from any AI assistant.** "Process these invoices, redact PII, archive, and create a data room" as a natural language instruction — no custom integration work.
+4. **Cryptographic audit trail per processing step.** Merkle-chained, independently verifiable, per-step — especially for lending, healthcare, legal, and M&A.
+5. **Self-hosted, air-gapped, data-sovereign.** Every processing step can run in the operator's own infrastructure.
+6. **Deployment in hours, not months.** `helm install clawql charts/clawql-full-stack --namespace clawql`.
+
+### The Claim to Avoid Until It's Earned
+
+**"Best IDP on the planet"** — not claimable as a blanket statement yet. Claimable with specificity: "the best IDP for teams that need pipeline integration, data sovereignty, agentic access, and price efficiency."
+
+---
+
+## Part 3: The Standalone IDP GTM Motion
+
+### The IDP Buyer Is a Different Person
+
+The inference-first motion targets developers. The IDP buyer is often:
+
+- A **VP of Operations** at a lending company who processes 400 mortgage applications a month
+- A **Legal Ops Manager** at a law firm who manages discovery document sets across matters
+- A **Transaction Coordinator** at a real estate brokerage who assembles deal packages for 30 transactions at a time
+- A **Controller** at a Series C who manually re-enters invoice data from a disconnected OCR tool
+- A **Compliance Officer** at a healthcare organization who needs HIPAA-compliant document processing with a verifiable audit trail
+
+None of these people care about PAL routing or the Intelligence Flywheel first. They need: process my documents, redact what needs redacting, archive them properly, share them securely — for less than I'm paying now, without a 6-month implementation.
+
+### The IDP Entry Points
+
+1. **SaaS replacement** — "You're paying for 5–10 tools. We're one system." Target: teams paying $500–$5,000/month across disconnected SaaS.
+2. **VDR cost** — "You're paying $0.40–$0.85 per page. We include unlimited VDRs in $299/mo." Target: M&A, real estate, legal deal rooms.
+3. **Compliance** — "Your current IDP can't prove how a document was processed." Target: CISO-adjacent, compliance, regulated industries.
+4. **Integration** — "Your current IDP extracts and stops. Ours closes the loop from natural language." Target: ops leads, platform engineers.
+
+### The IDP Expansion Ladder
+
+Unlike inference-first (inference → memory → documents), IDP expands documents → everything else:
+
+| Horizon      | Outcome                                                           |
+| ------------ | ----------------------------------------------------------------- |
+| **Day one**  | Full pipeline operational (`helm install` or hosted trial)        |
+| **Week 2**   | Semantic cross-referencing via `knowledge_search_onyx`            |
+| **Month 2**  | HITL for low-confidence extractions (`hitl_enqueue_label_studio`) |
+| **Month 3**  | MCP access from AI assistants for natural-language ops            |
+| **Month 4+** | Inference + memory discovered on the same platform                |
+
+### The IDP Competitive Table for Sales Conversations
+
+| Dimension            | ABBYY Vantage          | Hyperscience          | Rossum               | Intralinks (VDR)       | ClawQL IDP                 |
+| -------------------- | ---------------------- | --------------------- | -------------------- | ---------------------- | -------------------------- |
+| Entry price          | $15,000+/yr (est)      | $30,000+/yr (est)     | $18,000/yr           | $10,000+/yr            | **$3,588/yr**              |
+| Per-document meter   | Yes ($0.02–$0.10/page) | Yes (~$1.50/page est) | Yes                  | Yes ($0.40–$0.85/page) | **No**                     |
+| Implementation time  | Weeks to months        | 3–12 months           | Weeks to months      | Days                   | **Hours**                  |
+| Self-hosted          | Partial                | Partial               | No                   | No                     | **Yes (free)**             |
+| VDR included         | No                     | No                    | No                   | VDR only (no pipeline) | **Yes**                    |
+| Pipeline integration | Extraction + handoff   | Extraction + handoff  | Extraction + handoff | Distribution only      | **Full pipeline**          |
+| MCP-native           | No                     | No                    | No                   | No                     | **Yes**                    |
+| Cryptographic audit  | No                     | No                    | No                   | No                     | **Yes (Merkle)**           |
+| AI agent interface   | No                     | No                    | No                   | No                     | **Yes**                    |
+| Semantic search      | No                     | No                    | No                   | No                     | **Yes (Onyx)**             |
+| Deployment model     | Cloud/partial on-prem  | Cloud/on-prem         | Cloud                | Cloud                  | **Self-hosted or managed** |
+| Inference gateway    | No                     | No                    | No                   | No                     | **Yes (same binary)**      |
+
+### IDP Objection Handlers
+
+**"We need a Gartner Magic Quadrant vendor."**  
+Gartner's MQ validated the category ClawQL competes in; it did not evaluate open-source IDP platforms in that cycle. Evaluate on your document types, deployment timeline, TCO, and whether the IDP stops at extraction or closes the full pipeline.
+
+**"We need proven enterprise scale — millions of documents per month."**  
+At true millions-per-month scale, Hyperscience/Tungsten may be the better fit. ClawQL targets hundreds to tens of thousands of documents per month with pipeline integration, sovereignty, and cost efficiency.
+
+**"We need FedRAMP."**  
+ClawQL does not have FedRAMP authorization. Tungsten Automation achieved FedRAMP High ATO in March 2026 — tell buyers this before evaluation.
+
+**"Your pipeline sounds complex to set up."**  
+One Helm chart. One command. Competitors require dedicated implementation teams and months of configuration.
+
+**"We already have Paperless-ngx / Nextcloud / Stirling individually."**  
+ClawQL is the orchestration layer that connects them, makes them MCP-callable, and closes the loop with Onyx + ConeShare VDR.
+
+---
+
+## Part 4: clawql.com/idp — Landing Page Brief
+
+### Purpose
+
+Convert the IDP buyer who has never heard of ClawQL and doesn't know it's also an inference gateway. Answer "Is this the document processing platform I've been looking for?" in 10 seconds; trial or demo in 60 seconds.
+
+**Do not lead with:** PAL routing, Intelligence Flywheel, inference, WORM call store, or developer-tool framing. Those are expansion reasons, not entry reasons.
+
+### Above the Fold
+
+**Headline (test both):**
+
+- Option A: "Document processing that doesn't stop at extraction."
+- Option B: "Your IDP costs $150,000/year. Ours costs $299/month. And it does more."
+
+**Subheadline:** ClawQL is the only document processing platform that closes the full document lifecycle — ingest, convert, OCR, redact, archive, semantic search, and secure distribution — in a single system, orchestrated by AI agents, at a price no incumbent can match.
+
+**CTAs:** `Start free trial` (14-day Starter, no card) · `Deploy self-hosted` → docs quickstart IDP
+
+**Trust anchors:** Apache 2.0 core · 1,000+ formats · Deploys in hours · Merkle audit trail per step
+
+### Page Sections (build order)
+
+1. **Pipeline visual** — Intake → Convert → Process → Archive → Distribute (Nextcloud/Email → Gotenberg → Stirling → Onyx → ConeShare)
+2. **Price comparison table** — ABBYY / Hyperscience / Intralinks / ClawQL hard numbers
+3. **Three things your current IDP can't do** — cross-reference during processing; close the VDR loop; prove it cryptographically
+4. **Five-minute setup** — Helm one-liner + natural-language workflow example + hosted trial link
+5. **Supported document types** — industry grid (financial, legal, real estate, healthcare, general)
+6. **Vertical callouts** — Lending · Legal/M&A · Real estate → plugins/verticals
+7. **Security and compliance** — self-hosted/air-gapped · Merkle · PII redaction · Istio mTLS
+8. **Pricing expanded** — Starter callout vs ABBYY median / Intralinks per-page
+9. **Footer CTAs** — trial · self-host · enterprise call
+
+---
+
+## Part 5: Where clawql.com/idp Sits in the Site Architecture
+
+**Recommendation: section of clawql.com, not a separate microsite.**
+
+Keep SEO authority, shared pricing/docs/trial, and a natural path from IDP buyer → full platform. Artificial microsite walls slow expansion.
+
+**Navigation (target):**
+
+```
+clawql.com/inference    → inference-first motion (developer audience)
+clawql.com/idp          → IDP-first motion (operations/compliance audience)
+clawql.com/enterprise   → enterprise/sovereign motion (CISO/CTO audience)
+```
+
+This playbook lives at **[clawql.com/idp/gtm](https://clawql.com/idp/gtm)**. The public marketing landing (`clawql.com/idp`) should implement Part 4 when ready.
+
+---
+
+## Part 6: The IDP-First GTM as Its Own Revenue Motion
+
+The inference-first motion is product-led. The IDP-first motion often hits budget owners already spending $500–$5,000/month on disconnected SaaS — a cleaner "replace my stack" conversation.
+
+ClawQL IDP is **not** "the document plugin for ClawQL." It is a standalone Intelligent Document Processing platform that competes with ABBYY Vantage, Hyperscience, and Intralinks — and wins on price, deployment speed, pipeline integration, and agentic access. The inference gateway is what happens when an IDP buyer discovers ClawQL does more than documents.
+
+### Funnel
+
+```
+PragmaticVectors essays          clawql.com/idp              docs.clawql.com
+─────────────────────────    →   ─────────────────────   →   ─────────────────────
+"Why Your IDP Doesn't              "This solves it"            Pipeline + Helm
+Know About Your APIs"
+"The Audit Trail You               Price comparison            Vertical guides
+Can't Reconstruct"                 Pipeline diagram            HITL / security
+                                   Vertical callouts
+                                   Trial CTA
+```
+
+### Planned PragmaticVectors essays
+
+- **Essay 9:** "The $150,000 Invoice" — real TCO of ABBYY/Hyperscience vs ClawQL
+- **Essay 10:** "The Per-Page Trap" — Intralinks-style VDR pricing opacity vs flat-rate pipeline+VDR
+
+---
+
+## Part 7: The IDP Positioning Statement (One Paragraph)
+
+> ClawQL is the Intelligent Document Processing platform that closes the full document lifecycle — ingest, convert, OCR, redact, archive, semantic search, and secure distribution — in a single system, orchestrated by AI agents, with a cryptographic audit trail at every step. It deploys in hours, starts at $299/month (versus $15,000–$150,000+ for ABBYY or Hyperscience), includes unlimited VDRs (versus $0.40–$0.85 per page for Intralinks), and is available self-hosted for free. It is the only IDP platform that is also a native MCP server — meaning any AI assistant that supports MCP can operate the full pipeline via natural language, without custom integration code. For teams in lending, legal, real estate, healthcare, or M&A who need document intelligence without a six-figure contract, a six-month implementation, or a per-page surprise on every invoice.
+
+---
+
+_July 2026 · ClawQL IDP GTM, Landing Page Brief & Positioning_  
+_For internal use. Do not distribute without review._

--- a/docs/vision/clawql-idp-platform.md
+++ b/docs/vision/clawql-idp-platform.md
@@ -5,7 +5,7 @@
 
 **Audience:** Investors · Developers & architects · Operators
 
-**Related:** [IDP pipeline hub](../providers/idp-pipeline.md) · [Requirements matrix](../roadmap/idp-master-requirements-matrix.md) · [OpenClaw IDP skill profile](../openclaw/openclaw-idp-skill-profile.md) · [Master enablement guide](./clawql-master-enablement-guide.md) · [Deployment guide](../deployment/clawql-deployment-operations-guide.md)
+**Related:** [IDP GTM strategy & landing brief](./clawql-idp-gtm.md) · [Public IDP GTM playbook](https://clawql.com/idp/gtm) · [IDP pipeline hub](../providers/idp-pipeline.md) · [Requirements matrix](../roadmap/idp-master-requirements-matrix.md) · [OpenClaw IDP skill profile](../openclaw/openclaw-idp-skill-profile.md) · [Master enablement guide](./clawql-master-enablement-guide.md) · [Deployment guide](../deployment/clawql-deployment-operations-guide.md)
 
 ---
 

--- a/landing-page/demo/src/app/idp/gtm/page.tsx
+++ b/landing-page/demo/src/app/idp/gtm/page.tsx
@@ -1,0 +1,74 @@
+import { ButtonLink, PlainButtonLink } from '@/components/elements/button'
+import { Link } from '@/components/elements/link'
+import { ArrowNarrowRightIcon } from '@/components/icons/arrow-narrow-right-icon'
+import { CallToActionSimpleCentered } from '@/components/sections/call-to-action-simple-centered'
+import { HeroSimpleCentered } from '@/components/sections/hero-simple-centered'
+import { IdpGtmPlaybook } from '@/components/sections/idp-gtm-playbook'
+import { pageMetadata } from '@/lib/seo'
+import { site } from '@/lib/site'
+
+export const metadata = pageMetadata({
+  title: 'IDP-first GTM playbook',
+  description:
+    'Standalone ClawQL IDP go-to-market: market reality, honest positioning, sales motion, landing-page brief, and competitive tables vs ABBYY, Hyperscience, and Intralinks.',
+  path: '/idp/gtm',
+})
+
+export default function Page() {
+  return (
+    <>
+      <HeroSimpleCentered
+        id="hero"
+        eyebrow={<p className="text-sm/7 font-medium text-mist-600 dark:text-mist-300">IDP-first GTM · July 2026</p>}
+        headline="Document processing that doesn't stop at extraction"
+        subheadline={
+          <p>
+            Standalone Intelligent Document Processing motion for ops, compliance, legal, lending, and M&amp;A — full
+            lifecycle from ingest to secure distribution, Merkle audit trails, MCP-native agents, Starter at $299/mo.
+            Developer motion: <Link href={site.urls.inferenceGtm}>inference-first GTM</Link>. Enterprise motion:{' '}
+            <Link href={site.urls.enterpriseGtm}>enterprise GTM</Link>.
+          </p>
+        }
+        cta={
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-center">
+            <ButtonLink href={site.urls.signup} size="lg">
+              Start free trial
+            </ButtonLink>
+            <PlainButtonLink href={`${site.urls.docs}/vision/idp-platform`} size="lg">
+              IDP platform docs <ArrowNarrowRightIcon />
+            </PlainButtonLink>
+            <PlainButtonLink href={`${site.urls.docs}/deployment/kubernetes`} size="lg">
+              Deploy with Helm <ArrowNarrowRightIcon />
+            </PlainButtonLink>
+          </div>
+        }
+      />
+
+      <IdpGtmPlaybook />
+
+      <CallToActionSimpleCentered
+        id="cta"
+        headline="Close the document loop. Expand to the platform later."
+        subheadline={
+          <p>
+            Land with pipeline + VDR + auditability at a price incumbents cannot match. When buyers are ready, the same
+            endpoint is also an inference gateway and memory system — without a second vendor conversation.
+          </p>
+        }
+        cta={
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-center">
+            <ButtonLink href={site.urls.signup} size="lg">
+              Start 14-day trial
+            </ButtonLink>
+            <PlainButtonLink href={`${site.urls.docs}/vision/idp-platform`} size="lg">
+              Read IDP docs <ArrowNarrowRightIcon />
+            </PlainButtonLink>
+            <PlainButtonLink href={site.urls.pricing} size="lg">
+              View pricing <ArrowNarrowRightIcon />
+            </PlainButtonLink>
+          </div>
+        }
+      />
+    </>
+  )
+}

--- a/landing-page/demo/src/app/layout.tsx
+++ b/landing-page/demo/src/app/layout.tsx
@@ -192,6 +192,7 @@ export default function RootLayout({
                 <FooterCategory title="Company">
                   <FooterLink href={site.urls.about}>About</FooterLink>
                   <FooterLink href={site.urls.inferenceGtm}>Inference GTM</FooterLink>
+                  <FooterLink href={site.urls.idpGtm}>IDP GTM</FooterLink>
                   <FooterLink href={site.urls.enterpriseGtm}>Enterprise GTM</FooterLink>
                   <FooterLink href={site.urls.contact}>Contact</FooterLink>
                 </FooterCategory>

--- a/landing-page/demo/src/app/sitemap.ts
+++ b/landing-page/demo/src/app/sitemap.ts
@@ -14,6 +14,7 @@ const ROUTES: Array<{
   { path: '/signup', changeFrequency: 'monthly', priority: 0.85 },
   { path: '/about', changeFrequency: 'monthly', priority: 0.7 },
   { path: '/inference/gtm', changeFrequency: 'monthly', priority: 0.9 },
+  { path: '/idp/gtm', changeFrequency: 'monthly', priority: 0.88 },
   { path: '/enterprise/gtm', changeFrequency: 'monthly', priority: 0.75 },
   { path: '/privacy-policy', changeFrequency: 'yearly', priority: 0.3 },
   { path: '/industries', changeFrequency: 'monthly', priority: 0.75 },

--- a/landing-page/demo/src/components/sections/enterprise-gtm-playbook.tsx
+++ b/landing-page/demo/src/components/sections/enterprise-gtm-playbook.tsx
@@ -739,12 +739,18 @@ export function EnterpriseGtmPlaybook() {
 
           <h2 id="idp-gtm">Part VIII — ClawQL IDP standalone GTM</h2>
           <p>
-            IDP is a platform strategy sale (VP Eng / platform lead), not only an engineering infrastructure swap. Pain
-            is agent sprawl and lead time for new agent services — not token bills alone.
+            IDP is a <strong>standalone revenue motion</strong> for ops, compliance, legal, lending, and M&amp;A buyers
+            — not only an engineering infrastructure swap. Pain is SaaS sprawl, per-page VDR fees, six-month
+            implementations, and IDPs that stop at extraction. Full competitive tables, landing-page brief, and honest
+            positioning live in the dedicated playbook:
+          </p>
+          <p>
+            <Link href={site.urls.idpGtm}>IDP-first GTM playbook →</Link>
           </p>
           <Callout>
-            ClawQL IDP is not a replacement for Backstage or Crossplane. It is the agentic governance layer around them:
-            Backstage catalogs services; ClawQL governs what agents built on those services are allowed to do.
+            ClawQL IDP competes with ABBYY, Hyperscience, and Intralinks on price, deployment speed, full-pipeline
+            integration, Merkle audit trails, and MCP-native agent access — then expands organically into inference and
+            memory on the same endpoint.
           </Callout>
 
           <h2 id="pitch-deck">Part IX — Enterprise pitch deck outline</h2>

--- a/landing-page/demo/src/components/sections/idp-gtm-playbook.tsx
+++ b/landing-page/demo/src/components/sections/idp-gtm-playbook.tsx
@@ -1,0 +1,495 @@
+import { Document } from '@/components/elements/document'
+import { Link } from '@/components/elements/link'
+import { Section } from '@/components/elements/section'
+import { site } from '@/lib/site'
+
+import type { ReactNode } from 'react'
+
+const toc = [
+  { href: '#market-reality', label: 'Part 1 — Market reality' },
+  { href: '#honest-positioning', label: 'Part 2 — Honest positioning' },
+  { href: '#gtm-motion', label: 'Part 3 — Standalone GTM motion' },
+  { href: '#landing-brief', label: 'Part 4 — Landing page brief' },
+  { href: '#site-architecture', label: 'Part 5 — Site architecture' },
+  { href: '#revenue-motion', label: 'Part 6 — Revenue motion' },
+  { href: '#positioning-statement', label: 'Part 7 — Positioning statement' },
+] as const
+
+function Callout({ children }: { children: ReactNode }) {
+  return <blockquote>{children}</blockquote>
+}
+
+function ScrollTable({ children }: { children: ReactNode }) {
+  return <div className="overflow-x-auto">{children}</div>
+}
+
+export function IdpGtmPlaybook() {
+  return (
+    <Section id="playbook" className="pt-0">
+      <div className="flex flex-col gap-10">
+        <nav aria-label="Playbook contents" className="mx-auto w-full max-w-3xl">
+          <p className="text-xs font-semibold tracking-wide text-mist-500 uppercase">In this playbook</p>
+          <ol className="mt-3 grid gap-2 text-sm text-mist-700 sm:grid-cols-2 dark:text-mist-300">
+            {toc.map((item, index) => (
+              <li key={item.href}>
+                <Link href={item.href} className="hover:text-mist-950 dark:hover:text-white">
+                  <span className="text-mist-400 tabular-nums">{String(index + 1).padStart(2, '0')}</span> {item.label}
+                </Link>
+              </li>
+            ))}
+          </ol>
+        </nav>
+
+        <Document className="mx-auto w-full max-w-3xl">
+          <p>
+            This playbook defines ClawQL&apos;s <strong>IDP-first</strong> go-to-market motion: a standalone Intelligent
+            Document Processing platform for operations, compliance, legal, lending, and M&amp;A buyers — not a feature
+            footnote under inference. Default developer motion:{' '}
+            <Link href={site.urls.inferenceGtm}>inference-first GTM</Link>. Enterprise / sovereign motion:{' '}
+            <Link href={site.urls.enterpriseGtm}>enterprise GTM</Link>. Product ground truth:{' '}
+            <Link href={`${site.urls.docs}/vision/idp-platform`}>IDP platform docs</Link>.
+          </p>
+
+          <Callout>
+            Internal strategy + landing-page brief (July 2026). Do not distribute externally without review. Canonical
+            markdown: <code>docs/vision/clawql-idp-gtm.md</code>.
+          </Callout>
+
+          <h2 id="market-reality">Part 1 — The market reality that creates the opportunity</h2>
+          <p>
+            Gartner&apos;s first Magic Quadrant for Intelligent Document Processing (September 2025) named five Leaders
+            among 18 vendors. Extraction accuracy has converged (top platforms advertise 90–99% on common formats). The
+            traditional moat — &quot;our model is more accurate&quot; — is disappearing. The battleground is{' '}
+            <strong>integration depth</strong>, <strong>deployment model</strong>, and <strong>TCO</strong>. ClawQL wins
+            all three on verifiable numbers.
+          </p>
+
+          <h3>The pricing chasm</h3>
+          <ScrollTable>
+            <table>
+              <thead>
+                <tr>
+                  <th>Vendor</th>
+                  <th>Pricing model</th>
+                  <th>Real cost</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>ABBYY Vantage</td>
+                  <td>Per-page, custom quote</td>
+                  <td>$0.02–$0.10/page; median enterprise ~$150K/year + $20–$150K implementation</td>
+                </tr>
+                <tr>
+                  <td>Hyperscience</td>
+                  <td>Custom quote</td>
+                  <td>Up to $1.50/page; $30K–$100K+ to start</td>
+                </tr>
+                <tr>
+                  <td>Kofax TotalAgility</td>
+                  <td>Custom quote</td>
+                  <td>Mid-five to seven figures annually</td>
+                </tr>
+                <tr>
+                  <td>Rossum</td>
+                  <td>Tiered from $18K/year</td>
+                  <td>$18K+ entry; SAP/Coupa-focused</td>
+                </tr>
+                <tr>
+                  <td>Intralinks VDR</td>
+                  <td>$0.40–$0.85/page</td>
+                  <td>$15K–$200K+ per M&amp;A deal</td>
+                </tr>
+                <tr>
+                  <td>Datasite VDR</td>
+                  <td>Custom quote</td>
+                  <td>Up to $720K/year for large implementations</td>
+                </tr>
+                <tr>
+                  <td>
+                    <strong>ClawQL IDP (Starter)</strong>
+                  </td>
+                  <td>
+                    <strong>Flat $299/mo</strong>
+                  </td>
+                  <td>
+                    <strong>$3,588/year. Unlimited documents. VDR included.</strong>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </ScrollTable>
+          <p>
+            A team that would pay $150,000/year for ABBYY pays $3,588/year for ClawQL Starter — for a platform that does
+            more, deploys faster, and does not require a dedicated implementation team.
+          </p>
+
+          <h3>The integration gap no incumbent fills</h3>
+          <p>
+            Incumbent IDP stops at extraction and delivery. Cross-referencing institutional knowledge, triggering
+            downstream APIs, Merkle-chained archive, and secure counterparty distribution are left for the team to
+            build. ClawQL runs ingestion through secure external distribution on one MCP endpoint. That integration is
+            structural, not additive.
+          </p>
+
+          <h3>Three buyer problems nobody is solving</h3>
+          <ol>
+            <li>
+              <strong>SaaS sprawl tax</strong> — 5–10 disconnected tools (OCR, PDF, DMS, search, VDR) with separate
+              billing, compliance postures, and breach surfaces.
+            </li>
+            <li>
+              <strong>Implementation tax</strong> — 3–12 months, dedicated PS teams, $20K–$150K on top of license fees.
+            </li>
+            <li>
+              <strong>Pipeline–VDR gap</strong> — Intralinks/Datasite charge $0.40–$0.85/page with no pipeline;
+              documents arrive via manual OCR → redact → archive → upload.
+            </li>
+          </ol>
+          <p>ClawQL closes all three simultaneously.</p>
+
+          <h2 id="honest-positioning">Part 2 — The honest positioning</h2>
+          <h3>What ClawQL IDP is</h3>
+          <p>
+            A sovereign, modular IDP that closes the full document lifecycle in one system:{' '}
+            <strong>
+              Ingest → Classify → Convert → OCR → Redact → Archive → Semantically index → Distribute securely
+            </strong>
+            . Self-hosted (Apache 2.0, free forever) or managed hosted (Starter $299/mo). AI agents orchestrate via MCP
+            / natural language in Cursor or Claude Code — no custom integration code.
+          </p>
+
+          <h3>What ClawQL IDP is not</h3>
+          <ul>
+            <li>
+              <strong>Not</strong> a replacement for ABBYY/Hyperscience at millions-of-documents-per-month scale — those
+              buyers may need deeper vertical extraction models.
+            </li>
+            <li>
+              <strong>Not yet FedRAMP authorized</strong> — Tungsten Automation achieved FedRAMP High ATO (March 2026);
+              US federal procurement is out of scope today.
+            </li>
+            <li>
+              <strong>Not</strong> a forms-automation RPA platform — ClawQL uses AI agents, not UiPath-style RPA bots.
+            </li>
+          </ul>
+
+          <h3>Claimable differentiators (now)</h3>
+          <ol>
+            <li>
+              <strong>Most affordable full-pipeline IDP with VDR</strong> — $299/mo, unlimited documents, no per-page
+              meter; VDR included.
+            </li>
+            <li>
+              <strong>Only IDP that is also an inference gateway and MCP server</strong> — expand without changing
+              endpoint or vendor.
+            </li>
+            <li>
+              <strong>Native MCP from any AI assistant</strong> — full pipeline via natural language.
+            </li>
+            <li>
+              <strong>Merkle audit trail per step</strong> — independently verifiable for regulated industries.
+            </li>
+            <li>
+              <strong>Self-hosted / air-gapped / data-sovereign</strong> — no document data must leave the environment.
+            </li>
+            <li>
+              <strong>Deploy in hours, not months</strong> —{' '}
+              <code>helm install clawql charts/clawql-full-stack --namespace clawql</code>.
+            </li>
+          </ol>
+          <Callout>
+            Avoid &quot;best IDP on the planet&quot; until earned. Prefer:{' '}
+            <em>
+              best IDP for teams that need pipeline integration, data sovereignty, agentic access, and price efficiency
+            </em>
+            .
+          </Callout>
+
+          <h2 id="gtm-motion">Part 3 — The standalone IDP GTM motion</h2>
+          <p>
+            The IDP buyer is often a VP of Ops, Legal Ops Manager, transaction coordinator, controller, or compliance
+            officer — not a developer optimizing PAL routing. Lead with documents, cost, auditability, and time-to-value
+            in their language.
+          </p>
+
+          <h3>Entry points</h3>
+          <ol>
+            <li>
+              <strong>SaaS replacement</strong> — one system vs 5–10 tools ($500–$5,000/mo current spend).
+            </li>
+            <li>
+              <strong>VDR cost</strong> — unlimited VDRs in $299/mo vs $0.40–$0.85/page.
+            </li>
+            <li>
+              <strong>Compliance</strong> — cryptographic proof of how a document was processed.
+            </li>
+            <li>
+              <strong>Integration</strong> — extract → knowledge → APIs → archive → distribute from one NL instruction.
+            </li>
+          </ol>
+
+          <h3>Expansion ladder (documents → platform)</h3>
+          <ScrollTable>
+            <table>
+              <thead>
+                <tr>
+                  <th>Horizon</th>
+                  <th>Outcome</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Day one</td>
+                  <td>Full pipeline operational (Helm or hosted trial)</td>
+                </tr>
+                <tr>
+                  <td>Week 2</td>
+                  <td>
+                    Semantic cross-reference via <code>knowledge_search_onyx</code>
+                  </td>
+                </tr>
+                <tr>
+                  <td>Month 2</td>
+                  <td>
+                    HITL for low-confidence extractions (<code>hitl_enqueue_label_studio</code>)
+                  </td>
+                </tr>
+                <tr>
+                  <td>Month 3</td>
+                  <td>MCP from AI assistants for natural-language ops</td>
+                </tr>
+                <tr>
+                  <td>Month 4+</td>
+                  <td>Inference + memory discovered on the same platform</td>
+                </tr>
+              </tbody>
+            </table>
+          </ScrollTable>
+
+          <h3>Competitive table (sales)</h3>
+          <ScrollTable>
+            <table>
+              <thead>
+                <tr>
+                  <th>Dimension</th>
+                  <th>ABBYY</th>
+                  <th>Hyperscience</th>
+                  <th>Rossum</th>
+                  <th>Intralinks</th>
+                  <th>ClawQL IDP</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Entry price</td>
+                  <td>$15K+/yr est</td>
+                  <td>$30K+/yr est</td>
+                  <td>$18K/yr</td>
+                  <td>$10K+/yr</td>
+                  <td>
+                    <strong>$3,588/yr</strong>
+                  </td>
+                </tr>
+                <tr>
+                  <td>Per-doc meter</td>
+                  <td>Yes</td>
+                  <td>Yes</td>
+                  <td>Yes</td>
+                  <td>Yes</td>
+                  <td>
+                    <strong>No</strong>
+                  </td>
+                </tr>
+                <tr>
+                  <td>Implementation</td>
+                  <td>Weeks–months</td>
+                  <td>3–12 months</td>
+                  <td>Weeks–months</td>
+                  <td>Days</td>
+                  <td>
+                    <strong>Hours</strong>
+                  </td>
+                </tr>
+                <tr>
+                  <td>Self-hosted</td>
+                  <td>Partial</td>
+                  <td>Partial</td>
+                  <td>No</td>
+                  <td>No</td>
+                  <td>
+                    <strong>Yes (free)</strong>
+                  </td>
+                </tr>
+                <tr>
+                  <td>VDR included</td>
+                  <td>No</td>
+                  <td>No</td>
+                  <td>No</td>
+                  <td>VDR only</td>
+                  <td>
+                    <strong>Yes</strong>
+                  </td>
+                </tr>
+                <tr>
+                  <td>Pipeline</td>
+                  <td>Extract + handoff</td>
+                  <td>Extract + handoff</td>
+                  <td>Extract + handoff</td>
+                  <td>Distribute only</td>
+                  <td>
+                    <strong>Full lifecycle</strong>
+                  </td>
+                </tr>
+                <tr>
+                  <td>MCP-native</td>
+                  <td>No</td>
+                  <td>No</td>
+                  <td>No</td>
+                  <td>No</td>
+                  <td>
+                    <strong>Yes</strong>
+                  </td>
+                </tr>
+                <tr>
+                  <td>Merkle audit</td>
+                  <td>No</td>
+                  <td>No</td>
+                  <td>No</td>
+                  <td>No</td>
+                  <td>
+                    <strong>Yes</strong>
+                  </td>
+                </tr>
+                <tr>
+                  <td>Inference gateway</td>
+                  <td>No</td>
+                  <td>No</td>
+                  <td>No</td>
+                  <td>No</td>
+                  <td>
+                    <strong>Same binary</strong>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </ScrollTable>
+
+          <h3>Objection handlers (short)</h3>
+          <ul>
+            <li>
+              <strong>Gartner MQ vendor:</strong> MQ validated the category; evaluate on your docs, timeline, TCO, and
+              whether the IDP stops at extraction.
+            </li>
+            <li>
+              <strong>Millions of docs/month:</strong> be honest — Hyperscience/Tungsten may fit; ClawQL targets
+              hundreds→tens of thousands/month with pipeline + sovereignty + cost.
+            </li>
+            <li>
+              <strong>FedRAMP:</strong> we do not have it; say so before evaluation.
+            </li>
+            <li>
+              <strong>Setup complexity:</strong> one Helm chart vs months of PS.
+            </li>
+            <li>
+              <strong>Already run Stirling/Paperless/Nextcloud:</strong> ClawQL is the orchestration + MCP + VDR loop on
+              top.
+            </li>
+          </ul>
+
+          <h2 id="landing-brief">Part 4 — clawql.com/idp landing page brief</h2>
+          <p>
+            Convert an IDP buyer who has never heard of ClawQL. Answer &quot;Is this the document platform I&apos;ve
+            been looking for?&quot; in ~10 seconds; trial/demo in ~60. Do <strong>not</strong> lead with PAL, Flywheel,
+            WORM, or developer framing.
+          </p>
+
+          <h3>Above the fold (test both headlines)</h3>
+          <ul>
+            <li>
+              <strong>A:</strong> Document processing that doesn&apos;t stop at extraction.
+            </li>
+            <li>
+              <strong>B:</strong> Your IDP costs $150,000/year. Ours costs $299/month. And it does more.
+            </li>
+          </ul>
+          <p>
+            Subhead: full lifecycle (ingest → distribute) in one system, AI-agent orchestrated, price incumbents cannot
+            match. CTAs: Start free trial · Deploy self-hosted. Trust: Apache 2.0 · 1,000+ formats · hours not months ·
+            Merkle per step.
+          </p>
+
+          <h3>Build sections</h3>
+          <ol>
+            <li>Pipeline visual (Intake → Convert → Process → Archive → Distribute)</li>
+            <li>Price comparison table (hard numbers)</li>
+            <li>Three things your current IDP can&apos;t do (cross-ref · VDR loop · crypto proof)</li>
+            <li>Five-minute setup (Helm + NL example + hosted trial)</li>
+            <li>Supported document types by industry</li>
+            <li>
+              Vertical callouts (Lending · Legal/M&amp;A · Real estate) →{' '}
+              <Link href={`${site.urls.docs}/plugins`}>plugins / verticals</Link>
+            </li>
+            <li>Security cards (air-gap · Merkle · Stirling redaction · Istio mTLS)</li>
+            <li>Pricing expanded + Starter callout</li>
+            <li>Footer CTAs by buyer type</li>
+          </ol>
+          <p>
+            Implement the public marketing page at <code>/idp</code> when ready; this playbook is the strategy source of
+            truth at <code>/idp/gtm</code>.
+          </p>
+
+          <h2 id="site-architecture">Part 5 — Site architecture</h2>
+          <p>
+            <strong>Recommendation: section of clawql.com, not a separate microsite</strong> — shared SEO, pricing,
+            docs, and trial; natural expansion into the broader platform.
+          </p>
+          <pre>
+            <code>{`clawql.com/inference  → inference-first (developers)
+clawql.com/idp        → IDP-first (ops / compliance)
+clawql.com/enterprise → sovereign / CISO-CTO motion`}</code>
+          </pre>
+
+          <h2 id="revenue-motion">Part 6 — IDP-first as its own revenue motion</h2>
+          <p>
+            Inference-first is PLG. IDP-first often hits budget owners already spending on SaaS — a cleaner
+            &quot;replace my stack&quot; sale. Starter converters are budget-approved, problem-aware, and warm leads for
+            Business / Professional and eventually inference + memory.
+          </p>
+          <Callout>
+            ClawQL IDP is not &quot;the document plugin for ClawQL.&quot; It is a standalone IDP that competes with
+            ABBYY, Hyperscience, and Intralinks — and wins on price, speed, pipeline integration, and agentic access.
+          </Callout>
+          <p>
+            Funnel: PragmaticVectors essays → <code>clawql.com/idp</code> → docs. Planned essays: &quot;The $150,000
+            Invoice&quot; and &quot;The Per-Page Trap.&quot;
+          </p>
+
+          <h2 id="positioning-statement">Part 7 — Positioning statement (one paragraph)</h2>
+          <Callout>
+            ClawQL is the Intelligent Document Processing platform that closes the full document lifecycle — ingest,
+            convert, OCR, redact, archive, semantic search, and secure distribution — in a single system, orchestrated
+            by AI agents, with a cryptographic audit trail at every step. It deploys in hours, starts at $299/month
+            (versus $15,000–$150,000+ for ABBYY or Hyperscience), includes unlimited VDRs (versus $0.40–$0.85 per page
+            for Intralinks), and is available self-hosted for free. It is the only IDP platform that is also a native
+            MCP server — meaning any AI assistant that supports MCP can operate the full pipeline via natural language,
+            without custom integration code. For teams in lending, legal, real estate, healthcare, or M&amp;A who need
+            document intelligence without a six-figure contract, a six-month implementation, or a per-page surprise on
+            every invoice.
+          </Callout>
+
+          <p className="mt-10 text-xs text-mist-500">
+            July 2026 · ClawQL IDP GTM ·{' '}
+            <Link href={`${site.urls.docs}/vision/idp-platform`} className="text-mist-500">
+              IDP platform docs
+            </Link>{' '}
+            ·{' '}
+            <Link href={site.urls.inferenceGtm} className="text-mist-500">
+              Inference GTM
+            </Link>
+          </p>
+        </Document>
+      </div>
+    </Section>
+  )
+}

--- a/landing-page/demo/src/lib/agent-discovery.ts
+++ b/landing-page/demo/src/lib/agent-discovery.ts
@@ -385,6 +385,7 @@ export function getAgentMarkdownMap(origin = getSiteOriginString()): Record<stri
     '/privacy-policy': `# Privacy Policy\n\nSee ${origin}/privacy-policy/ for the full policy.`,
     '/industries': `# Industries\n\nVertical workflows for lending, real estate, healthcare, legal, insurance, and education.\n\n${origin}/industries/`,
     '/inference/gtm': `# Inference-first GTM playbook\n\nClawQL provides the Agentic Gateway as the Foundational Platform for Auditable Production AI — Zero-Trust Agentic Fabric.\n\nSee ${origin}/inference/gtm/.`,
+    '/idp/gtm': `# IDP-first GTM playbook\n\nStandalone ClawQL Intelligent Document Processing go-to-market — market reality, honest positioning, sales motion, and landing-page brief vs ABBYY, Hyperscience, and Intralinks.\n\nSee ${origin}/idp/gtm/.`,
     '/enterprise/gtm': `# Enterprise GTM playbook\n\nSecondary enterprise motion — Auditable Production AI on the Zero-Trust Agentic Fabric.\n\nSee ${origin}/enterprise/gtm/.`,
   }
 }

--- a/landing-page/demo/src/lib/site.ts
+++ b/landing-page/demo/src/lib/site.ts
@@ -23,6 +23,8 @@ export const site = {
     about: '/about',
     /** Default / primary GTM motion — Agentic Gateway as Foundational Platform for Auditable Production AI. */
     inferenceGtm: '/inference/gtm',
+    /** IDP-first GTM motion — standalone document lifecycle for ops / compliance buyers. */
+    idpGtm: '/idp/gtm',
     /** Secondary enterprise / Palantir-facing GTM motion. */
     enterpriseGtm: '/enterprise/gtm',
     privacy: '/privacy-policy',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a dedicated **IDP-first GTM** strategy document and public playbook page, parallel to inference-first and enterprise GTM.

## Deliverables

- **Canonical markdown:** [`docs/vision/clawql-idp-gtm.md`](docs/vision/clawql-idp-gtm.md) — market reality, honest positioning, sales motion, landing-page brief (`clawql.com/idp`), site architecture, revenue motion, one-paragraph positioning
- **Public playbook:** [`clawql.com/idp/gtm`](https://clawql.com/idp/gtm) — `IdpGtmPlaybook` + hero/CTA (same pattern as `/inference/gtm` and `/enterprise/gtm`)
- **Wiring:** `site.urls.idpGtm`, sitemap, footer “IDP GTM”, agent-discovery markdown, enterprise GTM Part VIII points here
- **Cross-links:** IDP platform doc + docs index

## Notes

- Part 4 is a **landing-page brief** for a future `clawql.com/idp` marketing page; this PR ships the GTM playbook at `/idp/gtm`, not the full consumer landing yet.
- Document marked internal — do not distribute without review.

## Test plan

- [ ] `/idp/gtm` renders with TOC and all seven parts
- [ ] Footer shows IDP GTM next to Inference / Enterprise
- [ ] Enterprise GTM Part VIII links to `/idp/gtm`
- [ ] `docs/vision/clawql-idp-gtm.md` matches strategy content

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9b5e-4d74-72e6-90bb-d0c2100f09d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9b5e-4d74-72e6-90bb-d0c2100f09d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

