### PR TITLE
feat(memory): index-first recall via OKF index.md + log.md survey

### DIFF
--- a/docs/memory/okf.md
+++ b/docs/memory/okf.md
@@ -124,11 +124,14 @@ const issues = lintOkfMarkdown(next, { checkStale: true, requireWormRef: path.en
 
 ## Env knobs
 
-| Env                          | Default | Effect                                          |
-| ---------------------------- | ------- | ----------------------------------------------- |
-| `CLAWQL_MEMORY_INDEX_PAGE=0` | on      | Disables `_INDEX_*` **and** OKF `index.md`      |
-| `CLAWQL_MEMORY_OKF_INDEX=0`  | on      | Disables only OKF `index.md` (keeps `_INDEX_*`) |
-| `CLAWQL_MEMORY_OKF_LOG=0`    | on      | Disables `log.md` append                        |
+| Env                                          | Default | Effect                                                                |
+| -------------------------------------------- | ------- | --------------------------------------------------------------------- |
+| `CLAWQL_MEMORY_INDEX_PAGE=0`                 | on      | Disables `_INDEX_*` **and** OKF `index.md`                            |
+| `CLAWQL_MEMORY_OKF_INDEX=0`                  | on      | Disables only OKF `index.md` (keeps `_INDEX_*`)                       |
+| `CLAWQL_MEMORY_OKF_LOG=0`                    | on      | Disables `log.md` append                                              |
+| `CLAWQL_MEMORY_RECALL_INDEX_FIRST=0`         | on      | Disables index-first survey (`index.md` + `log.md` before bodies)     |
+| `CLAWQL_MEMORY_RECALL_INDEX_FIRST_THRESHOLD` | `48`    | Above this file count, load bodies only for catalog/vector candidates |
+| `CLAWQL_MEMORY_RECALL_MIN_SCORE`             | `0.05`  | Minimum keyword/IDF score to seed recall (fractional under IDF)       |
 
 ## Flywheel export filters (planned / next)
 

--- a/packages/clawql-memory/src/effect/memory-recall-effect.ts
+++ b/packages/clawql-memory/src/effect/memory-recall-effect.ts
@@ -35,6 +35,13 @@ import {
 } from "../recall/codegraph-recall.js";
 import { recallPageIndexSupplement } from "../recall/pageindex-recall.js";
 import { recallOnyxSupplement } from "../recall/onyx-recall.js";
+import {
+  catalogCandidatePaths,
+  indexFirstBodyLoadThreshold,
+  indexFirstRecallEnabled,
+  surveyOkfIndex,
+  type OkfIndexSurvey,
+} from "../recall/index-survey.js";
 
 const VAULT_NOT_CONFIGURED =
   "Obsidian vault is not configured. Set CLAWQL_OBSIDIAN_VAULT_PATH to a writable directory.";
@@ -150,23 +157,63 @@ export function executeMemoryRecallCoreEffect(
     let cuckooVectorChunksDropped: number | undefined;
     let recallArtifacts: RecallDbArtifacts | null = null;
     let codeGraphHits: CodeGraphRecallHit[] | undefined;
+    let indexSurvey: OkfIndexSurvey | undefined;
+    let indexFirstBodyLoad = false;
+    let bodiesLoaded = 0;
 
     if (wantVault || wantVector) {
+      const useIndexFirst = indexFirstRecallEnabled();
+      if (useIndexFirst) {
+        indexSurvey = yield* memoryFromPromise(() =>
+          surveyOkfIndex({
+            vault,
+            query,
+            scanRoot,
+            catalogLimit: envInt("CLAWQL_MEMORY_RECALL_CATALOG_LIMIT", Math.max(limit * 2, 12)),
+            logLimit: envInt("CLAWQL_MEMORY_RECALL_LOG_LIMIT", 8),
+          })
+        );
+      }
+
       const scanExit = yield* Effect.exit(
         memoryFromPromise(() => listVaultMarkdownRelPaths(vault, scanRoot, maxFiles))
       );
       if (Exit.isFailure(scanExit)) {
         const reason = Cause.squash(scanExit.cause);
         const msg = reason instanceof Error ? reason.message : String(reason);
-        return { ok: false, error: `Cannot scan vault: ${msg}`, sourcesUsed };
+        return { ok: false, error: `Cannot scan vault: ${msg}`, sourcesUsed, indexSurvey };
       }
       const mdFiles = scanExit.value;
       truncated = mdFiles.length >= maxFiles;
+
+      // Prefer catalog + recent-log paths for body load when vault is large.
+      const catalogPaths = indexSurvey
+        ? catalogCandidatePaths(
+            indexSurvey,
+            envInt("CLAWQL_MEMORY_RECALL_INDEX_BODY_CANDIDATES", Math.max(limit * 4, 24))
+          )
+        : [];
+      const restrictBodies =
+        useIndexFirst && mdFiles.length > indexFirstBodyLoadThreshold() && catalogPaths.length > 0;
+      indexFirstBodyLoad = restrictBodies;
+
+      // Always include index/log so catalog stays in the graph; plus catalog candidates.
+      const preferLoad = new Set<string>(catalogPaths);
+      for (const rel of mdFiles) {
+        const base = rel.replace(/\\/g, "/").split("/").pop() ?? "";
+        if (base === "index.md" || base === "log.md" || base.startsWith("_INDEX_")) {
+          preferLoad.add(rel);
+        }
+      }
 
       type FileInfo = { rel: string; text: string; score: number };
       const files: FileInfo[] = [];
       const corpusTexts: string[] = [];
       for (const rel of mdFiles) {
+        if (restrictBodies && !preferLoad.has(rel)) {
+          // Skip full body — vector pass still sees path via mdFiles / memory.db.
+          continue;
+        }
         const text = yield* memoryFromPromise(() => readVaultTextFile(vault, rel)).pipe(
           Effect.catchAll(() => Effect.succeed(undefined))
         );
@@ -177,10 +224,18 @@ export function executeMemoryRecallCoreEffect(
         corpusTexts.push(text);
         files.push({ rel, text, score: 0 });
       }
-      scannedFiles = files.length;
+      bodiesLoaded = files.length;
+      scannedFiles = restrictBodies ? mdFiles.length : files.length;
 
       // Corpus IDF so ubiquitous tokens (shared vocabulary) do not bury distinctive matches.
       const idf = wantVault ? buildCorpusIdf(corpusTexts) : undefined;
+      const catalogScoreByPath = new Map<string, number>();
+      if (indexSurvey) {
+        for (const h of indexSurvey.catalogHits) {
+          if (!h.path) continue;
+          catalogScoreByPath.set(h.path.replace(/\\/g, "/"), h.score);
+        }
+      }
       for (const f of files) {
         const fm = parseVaultFrontmatter(f.text);
         let score = wantVault && idf ? keywordScore(query, f.text, idf) : 0;
@@ -189,6 +244,9 @@ export function executeMemoryRecallCoreEffect(
           // Prefer OKF catalogs and ontology schema notes (essay Layer 6 / index-first recall).
           if (/(^|\/)index\.md$/i.test(relNorm)) score += 8;
           if (/ontology/i.test(relNorm) || /type:\s*["']?ontology_/i.test(f.text)) score += 5;
+          // Catalog title match is a cheap relevance prior (index-first).
+          const cat = catalogScoreByPath.get(relNorm);
+          if (cat && cat > 0) score += cat * 2;
           if (isOkfStale(fm)) score = Math.max(0, score - 3);
         }
         f.score = score;
@@ -256,6 +314,48 @@ export function executeMemoryRecallCoreEffect(
         }
       } else {
         sourceNotes.vector = "vector source not requested";
+      }
+
+      // Index-first: load any vector-hit bodies that were skipped in the restricted pass.
+      if (restrictBodies && wantVector) {
+        const minVectorSimLoad = envFloat("CLAWQL_MEMORY_VECTOR_MIN_SIM", 0.28);
+        for (const [p, sim] of vectorByRel) {
+          if (sim < minVectorSimLoad) continue;
+          if (textByRel.has(p)) continue;
+          const text = yield* memoryFromPromise(() => readVaultTextFile(vault, p)).pipe(
+            Effect.catchAll(() => Effect.succeed(undefined))
+          );
+          if (text === undefined) continue;
+          const fm = parseVaultFrontmatter(text);
+          if (isOkfRetracted(fm)) continue;
+          files.push({ rel: p, text, score: 0 });
+          corpusTexts.push(text);
+          textByRel.set(p, text);
+        }
+        // Recompute IDF + keyword scores over the expanded body set.
+        if (wantVault) {
+          const idf2 = buildCorpusIdf(corpusTexts);
+          for (const f of files) {
+            const fm = parseVaultFrontmatter(f.text);
+            let score = keywordScore(query, f.text, idf2);
+            const relNorm = f.rel.replace(/\\/g, "/");
+            if (/(^|\/)index\.md$/i.test(relNorm)) score += 8;
+            if (/ontology/i.test(relNorm) || /type:\s*["']?ontology_/i.test(f.text)) score += 5;
+            if (isOkfStale(fm)) score = Math.max(0, score - 3);
+            f.score = score;
+          }
+        }
+        bodiesLoaded = files.length;
+        // Rebuild slug map + edges for newly loaded bodies.
+        const slug2 = buildSlugToVaultPath(files.map((f) => ({ path: f.rel, text: f.text })));
+        for (const [k, v] of slug2) slugToPath.set(k, v);
+        for (const { rel, text } of files) {
+          for (const target of extractWikilinkTargets(text)) {
+            const slug = slugifyTitle(target);
+            const dest = slugToPath.get(slug);
+            if (dest) addEdge(rel, dest);
+          }
+        }
       }
 
       const vectorBoost = envFloat("CLAWQL_MEMORY_VECTOR_SCORE_BOOST", 50);
@@ -438,6 +538,9 @@ export function executeMemoryRecallCoreEffect(
       sourceNotes: Object.keys(sourceNotes).length > 0 ? sourceNotes : undefined,
       truncated: wantVault || wantVector ? truncated : undefined,
       scannedFiles: wantVault || wantVector ? scannedFiles : undefined,
+      indexSurvey,
+      indexFirstBodyLoad: indexFirstBodyLoad || undefined,
+      bodiesLoaded: wantVault || wantVector ? bodiesLoaded : undefined,
     };
 
     if (codeGraphHits) {

--- a/packages/clawql-memory/src/recall/index-survey.test.ts
+++ b/packages/clawql-memory/src/recall/index-survey.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  catalogCandidatePaths,
+  indexFirstRecallEnabled,
+  parseOkfIndexCatalog,
+  parseOkfRecentLog,
+  scoreCatalogEntries,
+  type OkfIndexSurvey,
+} from "./index-survey.js";
+
+const SAMPLE_INDEX = `---
+type: "index"
+title: "Memory index"
+---
+
+# Memory index
+
+## Summary
+
+- **Notes:** 3
+- **Recall subtree:** \`Memory/\`
+
+## By folder
+
+### \`Memory/\`
+
+- [[JWT over sessions]] \`(Memory/auth-jwt-over-sessions.md)\`
+- [[GOMAXPROCS pin]] \`(Memory/gomaxprocs.md)\`
+- [[Ontology kinetic]] \`(Memory/ontology-kinetic.md)\`
+
+## All notes (A–Z) (3)
+
+- [[GOMAXPROCS pin]]
+- [[JWT over sessions]]
+- [[Ontology kinetic]]
+
+<!-- clawql-index:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -->
+`;
+
+const SAMPLE_LOG = `---
+type: "log"
+---
+
+# Memory vault log
+
+## 2026-08-04
+
+- **2026-08-04T10:00:00.000Z** — [[JWT over sessions]] (\`Memory/auth-jwt-over-sessions.md\`) type=\`decision\` · correlation \`sess-1\`
+- **2026-08-04T12:00:00.000Z** — [[Ontology kinetic]] (\`Memory/ontology-kinetic.md\`) type=\`decision\`
+`;
+
+describe("parseOkfIndexCatalog", () => {
+  it("extracts path-bearing catalog rows and note count", () => {
+    const { entries, noteCount } = parseOkfIndexCatalog(SAMPLE_INDEX);
+    expect(noteCount).toBe(3);
+    const withPath = entries.filter((e) => e.path);
+    expect(withPath.length).toBeGreaterThanOrEqual(3);
+    expect(withPath.some((e) => e.path === "Memory/auth-jwt-over-sessions.md")).toBe(true);
+  });
+});
+
+describe("scoreCatalogEntries", () => {
+  it("ranks JWT catalog entry above unrelated titles", () => {
+    const { entries } = parseOkfIndexCatalog(SAMPLE_INDEX);
+    const hits = scoreCatalogEntries("jwt sessions authentication", entries, 5);
+    expect(hits[0]?.path).toBe("Memory/auth-jwt-over-sessions.md");
+    expect(hits[0]!.score).toBeGreaterThan(0);
+  });
+});
+
+describe("parseOkfRecentLog", () => {
+  it("returns newest first", () => {
+    const recent = parseOkfRecentLog(SAMPLE_LOG, 2);
+    expect(recent).toHaveLength(2);
+    expect(recent[0]!.path).toBe("Memory/ontology-kinetic.md");
+    expect(recent[1]!.path).toBe("Memory/auth-jwt-over-sessions.md");
+  });
+});
+
+describe("catalogCandidatePaths", () => {
+  it("unions catalog hits and recent log paths", () => {
+    const survey: OkfIndexSurvey = {
+      indexFound: true,
+      catalogHits: [
+        { title: "JWT", path: "Memory/auth-jwt-over-sessions.md", score: 5 },
+        { title: "CPU", path: "Memory/gomaxprocs.md", score: 2 },
+      ],
+      recentLog: [{ timestamp: "t", title: "Ontology", path: "Memory/ontology-kinetic.md" }],
+      surveyTokenEstimate: 100,
+    };
+    const paths = catalogCandidatePaths(survey, 10);
+    expect(paths).toEqual([
+      "Memory/auth-jwt-over-sessions.md",
+      "Memory/gomaxprocs.md",
+      "Memory/ontology-kinetic.md",
+    ]);
+  });
+});
+
+describe("indexFirstRecallEnabled", () => {
+  it("defaults to on", () => {
+    const saved = process.env.CLAWQL_MEMORY_RECALL_INDEX_FIRST;
+    delete process.env.CLAWQL_MEMORY_RECALL_INDEX_FIRST;
+    try {
+      expect(indexFirstRecallEnabled()).toBe(true);
+    } finally {
+      if (saved === undefined) delete process.env.CLAWQL_MEMORY_RECALL_INDEX_FIRST;
+      else process.env.CLAWQL_MEMORY_RECALL_INDEX_FIRST = saved;
+    }
+  });
+});

--- a/packages/clawql-memory/src/recall/index-survey.ts
+++ b/packages/clawql-memory/src/recall/index-survey.ts
@@ -1,0 +1,258 @@
+/**
+ * OKF index-first recall — survey `index.md` + recent `log.md` before loading note bodies.
+ * Keeps recall economical as vaults grow (agent-memory-stack Layer 1 economics).
+ */
+
+import { basename } from "node:path/posix";
+import { readVaultTextFile } from "../vault/utils.js";
+import { stripVaultFrontmatter } from "../vault/markdown.js";
+import { keywordScore, tokenizeQuery } from "./recall.js";
+
+export type IndexCatalogEntry = {
+  /** Vault-relative path when present in catalog, else undefined. */
+  path?: string;
+  title: string;
+  folder?: string;
+  /** Catalog line score against the query. */
+  score: number;
+};
+
+export type RecentLogEntry = {
+  timestamp: string;
+  title: string;
+  path?: string;
+  type?: string;
+};
+
+export type OkfIndexSurvey = {
+  /** Catalog path that was read (e.g. Memory/index.md). */
+  indexPath?: string;
+  /** Whether the catalog file was found. */
+  indexFound: boolean;
+  noteCount?: number;
+  /** Top catalog matches for the query (titles/paths only — cheap). */
+  catalogHits: IndexCatalogEntry[];
+  /** Recent ingest lines from log.md for session continuity. */
+  recentLog: RecentLogEntry[];
+  /** Approximate token cost of the survey payload (catalog+log text). */
+  surveyTokenEstimate: number;
+};
+
+function defaultScanRoot(): string {
+  const v = process.env.CLAWQL_MEMORY_RECALL_SCAN_ROOT;
+  if (v === undefined) return "Memory";
+  const t = v.trim();
+  return t === "" ? "" : t;
+}
+
+function okfIndexRel(scanRoot: string): string {
+  const root = scanRoot.replace(/\\/g, "/").replace(/^\/+/, "");
+  return root ? `${root}/index.md` : "index.md";
+}
+
+function okfLogRel(scanRoot: string): string {
+  const root = scanRoot.replace(/\\/g, "/").replace(/^\/+/, "");
+  return root ? `${root}/log.md` : "log.md";
+}
+
+/** Disable with CLAWQL_MEMORY_RECALL_INDEX_FIRST=0. Default on. */
+export function indexFirstRecallEnabled(): boolean {
+  const v = process.env.CLAWQL_MEMORY_RECALL_INDEX_FIRST?.trim().toLowerCase();
+  if (v === "0" || v === "false" || v === "off" || v === "no") return false;
+  return true;
+}
+
+/**
+ * When vault file count exceeds this, only load full bodies for catalog + vector
+ * candidates (plus a small IDF sample). Below threshold: full scan for quality.
+ * Default 48. Set CLAWQL_MEMORY_RECALL_INDEX_FIRST_THRESHOLD.
+ */
+export function indexFirstBodyLoadThreshold(): number {
+  const v = process.env.CLAWQL_MEMORY_RECALL_INDEX_FIRST_THRESHOLD?.trim();
+  if (!v) return 48;
+  const n = Number.parseInt(v, 10);
+  return Number.isFinite(n) && n >= 0 ? n : 48;
+}
+
+const CATALOG_LINE_RE = /^\s*-\s*\[\[([^\]]+)\]\](?:\s*`\(([^)`]+)\)`)?(?:\s*[—-]\s*(.+))?/;
+
+/**
+ * Parse OKF / provider index markdown into catalog entries (path + title).
+ * Exported for unit tests.
+ */
+export function parseOkfIndexCatalog(markdown: string): {
+  entries: Omit<IndexCatalogEntry, "score">[];
+  noteCount?: number;
+} {
+  const body = stripVaultFrontmatter(markdown);
+  const entries: Omit<IndexCatalogEntry, "score">[] = [];
+  let noteCount: number | undefined;
+  let folder: string | undefined;
+
+  for (const line of body.split("\n")) {
+    const summaryNotes = line.match(/^\s*-\s*\*\*Notes:\*\*\s*(\d+)/i);
+    if (summaryNotes) {
+      noteCount = Number.parseInt(summaryNotes[1]!, 10);
+      continue;
+    }
+    const folderMatch = line.match(/^###\s+`([^`]+)`\/?\s*$/);
+    if (folderMatch) {
+      folder = folderMatch[1]!.replace(/\/$/, "");
+      if (folder === "(paths with no directory segment)") folder = ".";
+      continue;
+    }
+    const m = line.match(CATALOG_LINE_RE);
+    if (!m) continue;
+    const title = m[1]!.trim();
+    const path = m[2]?.trim();
+    if (!title) continue;
+    // Prefer path-bearing lines (By folder); skip A–Z title-only duplicates when path known later.
+    entries.push({ title, path, folder });
+  }
+
+  // Dedupe: prefer entries with path.
+  const byKey = new Map<string, Omit<IndexCatalogEntry, "score">>();
+  for (const e of entries) {
+    const key = (e.path ?? e.title).toLowerCase();
+    const prev = byKey.get(key);
+    if (!prev || (!prev.path && e.path)) byKey.set(key, e);
+  }
+  return { entries: [...byKey.values()], noteCount };
+}
+
+const LOG_LINE_RE =
+  /^\s*-\s*\*\*([^*]+)\*\*\s*—\s*\[\[([^\]]+)\]\](?:\s*\(`([^`]+)`\))?(?:\s*type=`([^`]+)`)?/;
+
+/**
+ * Parse recent OKF log.md lines (newest first). Exported for tests.
+ */
+export function parseOkfRecentLog(markdown: string, maxEntries: number): RecentLogEntry[] {
+  const body = stripVaultFrontmatter(markdown);
+  const out: RecentLogEntry[] = [];
+  for (const line of body.split("\n")) {
+    const m = line.match(LOG_LINE_RE);
+    if (!m) continue;
+    out.push({
+      timestamp: m[1]!.trim(),
+      title: m[2]!.trim(),
+      path: m[3]?.trim(),
+      type: m[4]?.trim(),
+    });
+  }
+  // File is chronological ascending; return newest first.
+  out.reverse();
+  return out.slice(0, Math.max(0, maxEntries));
+}
+
+function estimateTokens(text: string): number {
+  // Rough 4 chars/token — good enough for survey economics reporting.
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+/**
+ * Score catalog entries against a query (title + path tokens). Cheap — no body load.
+ */
+export function scoreCatalogEntries(
+  query: string,
+  entries: readonly Omit<IndexCatalogEntry, "score">[],
+  limit: number
+): IndexCatalogEntry[] {
+  const scored = entries.map((e) => {
+    const hay = `${e.title} ${e.path ?? ""} ${e.folder ?? ""}`;
+    return { ...e, score: keywordScore(query, hay) };
+  });
+  scored.sort((a, b) => b.score - a.score || a.title.localeCompare(b.title));
+  const hits = scored.filter((e) => e.score > 0).slice(0, limit);
+  // If nothing matched tokens, still return top folder/title diversity (empty query edge).
+  if (hits.length === 0 && tokenizeQuery(query).length === 0) {
+    return scored.slice(0, limit).map((e) => ({ ...e, score: 0 }));
+  }
+  return hits;
+}
+
+export type SurveyOkfIndexInput = {
+  vault: string;
+  query: string;
+  scanRoot?: string;
+  catalogLimit?: number;
+  logLimit?: number;
+};
+
+/**
+ * Read index.md + log.md and produce a survey payload for memory_recall.
+ */
+export async function surveyOkfIndex(input: SurveyOkfIndexInput): Promise<OkfIndexSurvey> {
+  const scanRoot = input.scanRoot ?? defaultScanRoot();
+  const catalogLimit = input.catalogLimit ?? 12;
+  const logLimit = input.logLimit ?? 8;
+  const indexPath = okfIndexRel(scanRoot);
+  const logPath = okfLogRel(scanRoot);
+
+  let indexText = "";
+  let indexFound = false;
+  try {
+    indexText = await readVaultTextFile(input.vault, indexPath);
+    indexFound = true;
+  } catch {
+    // Try legacy _INDEX_* under scan root — best-effort.
+    try {
+      const { listVaultMarkdownRelPaths } = await import("../vault/slug-index.js");
+      const files = await listVaultMarkdownRelPaths(input.vault, scanRoot, 50);
+      const legacy = files.find((f) => basename(f).startsWith("_INDEX_") && f.endsWith(".md"));
+      if (legacy) {
+        indexText = await readVaultTextFile(input.vault, legacy);
+        indexFound = true;
+      }
+    } catch {
+      /* none */
+    }
+  }
+
+  let logText = "";
+  try {
+    logText = await readVaultTextFile(input.vault, logPath);
+  } catch {
+    /* optional */
+  }
+
+  const parsed = indexFound
+    ? parseOkfIndexCatalog(indexText)
+    : { entries: [], noteCount: undefined };
+  const catalogHits = scoreCatalogEntries(input.query, parsed.entries, catalogLimit);
+  const recentLog = logText ? parseOkfRecentLog(logText, logLimit) : [];
+
+  const pathCount = parsed.entries.filter((e) => e.path).length;
+  return {
+    indexPath: indexFound ? indexPath : undefined,
+    indexFound,
+    noteCount: parsed.noteCount ?? (pathCount > 0 ? pathCount : undefined),
+    catalogHits,
+    recentLog,
+    surveyTokenEstimate: estimateTokens(indexText) + estimateTokens(logText),
+  };
+}
+
+/**
+ * Paths to prefer for full-body load from an index survey (catalog hits with paths).
+ */
+export function catalogCandidatePaths(survey: OkfIndexSurvey, limit: number): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const h of survey.catalogHits) {
+    if (!h.path) continue;
+    const p = h.path.replace(/\\/g, "/");
+    if (seen.has(p)) continue;
+    seen.add(p);
+    out.push(p);
+    if (out.length >= limit) break;
+  }
+  for (const e of survey.recentLog) {
+    if (!e.path) continue;
+    const p = e.path.replace(/\\/g, "/");
+    if (seen.has(p)) continue;
+    seen.add(p);
+    out.push(p);
+    if (out.length >= limit) break;
+  }
+  return out;
+}

--- a/packages/clawql-memory/src/recall/recall.ts
+++ b/packages/clawql-memory/src/recall/recall.ts
@@ -98,6 +98,15 @@ export type MemoryRecallResult = {
   } | null;
   /** When **`CLAWQL_CUCKOO_ENABLED=1`** and a filter is loaded: vector-ranked chunk ids that failed membership (stale/inconsistent). */
   cuckooVectorChunksDropped?: number;
+  /**
+   * OKF index-first survey (`index.md` + recent `log.md`) — cheap catalog before full bodies.
+   * Present when index-first is enabled (default) and vault/vector sources are queried.
+   */
+  indexSurvey?: import("./index-survey.js").OkfIndexSurvey;
+  /** True when full bodies were loaded only for catalog/vector candidates (large vault). */
+  indexFirstBodyLoad?: boolean;
+  /** Paths whose bodies were loaded when index-first body restriction applied. */
+  bodiesLoaded?: number;
 };
 
 function tokenize(text: string): string[] {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the P0 **index-first economics** gap from the agent-memory-stack vision.

- Survey `Memory/index.md` + recent `Memory/log.md` before loading note bodies
- Return `indexSurvey` on `memory_recall` (catalog hits, recent log, token estimate)
- On large vaults (>48 files by default), restrict full-body reads to catalog + vector candidates; vector ranking still uses `memory.db`
- Catalog title matches boost keyword seeding
- Docs: env knobs in `docs/memory/okf.md`

## Depends on

Landed via [#801](https://github.com/danielsmithdevelopment/ClawQL/pull/801) (merged). Base is now `main`.

## Verification

- `index-survey.test.ts` — parse/score/catalog paths
- Keyword recall still works with fractional IDF + minScore 0.05
- Bakeoff regressions from #801 still pass

## Next

[#804](https://github.com/danielsmithdevelopment/ClawQL/pull/804) git-native Mode A → hybrid rerank → WORM → ontology → codegraph flywheel

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

