### PR TITLE
feat(memory): reciprocal rank fusion + hybrid master switch

### DIFF
--- a/docs/memory/okf.md
+++ b/docs/memory/okf.md
@@ -136,6 +136,8 @@ const issues = lintOkfMarkdown(next, { checkStale: true, requireWormRef: path.en
 | `CLAWQL_MEMORY_GIT_COMMIT_ON`                | ingest* | `off` disables commits; `*` default when backend=git                  |
 | `CLAWQL_MEMORY_GIT_PUSH_MODE`                | async†  | `async` \| `sync` \| `off` — †async when `GIT_REMOTE` set, else off   |
 | `CLAWQL_MEMORY_GIT_REMOTE`                   | —       | Remote URL (adds `origin` on first `git init`)                        |
+| `CLAWQL_MEMORY_RECALL_HYBRID=1`              | off     | Also query codegraph / pageindex / onyx when those layers are enabled |
+| `CLAWQL_MEMORY_RECALL_RRF=0`                 | on      | Disable reciprocal-rank fusion across multi-source `hits`             |
 
 ## Flywheel export filters (planned / next)
 

--- a/packages/clawql-memory/src/effect/memory-recall-effect.ts
+++ b/packages/clawql-memory/src/effect/memory-recall-effect.ts
@@ -42,6 +42,7 @@ import {
   surveyOkfIndex,
   type OkfIndexSurvey,
 } from "../recall/index-survey.js";
+import { rerankNormalizedHitsRrf } from "../recall/hybrid-rerank.js";
 
 const VAULT_NOT_CONFIGURED =
   "Obsidian vault is not configured. Set CLAWQL_OBSIDIAN_VAULT_PATH to a writable directory.";
@@ -527,12 +528,24 @@ export function executeMemoryRecallCoreEffect(
     }
 
     normalizedHits.sort((a, b) => b.score - a.score);
+    // Cross-source RRF when ≥2 source kinds contributed (incompatible score scales).
+    const sourceKinds = new Set(normalizedHits.map((h) => h.source));
+    const useRrf =
+      sourceKinds.size >= 2 &&
+      process.env.CLAWQL_MEMORY_RECALL_RRF?.trim().toLowerCase() !== "0" &&
+      process.env.CLAWQL_MEMORY_RECALL_RRF?.trim().toLowerCase() !== "false";
+    const rankedHits = useRrf
+      ? rerankNormalizedHitsRrf(normalizedHits, {
+          k: envInt("CLAWQL_MEMORY_RECALL_RRF_K", 60),
+          limit: Math.max(limit * 2, normalizedHits.length),
+        }).slice(0, Math.max(limit, normalizedHits.length))
+      : normalizedHits;
 
     const result: MemoryRecallResult = {
       ok: true,
       query,
       results: vaultHits,
-      hits: normalizedHits,
+      hits: rankedHits,
       followUps: followUps.length > 0 ? dedupeFollowUps(followUps) : undefined,
       sourcesUsed,
       sourceNotes: Object.keys(sourceNotes).length > 0 ? sourceNotes : undefined,

--- a/packages/clawql-memory/src/recall/codegraph-recall.ts
+++ b/packages/clawql-memory/src/recall/codegraph-recall.ts
@@ -25,7 +25,9 @@ export function defaultCodeGraphRoot(): string {
 export function hybridCodeGraphRecallEnabled(): boolean {
   if (!codeGraphEnabled()) return false;
   const v = process.env.CLAWQL_MEMORY_RECALL_HYBRID_CODEGRAPH?.trim().toLowerCase();
-  return v === "1" || v === "true" || v === "yes";
+  if (v === "1" || v === "true" || v === "yes") return true;
+  const master = process.env.CLAWQL_MEMORY_RECALL_HYBRID?.trim().toLowerCase();
+  return master === "1" || master === "true" || master === "yes" || master === "on";
 }
 
 export type CodeGraphRecallHit = {

--- a/packages/clawql-memory/src/recall/hybrid-rerank.test.ts
+++ b/packages/clawql-memory/src/recall/hybrid-rerank.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { reciprocalRankFusion, rerankNormalizedHitsRrf } from "./hybrid-rerank.js";
+import type { NormalizedRecallHit } from "./recall-sources.js";
+
+function hit(
+  source: NormalizedRecallHit["source"],
+  id: string,
+  score: number,
+  path?: string
+): NormalizedRecallHit {
+  return { source, id, score, snippet: id, path: path ?? id };
+}
+
+describe("reciprocalRankFusion", () => {
+  it("prefers items ranked high in multiple lists", () => {
+    const vault = [hit("vault", "b", 10), hit("vault", "a", 5), hit("vault", "c", 1)];
+    const vector = [hit("vector", "b", 0.9), hit("vector", "a", 0.5), hit("vector", "d", 0.4)];
+    const fused = reciprocalRankFusion([vault, vector], { k: 60, limit: 4 });
+    expect(fused[0]?.id).toBe("b"); // #1 in both lists
+    expect(fused.map((h) => h.id)).toContain("a");
+  });
+});
+
+describe("rerankNormalizedHitsRrf", () => {
+  it("partitions by source then fuses", () => {
+    const hits = [
+      hit("vault", "x", 100),
+      hit("onyx", "y", 0.1),
+      hit("vault", "z", 50),
+      hit("onyx", "x", 0.99),
+    ];
+    const fused = rerankNormalizedHitsRrf(hits, { limit: 3 });
+    expect(fused[0]?.id).toBe("x"); // appears in vault + onyx
+    expect(fused[0]?.meta?.rrf).toBeGreaterThan(0);
+  });
+});

--- a/packages/clawql-memory/src/recall/hybrid-rerank.ts
+++ b/packages/clawql-memory/src/recall/hybrid-rerank.ts
@@ -1,0 +1,82 @@
+/**
+ * Reciprocal Rank Fusion across multi-source memory_recall hits.
+ * Merges vault/vector/link/codegraph/pageindex/onyx lists into one ranked list
+ * without requiring calibrated cross-source scores (agent-memory-stack composition).
+ */
+
+import type { NormalizedRecallHit } from "./recall-sources.js";
+
+export type RrfOptions = {
+  /** RRF constant k (default 60). */
+  k?: number;
+  /** Max results to return. */
+  limit?: number;
+};
+
+/**
+ * Fuse ranked lists via Reciprocal Rank Fusion.
+ * Each input list should already be sorted best-first.
+ * Hits with the same `source:id` key accumulate 1/(k+rank).
+ */
+export function reciprocalRankFusion(
+  lists: readonly (readonly NormalizedRecallHit[])[],
+  opts?: RrfOptions
+): NormalizedRecallHit[] {
+  const k = opts?.k ?? 60;
+  const limit = opts?.limit ?? 20;
+  const scores = new Map<string, { hit: NormalizedRecallHit; rrf: number }>();
+
+  for (const list of lists) {
+    list.forEach((hit, idx) => {
+      // Fuse same document across sources by path when available (vault/vector/link).
+      const key = hit.path?.replace(/\\/g, "/") || `${hit.source}:${hit.id}`;
+      const add = 1 / (k + idx + 1);
+      const prev = scores.get(key);
+      if (!prev) {
+        scores.set(key, { hit: { ...hit }, rrf: add });
+      } else {
+        prev.rrf += add;
+        // Keep the richer snippet / higher native score as payload.
+        if (hit.score > prev.hit.score) {
+          prev.hit = { ...hit };
+        }
+      }
+    });
+  }
+
+  const out = [...scores.values()]
+    .sort((a, b) => b.rrf - a.rrf || b.hit.score - a.hit.score)
+    .slice(0, Math.max(0, limit))
+    .map(({ hit, rrf }) => ({
+      ...hit,
+      score: rrf,
+      meta: { ...(hit.meta ?? {}), rrf, nativeScore: hit.score },
+    }));
+  return out;
+}
+
+/**
+ * Partition normalized hits by source, then RRF-merge.
+ * Prefer this over raw score sort when sources use incompatible scales.
+ */
+export function rerankNormalizedHitsRrf(
+  hits: readonly NormalizedRecallHit[],
+  opts?: RrfOptions
+): NormalizedRecallHit[] {
+  const bySource = new Map<string, NormalizedRecallHit[]>();
+  for (const h of hits) {
+    const key = h.source;
+    if (!bySource.has(key)) bySource.set(key, []);
+    bySource.get(key)!.push(h);
+  }
+  for (const list of bySource.values()) {
+    list.sort((a, b) => b.score - a.score);
+  }
+  return reciprocalRankFusion([...bySource.values()], opts);
+}
+
+/** Master hybrid switch: CLAWQL_MEMORY_RECALL_HYBRID=1 enables optional layers by default. */
+export function hybridRecallMasterEnabled(): boolean {
+  const v = process.env.CLAWQL_MEMORY_RECALL_HYBRID?.trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes" || v === "on";
+}

--- a/packages/clawql-memory/src/recall/recall-sources.ts
+++ b/packages/clawql-memory/src/recall/recall-sources.ts
@@ -37,12 +37,18 @@ export function envFlagTruthy(key: string): boolean {
 
 /** Env-gated hybrid pageindex merge into memory_recall defaults. */
 export function hybridPageIndexRecallEnabled(): boolean {
-  return envFlagTruthy("CLAWQL_MEMORY_RECALL_HYBRID_PAGEINDEX");
+  return (
+    envFlagTruthy("CLAWQL_MEMORY_RECALL_HYBRID_PAGEINDEX") ||
+    envFlagTruthy("CLAWQL_MEMORY_RECALL_HYBRID")
+  );
 }
 
 /** Env-gated hybrid Onyx merge into memory_recall defaults. */
 export function hybridOnyxRecallEnabled(): boolean {
-  return envFlagTruthy("CLAWQL_MEMORY_RECALL_HYBRID_ONYX");
+  return (
+    envFlagTruthy("CLAWQL_MEMORY_RECALL_HYBRID_ONYX") ||
+    envFlagTruthy("CLAWQL_MEMORY_RECALL_HYBRID")
+  );
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes P1 **unified hybrid rerank** from the agent-memory-stack composition story.

- Reciprocal Rank Fusion (`rerankNormalizedHitsRrf`) across vault/vector/link/codegraph/pageindex/onyx
- Path-keyed fusion so the same note from keyword + vector ranks bubbles up
- `CLAWQL_MEMORY_RECALL_HYBRID=1` master switch enables optional layers
- RRF on by default when ≥2 source kinds contribute (`CLAWQL_MEMORY_RECALL_RRF=0` to disable)

## Stacked on

[#803](https://github.com/danielsmithdevelopment/ClawQL/pull/803) index-first (after [#801](https://github.com/danielsmithdevelopment/ClawQL/pull/801) merged).

## Next

Git Mode A (#804), WORM sealing, ontology publish bar, codegraph→vault flywheel

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

