### PR TITLE
feat(memory): CodeGraph impact → type:code_change vault flywheel

### DIFF
--- a/packages/clawql-memory/src/plugin/memory-plugin.ts
+++ b/packages/clawql-memory/src/plugin/memory-plugin.ts
@@ -284,6 +284,31 @@ async function handleCodegraphSync(args: unknown): Promise<{
   };
 }
 
+async function handleCodegraphImpact(args: unknown): Promise<{
+  content: { type: "text"; text: string }[];
+}> {
+  const impact = await codegraphImpact(args);
+  let vaultIngestResult: unknown;
+  const { codeChangeVaultFlywheelEnabled, buildCodeChangeIngestProposal } =
+    await import("../recall/codegraph-code-change.js");
+  if (codeChangeVaultFlywheelEnabled()) {
+    const proposal = buildCodeChangeIngestProposal(
+      impact as Parameters<typeof buildCodeChangeIngestProposal>[0]
+    );
+    if (proposal) {
+      vaultIngestResult = await runMemoryIngest(proposal);
+    }
+  }
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({ ...impact, vaultIngestResult }, null, 2),
+      },
+    ],
+  };
+}
+
 async function handleCodegraphSyncGraphify(args: unknown): Promise<{
   content: { type: "text"; text: string }[];
 }> {
@@ -440,11 +465,7 @@ export function createMemoryPlugin(): Plugin {
           yield* api.registerMcpTool({
             name: "codegraph_impact",
             schema: codegraphImpactToolSchema,
-            handler: async (args) => ({
-              content: [
-                { type: "text", text: JSON.stringify(await codegraphImpact(args), null, 2) },
-              ],
-            }),
+            handler: (args) => handleCodegraphImpact(args),
           });
           yield* api.registerMcpTool({
             name: "codegraph_import_graphify",

--- a/packages/clawql-memory/src/recall/codegraph-code-change.test.ts
+++ b/packages/clawql-memory/src/recall/codegraph-code-change.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCodeChangeIngestProposal,
+  codeChangeVaultFlywheelEnabled,
+} from "./codegraph-code-change.js";
+
+describe("codegraph-code-change flywheel", () => {
+  it("returns null for empty impact", () => {
+    expect(
+      buildCodeChangeIngestProposal({
+        seedQuery: "x",
+        depth: 2,
+        impacted: [],
+        files: [],
+      })
+    ).toBeNull();
+  });
+
+  it("builds type:code_change proposal from impact hits", () => {
+    const p = buildCodeChangeIngestProposal({
+      seedQuery: "parseConfig",
+      seedNodeId: "n1",
+      depth: 2,
+      impacted: [
+        {
+          nodeId: "n2",
+          name: "loadConfig",
+          kind: "function",
+          filePath: "src/config.ts",
+          distance: 1,
+        },
+      ],
+      files: ["src/config.ts", "src/cli.ts"],
+    });
+    expect(p).not.toBeNull();
+    expect(p!.type).toBe("code_change");
+    expect(p!.title).toContain("parseConfig");
+    expect(p!.insights).toContain("loadConfig");
+    expect(p!.tags).toContain("codegraph");
+  });
+
+  it("flywheel enabled by default", () => {
+    const saved = process.env.CLAWQL_CODEGRAPH_CODE_CHANGE_INGEST;
+    delete process.env.CLAWQL_CODEGRAPH_CODE_CHANGE_INGEST;
+    try {
+      expect(codeChangeVaultFlywheelEnabled()).toBe(true);
+    } finally {
+      if (saved === undefined) delete process.env.CLAWQL_CODEGRAPH_CODE_CHANGE_INGEST;
+      else process.env.CLAWQL_CODEGRAPH_CODE_CHANGE_INGEST = saved;
+    }
+  });
+});

--- a/packages/clawql-memory/src/recall/codegraph-code-change.ts
+++ b/packages/clawql-memory/src/recall/codegraph-code-change.ts
@@ -1,0 +1,96 @@
+/**
+ * CodeGraph → vault flywheel: turn impact analysis into type:code_change OKF notes.
+ * Enabled by default when CLAWQL_CODEGRAPH_CODE_CHANGE_INGEST is unset;
+ * set to 0/false/off to disable.
+ */
+
+export function codeChangeVaultFlywheelEnabled(): boolean {
+  const v = process.env.CLAWQL_CODEGRAPH_CODE_CHANGE_INGEST?.trim().toLowerCase();
+  if (v === "0" || v === "false" || v === "off" || v === "no") return false;
+  return true;
+}
+
+export type ImpactLike = {
+  seedQuery: string;
+  seedNodeId?: string;
+  depth: number;
+  impacted: readonly {
+    nodeId: string;
+    name: string;
+    kind: string;
+    filePath?: string;
+    distance: number;
+  }[];
+  files: readonly string[];
+};
+
+export type CodeChangeIngestProposal = {
+  title: string;
+  type: "code_change";
+  description: string;
+  insights: string;
+  wikilinks: string[];
+  tags: string[];
+  toolOutputs: string;
+  append: true;
+};
+
+/**
+ * Build a memory_ingest proposal from a codegraph impact result.
+ * Returns null when there is nothing meaningful to record.
+ */
+export function buildCodeChangeIngestProposal(
+  impact: ImpactLike,
+  opts?: { reasoning?: string; correlationId?: string }
+): CodeChangeIngestProposal | null {
+  if (!impact.seedNodeId && impact.impacted.length === 0 && impact.files.length === 0) {
+    return null;
+  }
+  const seed = impact.seedQuery.trim() || "unknown-symbol";
+  const symbols = [seed, ...impact.impacted.slice(0, 24).map((h) => h.name)];
+  const uniqueSymbols = [...new Set(symbols)].slice(0, 30);
+  const files = [...impact.files].slice(0, 40);
+  const title = `code_change: ${seed} impact (depth ${impact.depth})`;
+  const reasoning = opts?.reasoning?.trim();
+  const insights = [
+    "## Impact",
+    "",
+    `- **Seed:** \`${seed}\`${impact.seedNodeId ? ` (\`${impact.seedNodeId}\`)` : ""}`,
+    `- **Depth:** ${impact.depth}`,
+    `- **Impacted symbols:** ${impact.impacted.length}`,
+    `- **Files:** ${files.length}`,
+    "",
+    ...(reasoning ? ["## Reasoning", "", reasoning, ""] : []),
+    "## Affected symbols",
+    "",
+    ...uniqueSymbols.map((s) => `- \`${s}\``),
+    "",
+    "## Affected files",
+    "",
+    ...(files.length ? files.map((f) => `- \`${f}\``) : ["- _(none)_"]),
+    "",
+    "<!-- clawql-code-change -->",
+  ].join("\n");
+
+  return {
+    title,
+    type: "code_change",
+    description: `CodeGraph impact for ${seed}: ${impact.impacted.length} symbols, ${files.length} files`,
+    insights,
+    wikilinks: ["Codegraph Impact", seed],
+    tags: ["codegraph", "code-change", "impact"],
+    toolOutputs: JSON.stringify(
+      {
+        seedQuery: impact.seedQuery,
+        seedNodeId: impact.seedNodeId,
+        depth: impact.depth,
+        impacted: impact.impacted.slice(0, 50),
+        files,
+        correlationId: opts?.correlationId,
+      },
+      null,
+      2
+    ),
+    append: true,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes P2 **CodeGraph → vault `type:code_change` flywheel** from the agent-memory-stack vision.

- `codegraph_impact` builds and auto-ingests an OKF `code_change` note (affected symbols + files)
- Disable with `CLAWQL_CODEGRAPH_CODE_CHANGE_INGEST=0`
- Unit tests for proposal builder

## Related

Sync already proposes architecture vault notes; this covers the impact / edit path the essay describes.

## Stack status

- ✅ #801 Layer 2 vectors/IDF (merged)
- ✅ #803 index-first (merged)
- ✅ #804 git Mode A (merged)
- ✅ #806 hybrid RRF (merged)
- 🔄 #807 WORM seal (CI)
- 🔄 this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

