### PR TITLE
Cloud Agent: stdio ClawQL MCP + R2 sync bootstrap

### DIFF
--- a/.cursor/mcp.json.example
+++ b/.cursor/mcp.json.example
@@ -1,7 +1,11 @@
 {
   "mcpServers": {
     "clawql": {
-      "url": "http://127.0.0.1/mcp"
+      "command": "npx",
+      "args": ["-p", "clawql-mcp", "clawql-mcp"],
+      "env": {
+        "CLAWQL_HOME": "/home/ubuntu/.ClawQL"
+      }
     }
   }
 }

--- a/.cursor/scripts/cloud-agent-install.sh
+++ b/.cursor/scripts/cloud-agent-install.sh
@@ -44,12 +44,38 @@ CLAWQL_SYNC_AUTO_PULL_ON_START=1
 EOF
 fi
 
-# Pull team vault from R2 when sync credentials are present (Cursor Secrets)
+# Ensure workspace MCP example is available for Cloud Agent stdio (gitignored copy)
+if [[ ! -f "$ROOT/.cursor/mcp.json" && -f "$ROOT/.cursor/mcp.json.example" ]]; then
+  cp "$ROOT/.cursor/mcp.json.example" "$ROOT/.cursor/mcp.json"
+  echo "[cloud-agent-install] Wrote .cursor/mcp.json from example (stdio clawql-mcp)"
+fi
+
+# Team vault sync — Cursor Secrets inject CLAWQL_SYNC_* + CLAWQL_R2_ACCOUNT_ID
 if [[ -n "${CLAWQL_SYNC_BUCKET:-}" && -n "${CLAWQL_SYNC_ACCESS_KEY_ID:-}" && -n "${CLAWQL_SYNC_SECRET_ACCESS_KEY:-}" ]]; then
-  echo "[cloud-agent-install] R2 sync configured — pulling team vault"
-  npx clawql sync pull || echo "[cloud-agent-install] sync pull skipped (bucket empty or first run)"
+  if [[ -z "${CLAWQL_R2_ACCOUNT_ID:-}${CLAWQL_CLOUDFLARE_ACCOUNT_ID:-}${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+    echo "[cloud-agent-install] WARN: CLAWQL_R2_ACCOUNT_ID missing — R2 endpoint cannot be resolved"
+  fi
+  echo "[cloud-agent-install] R2 sync configured — writing sync.json + pulling team vault"
+  node "$ROOT/bin/clawql.mjs" sync init --yes \
+    --bucket "${CLAWQL_SYNC_BUCKET}" \
+    ${CLAWQL_SYNC_PREFIX:+--prefix "${CLAWQL_SYNC_PREFIX}"} \
+    || echo "[cloud-agent-install] sync init skipped"
+  node "$ROOT/bin/clawql.mjs" sync pull \
+    || echo "[cloud-agent-install] sync pull skipped (bucket empty or first run)"
 else
-  echo "[cloud-agent-install] R2 sync secrets not set — skipping pull (configure in Cursor Secrets)"
+  echo "[cloud-agent-install] R2 sync secrets not set — skipping pull"
+  echo "[cloud-agent-install]   Add in Cursor → Cloud Agents → Secrets:"
+  echo "[cloud-agent-install]   CLAWQL_R2_ACCOUNT_ID, CLAWQL_SYNC_BUCKET, CLAWQL_SYNC_PREFIX,"
+  echo "[cloud-agent-install]   CLAWQL_SYNC_ACCESS_KEY_ID, CLAWQL_SYNC_SECRET_ACCESS_KEY,"
+  echo "[cloud-agent-install]   CLAWQL_SYNC_AUTO=1, CLAWQL_SYNC_AUTO_PULL=1, CLAWQL_SYNC_AUTO_PULL_ON_START=1"
+  echo "[cloud-agent-install]   Optional: OPENROUTER_API_KEY (inference), CLOUDFLARE_API_TOKEN (execute)"
+fi
+
+# Stdio MCP config for this VM user (Cursor Cloud Agent)
+if [[ ! -f "$HOME/.cursor/mcp.json" ]]; then
+  mkdir -p "$HOME/.cursor"
+  node "$ROOT/bin/clawql.mjs" mcp-config --write cursor \
+    || echo "[cloud-agent-install] mcp-config write skipped"
 fi
 
 echo "[cloud-agent-install] done"

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ Thumbs.db
 # IDE / editors
 .idea/
 .vscode/
-# Cursor MCP — copy .cursor/mcp.json.example → .cursor/mcp.json and set your URL
+# Cursor MCP — copy .cursor/mcp.json.example → .cursor/mcp.json (stdio; local to VM)
 .cursor/mcp.json
 *.swp
 *.swo


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens the Cloud Agent path so enabling ClawQL is mostly “set Cursor Secrets + turn on MCP.”

## Changes

- **`.cursor/mcp.json.example`** — stdio `npx -p clawql-mcp clawql-mcp` with `CLAWQL_HOME` (replaces the misleading localhost HTTP URL).
- **`cloud-agent-install.sh`** — when R2 sync secrets are present: write `sync.json`, pull the team vault, ensure MCP config; when missing: print the exact Cursor Secrets checklist. Also copies the MCP example into gitignored `.cursor/mcp.json` when absent.
- **`.gitignore` comment** — reflects stdio MCP, not HTTP URL.

## Operator checklist (Cursor → Cloud Agents → Secrets)

| Secret | Purpose |
|--------|---------|
| `CLAWQL_R2_ACCOUNT_ID` | Cloudflare account id (builds R2 S3 endpoint) |
| `CLAWQL_SYNC_BUCKET` | Team R2 bucket |
| `CLAWQL_SYNC_PREFIX` | e.g. `teams/engineering/` |
| `CLAWQL_SYNC_ACCESS_KEY_ID` | R2 S3 access key |
| `CLAWQL_SYNC_SECRET_ACCESS_KEY` | R2 S3 secret |
| `CLAWQL_SYNC_AUTO=1` | Push after memory_ingest |
| `CLAWQL_SYNC_AUTO_PULL=1` | Pull before memory_recall |
| `CLAWQL_SYNC_AUTO_PULL_ON_START=1` | Pull on MCP start |
| `OPENROUTER_API_KEY` | Optional — clawql-inference day-one |
| `CLOUDFLARE_API_TOKEN` | Optional — Cloudflare execute (separate from R2 keys) |

Enable **clawql** MCP on the next Cloud Agent run. Secrets are injected at start — a new run is required after adding them.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

