### PR TITLE
fix(sync): rate-limit R2 auto-push; flush dirty writes on exit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -306,8 +306,9 @@
 # CLAWQL_SYNC_REGION=auto
 
 # Auto sync (after memory_ingest / before memory_recall)
-# CLAWQL_SYNC_AUTO=1                  # debounced push after successful memory_ingest
-# CLAWQL_SYNC_AUTO_DEBOUNCE_MS=2000   # default 2s — coalesce bursts; avoid long waits on short agent sessions
+# CLAWQL_SYNC_AUTO=1                  # auto-push after successful memory_ingest
+# CLAWQL_SYNC_AUTO_DEBOUNCE_MS=2000   # quiet period to coalesce note+index writes (default 2s)
+# CLAWQL_SYNC_AUTO_PUSH_MIN_MS=30000  # min gap between pushes while ingesting steadily (default 30s); shutdown flush bypasses this
 # CLAWQL_SYNC_AUTO_PULL=1             # throttled pull before memory_recall
 # CLAWQL_SYNC_AUTO_PULL_MIN_MS=60000
 # CLAWQL_SYNC_AUTO_PULL_ON_START=1    # pull once at MCP startup

--- a/.env.example
+++ b/.env.example
@@ -307,7 +307,7 @@
 
 # Auto sync (after memory_ingest / before memory_recall)
 # CLAWQL_SYNC_AUTO=1                  # debounced push after successful memory_ingest
-# CLAWQL_SYNC_AUTO_DEBOUNCE_MS=30000
+# CLAWQL_SYNC_AUTO_DEBOUNCE_MS=2000   # default 2s — coalesce bursts; avoid long waits on short agent sessions
 # CLAWQL_SYNC_AUTO_PULL=1             # throttled pull before memory_recall
 # CLAWQL_SYNC_AUTO_PULL_MIN_MS=60000
 # CLAWQL_SYNC_AUTO_PULL_ON_START=1    # pull once at MCP startup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Team vault auto-push debounce** — default `CLAWQL_SYNC_AUTO_DEBOUNCE_MS` **30s → 2s** (still coalesces a short ingest burst; short enough for Cloud Agent / MCP process lifetimes). Pending push also flushes on SIGINT/SIGTERM/`beforeExit`.
+
 ### Fixed
 
 - **MCP stdio / Cursor discovery** — `dotenv` ≥17 prints `◇ injected env …` to **stdout** by default; that corrupts JSON-RPC and makes Cursor report `clawql` as failed tool discovery. `src/load-env.ts` now always passes **`quiet: true`**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Team vault auto-push debounce** — default `CLAWQL_SYNC_AUTO_DEBOUNCE_MS` **30s → 2s** (still coalesces a short ingest burst; short enough for Cloud Agent / MCP process lifetimes). Pending push also flushes on SIGINT/SIGTERM/`beforeExit`.
+- **Team vault auto-push** — quiet debounce default **2s** (coalesce bursts) plus **30s min interval** between pushes during sustained ingest (no R2 spam). Pending dirty writes still **flush on shutdown** so short-lived MCP/Cloud Agent processes do not drop notes. Env: `CLAWQL_SYNC_AUTO_DEBOUNCE_MS`, `CLAWQL_SYNC_AUTO_PUSH_MIN_MS`.
 
 ### Fixed
 

--- a/charts/clawql-mcp/templates/deployment.yaml
+++ b/charts/clawql-mcp/templates/deployment.yaml
@@ -337,6 +337,8 @@ spec:
               value: "1"
             - name: CLAWQL_SYNC_AUTO_DEBOUNCE_MS
               value: {{ (.Values.teamSync.autoPushDebounceMs | default 2000) | int | quote }}
+            - name: CLAWQL_SYNC_AUTO_PUSH_MIN_MS
+              value: {{ (.Values.teamSync.autoPushMinMs | default 30000) | int | quote }}
             {{- end }}
             {{- if .Values.teamSync.autoPull }}
             - name: CLAWQL_SYNC_AUTO_PULL

