### PR TITLE
feat(sync): clawql sync ensure auto-creates R2/S3 team vault buckets

### DIFF
--- a/.cursor/mcp.json.example
+++ b/.cursor/mcp.json.example
@@ -1,7 +1,11 @@
 {
   "mcpServers": {
     "clawql": {
-      "url": "http://127.0.0.1/mcp"
+      "command": "npx",
+      "args": ["-p", "clawql-mcp", "clawql-mcp"],
+      "env": {
+        "CLAWQL_HOME": "/home/ubuntu/.ClawQL"
+      }
     }
   }
 }

--- a/.cursor/scripts/cloud-agent-install.sh
+++ b/.cursor/scripts/cloud-agent-install.sh
@@ -44,12 +44,38 @@ CLAWQL_SYNC_AUTO_PULL_ON_START=1
 EOF
 fi
 
-# Pull team vault from R2 when sync credentials are present (Cursor Secrets)
+# Ensure workspace MCP example is available for Cloud Agent stdio (gitignored copy)
+if [[ ! -f "$ROOT/.cursor/mcp.json" && -f "$ROOT/.cursor/mcp.json.example" ]]; then
+  cp "$ROOT/.cursor/mcp.json.example" "$ROOT/.cursor/mcp.json"
+  echo "[cloud-agent-install] Wrote .cursor/mcp.json from example (stdio clawql-mcp)"
+fi
+
+# Team vault sync — Cursor Secrets inject CLAWQL_SYNC_* + CLAWQL_R2_ACCOUNT_ID
 if [[ -n "${CLAWQL_SYNC_BUCKET:-}" && -n "${CLAWQL_SYNC_ACCESS_KEY_ID:-}" && -n "${CLAWQL_SYNC_SECRET_ACCESS_KEY:-}" ]]; then
