### PR TITLE
fix(mcp-api-adapter): normalize gRPC CallTool content for /mcp

### DIFF
--- a/packages/mcp-api-adapter/CHANGELOG.md
+++ b/packages/mcp-api-adapter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1
+
+- Fix Streamable HTTP `/mcp` when upstream is **gRPC**: normalize protobuf CallTool content oneofs into MCP `{ type: "text", text }` blocks (SDK validation was rejecting raw wire shapes).
+
 ## 0.5.0
 
 - **Streamable HTTP `/mcp`:** re-export the same tools as MCP for IDE/agent clients (`--mcp-path`, `--no-mcp`).

--- a/packages/mcp-api-adapter/package.json
+++ b/packages/mcp-api-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-api-adapter",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Standalone adapter: point at any MCP server and instantly serve OpenAPI + GraphQL + Streamable HTTP /mcp + gRPC, plus gen-cli for a thin tool CLI",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/mcp-api-adapter/src/call.ts
+++ b/packages/mcp-api-adapter/src/call.ts
@@ -39,6 +39,52 @@ export function httpBodyFromCollapsed(result: CollapsedToolResult): unknown {
 }
 
 /**
+ * Convert a collapsed gRPC CallTool result into an MCP SDK-shaped CallToolResult.
+ * gRPC wire content uses protobuf oneofs (`{ text: { text } }`); MCP expects `{ type, text }`.
+ */
+export function mcpCallToolResultFromCollapsed(collapsed: CollapsedToolResult): {
+  content: Array<{ type: "text"; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+} {
+  const content = normalizeMcpTextContent(collapsed);
+  return {
+    content,
+    ...(hasUsefulValues(collapsed.structuredContent)
+      ? { structuredContent: collapsed.structuredContent }
+      : {}),
+    ...(collapsed.isError !== undefined ? { isError: collapsed.isError } : {}),
+  };
+}
+
+function normalizeMcpTextContent(
+  collapsed: CollapsedToolResult
+): Array<{ type: "text"; text: string }> {
+  if (typeof collapsed.text === "string" && collapsed.text.length > 0) {
+    return [{ type: "text", text: collapsed.text }];
+  }
+  const out: Array<{ type: "text"; text: string }> = [];
+  for (const item of collapsed.content ?? []) {
+    if (!item || typeof item !== "object") continue;
+    const o = item as Record<string, unknown>;
+    if (o.type === "text" && typeof o.text === "string") {
+      out.push({ type: "text", text: o.text });
+      continue;
+    }
+    // protobuf-js oneof: { text: { text: "…" }, image: null, … }
+    const nested = o.text;
+    if (nested && typeof nested === "object") {
+      const t = (nested as { text?: unknown }).text;
+      if (typeof t === "string") out.push({ type: "text", text: t });
+    }
+  }
+  if (out.length === 0 && hasUsefulValues(collapsed.structuredContent)) {
+    return [{ type: "text", text: JSON.stringify(collapsed.structuredContent) }];
+  }
+  return out;
+}
+
+/**
  * Normalize an MCP SDK `CallToolResult` (stdio / Streamable HTTP) into the same
  * collapsed shape used for gRPC CallTool responses.
  */

--- a/packages/mcp-api-adapter/src/delegate.ts
+++ b/packages/mcp-api-adapter/src/delegate.ts
@@ -18,7 +18,7 @@ import {
   callToolServerStreamingGrpc,
   listToolsUnaryGrpc,
 } from "mcp-grpc-transport";
-import { collapseCallToolMessages } from "./call.js";
+import { collapseCallToolMessages, mcpCallToolResultFromCollapsed } from "./call.js";
 
 export function wireDelegationHandlers(server: Server, client: Client): void {
   server.setRequestHandler(ListToolsRequestSchema, async () => client.listTools());
@@ -82,20 +82,7 @@ export function wireGrpcDelegationHandlers(
       arguments: (request.params.arguments as Record<string, unknown> | undefined) ?? {},
       protocolVersion: options.protocolVersion,
     });
-    const collapsed = collapseCallToolMessages(messages);
-    const content =
-      Array.isArray(collapsed.content) && collapsed.content.length > 0
-        ? collapsed.content
-        : collapsed.text
-          ? [{ type: "text" as const, text: collapsed.text }]
-          : [];
-    return {
-      content,
-      ...(collapsed.structuredContent
-        ? { structuredContent: collapsed.structuredContent }
-        : {}),
-      ...(collapsed.isError !== undefined ? { isError: collapsed.isError } : {}),
-    };
+    return mcpCallToolResultFromCollapsed(collapseCallToolMessages(messages));
   });
 
   server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources: [] }));

