### PR TITLE
feat(memory): git-native vault Mode A — commit-on-ingest

### DIFF
--- a/docs/memory/okf.md
+++ b/docs/memory/okf.md
@@ -132,6 +132,10 @@ const issues = lintOkfMarkdown(next, { checkStale: true, requireWormRef: path.en
 | `CLAWQL_MEMORY_RECALL_INDEX_FIRST=0`         | on      | Disables index-first survey (`index.md` + `log.md` before bodies)     |
 | `CLAWQL_MEMORY_RECALL_INDEX_FIRST_THRESHOLD` | `48`    | Above this file count, load bodies only for catalog/vector candidates |
 | `CLAWQL_MEMORY_RECALL_MIN_SCORE`             | `0.05`  | Minimum keyword/IDF score to seed recall (fractional under IDF)       |
+| `CLAWQL_MEMORY_BACKEND=git`                  | fs      | Git-native vault: commit after each successful `memory_ingest`        |
+| `CLAWQL_MEMORY_GIT_COMMIT_ON`                | ingest* | `off` disables commits; `*` default when backend=git                  |
+| `CLAWQL_MEMORY_GIT_PUSH_MODE`                | async†  | `async` \| `sync` \| `off` — †async when `GIT_REMOTE` set, else off   |
+| `CLAWQL_MEMORY_GIT_REMOTE`                   | —       | Remote URL (adds `origin` on first `git init`)                        |
 
 ## Flywheel export filters (planned / next)
 

--- a/packages/clawql-memory/src/effect/memory-ingest-effect.ts
+++ b/packages/clawql-memory/src/effect/memory-ingest-effect.ts
@@ -112,10 +112,24 @@ export function executeMemoryIngestCoreEffect(
       await runAfterIngestVaultSync();
     });
 
+    let git: MemoryIngestResult["git"];
+    if (result.ok && !result.skipped) {
+      git = yield* memoryFromPromise(async () => {
+        const { commitVaultAfterIngest } = await import("../vault/git-backend.js");
+        return commitVaultAfterIngest({
+          vault,
+          path: result.path,
+          title,
+          correlationId: effective.correlationId ?? effective.sessionId,
+        });
+      });
+    }
+
     return {
       ...result,
       ...extras,
       rebuild: Object.keys(rebuild).length > 0 ? rebuild : undefined,
+      git,
     };
   });
 }

--- a/packages/clawql-memory/src/ingest/ingest.ts
+++ b/packages/clawql-memory/src/ingest/ingest.ts
@@ -122,6 +122,15 @@ export type MemoryIngestResult = {
     pageindex?: { docId: string; nodeCount: number } | { error: string };
     embeddings?: { synced: boolean; skipped?: string };
   };