--- a/charts/clawql-mcp/templates/deployment.yaml
+++ b/charts/clawql-mcp/templates/deployment.yaml
@@ -336,7 +336,7 @@ spec:
             - name: CLAWQL_SYNC_AUTO
               value: "1"
             - name: CLAWQL_SYNC_AUTO_DEBOUNCE_MS
-              value: {{ (.Values.teamSync.autoPushDebounceMs | default 30000) | int | quote }}
+              value: {{ (.Values.teamSync.autoPushDebounceMs | default 2000) | int | quote }}
             {{- end }}
             {{- if .Values.teamSync.autoPull }}
             - name: CLAWQL_SYNC_AUTO_PULL

--- a/charts/clawql-mcp/values.yaml
+++ b/charts/clawql-mcp/values.yaml
@@ -960,7 +960,7 @@ teamSync:
   region: auto
   endpoint: "" # optional override (gcs defaults to https://storage.googleapis.com in template)
   autoPush: false # CLAWQL_SYNC_AUTO=1 — debounced push after memory_ingest
-  autoPushDebounceMs: 30000
+  autoPushDebounceMs: 2000
   autoPull: false # CLAWQL_SYNC_AUTO_PULL=1 — throttled pull before memory_recall
   autoPullMinMs: 60000
   autoPullOnStart: false # CLAWQL_SYNC_AUTO_PULL_ON_START=1 — pull once at MCP startup

--- a/charts/clawql-mcp/values.yaml
+++ b/charts/clawql-mcp/values.yaml
@@ -959,8 +959,9 @@ teamSync:
   prefix: "" # shared key prefix, e.g. teams/engineering/
   region: auto
   endpoint: "" # optional override (gcs defaults to https://storage.googleapis.com in template)
-  autoPush: false # CLAWQL_SYNC_AUTO=1 — debounced push after memory_ingest
+  autoPush: false # CLAWQL_SYNC_AUTO=1 — quiet debounce + min-interval push after memory_ingest; shutdown flush if dirty
   autoPushDebounceMs: 2000
+  autoPushMinMs: 30000 # CLAWQL_SYNC_AUTO_PUSH_MIN_MS — min gap between pushes; shutdown flush bypasses
   autoPull: false # CLAWQL_SYNC_AUTO_PULL=1 — throttled pull before memory_recall
   autoPullMinMs: 60000
   autoPullOnStart: false # CLAWQL_SYNC_AUTO_PULL_ON_START=1 — pull once at MCP startup