--- a/packages/mcp-api-adapter/src/gateway.e2e.test.ts
+++ b/packages/mcp-api-adapter/src/gateway.e2e.test.ts
@@ -111,7 +111,7 @@ describe("mcp-api-adapter e2e (gRPC upstream)", () => {
     grpc = undefined;
   });
 
-  it("serves the same tool results over REST, GraphQL, and gRPC", async () => {
+  it("serves the same tool results over REST, GraphQL, gRPC, and /mcp", async () => {
     process.env.ENABLE_GRPC = "1";
     process.env.ENABLE_GRPC_REFLECTION = "0";
 
@@ -127,6 +127,7 @@ describe("mcp-api-adapter e2e (gRPC upstream)", () => {
       port: 0,
       title: "e2e demo",
       grpcListen: false,
+      mcpPath: "/mcp",
     });
 
     const toolsRes = await fetch(`${gateway.url}/tools`);
@@ -169,6 +170,24 @@ describe("mcp-api-adapter e2e (gRPC upstream)", () => {
     };
     expect(gqlEchoBody.errors).toBeUndefined();
     expect(gqlEchoBody.data?.echo?.echo).toBe("hello-graphql");
+
+    // gRPC upstream → Streamable HTTP /mcp (protobuf content must be normalized)
+    const mcpClient = new Client({ name: "e2e-grpc-mcp", version: "0.0.0" });
+    const mcpTransport = new StreamableHTTPClientTransport(
+      new URL(`${gateway.url}${gateway.mcpPath}`)
+    );
+    await mcpClient.connect(mcpTransport);
+    try {
+      const result = await mcpClient.callTool({
+        name: "echo",
+        arguments: { message: "hello-mcp-over-grpc" },
+      });
+      const collapsed = collapseSdkToolResult(result);
+      expect(collapsed.structuredContent?.echo).toBe("hello-mcp-over-grpc");
+    } finally {
+      await mcpClient.close().catch(() => {});
+      await mcpTransport.close().catch(() => {});
+    }
   });
 });
 

--- a/packages/mcp-api-adapter/src/index.ts
+++ b/packages/mcp-api-adapter/src/index.ts
@@ -22,6 +22,7 @@ export {
   collapseCallToolMessages,
   collapseSdkToolResult,
   httpBodyFromCollapsed,
+  mcpCallToolResultFromCollapsed,
 } from "./call.js";
 export {
   isSafeToolPathName,

--- a/packages/mcp-api-adapter/src/upstream.ts
+++ b/packages/mcp-api-adapter/src/upstream.ts
@@ -24,7 +24,7 @@ import type {
   UpstreamOptions,
 } from "./types.js";
 
-const ADAPTER_VERSION = "0.5.0";
+const ADAPTER_VERSION = "0.5.1";
 
 const BRIDGE_CAPS = {
   capabilities: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Live testing found that **gRPC upstream → Streamable HTTP `/mcp`** returned invalid MCP `CallToolResult` content: protobuf oneofs (`{ text: { text } }`) were forwarded raw and failed SDK validation.

## Fix

- Map collapsed gRPC results to MCP `{ type: "text", text }` (+ `structuredContent`) via `mcpCallToolResultFromCollapsed`
- E2E coverage for gRPC upstream calling tools through `/mcp`
- Bump to **0.5.1**

## Verification

Local package tests (9) + live smoke (REST, GraphQL, gRPC, `/mcp`, `gen-cli`) all passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