+  /** Git-native vault: commit-on-ingest outcome when CLAWQL_MEMORY_BACKEND=git. */
+  git?: {
+    committed: boolean;
+    commitSha?: string;
+    skipped?: string;
+    pushed?: boolean;
+    pushError?: string;
+    error?: string;
+  };
 };
 
 function normalizeWikilink(name: string): string {

--- a/packages/clawql-memory/src/vault/git-backend.test.ts
+++ b/packages/clawql-memory/src/vault/git-backend.test.ts
@@ -1,0 +1,94 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { commitVaultAfterIngest, memoryGitBackendEnabled } from "./git-backend.js";
+
+const execFileAsync = promisify(execFile);
+
+describe("git-backend commit-on-ingest", () => {
+  let home: string;
+  const saved: Record<string, string | undefined> = {};
+
+  function stash(keys: string[]) {
+    for (const k of keys) saved[k] = process.env[k];
+  }
+  function restore() {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "clawql-git-vault-"));
+    await mkdir(join(home, "Memory"), { recursive: true });
+    stash([
+      "CLAWQL_MEMORY_BACKEND",
+      "CLAWQL_MEMORY_GIT_COMMIT_ON",
+      "CLAWQL_MEMORY_GIT_PUSH_MODE",
+      "CLAWQL_MEMORY_GIT_REMOTE",
+      "CLAWQL_MEMORY_GIT_AUTHOR_NAME",
+      "CLAWQL_MEMORY_GIT_AUTHOR_EMAIL",
+    ]);
+  });
+
+  afterEach(async () => {
+    restore();
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("memoryGitBackendEnabled reads CLAWQL_MEMORY_BACKEND=git", () => {
+    process.env.CLAWQL_MEMORY_BACKEND = "git";
+    expect(memoryGitBackendEnabled()).toBe(true);
+  });
+
+  it("skips when git backend disabled", async () => {
+    delete process.env.CLAWQL_MEMORY_BACKEND;
+    delete process.env.CLAWQL_MEMORY_GIT_COMMIT_ON;
+    const r = await commitVaultAfterIngest({ vault: home, title: "x" });
+    expect(r.committed).toBe(false);
+    expect(r.skipped).toMatch(/disabled/i);
+  });
+
+  it("inits repo and commits on ingest", async () => {
+    process.env.CLAWQL_MEMORY_BACKEND = "git";
+    process.env.CLAWQL_MEMORY_GIT_PUSH_MODE = "off";
+    process.env.CLAWQL_MEMORY_GIT_AUTHOR_NAME = "Test Agent";
+    process.env.CLAWQL_MEMORY_GIT_AUTHOR_EMAIL = "test@clawql.local";
+
+    await writeFile(
+      join(home, "Memory", "decision.md"),
+      "# Decision\n\nJWT over sessions.\n",
+      "utf8"
+    );
+
+    const r = await commitVaultAfterIngest({
+      vault: home,
+      path: "Memory/decision.md",
+      title: "JWT over sessions",
+      correlationId: "sess-1",
+    });
+
+    expect(r.committed).toBe(true);
+    expect(r.commitSha).toMatch(/^[a-f0-9]{40}$/);
+    expect(r.error).toBeUndefined();
+
+    const { stdout } = await execFileAsync("git", ["-C", home, "log", "-1", "--pretty=%s"]);
+    expect(stdout.trim()).toContain("memory_ingest: JWT over sessions");
+    expect(stdout.trim()).toContain("sess-1");
+  });
+
+  it("returns nothing-to-commit on second identical call", async () => {
+    process.env.CLAWQL_MEMORY_BACKEND = "git";
+    process.env.CLAWQL_MEMORY_GIT_PUSH_MODE = "off";
+    await writeFile(join(home, "Memory", "a.md"), "a\n", "utf8");
+    const first = await commitVaultAfterIngest({ vault: home, title: "a" });
+    expect(first.committed).toBe(true);
+    const second = await commitVaultAfterIngest({ vault: home, title: "a" });
+    expect(second.committed).toBe(false);
+    expect(second.skipped).toMatch(/nothing to commit/i);
+  });
+});

