### PR TITLE
fix(website): unblock Cloudflare docs deploy (brace-expansion / OpenNext)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -3707,6 +3707,23 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@node-minify/core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@node-minify/core/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/@node-minify/core/node_modules/glob": {
       "version": "9.3.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",

--- a/website/package.json
+++ b/website/package.json
@@ -73,9 +73,8 @@
   "overrides": {
     "@node-minify/core": {
       "minimatch": {
-        "brace-expansion": "5.0.9"
-      },
-      "brace-expansion": "5.0.9"
+        "brace-expansion": "2.1.4"
+      }
     },
     "@babel/core": "7.29.6",
     "@opentelemetry/core": "2.8.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`Deploy docs (Cloudflare)` on main has been failing because the global `brace-expansion@5.0.9` override was forced under `@node-minify/core` → `minimatch@8`, which expects `brace-expansion@^2` with a default ESM export. That broke `opennextjs-cloudflare` and left **docs.clawql.com** on pre-rewrite content after #790.

This pins `brace-expansion@2.1.4` (patched on the 2.x line) only under `@node-minify/core`, while keeping top-level `5.0.9` for minimatch 10+.

## Why
- [clawql.com](https://clawql.com/) already has #790 marketing copy (landing deploy succeeded).
- [docs.clawql.com](https://docs.clawql.com/) still serves the old homepage (docs deploy failed).

## Test plan
- [x] Nested `@node-minify` minimatch ESM import succeeds locally
- [x] Full-repo OSV scan still clean with `osv-scanner.toml`
- [ ] CI green
- [ ] Post-merge: `Deploy docs (Cloudflare)` succeeds and docs homepage shows rewrite lead (“Everything flows through one intelligent gateway…”)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9b5e-4d74-72e6-90bb-d0c2100f09d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9b5e-4d74-72e6-90bb-d0c2100f09d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