-  echo "[cloud-agent-install] R2 sync configured — pulling team vault"
-  npx clawql sync pull || echo "[cloud-agent-install] sync pull skipped (bucket empty or first run)"
+  if [[ -z "${CLAWQL_R2_ACCOUNT_ID:-}${CLAWQL_CLOUDFLARE_ACCOUNT_ID:-}${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+    echo "[cloud-agent-install] WARN: CLAWQL_R2_ACCOUNT_ID missing — R2 endpoint cannot be resolved"
+  fi
+  echo "[cloud-agent-install] R2 sync configured — writing sync.json + pulling team vault"
+  node "$ROOT/bin/clawql.mjs" sync init --yes \
+    --bucket "${CLAWQL_SYNC_BUCKET}" \
+    ${CLAWQL_SYNC_PREFIX:+--prefix "${CLAWQL_SYNC_PREFIX}"} \
+    || echo "[cloud-agent-install] sync init skipped"
+  node "$ROOT/bin/clawql.mjs" sync pull \
+    || echo "[cloud-agent-install] sync pull skipped (bucket empty or first run)"
 else
-  echo "[cloud-agent-install] R2 sync secrets not set — skipping pull (configure in Cursor Secrets)"
+  echo "[cloud-agent-install] R2 sync secrets not set — skipping pull"
+  echo "[cloud-agent-install]   Add in Cursor → Cloud Agents → Secrets:"
+  echo "[cloud-agent-install]   CLAWQL_R2_ACCOUNT_ID, CLAWQL_SYNC_BUCKET, CLAWQL_SYNC_PREFIX,"
+  echo "[cloud-agent-install]   CLAWQL_SYNC_ACCESS_KEY_ID, CLAWQL_SYNC_SECRET_ACCESS_KEY,"
+  echo "[cloud-agent-install]   CLAWQL_SYNC_AUTO=1, CLAWQL_SYNC_AUTO_PULL=1, CLAWQL_SYNC_AUTO_PULL_ON_START=1"
+  echo "[cloud-agent-install]   Optional: OPENROUTER_API_KEY (inference), CLOUDFLARE_API_TOKEN (execute)"
+fi
+
+# Stdio MCP config for this VM user (Cursor Cloud Agent)
+if [[ ! -f "$HOME/.cursor/mcp.json" ]]; then
+  mkdir -p "$HOME/.cursor"
+  node "$ROOT/bin/clawql.mjs" mcp-config --write cursor \
+    || echo "[cloud-agent-install] mcp-config write skipped"
 fi
 
 echo "[cloud-agent-install] done"

--- a/.cursor/scripts/cloud-agent-install.sh
+++ b/.cursor/scripts/cloud-agent-install.sh
@@ -51,11 +51,34 @@ if [[ ! -f "$ROOT/.cursor/mcp.json" && -f "$ROOT/.cursor/mcp.json.example" ]]; t
 fi
 
 # Team vault sync — Cursor Secrets inject CLAWQL_SYNC_* + CLAWQL_R2_ACCOUNT_ID
-if [[ -n "${CLAWQL_SYNC_BUCKET:-}" && -n "${CLAWQL_SYNC_ACCESS_KEY_ID:-}" && -n "${CLAWQL_SYNC_SECRET_ACCESS_KEY:-}" ]]; then
-  if [[ -z "${CLAWQL_R2_ACCOUNT_ID:-}${CLAWQL_CLOUDFLARE_ACCOUNT_ID:-}${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
-    echo "[cloud-agent-install] WARN: CLAWQL_R2_ACCOUNT_ID missing — R2 endpoint cannot be resolved"
+# Prefer `sync ensure` so ClawQL can create clawql-team-vault when Admin R2 keys
+# or CLOUDFLARE_API_TOKEN (Workers R2 Storage Write) are present.
+has_r2_account="${CLAWQL_R2_ACCOUNT_ID:-${CLAWQL_CLOUDFLARE_ACCOUNT_ID:-${CLOUDFLARE_ACCOUNT_ID:-}}}"
+has_sync_keys=false
+if [[ -n "${CLAWQL_SYNC_ACCESS_KEY_ID:-}" && -n "${CLAWQL_SYNC_SECRET_ACCESS_KEY:-}" ]]; then
+  has_sync_keys=true
+fi
+has_cf_api="${CLAWQL_CLOUDFLARE_API_TOKEN:-${CLOUDFLARE_API_TOKEN:-}}"
+
+if [[ -n "$has_r2_account" && ( "$has_sync_keys" == true || -n "$has_cf_api" ) ]]; then
+  echo "[cloud-agent-install] Ensuring R2 team vault bucket + sync.json"
+  ensure_args=(sync ensure --yes --provider r2)
+  if [[ -n "${CLAWQL_SYNC_BUCKET:-}" ]]; then
+    ensure_args+=(--bucket "${CLAWQL_SYNC_BUCKET}")
   fi
-  echo "[cloud-agent-install] R2 sync configured — writing sync.json + pulling team vault"
+  if [[ -n "${CLAWQL_SYNC_PREFIX:-}" ]]; then
+    ensure_args+=(--prefix "${CLAWQL_SYNC_PREFIX}")
+  fi
+  node "$ROOT/bin/clawql.mjs" "${ensure_args[@]}" \
+    || echo "[cloud-agent-install] sync ensure skipped (need Admin R2 keys or CLOUDFLARE_API_TOKEN)"
+  if [[ "$has_sync_keys" == true ]]; then
+    node "$ROOT/bin/clawql.mjs" sync pull \
+      || echo "[cloud-agent-install] sync pull skipped (bucket empty or first run)"
+  else
+    echo "[cloud-agent-install] Sync object keys not set — bucket may exist, but pull needs CLAWQL_SYNC_ACCESS_KEY_ID / SECRET"
+  fi
+elif [[ -n "${CLAWQL_SYNC_BUCKET:-}" && "$has_sync_keys" == true ]]; then
+  echo "[cloud-agent-install] R2 sync bucket preset — writing sync.json + pulling"
   node "$ROOT/bin/clawql.mjs" sync init --yes \
     --bucket "${CLAWQL_SYNC_BUCKET}" \
     ${CLAWQL_SYNC_PREFIX:+--prefix "${CLAWQL_SYNC_PREFIX}"} \
@@ -63,12 +86,16 @@ if [[ -n "${CLAWQL_SYNC_BUCKET:-}" && -n "${CLAWQL_SYNC_ACCESS_KEY_ID:-}" && -n 
   node "$ROOT/bin/clawql.mjs" sync pull \
     || echo "[cloud-agent-install] sync pull skipped (bucket empty or first run)"
 else
-  echo "[cloud-agent-install] R2 sync secrets not set — skipping pull"
+  echo "[cloud-agent-install] R2 sync secrets not set — skipping ensure/pull"
   echo "[cloud-agent-install]   Add in Cursor → Cloud Agents → Secrets:"
-  echo "[cloud-agent-install]   CLAWQL_R2_ACCOUNT_ID, CLAWQL_SYNC_BUCKET, CLAWQL_SYNC_PREFIX,"
-  echo "[cloud-agent-install]   CLAWQL_SYNC_ACCESS_KEY_ID, CLAWQL_SYNC_SECRET_ACCESS_KEY,"
-  echo "[cloud-agent-install]   CLAWQL_SYNC_AUTO=1, CLAWQL_SYNC_AUTO_PULL=1, CLAWQL_SYNC_AUTO_PULL_ON_START=1"
-  echo "[cloud-agent-install]   Optional: OPENROUTER_API_KEY (inference), CLOUDFLARE_API_TOKEN (execute)"
+  echo "[cloud-agent-install]   CLAWQL_R2_ACCOUNT_ID"
+  echo "[cloud-agent-install]   CLAWQL_SYNC_ACCESS_KEY_ID + CLAWQL_SYNC_SECRET_ACCESS_KEY"
+  echo "[cloud-agent-install]     (R2 token with Admin Read & Write so sync ensure can create the bucket)"
+  echo "[cloud-agent-install]   OR CLOUDFLARE_API_TOKEN with Workers R2 Storage Write (bucket create)"
+  echo "[cloud-agent-install]   Optional: CLAWQL_SYNC_BUCKET (default clawql-team-vault),"
+  echo "[cloud-agent-install]            CLAWQL_SYNC_PREFIX (default teams/shared/),"
+  echo "[cloud-agent-install]            CLAWQL_SYNC_AUTO=1, CLAWQL_SYNC_AUTO_PULL=1,"
+  echo "[cloud-agent-install]            CLAWQL_SYNC_AUTO_PULL_ON_START=1, OPENROUTER_API_KEY"
 fi
 
 # Stdio MCP config for this VM user (Cursor Cloud Agent)

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ Thumbs.db
 # IDE / editors
 .idea/
 .vscode/
-# Cursor MCP — copy .cursor/mcp.json.example → .cursor/mcp.json and set your URL
+# Cursor MCP — copy .cursor/mcp.json.example → .cursor/mcp.json (stdio; local to VM)
 .cursor/mcp.json
 *.swp
 *.swo

--- a/docs/deployment/cloud-agent-r2-tailscale-runbook.md
+++ b/docs/deployment/cloud-agent-r2-tailscale-runbook.md
@@ -55,13 +55,14 @@ flowchart LR
 ### 1a. Prerequisites (your Cloudflare account)
 
 1. **R2** enabled on the account.
-2. **Two buckets** (recommended):
-   - `clawql-team-vault` — memory notes (`Memory/`, `sources/`, …)
-   - `clawql-pulumi-state` — Pulumi stack state (optional but preferred per ADR 0007)
-3. **R2 API token** with Object Read & Write on those buckets.
-4. **Cloudflare API token** for Pulumi with **R2 Edit** (and account read) — used only at provision time, not stored in git.
+2. **R2 S3 API token** — prefer **Admin Read & Write** so `clawql sync ensure` can create
+   `clawql-team-vault` for you. Object Read & Write alone is enough after the bucket exists.
+3. Optional: **Cloudflare API token** with **Workers R2 Storage Write** — alternate path for
+   `sync ensure` / Pulumi when S3 keys cannot CreateBucket.
+4. Optional second bucket `clawql-pulumi-state` for Pulumi stack state (ADR 0007).
 
 Create R2 S3 credentials in: Cloudflare Dashboard → R2 → Manage R2 API tokens.
+Day-one without Pulumi: set Cursor Secrets → run Cloud Agent install → `clawql sync ensure`.
 
 ### 1b. Pulumi state backend (one-time, your laptop or Cloud Agent)
 

--- a/docs/getting-started/agent-setup.md
+++ b/docs/getting-started/agent-setup.md
@@ -130,18 +130,18 @@ clawql sync push   # seed Memory/ from an existing ~/.ClawQL
 
 Add these under **Cursor → Settings → Cloud → Secrets** (or your team's secret store). They are injected into every Cloud Agent run for the repo.
 
-| Secret                           | Purpose                                           |
-| -------------------------------- | ------------------------------------------------- |
-| `CLAWQL_HOME`                    | Vault root on the VM, e.g. `/home/ubuntu/.ClawQL` |
-| `CLAWQL_R2_ACCOUNT_ID`           | Cloudflare account id (R2 endpoint)               |
-| `CLAWQL_SYNC_ACCESS_KEY_ID`      | R2 S3 API access key (Admin Read & Write to auto-create bucket) |
-| `CLAWQL_SYNC_SECRET_ACCESS_KEY`  | R2 S3 API secret                                  |
+| Secret                           | Purpose                                                            |
+| -------------------------------- | ------------------------------------------------------------------ |
+| `CLAWQL_HOME`                    | Vault root on the VM, e.g. `/home/ubuntu/.ClawQL`                  |
+| `CLAWQL_R2_ACCOUNT_ID`           | Cloudflare account id (R2 endpoint)                                |
+| `CLAWQL_SYNC_ACCESS_KEY_ID`      | R2 S3 API access key (Admin Read & Write to auto-create bucket)    |
+| `CLAWQL_SYNC_SECRET_ACCESS_KEY`  | R2 S3 API secret                                                   |
 | `CLOUDFLARE_API_TOKEN`           | Optional — Workers R2 Storage Write if S3 keys cannot CreateBucket |
-| `CLAWQL_SYNC_BUCKET`             | Optional — default `clawql-team-vault` via `sync ensure` |
-| `CLAWQL_SYNC_PREFIX`             | Optional — default `teams/shared/`                |
-| `CLAWQL_SYNC_AUTO`               | `1` — debounced push after **`memory_ingest`**    |
-| `CLAWQL_SYNC_AUTO_PULL`          | `1` — throttled pull before **`memory_recall`**   |
-| `CLAWQL_SYNC_AUTO_PULL_ON_START` | `1` — pull once when MCP starts                   |
+| `CLAWQL_SYNC_BUCKET`             | Optional — default `clawql-team-vault` via `sync ensure`           |
+| `CLAWQL_SYNC_PREFIX`             | Optional — default `teams/shared/`                                 |
+| `CLAWQL_SYNC_AUTO`               | `1` — debounced push after **`memory_ingest`**                     |
+| `CLAWQL_SYNC_AUTO_PULL`          | `1` — throttled pull before **`memory_recall`**                    |
+| `CLAWQL_SYNC_AUTO_PULL_ON_START` | `1` — pull once when MCP starts                                    |
 
 For **S3** or **GCS**, use the credential variables from [For teams — Environment](./getting-started-for-teams.md#environment) instead of R2 keys.
 

--- a/docs/getting-started/agent-setup.md
+++ b/docs/getting-started/agent-setup.md
@@ -134,10 +134,11 @@ Add these under **Cursor → Settings → Cloud → Secrets** (or your team's se
 | -------------------------------- | ------------------------------------------------- |
 | `CLAWQL_HOME`                    | Vault root on the VM, e.g. `/home/ubuntu/.ClawQL` |
 | `CLAWQL_R2_ACCOUNT_ID`           | Cloudflare account id (R2 endpoint)               |
-| `CLAWQL_SYNC_BUCKET`             | Team bucket name                                  |
-| `CLAWQL_SYNC_PREFIX`             | Shared prefix, e.g. `teams/engineering/`          |
-| `CLAWQL_SYNC_ACCESS_KEY_ID`      | R2 S3 API access key                              |
+| `CLAWQL_SYNC_ACCESS_KEY_ID`      | R2 S3 API access key (Admin Read & Write to auto-create bucket) |
 | `CLAWQL_SYNC_SECRET_ACCESS_KEY`  | R2 S3 API secret                                  |
+| `CLOUDFLARE_API_TOKEN`           | Optional — Workers R2 Storage Write if S3 keys cannot CreateBucket |
+| `CLAWQL_SYNC_BUCKET`             | Optional — default `clawql-team-vault` via `sync ensure` |
+| `CLAWQL_SYNC_PREFIX`             | Optional — default `teams/shared/`                |
 | `CLAWQL_SYNC_AUTO`               | `1` — debounced push after **`memory_ingest`**    |
 | `CLAWQL_SYNC_AUTO_PULL`          | `1` — throttled pull before **`memory_recall`**   |
 | `CLAWQL_SYNC_AUTO_PULL_ON_START` | `1` — pull once when MCP starts                   |

--- a/docs/getting-started/getting-started-for-teams.md
+++ b/docs/getting-started/getting-started-for-teams.md
@@ -77,20 +77,23 @@ Share **`~/.ClawQL`** memory notes across your team via a centralized object-sto
 
 ### Quick start (R2)
 
-1. Create an R2 bucket in Cloudflare (e.g. `acme-clawql-team`).
-2. Create **R2 S3 API credentials** (Manage R2 API tokens → Create API token with Object Read & Write).
-3. Configure sync:
+1. Create **R2 S3 API credentials** (Manage R2 API tokens → Create API token).
+   Prefer **Admin Read & Write** so ClawQL can create the bucket for you.
+   Object Read & Write alone can sync an existing bucket but cannot create one.
+2. Ensure the bucket (ClawQL declares a default name if you skip `--bucket`):
 
 ```bash
-clawql sync init --interactive
-# provider: r2 (default)
-# bucket: acme-clawql-team
-# prefix: teams/engineering/
-
 export CLAWQL_R2_ACCOUNT_ID="<cloudflare-account-id>"
 export CLAWQL_SYNC_ACCESS_KEY_ID="<r2-access-key>"
 export CLAWQL_SYNC_SECRET_ACCESS_KEY="<r2-secret>"
+
+# Creates clawql-team-vault (if missing) + writes ~/.ClawQL/sync.json
+clawql sync ensure
+# optional: --bucket acme-clawql-team --prefix teams/engineering/
 ```
+
+Alternative create path (when S3 keys are Object-only): set `CLOUDFLARE_API_TOKEN` with
+**Workers R2 Storage Write**, then `clawql sync ensure` uses the Cloudflare REST API.
 
 Or store credentials in the local vault (loaded at MCP/CLI startup):
 
@@ -98,33 +101,43 @@ Or store credentials in the local vault (loaded at MCP/CLI startup):
 clawql secrets set r2AccessKeyId
 clawql secrets set r2SecretAccessKey
 clawql secrets set cloudflareAccountId
+# optional for ensure via REST: clawql secrets set cloudflare
+clawql sync ensure
 ```
 
-4. Push your notes:
+3. Push your notes:
 
 ```bash
 clawql sync push
 ```
 
-5. Teammates pull:
+4. Teammates pull (same bucket/prefix; they do not need CreateBucket):
 
 ```bash
-clawql sync init --bucket acme-clawql-team --prefix teams/engineering/
+clawql sync init --bucket clawql-team-vault --prefix teams/shared/
 clawql sync pull
 clawql doctor
 ```
 
 ### Quick start (S3)
 
-1. Create an S3 bucket (e.g. `acme-clawql-team`) and an IAM user with `s3:GetObject`, `s3:PutObject`, `s3:ListBucket` on that bucket.
-2. Configure sync:
+1. Use an IAM user/role with `s3:CreateBucket` (first run) plus `s3:GetObject`,
+   `s3:PutObject`, `s3:ListBucket` on the team vault bucket.
+2. Let ClawQL create the bucket + write sync config:
 
 ```bash
-clawql sync init --provider s3 --bucket acme-clawql-team --prefix teams/engineering/
-
 export CLAWQL_AWS_ACCESS_KEY_ID="<iam-access-key>"
 export CLAWQL_AWS_SECRET_ACCESS_KEY="<iam-secret>"
 export CLAWQL_AWS_REGION="us-east-1"   # or CLAWQL_SYNC_REGION
+
+clawql sync ensure --provider s3
+# optional: --bucket acme-clawql-team --prefix teams/engineering/
+```
+
+Or point at a pre-created bucket:
+
+```bash
+clawql sync init --provider s3 --bucket acme-clawql-team --prefix teams/engineering/
 ```
 
 Or store credentials in the local vault:
@@ -180,7 +193,8 @@ clawql doctor
 
 | Command              | Purpose                                                                |
 | -------------------- | ---------------------------------------------------------------------- |
-| `clawql sync init`   | Write `~/.ClawQL/sync.json` (no secrets)                               |
+| `clawql sync ensure` | Create R2/S3 bucket if missing, then write `sync.json`                |
+| `clawql sync init`   | Write `~/.ClawQL/sync.json` only (no secrets; no bucket create)        |
 | `clawql sync push`   | Upload changed local files + update remote manifest                    |
 | `clawql sync pull`   | Download changed remote files                                          |
 | `clawql sync status` | Compare local vs remote (conflicts listed)                             |

--- a/docs/getting-started/getting-started-for-teams.md
+++ b/docs/getting-started/getting-started-for-teams.md
@@ -193,7 +193,7 @@ clawql doctor
 
 | Command              | Purpose                                                                |
 | -------------------- | ---------------------------------------------------------------------- |
-| `clawql sync ensure` | Create R2/S3 bucket if missing, then write `sync.json`                |
+| `clawql sync ensure` | Create R2/S3 bucket if missing, then write `sync.json`                 |
 | `clawql sync init`   | Write `~/.ClawQL/sync.json` only (no secrets; no bucket create)        |
 | `clawql sync push`   | Upload changed local files + update remote manifest                    |
 | `clawql sync pull`   | Download changed remote files                                          |

--- a/src/home-sync/ensure-bucket.test.ts
+++ b/src/home-sync/ensure-bucket.test.ts
@@ -1,0 +1,182 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_SYNC_BUCKET,
+  DEFAULT_SYNC_PREFIX,
+  defaultEnsureBucketName,
+  defaultEnsurePrefix,
+  ensureR2BucketViaCloudflareApi,
+  ensureSyncBucket,
+} from "./ensure-bucket.js";
+
+describe("defaultEnsureBucketName / prefix", () => {
+  afterEach(() => {
+    delete process.env.CLAWQL_SYNC_BUCKET;
+    delete process.env.CLAWQL_SYNC_PREFIX;
+  });
+
+  it("defaults to clawql-team-vault and teams/shared/", () => {
+    expect(defaultEnsureBucketName("r2")).toBe(DEFAULT_SYNC_BUCKET);
+    expect(defaultEnsurePrefix()).toBe(DEFAULT_SYNC_PREFIX);
+  });
+
+  it("honors CLAWQL_SYNC_BUCKET env", () => {
+    process.env.CLAWQL_SYNC_BUCKET = "Acme_ClawQL_Team";
+    expect(defaultEnsureBucketName("r2")).toBe("acme-clawql-team");
+  });
+});
+
+describe("ensureR2BucketViaCloudflareApi", () => {
+  it("returns already-exists when GET is ok", async () => {
+    const fetchFn = vi.fn(async () => new Response("{}", { status: 200 }));
+    const result = await ensureR2BucketViaCloudflareApi({
+      accountId: "acct",
+      token: "tok",
+      bucket: "clawql-team-vault",
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    expect(result).toEqual({ created: false, method: "already-exists" });
+    expect(fetchFn).toHaveBeenCalledOnce();
+  });
+
+  it("creates via POST when GET is 404", async () => {
+    const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
+      if ((init?.method ?? "GET") === "GET") {
+        return new Response("missing", { status: 404 });
+      }
+      expect(url).toContain("/r2/buckets");
+      expect(init?.method).toBe("POST");
+      const body = JSON.parse(String(init?.body));
+      expect(body.name).toBe("clawql-team-vault");
+      expect(body.locationHint).toBe("weur");
+      return new Response("{}", { status: 200 });
+    });
+    const result = await ensureR2BucketViaCloudflareApi({
+      accountId: "acct",
+      token: "tok",
+      bucket: "clawql-team-vault",
+      locationHint: "weur",
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    expect(result).toEqual({ created: true, method: "cloudflare-api" });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("dry-run skips POST", async () => {
+    const fetchFn = vi.fn(async () => new Response("missing", { status: 404 }));
+    const result = await ensureR2BucketViaCloudflareApi({
+      accountId: "acct",
+      token: "tok",
+      bucket: "clawql-team-vault",
+      dryRun: true,
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    expect(result).toEqual({ created: true, method: "cloudflare-api" });
+    expect(fetchFn).toHaveBeenCalledOnce();
+  });
+});
+
+describe("ensureSyncBucket", () => {
+  let home: string;
+  const prevEnv: Record<string, string | undefined> = {};
+
+  afterEach(async () => {
+    if (home) await rm(home, { recursive: true, force: true });
+    for (const [k, v] of Object.entries(prevEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  function stubEnv(map: Record<string, string>) {
+    for (const [k, v] of Object.entries(map)) {
+      if (!(k in prevEnv)) prevEnv[k] = process.env[k];
+      process.env[k] = v;
+    }
+  }
+
+  it("creates R2 bucket via Cloudflare API and writes sync.json", async () => {
+    home = await mkdtemp(join(tmpdir(), "clawql-ensure-"));
+    stubEnv({
+      CLAWQL_HOME: home,
+      CLAWQL_R2_ACCOUNT_ID: "acct123",
+      CLOUDFLARE_API_TOKEN: "cf-tok",
+    });
+    delete process.env.CLAWQL_SYNC_ACCESS_KEY_ID;
+    delete process.env.CLAWQL_SYNC_SECRET_ACCESS_KEY;
+    delete process.env.R2_ACCESS_KEY_ID;
+    delete process.env.R2_SECRET_ACCESS_KEY;
+
+    const fetchFn = vi.fn(async (_url: string, init?: RequestInit) => {
+      if ((init?.method ?? "GET") === "GET") return new Response("no", { status: 404 });
+      return new Response("{}", { status: 200 });
+    });
+
+    const result = await ensureSyncBucket({
+      home,
+      provider: "r2",
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+
+    expect(result.created).toBe(true);
+    expect(result.method).toBe("cloudflare-api");
+    expect(result.bucket).toBe(DEFAULT_SYNC_BUCKET);
+    expect(result.prefix).toBe(DEFAULT_SYNC_PREFIX);
+
+    const raw = await readFile(join(home, "sync.json"), "utf8");
+    const cfg = JSON.parse(raw) as { bucket: string; provider: string; prefix: string; version: number };
+    expect(cfg).toMatchObject({
+      version: 1,
+      provider: "r2",
+      bucket: DEFAULT_SYNC_BUCKET,
+      prefix: DEFAULT_SYNC_PREFIX,
+    });
+  });
+
+  it("uses S3 CreateBucket when HeadBucket is not found", async () => {
+    home = await mkdtemp(join(tmpdir(), "clawql-ensure-s3-"));
+    stubEnv({
+      CLAWQL_HOME: home,
+      CLAWQL_AWS_ACCESS_KEY_ID: "AKIA",
+      CLAWQL_AWS_SECRET_ACCESS_KEY: "secret",
+      CLAWQL_AWS_REGION: "us-east-1",
+    });
+
+    const send = vi.fn(async (cmd: { constructor: { name: string } }) => {
+      const name = cmd.constructor.name;
+      if (name === "HeadBucketCommand") {
+        const err = new Error("Not Found") as Error & {
+          name: string;
+          $metadata: { httpStatusCode: number };
+        };
+        err.name = "NotFound";
+        err.$metadata = { httpStatusCode: 404 };
+        throw err;
+      }
+      if (name === "CreateBucketCommand") return {};
+      throw new Error(`unexpected ${name}`);
+    });
+
+    const result = await ensureSyncBucket({
+      home,
+      provider: "s3",
+      bucket: "my-team-vault",
+      prefix: "teams/eng/",
+      createS3Client: () => ({ send }),
+    });
+
+    expect(result.created).toBe(true);
+    expect(result.method).toBe("s3-api");
+    expect(result.bucket).toBe("my-team-vault");
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects gcs with a clear error", async () => {
+    home = await mkdtemp(join(tmpdir(), "clawql-ensure-gcs-"));
+    await expect(ensureSyncBucket({ home, provider: "gcs" })).rejects.toThrow(
+      /GCS bucket auto-create/
+    );
+  });
+});

--- a/src/home-sync/ensure-bucket.test.ts
+++ b/src/home-sync/ensure-bucket.test.ts
@@ -126,7 +126,12 @@ describe("ensureSyncBucket", () => {
     expect(result.prefix).toBe(DEFAULT_SYNC_PREFIX);
 
     const raw = await readFile(join(home, "sync.json"), "utf8");
-    const cfg = JSON.parse(raw) as { bucket: string; provider: string; prefix: string; version: number };
+    const cfg = JSON.parse(raw) as {
+      bucket: string;
+      provider: string;
+      prefix: string;
+      version: number;
+    };
     expect(cfg).toMatchObject({
       version: 1,
       provider: "r2",

--- a/src/home-sync/ensure-bucket.ts
+++ b/src/home-sync/ensure-bucket.ts
@@ -202,8 +202,10 @@ async function headOrCreateViaS3(opts: {
   }
 
   try {
-    const input: { Bucket: string; CreateBucketConfiguration?: { LocationConstraint: BucketLocationConstraint } } =
-      { Bucket: bucket };
+    const input: {
+      Bucket: string;
+      CreateBucketConfiguration?: { LocationConstraint: BucketLocationConstraint };
+    } = { Bucket: bucket };
     if (provider === "s3" && region && region !== "us-east-1") {
       input.CreateBucketConfiguration = {
         LocationConstraint: region as BucketLocationConstraint,
@@ -290,11 +292,11 @@ function gcsEnsureError(): Error {
 /**
  * Ensure the team vault bucket exists and write `$CLAWQL_HOME/sync.json`.
  */
-export async function ensureSyncBucket(opts: EnsureBucketOptions = {}): Promise<EnsureBucketResult> {
+export async function ensureSyncBucket(
+  opts: EnsureBucketOptions = {}
+): Promise<EnsureBucketResult> {
   const home = opts.home;
-  const provider = parseSyncProvider(
-    opts.provider ?? envTrim("CLAWQL_SYNC_PROVIDER") ?? "r2"
-  );
+  const provider = parseSyncProvider(opts.provider ?? envTrim("CLAWQL_SYNC_PROVIDER") ?? "r2");
   if (provider === "gcs") {
     throw gcsEnsureError();
   }
@@ -309,10 +311,12 @@ export async function ensureSyncBucket(opts: EnsureBucketOptions = {}): Promise<
     throw new Error("Bucket name is empty after normalization");
   }
   const prefixRaw = opts.prefix ?? existing?.prefix ?? defaultEnsurePrefix();
-  const prefix = prefixRaw.endsWith("/") || !prefixRaw ? prefixRaw || DEFAULT_SYNC_PREFIX : `${prefixRaw}/`;
+  const prefix =
+    prefixRaw.endsWith("/") || !prefixRaw ? prefixRaw || DEFAULT_SYNC_PREFIX : `${prefixRaw}/`;
   const dryRun = Boolean(opts.dryRun);
   const configPath = getSyncConfigPath(home);
-  const location = opts.location?.trim() || envTrim("CLAWQL_SYNC_LOCATION") || DEFAULT_R2_LOCATION_HINT;
+  const location =
+    opts.location?.trim() || envTrim("CLAWQL_SYNC_LOCATION") || DEFAULT_R2_LOCATION_HINT;
 
   let created = false;
   let method: EnsureBucketMethod = "config-only";

--- a/src/home-sync/ensure-bucket.ts
+++ b/src/home-sync/ensure-bucket.ts
@@ -1,0 +1,398 @@
+/**
+ * Idempotent team-vault bucket ensure for clawql sync.
+ *
+ * R2: HeadBucket / CreateBucket via S3 API when keys allow; else Cloudflare
+ * REST API (`CLOUDFLARE_API_TOKEN`) with Workers R2 Storage Write.
+ * S3: HeadBucket / CreateBucket via AWS SDK when IAM allows CreateBucket.
+ * GCS: not auto-created (HMAC keys typically cannot create buckets).
+ */
+
+import {
+  CreateBucketCommand,
+  HeadBucketCommand,
+  S3Client,
+  type BucketLocationConstraint,
+  type S3ClientConfig,
+} from "@aws-sdk/client-s3";
+import { readLocalProvidersVault } from "../provider-vault/local-store.js";
+import { getLocalProvidersVaultPath } from "../onboarding/paths.js";
+import {
+  parseSyncProvider,
+  resolveHomeSyncConfig,
+  resolveSyncCredentials,
+  resolveSyncEndpoint,
+  writeSyncConfigFile,
+  readSyncConfigFile,
+} from "./config.js";
+import { getSyncConfigPath } from "./paths.js";
+import { syncProviderProfile } from "./providers.js";
+import type { HomeSyncConfigFile, SyncProvider } from "./types.js";
+
+export const DEFAULT_SYNC_BUCKET = "clawql-team-vault";
+export const DEFAULT_SYNC_PREFIX = "teams/shared/";
+export const DEFAULT_R2_LOCATION_HINT = "weur";
+
+export type EnsureBucketMethod = "already-exists" | "s3-api" | "cloudflare-api" | "config-only";
+
+export type EnsureBucketResult = {
+  provider: SyncProvider;
+  bucket: string;
+  prefix: string;
+  created: boolean;
+  method: EnsureBucketMethod;
+  dryRun: boolean;
+  configPath: string;
+};
+
+export type EnsureBucketOptions = {
+  home?: string;
+  provider?: SyncProvider;
+  bucket?: string;
+  prefix?: string;
+  /** R2 locationHint (e.g. weur). Ignored for S3 except via region. */
+  location?: string;
+  dryRun?: boolean;
+  /** Skip writing sync.json (tests / probe). */
+  skipWriteConfig?: boolean;
+  fetchFn?: typeof fetch;
+  createS3Client?: (config: S3ClientConfig) => {
+    send: (command: unknown) => Promise<unknown>;
+  };
+};
+
+function envTrim(key: string): string | undefined {
+  const v = process.env[key]?.trim();
+  return v || undefined;
+}
+
+function normalizeBucketName(raw: string): string {
+  return raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 63);
+}
+
+export function defaultEnsureBucketName(provider: SyncProvider): string {
+  const fromEnv = envTrim("CLAWQL_SYNC_BUCKET");
+  if (fromEnv) return normalizeBucketName(fromEnv);
+  if (provider === "s3") return DEFAULT_SYNC_BUCKET;
+  return DEFAULT_SYNC_BUCKET;
+}
+
+export function defaultEnsurePrefix(): string {
+  return envTrim("CLAWQL_SYNC_PREFIX") ?? DEFAULT_SYNC_PREFIX;
+}
+
+async function vaultData(home?: string): Promise<Record<string, string>> {
+  const vault = await readLocalProvidersVault(getLocalProvidersVaultPath(home));
+  return vault?.data ?? {};
+}
+
+export async function resolveCloudflareApiToken(home?: string): Promise<string | undefined> {
+  return (
+    envTrim("CLAWQL_CLOUDFLARE_API_TOKEN") ??
+    envTrim("CLOUDFLARE_API_TOKEN") ??
+    (await vaultData(home)).cloudflareApiToken
+  );
+}
+
+export async function resolveR2AccountId(home?: string): Promise<string | undefined> {
+  const vault = await vaultData(home);
+  return (
+    envTrim("CLAWQL_R2_ACCOUNT_ID") ??
+    envTrim("CLAWQL_CLOUDFLARE_ACCOUNT_ID") ??
+    envTrim("CLOUDFLARE_ACCOUNT_ID") ??
+    vault.cloudflareAccountId
+  );
+}
+
+function isNotFoundError(e: unknown): boolean {
+  const err = e as {
+    name?: string;
+    Code?: string;
+    $metadata?: { httpStatusCode?: number };
+    message?: string;
+  };
+  const status = err.$metadata?.httpStatusCode;
+  if (status === 404 || status === 403) {
+    // 403 on HeadBucket often means "no such bucket" for S3 (privacy).
+    // Treat 403 as "try create" only when name looks like missing-bucket paths;
+    // for HeadBucket, AWS returns 404 or 403 for missing — we try create next.
+  }
+  if (status === 404) return true;
+  const name = err.name ?? err.Code ?? "";
+  if (
+    name === "NotFound" ||
+    name === "NoSuchBucket" ||
+    name === "NotFoundException" ||
+    name === "404"
+  ) {
+    return true;
+  }
+  // AWS HeadBucket missing → 404 or 403 Forbidden
+  if (status === 403 && /HeadBucket|Not Found|NoSuchBucket/i.test(String(err.message ?? name))) {
+    return true;
+  }
+  if (status === 403) return true;
+  return false;
+}
+
+function isBucketAlreadyOwnedError(e: unknown): boolean {
+  const err = e as { name?: string; Code?: string; $metadata?: { httpStatusCode?: number } };
+  const name = err.name ?? err.Code ?? "";
+  return (
+    name === "BucketAlreadyOwnedByYou" ||
+    name === "BucketAlreadyExists" ||
+    err.$metadata?.httpStatusCode === 409
+  );
+}
+
+type S3Like = { send: (command: unknown) => Promise<unknown> };
+
+function buildS3ClientForEnsure(
+  provider: SyncProvider,
+  bucketHint: string,
+  home: string | undefined,
+  createS3Client: EnsureBucketOptions["createS3Client"]
+): { client: S3Like; region: string } {
+  const resolved = resolveHomeSyncConfig(
+    { version: 1, provider, bucket: bucketHint },
+    home ?? process.env.CLAWQL_HOME ?? "/tmp/.ClawQL"
+  );
+  const creds = resolveSyncCredentials(resolved);
+  const endpoint = resolveSyncEndpoint(resolved);
+  const profile = syncProviderProfile(provider);
+  const region = resolved.region ?? profile.defaultRegion ?? "us-east-1";
+  const clientConfig: S3ClientConfig = {
+    credentials: creds,
+    region,
+  };
+  if (endpoint) {
+    clientConfig.endpoint = endpoint;
+    clientConfig.forcePathStyle = profile.forcePathStyle;
+  }
+  const client = createS3Client
+    ? createS3Client(clientConfig)
+    : (new S3Client(clientConfig) as unknown as S3Like);
+  return { client, region };
+}
+
+async function headOrCreateViaS3(opts: {
+  client: S3Like;
+  bucket: string;
+  region: string;
+  provider: SyncProvider;
+  dryRun: boolean;
+}): Promise<{ created: boolean; method: EnsureBucketMethod } | null> {
+  const { client, bucket, region, provider, dryRun } = opts;
+  try {
+    await client.send(new HeadBucketCommand({ Bucket: bucket }));
+    return { created: false, method: "already-exists" };
+  } catch (e) {
+    if (!isNotFoundError(e)) {
+      // Credentials may lack HeadBucket — fall through to other methods.
+      return null;
+    }
+  }
+
+  if (dryRun) {
+    return { created: true, method: "s3-api" };
+  }
+
+  try {
+    const input: { Bucket: string; CreateBucketConfiguration?: { LocationConstraint: BucketLocationConstraint } } =
+      { Bucket: bucket };
+    if (provider === "s3" && region && region !== "us-east-1") {
+      input.CreateBucketConfiguration = {
+        LocationConstraint: region as BucketLocationConstraint,
+      };
+    }
+    await client.send(new CreateBucketCommand(input));
+    return { created: true, method: "s3-api" };
+  } catch (e) {
+    if (isBucketAlreadyOwnedError(e)) {
+      return { created: false, method: "already-exists" };
+    }
+    return null;
+  }
+}
+
+type CloudflareApiResult = { created: boolean; method: EnsureBucketMethod };
+
+export async function ensureR2BucketViaCloudflareApi(opts: {
+  accountId: string;
+  token: string;
+  bucket: string;
+  locationHint?: string;
+  dryRun?: boolean;
+  fetchFn?: typeof fetch;
+}): Promise<CloudflareApiResult> {
+  const fetchFn = opts.fetchFn ?? fetch;
+  const base = `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(opts.accountId)}/r2/buckets`;
+  const headers = {
+    Authorization: `Bearer ${opts.token}`,
+    "Content-Type": "application/json",
+  };
+
+  const getRes = await fetchFn(`${base}/${encodeURIComponent(opts.bucket)}`, {
+    method: "GET",
+    headers,
+  });
+  if (getRes.ok) {
+    return { created: false, method: "already-exists" };
+  }
+  if (getRes.status !== 404 && getRes.status !== 400) {
+    const body = await getRes.text().catch(() => "");
+    throw new Error(
+      `Cloudflare R2 get bucket failed (${getRes.status}): ${body.slice(0, 300) || getRes.statusText}`
+    );
+  }
+
+  if (opts.dryRun) {
+    return { created: true, method: "cloudflare-api" };
+  }
+
+  const payload: Record<string, string> = { name: opts.bucket };
+  if (opts.locationHint?.trim()) {
+    payload.locationHint = opts.locationHint.trim().toLowerCase();
+  }
+
+  const createRes = await fetchFn(base, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+  });
+  if (createRes.ok || createRes.status === 409) {
+    return {
+      created: createRes.status !== 409,
+      method: createRes.status === 409 ? "already-exists" : "cloudflare-api",
+    };
+  }
+  const body = await createRes.text().catch(() => "");
+  // Already exists sometimes returns 400 with specific errors
+  if (/already exists|10004|conflict/i.test(body)) {
+    return { created: false, method: "already-exists" };
+  }
+  throw new Error(
+    `Cloudflare R2 create bucket failed (${createRes.status}): ${body.slice(0, 400) || createRes.statusText}`
+  );
+}
+
+function gcsEnsureError(): Error {
+  return new Error(
+    "GCS bucket auto-create is not supported (HMAC keys cannot create buckets). " +
+      "Create the bucket in GCP Console, then run: clawql sync init --provider gcs --bucket <name>"
+  );
+}
+
+/**
+ * Ensure the team vault bucket exists and write `$CLAWQL_HOME/sync.json`.
+ */
+export async function ensureSyncBucket(opts: EnsureBucketOptions = {}): Promise<EnsureBucketResult> {
+  const home = opts.home;
+  const provider = parseSyncProvider(
+    opts.provider ?? envTrim("CLAWQL_SYNC_PROVIDER") ?? "r2"
+  );
+  if (provider === "gcs") {
+    throw gcsEnsureError();
+  }
+
+  const existing = home
+    ? await readSyncConfigFile(getSyncConfigPath(home))
+    : await readSyncConfigFile();
+  const bucket = normalizeBucketName(
+    opts.bucket?.trim() || existing?.bucket || defaultEnsureBucketName(provider)
+  );
+  if (!bucket) {
+    throw new Error("Bucket name is empty after normalization");
+  }
+  const prefixRaw = opts.prefix ?? existing?.prefix ?? defaultEnsurePrefix();
+  const prefix = prefixRaw.endsWith("/") || !prefixRaw ? prefixRaw || DEFAULT_SYNC_PREFIX : `${prefixRaw}/`;
+  const dryRun = Boolean(opts.dryRun);
+  const configPath = getSyncConfigPath(home);
+  const location = opts.location?.trim() || envTrim("CLAWQL_SYNC_LOCATION") || DEFAULT_R2_LOCATION_HINT;
+
+  let created = false;
+  let method: EnsureBucketMethod = "config-only";
+
+  if (provider === "r2" || provider === "s3") {
+    // 1) Prefer S3-compatible Head/Create when sync (or AWS) keys are present.
+    try {
+      const { client, region } = buildS3ClientForEnsure(
+        provider,
+        bucket,
+        home,
+        opts.createS3Client
+      );
+      const s3Result = await headOrCreateViaS3({
+        client,
+        bucket,
+        region,
+        provider,
+        dryRun,
+      });
+      if (s3Result) {
+        created = s3Result.created;
+        method = s3Result.method;
+      }
+    } catch {
+      // Missing sync credentials — try Cloudflare API for R2 next.
+    }
+
+    if (method === "config-only" && provider === "r2") {
+      const token = await resolveCloudflareApiToken(home);
+      const accountId = await resolveR2AccountId(home);
+      if (!token) {
+        throw new Error(
+          "Cannot ensure R2 bucket — need either (A) R2 S3 API keys with Admin CreateBucket " +
+            "(CLAWQL_SYNC_ACCESS_KEY_ID / CLAWQL_SYNC_SECRET_ACCESS_KEY) that can Head/Create, or " +
+            "(B) CLOUDFLARE_API_TOKEN / CLAWQL_CLOUDFLARE_API_TOKEN with Workers R2 Storage Write, " +
+            "plus CLAWQL_R2_ACCOUNT_ID."
+        );
+      }
+      if (!accountId) {
+        throw new Error(
+          "Cannot ensure R2 bucket — set CLAWQL_R2_ACCOUNT_ID (Cloudflare account id)."
+        );
+      }
+      const cf = await ensureR2BucketViaCloudflareApi({
+        accountId,
+        token,
+        bucket,
+        locationHint: location,
+        dryRun,
+        fetchFn: opts.fetchFn,
+      });
+      created = cf.created;
+      method = cf.method;
+    } else if (method === "config-only" && provider === "s3") {
+      throw new Error(
+        "Cannot ensure S3 bucket — set CLAWQL_AWS_ACCESS_KEY_ID / CLAWQL_AWS_SECRET_ACCESS_KEY " +
+          "(or CLAWQL_SYNC_*) with s3:CreateBucket + s3:ListBucket (HeadBucket), " +
+          "plus CLAWQL_AWS_REGION or CLAWQL_SYNC_REGION."
+      );
+    }
+  }
+
+  if (!opts.skipWriteConfig && !dryRun) {
+    const config: HomeSyncConfigFile = {
+      version: 1,
+      provider,
+      bucket,
+      prefix,
+    };
+    await writeSyncConfigFile(config, configPath);
+  }
+
+  return {
+    provider,
+    bucket,
+    prefix,
+    created,
+    method,
+    dryRun,
+    configPath,
+  };
+}

--- a/src/onboarding/cli.ts
+++ b/src/onboarding/cli.ts
@@ -23,7 +23,13 @@ import {
   runReleasePublish,
   runReleaseVerify,
 } from "./release-cli.js";
-import { runSyncInit, runSyncPullCmd, runSyncPushCmd, runSyncStatusCmd } from "./sync-cli.js";
+import {
+  runSyncEnsure,
+  runSyncInit,
+  runSyncPullCmd,
+  runSyncPushCmd,
+  runSyncStatusCmd,
+} from "./sync-cli.js";
 import {
   runSandboxEditCmd,
   runSandboxInitCmd,
@@ -177,6 +183,7 @@ function parse(argv: string[]): {
     else if (a === "--provider") flags.provider = argv[++i] ?? "";
     else if (a === "--bucket") flags.bucket = argv[++i] ?? "";
     else if (a === "--prefix") flags.prefix = argv[++i] ?? "";
+    else if (a === "--location") flags.location = argv[++i] ?? "";
     else if (a === "--path") flags.path = argv[++i] ?? "";
     else if (a === "--harness") flags.harness = argv[++i] ?? "";
     else if (a === "--port") flags.port = argv[++i] ?? "";
@@ -323,7 +330,7 @@ Usage:
   clawql release init | collect | manifest | publish | verify <path>
   clawql ontology lint [--dir PATH] [files...] | generate --out DIR [--dir PATH]
   clawql ontology init | create-entity <Name> | import --pack legal
-  clawql sync init | push | pull | status [--dry-run] [--force]
+  clawql sync init | ensure | push | pull | status [--dry-run] [--force]
   clawql sandbox init | verify | status | edit --harness claude [--path DIR] [--skip-verify]
   clawql inference serve [--port 8080] | complete --model <provider/model> --message <text>
   clawql inference logs [--model M] [--since 24h] [--limit 50] | trace --correlation-id <id> | spend [--group-by model]
@@ -398,6 +405,9 @@ secrets:
 
 sync (team shared memory — R2 default):
   init            Write ~/.ClawQL/sync.json (bucket + prefix; credentials via env/vault)
+  ensure          Create bucket if missing (R2/S3), then write sync.json
+                  R2: S3 Admin keys and/or CLOUDFLARE_API_TOKEN + CLAWQL_R2_ACCOUNT_ID
+                  Default bucket: clawql-team-vault  prefix: teams/shared/
   push            Upload Memory/, sources/, chats/ to the team bucket
   pull            Download team notes to this machine
   status          Compare local vs remote manifest
@@ -609,6 +619,22 @@ async function main(): Promise<void> {
       });
       return;
     }
+    if (subcmd === "ensure") {
+      process.exitCode = await runSyncEnsure({
+        home,
+        interactive: Boolean(flags.interactive),
+        yes: Boolean(flags.yes),
+        dryRun: Boolean(flags.dryRun),
+        provider:
+          typeof flags.provider === "string" && flags.provider
+            ? (flags.provider as "r2" | "s3" | "gcs")
+            : undefined,
+        bucket: typeof flags.bucket === "string" ? flags.bucket : undefined,
+        prefix: typeof flags.prefix === "string" ? flags.prefix : undefined,
+        location: typeof flags.location === "string" ? flags.location : undefined,
+      });
+      return;
+    }
     if (subcmd === "push") {
       process.exitCode = await runSyncPushCmd({
         dryRun: Boolean(flags.dryRun),
@@ -627,7 +653,7 @@ async function main(): Promise<void> {
       process.exitCode = await runSyncStatusCmd();
       return;
     }
-    console.error("Usage: clawql sync init | push | pull | status");
+    console.error("Usage: clawql sync init | ensure | push | pull | status");
     process.exitCode = 1;
     return;
   }

--- a/src/onboarding/sync-cli.ts
+++ b/src/onboarding/sync-cli.ts
@@ -150,8 +150,14 @@ export async function runSyncEnsure(opts: SyncEnsureOptions): Promise<number> {
   if (opts.interactive) {
     const p = await prompt("Provider (r2|s3)", provider);
     provider = parseSyncProvider(p || provider);
-    bucket = await prompt(`Bucket name (default ${DEFAULT_SYNC_BUCKET})`, bucket || DEFAULT_SYNC_BUCKET);
-    prefix = await prompt(`Team prefix (default ${DEFAULT_SYNC_PREFIX})`, prefix || DEFAULT_SYNC_PREFIX);
+    bucket = await prompt(
+      `Bucket name (default ${DEFAULT_SYNC_BUCKET})`,
+      bucket || DEFAULT_SYNC_BUCKET
+    );
+    prefix = await prompt(
+      `Team prefix (default ${DEFAULT_SYNC_PREFIX})`,
+      prefix || DEFAULT_SYNC_PREFIX
+    );
     if (provider === "r2") {
       location = await prompt("R2 location hint (e.g. weur)", location || "weur");
     }

--- a/src/onboarding/sync-cli.ts
+++ b/src/onboarding/sync-cli.ts
@@ -6,6 +6,11 @@ import {
   writeSyncConfigFile,
   readSyncConfigFile,
 } from "../home-sync/config.js";
+import {
+  DEFAULT_SYNC_BUCKET,
+  DEFAULT_SYNC_PREFIX,
+  ensureSyncBucket,
+} from "../home-sync/ensure-bucket.js";
 import { getClawqlHome } from "./paths.js";
 import type { HomeSyncConfigFile, SyncProvider } from "../home-sync/types.js";
 import {
@@ -117,6 +122,65 @@ export async function runSyncStatusCmd(): Promise<number> {
   try {
     const status = await runSyncStatus();
     console.log(formatSyncStatus(status));
+    return 0;
+  } catch (e) {
+    console.error(e instanceof Error ? e.message : e);
+    return 1;
+  }
+}
+
+export type SyncEnsureOptions = {
+  home?: string;
+  interactive?: boolean;
+  provider?: SyncProvider;
+  bucket?: string;
+  prefix?: string;
+  location?: string;
+  dryRun?: boolean;
+  yes?: boolean;
+};
+
+export async function runSyncEnsure(opts: SyncEnsureOptions): Promise<number> {
+  const home = opts.home ?? getClawqlHome();
+  let provider: SyncProvider = opts.provider ?? "r2";
+  let bucket = opts.bucket ?? "";
+  let prefix = opts.prefix ?? "";
+  let location = opts.location ?? "";
+
+  if (opts.interactive) {
+    const p = await prompt("Provider (r2|s3)", provider);
+    provider = parseSyncProvider(p || provider);
+    bucket = await prompt(`Bucket name (default ${DEFAULT_SYNC_BUCKET})`, bucket || DEFAULT_SYNC_BUCKET);
+    prefix = await prompt(`Team prefix (default ${DEFAULT_SYNC_PREFIX})`, prefix || DEFAULT_SYNC_PREFIX);
+    if (provider === "r2") {
+      location = await prompt("R2 location hint (e.g. weur)", location || "weur");
+    }
+  }
+
+  try {
+    const result = await ensureSyncBucket({
+      home,
+      provider,
+      bucket: bucket || undefined,
+      prefix: prefix || undefined,
+      location: location || undefined,
+      dryRun: opts.dryRun,
+    });
+    console.log(opts.dryRun ? "Team sync ensure (dry-run)\n" : "Team sync ensured\n");
+    console.log(`  Config:   ${result.configPath}`);
+    console.log(`  Provider: ${result.provider} — ${syncProviderLabel(result.provider)}`);
+    console.log(`  Bucket:   ${result.bucket}`);
+    console.log(`  Prefix:   ${result.prefix}`);
+    console.log(
+      `  Status:   ${result.created ? "created" : "already exists"} via ${result.method}`
+    );
+    if (!opts.dryRun) {
+      printSyncCredentialHelp(result.provider);
+      console.log("\nNext:");
+      console.log("  clawql sync push    Upload Memory/ + sources to the team bucket");
+      console.log("  clawql sync pull    Download team notes to this machine");
+      console.log("  clawql sync status  Compare local vs remote\n");
+    }
     return 0;
   } catch (e) {
     console.error(e instanceof Error ? e.message : e);

--- a/src/onboarding/sync-credential-help.ts
+++ b/src/onboarding/sync-credential-help.ts
@@ -6,7 +6,9 @@ export function printSyncCredentialHelp(provider: SyncProvider): void {
     console.log("  CLAWQL_R2_ACCOUNT_ID            Cloudflare account id");
     console.log("  CLAWQL_SYNC_ACCESS_KEY_ID       R2 S3 API access key");
     console.log("  CLAWQL_SYNC_SECRET_ACCESS_KEY   R2 S3 API secret");
-    console.log("  CLOUDFLARE_API_TOKEN            Optional — R2 create via REST if S3 keys lack Admin");
+    console.log(
+      "  CLOUDFLARE_API_TOKEN            Optional — R2 create via REST if S3 keys lack Admin"
+    );
     console.log("  Or: r2AccessKeyId / r2SecretAccessKey / cloudflareAccountId in vault");
     return;
   }

--- a/src/onboarding/sync-credential-help.ts
+++ b/src/onboarding/sync-credential-help.ts
@@ -6,6 +6,7 @@ export function printSyncCredentialHelp(provider: SyncProvider): void {
     console.log("  CLAWQL_R2_ACCOUNT_ID            Cloudflare account id");
     console.log("  CLAWQL_SYNC_ACCESS_KEY_ID       R2 S3 API access key");
     console.log("  CLAWQL_SYNC_SECRET_ACCESS_KEY   R2 S3 API secret");
+    console.log("  CLOUDFLARE_API_TOKEN            Optional — R2 create via REST if S3 keys lack Admin");
     console.log("  Or: r2AccessKeyId / r2SecretAccessKey / cloudflareAccountId in vault");
     return;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Day-one Cloud Agent setup no longer requires manually creating an object-storage bucket. `clawql sync ensure` creates the team vault bucket when credentials allow, then writes `~/.ClawQL/sync.json`.

## Behavior

```bash
clawql sync ensure
# defaults: provider=r2, bucket=clawql-team-vault, prefix=teams/shared/
```

| Provider | How create works |
|----------|------------------|
| **R2** | 1) S3 `HeadBucket` / `CreateBucket` with sync keys (needs **Admin Read & Write** R2 token) → 2) fallback Cloudflare REST `r2-create-bucket` with `CLOUDFLARE_API_TOKEN` + `CLAWQL_R2_ACCOUNT_ID` |
| **S3** | AWS SDK `HeadBucket` / `CreateBucket` (`s3:CreateBucket` on first run) |
| **GCS** | Not auto-created (HMAC keys typically cannot create buckets) — clear error |

Cloud Agent install script now calls `sync ensure` when account id + sync keys (or CF API token) are present — `CLAWQL_SYNC_BUCKET` is optional.

## Operator notes

For the “three secrets only” path (`CLAWQL_R2_ACCOUNT_ID` + sync access/secret):

- Use an R2 API token with **Admin Read & Write** so CreateBucket works, **or**
- Also set `CLOUDFLARE_API_TOKEN` with **Workers R2 Storage Write**

Object Read & Write alone can sync after the bucket exists, but cannot create it.

Optional secrets: `CLAWQL_SYNC_BUCKET`, `CLAWQL_SYNC_PREFIX`, auto-pull flags, `OPENROUTER_API_KEY`.

## Tests

- `src/home-sync/ensure-bucket.test.ts` — CF REST + S3 create paths, GCS rejection
- `npx vitest run src/home-sync/` — green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