--- a/packages/clawql-memory/src/vault/git-backend.ts
+++ b/packages/clawql-memory/src/vault/git-backend.ts
@@ -1,0 +1,192 @@
+/**
+ * Git-native vault backend (Mode A) — commit-on-ingest + optional async push.
+ *
+ * Env:
+ * - CLAWQL_MEMORY_BACKEND=git — enable git commits after successful ingest
+ * - CLAWQL_MEMORY_GIT_COMMIT_ON=ingest|off — default ingest when backend=git
+ * - CLAWQL_MEMORY_GIT_REMOTE — remote URL/name (default: origin if configured)
+ * - CLAWQL_MEMORY_GIT_PUSH_MODE=async|sync|off — default async when remote set
+ * - CLAWQL_MEMORY_GIT_AUTHOR_NAME / CLAWQL_MEMORY_GIT_AUTHOR_EMAIL — commit identity
+ *
+ * Uses system `git` (no isomorphic-git dependency). Vault working tree = Obsidian path.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { access } from "node:fs/promises";
+import { join } from "node:path";
+
+const execFileAsync = promisify(execFile);
+
+export type GitCommitOnIngestResult = {
+  committed: boolean;
+  commitSha?: string;
+  skipped?: string;
+  pushed?: boolean;
+  pushError?: string;
+  error?: string;
+};
+
+function envTrim(key: string): string | undefined {
+  const v = process.env[key]?.trim();
+  return v || undefined;
+}
+
+/** True when vault writes should create git commits. */
+export function memoryGitBackendEnabled(): boolean {
+  const backend = envTrim("CLAWQL_MEMORY_BACKEND")?.toLowerCase();
+  if (backend === "git") return true;
+  const commitOn = envTrim("CLAWQL_MEMORY_GIT_COMMIT_ON")?.toLowerCase();
+  return commitOn === "ingest" || commitOn === "1" || commitOn === "true";
+}
+
+function gitCommitOnIngest(): boolean {
+  if (!memoryGitBackendEnabled()) return false;
+  const commitOn = envTrim("CLAWQL_MEMORY_GIT_COMMIT_ON")?.toLowerCase();
+  if (commitOn === "off" || commitOn === "0" || commitOn === "false" || commitOn === "none") {
+    return false;
+  }
+  return true;
+}
+
+function pushMode(): "async" | "sync" | "off" {
+  const m = envTrim("CLAWQL_MEMORY_GIT_PUSH_MODE")?.toLowerCase();
+  if (m === "sync" || m === "async" || m === "off") return m;
+  // Default: async push when a remote is configured; else off.
+  return envTrim("CLAWQL_MEMORY_GIT_REMOTE") ? "async" : "off";
+}
+
+async function git(
+  vault: string,
+  args: string[],
+  opts?: { env?: NodeJS.ProcessEnv }
+): Promise<{ stdout: string; stderr: string }> {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...opts?.env,
+    GIT_TERMINAL_PROMPT: "0",
+  };
+  const { stdout, stderr } = await execFileAsync("git", ["-C", vault, ...args], {
+    env,
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  return { stdout: String(stdout ?? ""), stderr: String(stderr ?? "") };
+}
+
+async function isGitRepo(vault: string): Promise<boolean> {
+  try {
+    await access(join(vault, ".git"));
+    const { stdout } = await git(vault, ["rev-parse", "--is-inside-work-tree"]);
+    return stdout.trim() === "true";
+  } catch {
+    return false;
+  }
+}
+
+async function ensureGitRepo(vault: string): Promise<void> {
+  if (await isGitRepo(vault)) return;
+  await git(vault, ["init"]);
+  // Quiet local identity for agent commits when unset.
+  const name = envTrim("CLAWQL_MEMORY_GIT_AUTHOR_NAME") ?? "ClawQL Memory";
+  const email = envTrim("CLAWQL_MEMORY_GIT_AUTHOR_EMAIL") ?? "memory@clawql.local";
+  await git(vault, ["config", "user.name", name]);
+  await git(vault, ["config", "user.email", email]);
+  const remote = envTrim("CLAWQL_MEMORY_GIT_REMOTE");
+  if (remote) {
+    try {
+      await git(vault, ["remote", "get-url", "origin"]);
+    } catch {
+      await git(vault, ["remote", "add", "origin", remote]);
+    }
+  }
+}
+
+function authorEnv(): NodeJS.ProcessEnv {
+  const name = envTrim("CLAWQL_MEMORY_GIT_AUTHOR_NAME") ?? "ClawQL Memory";
+  const email = envTrim("CLAWQL_MEMORY_GIT_AUTHOR_EMAIL") ?? "memory@clawql.local";
+  return {
+    GIT_AUTHOR_NAME: name,
+    GIT_AUTHOR_EMAIL: email,
+    GIT_COMMITTER_NAME: name,
+    GIT_COMMITTER_EMAIL: email,
+  };
+}
+
+async function pushVault(vault: string): Promise<{ ok: boolean; error?: string }> {
+  const remote = envTrim("CLAWQL_MEMORY_GIT_REMOTE") ?? "origin";
+  try {
+    // Prefer configured upstream; fall back to origin HEAD branch.
+    let branch = "main";
+    try {
+      const { stdout } = await git(vault, ["rev-parse", "--abbrev-ref", "HEAD"]);
+      branch = stdout.trim() || "main";
+    } catch {
+      /* keep main */
+    }
+    await git(vault, ["push", "-u", remote, branch]);
+    return { ok: true };
+  } catch (e: unknown) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/**
+ * After a successful memory_ingest vault write: stage + commit (and optionally push).
+ */
+export async function commitVaultAfterIngest(input: {
+  vault: string;
+  path?: string;
+  title?: string;
+  correlationId?: string;
+}): Promise<GitCommitOnIngestResult> {
+  if (!gitCommitOnIngest()) {
+    return { committed: false, skipped: "git commit-on-ingest disabled" };
+  }
+
+  try {
+    await ensureGitRepo(input.vault);
+
+    // Stage all vault changes (index.md / log.md / note) — not only the note path.
+    await git(input.vault, ["add", "-A"]);
+
+    const { stdout: status } = await git(input.vault, ["status", "--porcelain"]);
+    if (!status.trim()) {
+      return { committed: false, skipped: "nothing to commit" };
+    }
+
+    const title = (input.title ?? input.path ?? "memory ingest").replace(/"/g, "'");
+    const corr = input.correlationId?.trim() ? ` (${input.correlationId.trim()})` : "";
+    const msg = `memory_ingest: ${title}${corr}`;
+
+    await git(input.vault, ["commit", "-m", msg], { env: authorEnv() });
+    const { stdout: shaOut } = await git(input.vault, ["rev-parse", "HEAD"]);
+    const commitSha = shaOut.trim();
+
+    const mode = pushMode();
+    if (mode === "off") {
+      return { committed: true, commitSha };
+    }
+
+    if (mode === "sync") {
+      const push = await pushVault(input.vault);
+      return {
+        committed: true,
+        commitSha,
+        pushed: push.ok,
+        pushError: push.error,
+      };
+    }
+
+    // async — fire and forget; do not block ingest.
+    void pushVault(input.vault).then((push) => {
+      if (!push.ok) {
+        console.error(`[clawql-mcp] memory git async push failed: ${push.error}`);
+      }
+    });
+    return { committed: true, commitSha, pushed: undefined };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error(`[clawql-mcp] memory git commit-on-ingest failed: ${msg}`);
+    return { committed: false, error: msg };
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes P1 **git-native vault Mode A** (commit-on-ingest) from the git-native agent memory vision.

- `CLAWQL_MEMORY_BACKEND=git` → after successful `memory_ingest`, `git add -A` + commit in the vault working tree
- Auto-`git init` + local author identity when vault is not yet a repo
- Optional `CLAWQL_MEMORY_GIT_REMOTE` + `CLAWQL_MEMORY_GIT_PUSH_MODE` (`async` default / `sync` / `off`)
- `memory_ingest` result includes `git: { committed, commitSha, ... }`
- Unit tests cover init/commit/idempotent nothing-to-commit

## Stacked on

1. [#801](https://github.com/danielsmithdevelopment/ClawQL/pull/801) — Layer 2 vectors/IDF
2. [#803](https://github.com/danielsmithdevelopment/ClawQL/pull/803) — index-first recall

Merge in that order (or retarget base to `main` after lower PRs land).

## Not in this PR (follow-ups)

- GitHub App / PAT auth helpers for push
- PR-review gate before merge to shared vault (`main`)
- Mode B thin git HTTP backend in VG
- R2 git-bundle backup Actions workflow template

## Next after merge

1. Unified hybrid rerank
2. WORM sealing
3. Ontology publish bar
4. CodeGraph → vault flywheel

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