--- a/docs/getting-started/agent-setup.md
+++ b/docs/getting-started/agent-setup.md
@@ -205,7 +205,7 @@ Teams can add `.cursor/environment.json` with an install script that runs `clawq
 
 `memory_sync` replaces shell `clawql sync push` / `pull` on Cloud Agents. See [For teams — `memory_sync`](https://docs.clawql.com/getting-started/for-teams#memory-sync-mcp-tool).
 
-Auto sync (`CLAWQL_SYNC_AUTO=1`) debounces push after each `memory_ingest`; still call `memory_sync` at the end of important runs to flush immediately and reconcile conflicts.
+Auto sync (`CLAWQL_SYNC_AUTO=1`) debounces push after each `memory_ingest` (default **2s**); still call `memory_sync` at the end of important runs to flush immediately and reconcile conflicts. Pending auto-push also flushes on MCP process shutdown (SIGINT/SIGTERM).
 
 ### 5. Copy-paste prompt (iOS / Cloud Agent)
 

--- a/docs/getting-started/agent-setup.md
+++ b/docs/getting-started/agent-setup.md
@@ -205,7 +205,7 @@ Teams can add `.cursor/environment.json` with an install script that runs `clawq
 
 `memory_sync` replaces shell `clawql sync push` / `pull` on Cloud Agents. See [For teams — `memory_sync`](https://docs.clawql.com/getting-started/for-teams#memory-sync-mcp-tool).
 
-Auto sync (`CLAWQL_SYNC_AUTO=1`) debounces push after each `memory_ingest` (default **2s**); still call `memory_sync` at the end of important runs to flush immediately and reconcile conflicts. Pending auto-push also flushes on MCP process shutdown (SIGINT/SIGTERM).
+Auto sync (`CLAWQL_SYNC_AUTO=1`) waits a short quiet period after ingest (default **2s**), then rate-limits pushes (default **30s** min interval) so sustained sessions do not hammer R2. Pending dirty writes still **flush on MCP shutdown** (SIGINT/SIGTERM/`beforeExit`) so Cloud Agent exits do not drop notes. Call `memory_sync` at the end of important runs to flush immediately and reconcile conflicts.
 
 ### 5. Copy-paste prompt (iOS / Cloud Agent)
 

--- a/docs/getting-started/getting-started-for-teams.md
+++ b/docs/getting-started/getting-started-for-teams.md
@@ -232,14 +232,14 @@ Config file: `~/.ClawQL/sync.json` — safe to commit bucket/prefix in team docs
 
 When the MCP server runs with sync configured, enable automatic background sync:
 
-| Variable                           | Behavior                                                                    |
-| ---------------------------------- | --------------------------------------------------------------------------- |
-| `CLAWQL_SYNC_AUTO=1`               | Auto-push after `memory_ingest` (see debounce + min interval below) |
-| `CLAWQL_SYNC_AUTO_DEBOUNCE_MS`     | Quiet period after the last ingest before a push is considered (default `2000`) — coalesces note + index/log |
+| Variable                           | Behavior                                                                                                                                                                          |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CLAWQL_SYNC_AUTO=1`               | Auto-push after `memory_ingest` (see debounce + min interval below)                                                                                                               |
+| `CLAWQL_SYNC_AUTO_DEBOUNCE_MS`     | Quiet period after the last ingest before a push is considered (default `2000`) — coalesces note + index/log                                                                      |
 | `CLAWQL_SYNC_AUTO_PUSH_MIN_MS`     | Minimum gap between successful auto-pushes during sustained ingest (default `30000`) — avoids R2 spam; **shutdown flush ignores this** so short-lived processes do not drop notes |
-| `CLAWQL_SYNC_AUTO_PULL=1`          | Throttled pull before `memory_recall` (default min interval 60s)            |
-| `CLAWQL_SYNC_AUTO_PULL_MIN_MS`     | Min ms between auto-pulls (default `60000`)                                 |
-| `CLAWQL_SYNC_AUTO_PULL_ON_START=1` | Pull once when MCP starts                                                   |
+| `CLAWQL_SYNC_AUTO_PULL=1`          | Throttled pull before `memory_recall` (default min interval 60s)                                                                                                                  |
+| `CLAWQL_SYNC_AUTO_PULL_MIN_MS`     | Min ms between auto-pulls (default `60000`)                                                                                                                                       |
+| `CLAWQL_SYNC_AUTO_PULL_ON_START=1` | Pull once when MCP starts                                                                                                                                                         |
 
 Auto sync logs to stderr (`[clawql-mcp] team sync auto-push/...`). Failures are non-fatal — ingest/recall still succeed.
 

--- a/docs/getting-started/getting-started-for-teams.md
+++ b/docs/getting-started/getting-started-for-teams.md
@@ -234,8 +234,8 @@ When the MCP server runs with sync configured, enable automatic background sync:
 
 | Variable                           | Behavior                                                                    |
 | ---------------------------------- | --------------------------------------------------------------------------- |
-| `CLAWQL_SYNC_AUTO=1`               | Debounced push after each successful `memory_ingest` (default debounce 30s) |
-| `CLAWQL_SYNC_AUTO_DEBOUNCE_MS`     | Push debounce interval (default `30000`)                                    |
+| `CLAWQL_SYNC_AUTO=1`               | Debounced push after each successful `memory_ingest` (default debounce **2s**) |
+| `CLAWQL_SYNC_AUTO_DEBOUNCE_MS`     | Push debounce interval (default `2000`) — coalesces a short ingest burst; keep low so short-lived MCP/Cloud Agent processes still upload before exit |
 | `CLAWQL_SYNC_AUTO_PULL=1`          | Throttled pull before `memory_recall` (default min interval 60s)            |
 | `CLAWQL_SYNC_AUTO_PULL_MIN_MS`     | Min ms between auto-pulls (default `60000`)                                 |
 | `CLAWQL_SYNC_AUTO_PULL_ON_START=1` | Pull once when MCP starts                                                   |

--- a/docs/getting-started/getting-started-for-teams.md
+++ b/docs/getting-started/getting-started-for-teams.md
@@ -234,8 +234,9 @@ When the MCP server runs with sync configured, enable automatic background sync:
 
 | Variable                           | Behavior                                                                    |
 | ---------------------------------- | --------------------------------------------------------------------------- |
-| `CLAWQL_SYNC_AUTO=1`               | Debounced push after each successful `memory_ingest` (default debounce **2s**) |
-| `CLAWQL_SYNC_AUTO_DEBOUNCE_MS`     | Push debounce interval (default `2000`) — coalesces a short ingest burst; keep low so short-lived MCP/Cloud Agent processes still upload before exit |
+| `CLAWQL_SYNC_AUTO=1`               | Auto-push after `memory_ingest` (see debounce + min interval below) |
+| `CLAWQL_SYNC_AUTO_DEBOUNCE_MS`     | Quiet period after the last ingest before a push is considered (default `2000`) — coalesces note + index/log |
+| `CLAWQL_SYNC_AUTO_PUSH_MIN_MS`     | Minimum gap between successful auto-pushes during sustained ingest (default `30000`) — avoids R2 spam; **shutdown flush ignores this** so short-lived processes do not drop notes |
 | `CLAWQL_SYNC_AUTO_PULL=1`          | Throttled pull before `memory_recall` (default min interval 60s)            |
 | `CLAWQL_SYNC_AUTO_PULL_MIN_MS`     | Min ms between auto-pulls (default `60000`)                                 |
 | `CLAWQL_SYNC_AUTO_PULL_ON_START=1` | Pull once when MCP starts                                                   |

--- a/src/configure-home-sync.ts
+++ b/src/configure-home-sync.ts
@@ -1,11 +1,13 @@
 import { configureVaultSyncHooks } from "clawql-memory/sync/vault-sync-hooks";
 import {
+  flushPendingAutoPush,
   maybeAutoPullBeforeRecall,
   runAutoPullOnStartup,
   scheduleAutoPushAfterIngest,
 } from "./home-sync/auto.js";
 
 let wired = false;
+let shutdownHooksRegistered = false;
 
 /** Wire debounced team bucket sync to memory ingest/recall (idempotent). */
 export function configureHomeSyncHooks(): void {
@@ -16,6 +18,18 @@ export function configureHomeSyncHooks(): void {
     beforeRecall: maybeAutoPullBeforeRecall,
   });
   void runAutoPullOnStartup();
+  registerHomeSyncShutdownHooks();
+}
+
+function registerHomeSyncShutdownHooks(): void {
+  if (shutdownHooksRegistered) return;
+  shutdownHooksRegistered = true;
+  const flush = (): void => {
+    void flushPendingAutoPush().catch(() => undefined);
+  };
+  process.once("SIGINT", flush);
+  process.once("SIGTERM", flush);
+  process.once("beforeExit", flush);
 }
 
 export function resetHomeSyncHooksForTests(): void {

--- a/src/home-sync/auto.test.ts
+++ b/src/home-sync/auto.test.ts
@@ -45,9 +45,11 @@ vi.mock("./config.js", () => ({
 describe("home-sync auto", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.clearAllMocks();
     resetHomeSyncAutoForTests();
     delete process.env.CLAWQL_SYNC_AUTO;
     delete process.env.CLAWQL_SYNC_AUTO_PULL;
+    delete process.env.CLAWQL_SYNC_AUTO_DEBOUNCE_MS;
   });
 
   afterEach(() => {
@@ -75,7 +77,35 @@ describe("home-sync auto", () => {
     const { runSyncPush } = await import("./engine.js");
     scheduleAutoPushAfterIngest();
     expect(runSyncPush).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(4999);
+    expect(runSyncPush).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runSyncPush).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults to 2s debounce when CLAWQL_SYNC_AUTO_DEBOUNCE_MS unset", async () => {
+    process.env.CLAWQL_SYNC_AUTO = "1";
+    delete process.env.CLAWQL_SYNC_AUTO_DEBOUNCE_MS;
+    const { runSyncPush } = await import("./engine.js");
+    const { scheduleAutoPushAfterIngest: schedule, DEFAULT_AUTO_PUSH_DEBOUNCE_MS } =
+      await import("./auto.js");
+    expect(DEFAULT_AUTO_PUSH_DEBOUNCE_MS).toBe(2_000);
+    schedule();
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(runSyncPush).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runSyncPush).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushPendingAutoPush cancels debounce and pushes immediately", async () => {
+    process.env.CLAWQL_SYNC_AUTO = "1";
+    process.env.CLAWQL_SYNC_AUTO_DEBOUNCE_MS = "60000";
+    const { runSyncPush } = await import("./engine.js");
+    const { scheduleAutoPushAfterIngest: schedule, flushPendingAutoPush } =
+      await import("./auto.js");
+    schedule();
+    expect(runSyncPush).not.toHaveBeenCalled();
+    await flushPendingAutoPush();
     expect(runSyncPush).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/home-sync/auto.test.ts
+++ b/src/home-sync/auto.test.ts
@@ -2,6 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   autoPullEnabled,
   autoPushExplicitlyEnabled,
+  DEFAULT_AUTO_PUSH_DEBOUNCE_MS,
+  DEFAULT_AUTO_PUSH_MIN_INTERVAL_MS,
+  flushPendingAutoPush,
   resetHomeSyncAutoForTests,
   scheduleAutoPushAfterIngest,
 } from "./auto.js";
@@ -50,6 +53,7 @@ describe("home-sync auto", () => {
     delete process.env.CLAWQL_SYNC_AUTO;
     delete process.env.CLAWQL_SYNC_AUTO_PULL;
     delete process.env.CLAWQL_SYNC_AUTO_DEBOUNCE_MS;
+    delete process.env.CLAWQL_SYNC_AUTO_PUSH_MIN_MS;
   });
 
   afterEach(() => {
@@ -71,9 +75,10 @@ describe("home-sync auto", () => {
     expect(autoPullEnabled()).toBe(true);
   });
 
-  it("scheduleAutoPushAfterIngest debounces push", async () => {
+  it("debounces a quiet period before the first push", async () => {
     process.env.CLAWQL_SYNC_AUTO = "1";
     process.env.CLAWQL_SYNC_AUTO_DEBOUNCE_MS = "5000";
+    process.env.CLAWQL_SYNC_AUTO_PUSH_MIN_MS = "0";
     const { runSyncPush } = await import("./engine.js");
     scheduleAutoPushAfterIngest();
     expect(runSyncPush).not.toHaveBeenCalled();
@@ -83,29 +88,66 @@ describe("home-sync auto", () => {
     expect(runSyncPush).toHaveBeenCalledTimes(1);
   });
 
-  it("defaults to 2s debounce when CLAWQL_SYNC_AUTO_DEBOUNCE_MS unset", async () => {
-    process.env.CLAWQL_SYNC_AUTO = "1";
-    delete process.env.CLAWQL_SYNC_AUTO_DEBOUNCE_MS;
-    const { runSyncPush } = await import("./engine.js");
-    const { scheduleAutoPushAfterIngest: schedule, DEFAULT_AUTO_PUSH_DEBOUNCE_MS } =
-      await import("./auto.js");
+  it("defaults to 2s debounce and 30s min interval", () => {
     expect(DEFAULT_AUTO_PUSH_DEBOUNCE_MS).toBe(2_000);
-    schedule();
-    await vi.advanceTimersByTimeAsync(1_999);
+    expect(DEFAULT_AUTO_PUSH_MIN_INTERVAL_MS).toBe(30_000);
+  });
+
+  it("coalesces rapid ingests into one push after quiet", async () => {
+    process.env.CLAWQL_SYNC_AUTO = "1";
+    process.env.CLAWQL_SYNC_AUTO_DEBOUNCE_MS = "2000";
+    process.env.CLAWQL_SYNC_AUTO_PUSH_MIN_MS = "0";
+    const { runSyncPush } = await import("./engine.js");
+    scheduleAutoPushAfterIngest();
+    await vi.advanceTimersByTimeAsync(500);
+    scheduleAutoPushAfterIngest();
+    await vi.advanceTimersByTimeAsync(500);
+    scheduleAutoPushAfterIngest();
     expect(runSyncPush).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(2000);
     expect(runSyncPush).toHaveBeenCalledTimes(1);
   });
 
-  it("flushPendingAutoPush cancels debounce and pushes immediately", async () => {
+  it("rate-limits sustained ingest so pushes are not every couple seconds", async () => {
+    process.env.CLAWQL_SYNC_AUTO = "1";
+    process.env.CLAWQL_SYNC_AUTO_DEBOUNCE_MS = "100";
+    process.env.CLAWQL_SYNC_AUTO_PUSH_MIN_MS = "30000";
+    const { runSyncPush } = await import("./engine.js");
+
+    scheduleAutoPushAfterIngest();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(runSyncPush).toHaveBeenCalledTimes(1);
+
+    // More writes soon after — must wait out min interval, not push again at 100ms.
+    scheduleAutoPushAfterIngest();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(runSyncPush).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(29_900);
+    expect(runSyncPush).toHaveBeenCalledTimes(2);
+  });
+
+  it("flushPendingAutoPush pushes immediately even inside min-interval window", async () => {
     process.env.CLAWQL_SYNC_AUTO = "1";
     process.env.CLAWQL_SYNC_AUTO_DEBOUNCE_MS = "60000";
+    process.env.CLAWQL_SYNC_AUTO_PUSH_MIN_MS = "60000";
     const { runSyncPush } = await import("./engine.js");
-    const { scheduleAutoPushAfterIngest: schedule, flushPendingAutoPush } =
-      await import("./auto.js");
-    schedule();
+
+    scheduleAutoPushAfterIngest();
     expect(runSyncPush).not.toHaveBeenCalled();
     await flushPendingAutoPush();
     expect(runSyncPush).toHaveBeenCalledTimes(1);
+
+    // Second ingest inside throttle window — shutdown flush still uploads.
+    scheduleAutoPushAfterIngest();
+    await flushPendingAutoPush();
+    expect(runSyncPush).toHaveBeenCalledTimes(2);
+  });
+
+  it("flushPendingAutoPush is a no-op when nothing is pending", async () => {
+    process.env.CLAWQL_SYNC_AUTO = "1";
+    const { runSyncPush } = await import("./engine.js");
+    await flushPendingAutoPush();
+    expect(runSyncPush).not.toHaveBeenCalled();
   });
 });

--- a/src/home-sync/auto.ts
+++ b/src/home-sync/auto.ts
@@ -28,12 +28,23 @@ export function autoPullEnabled(): boolean {
   return envFlagOn("CLAWQL_SYNC_AUTO_PULL");
 }
 
-/** Default debounce: coalesce a short ingest burst (note + index/log) without
- * waiting so long that short-lived MCP/Cloud Agent processes exit first. */
+/**
+ * Quiet period after the last ingest before we consider pushing.
+ * Coalesces note + index/log writes into one PUT.
+ */
 export const DEFAULT_AUTO_PUSH_DEBOUNCE_MS = 2_000;
+
+/**
+ * Minimum time between successful auto-pushes during sustained ingest.
+ * Prevents R2 spam when agents ingest many notes over a long session.
+ * Shutdown flush ignores this so notes are not lost on process exit.
+ */
+export const DEFAULT_AUTO_PUSH_MIN_INTERVAL_MS = 30_000;
 
 let pushTimer: ReturnType<typeof setTimeout> | null = null;
 let pushInFlight = false;
+let pushDirty = false;
+let lastPushMs = 0;
 let lastPullMs = 0;
 let pullInFlight = false;
 
@@ -41,37 +52,71 @@ export function resetHomeSyncAutoForTests(): void {
   if (pushTimer) clearTimeout(pushTimer);
   pushTimer = null;
   pushInFlight = false;
+  pushDirty = false;
+  lastPushMs = 0;
   lastPullMs = 0;
   pullInFlight = false;
 }
 
-/** Debounced push after memory_ingest (and similar writes). */
-export function scheduleAutoPushAfterIngest(): void {
-  if (!autoPushExplicitlyEnabled()) return;
-  const debounceMs = envInt("CLAWQL_SYNC_AUTO_DEBOUNCE_MS", DEFAULT_AUTO_PUSH_DEBOUNCE_MS);
-  if (pushTimer) clearTimeout(pushTimer);
-  pushTimer = setTimeout(() => {
-    pushTimer = null;
-    void flushAutoPush();
-  }, debounceMs);
+function debounceMs(): number {
+  return envInt("CLAWQL_SYNC_AUTO_DEBOUNCE_MS", DEFAULT_AUTO_PUSH_DEBOUNCE_MS);
 }
 
-/** Cancel debounce and push now (shutdown / explicit flush). */
-export async function flushPendingAutoPush(): Promise<void> {
-  if (!autoPushExplicitlyEnabled()) return;
+function minIntervalMs(): number {
+  return envInt("CLAWQL_SYNC_AUTO_PUSH_MIN_MS", DEFAULT_AUTO_PUSH_MIN_INTERVAL_MS);
+}
+
+function clearPushTimer(): void {
   if (pushTimer) {
     clearTimeout(pushTimer);
     pushTimer = null;
   }
-  await flushAutoPush();
 }
 
-async function flushAutoPush(): Promise<void> {
+function armPushTimer(delayMs: number): void {
+  clearPushTimer();
+  pushTimer = setTimeout(() => {
+    pushTimer = null;
+    void tryAutoPush({ force: false });
+  }, Math.max(0, delayMs));
+}
+
+/** Debounced + rate-limited push after memory_ingest (and similar writes). */
+export function scheduleAutoPushAfterIngest(): void {
+  if (!autoPushExplicitlyEnabled()) return;
+  pushDirty = true;
+  armPushTimer(debounceMs());
+}
+
+/**
+ * Cancel timers and push now if there are pending writes (shutdown / explicit flush).
+ * Ignores the min-interval throttle so short-lived processes do not drop notes.
+ */
+export async function flushPendingAutoPush(): Promise<void> {
+  if (!autoPushExplicitlyEnabled()) return;
+  clearPushTimer();
+  if (!pushDirty && !pushInFlight) return;
+  await tryAutoPush({ force: true });
+}
+
+async function tryAutoPush(opts: { force: boolean }): Promise<void> {
+  if (!pushDirty) return;
   if (pushInFlight) return;
+
+  if (!opts.force) {
+    const wait = Math.max(0, minIntervalMs() - (Date.now() - lastPushMs));
+    if (wait > 0) {
+      armPushTimer(wait);
+      return;
+    }
+  }
+
   pushInFlight = true;
   try {
     await loadResolvedHomeSyncConfig();
     const result = await runSyncPush({});
+    pushDirty = false;
+    lastPushMs = Date.now();
     if (result.uploaded > 0) {
       console.error(
         `[clawql-mcp] team sync auto-push: uploaded ${result.uploaded} file(s) to ${result.provider}://${result.bucket}/${result.prefix}`
@@ -80,6 +125,7 @@ async function flushAutoPush(): Promise<void> {
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
     console.error(`[clawql-mcp] team sync auto-push failed: ${msg}`);
+    // Keep dirty so a later ingest / shutdown flush can retry.
   } finally {
     pushInFlight = false;
   }
@@ -88,9 +134,9 @@ async function flushAutoPush(): Promise<void> {
 /** Throttled pull before memory_recall when CLAWQL_SYNC_AUTO_PULL=1. */
 export async function maybeAutoPullBeforeRecall(): Promise<void> {
   if (!autoPullEnabled()) return;
-  const minIntervalMs = envInt("CLAWQL_SYNC_AUTO_PULL_MIN_MS", 60_000);
+  const minPullMs = envInt("CLAWQL_SYNC_AUTO_PULL_MIN_MS", 60_000);
   const now = Date.now();
-  if (pullInFlight || now - lastPullMs < minIntervalMs) return;
+  if (pullInFlight || now - lastPullMs < minPullMs) return;
   pullInFlight = true;
   lastPullMs = now;
   try {

--- a/src/home-sync/auto.ts
+++ b/src/home-sync/auto.ts
@@ -28,6 +28,10 @@ export function autoPullEnabled(): boolean {
   return envFlagOn("CLAWQL_SYNC_AUTO_PULL");
 }
 
+/** Default debounce: coalesce a short ingest burst (note + index/log) without
+ * waiting so long that short-lived MCP/Cloud Agent processes exit first. */
+export const DEFAULT_AUTO_PUSH_DEBOUNCE_MS = 2_000;
+
 let pushTimer: ReturnType<typeof setTimeout> | null = null;
 let pushInFlight = false;
 let lastPullMs = 0;
@@ -44,12 +48,22 @@ export function resetHomeSyncAutoForTests(): void {
 /** Debounced push after memory_ingest (and similar writes). */
 export function scheduleAutoPushAfterIngest(): void {
   if (!autoPushExplicitlyEnabled()) return;
-  const debounceMs = envInt("CLAWQL_SYNC_AUTO_DEBOUNCE_MS", 30_000);
+  const debounceMs = envInt("CLAWQL_SYNC_AUTO_DEBOUNCE_MS", DEFAULT_AUTO_PUSH_DEBOUNCE_MS);
   if (pushTimer) clearTimeout(pushTimer);
   pushTimer = setTimeout(() => {
     pushTimer = null;
     void flushAutoPush();
   }, debounceMs);
+}
+
+/** Cancel debounce and push now (shutdown / explicit flush). */
+export async function flushPendingAutoPush(): Promise<void> {
+  if (!autoPushExplicitlyEnabled()) return;
+  if (pushTimer) {
+    clearTimeout(pushTimer);
+    pushTimer = null;
+  }
+  await flushAutoPush();
 }
 
 async function flushAutoPush(): Promise<void> {

--- a/src/home-sync/auto.ts
+++ b/src/home-sync/auto.ts
@@ -75,10 +75,13 @@ function clearPushTimer(): void {
 
 function armPushTimer(delayMs: number): void {
   clearPushTimer();
-  pushTimer = setTimeout(() => {
-    pushTimer = null;
-    void tryAutoPush({ force: false });
-  }, Math.max(0, delayMs));
+  pushTimer = setTimeout(
+    () => {
+      pushTimer = null;
+      void tryAutoPush({ force: false });
+    },
+    Math.max(0, delayMs)
+  );
 }
 
 /** Debounced + rate-limited push after memory_ingest (and similar writes). */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Team vault auto-push needs two properties at once:

1. **Do not spam R2** during sustained `memory_ingest` sessions  
2. **Do not lose notes** when a Cloud Agent / MCP process exits

### Behavior

| Knob | Default | Role |
| --- | --- | --- |
| `CLAWQL_SYNC_AUTO_DEBOUNCE_MS` | **2s** | Quiet period after the *last* ingest — coalesces note + index/log |
| `CLAWQL_SYNC_AUTO_PUSH_MIN_MS` | **30s** | Min gap between successful auto-pushes while work continues |
| Shutdown flush | always | If dirty, push **immediately** on SIGINT/SIGTERM/`beforeExit` (bypasses min interval) |

So: a short burst → one push ~2s after quiet; a long session with many ingests → at most about one push per 30s; process stop → pending notes still upload.

Helm: `teamSync.autoPushDebounceMs` / `teamSync.autoPushMinMs`.

## Test plan

- [x] Vitest: debounce coalesce, min-interval rate limit, shutdown flush bypasses throttle, no-op when clean
- [ ] CI green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5a07-15ee-7a2a-828a-9ad0a5c8763c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5a07-15ee-7a2a-828a-9ad0a5c8763c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

