### PR TITLE
fix(release): soft-fail localPackExtras so v7.2.0 npm publish can finish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Minor release on the **7.0 Agentic Gateway** line: **Memory Stack 2.0**, Converg
 
 ### Fixed
 
+- **npm publish localPackExtras auth** — soft-fail `mcp-grpc-transport` / `mcp-api-adapter` publish when OIDC/NPM_TOKEN is unavailable (`ENEEDAUTH`) so `clawql-mcp` can still publish (own-cadence extras no longer abort the tag workflow).
 - **MCP stdio / Cursor discovery** ([#799](https://github.com/danielsmithdevelopment/ClawQL/pull/799)) — quiet `dotenv` (`quiet: true`) so stdout banners do not corrupt JSON-RPC.
 - **MCP stdio Ready latency** ([#799](https://github.com/danielsmithdevelopment/ClawQL/pull/799)) — default six-vendor `loadSpec()` warms after **Ready**.
 - **mcp-api-adapter gRPC CallTool content** normalization for `/mcp` ([#796](https://github.com/danielsmithdevelopment/ClawQL/pull/796)).

--- a/scripts/release/npm-publish-workspace.mjs
+++ b/scripts/release/npm-publish-workspace.mjs
@@ -29,7 +29,7 @@ function publishCmd(workspace) {
   return `npm publish -w ${workspace} --provenance --access public`;
 }
 
-function tryPublish(workspace) {
+function tryPublish(workspace, { softFail = false } = {}) {
   const cmd = publishCmd(workspace);
   if (dryRun) {
     console.log(`[dry-run] ${cmd}`);
@@ -42,6 +42,19 @@ function tryPublish(workspace) {
     const output = `${error.stdout ?? ""}${error.stderr ?? ""}${error.message ?? ""}`;
     if (output.includes("E404") || output.includes("404 Not Found")) {
       return { ok: false, reason: "404", output };
+    }
+    // Own-cadence extras (and first-time clawql-* names) may lack OIDC / NPM_TOKEN.
+    // Soft-fail so clawql-mcp can still publish (bundled or registry-linked).
+    if (
+      softFail &&
+      (output.includes("ENEEDAUTH") ||
+        output.includes("need auth") ||
+        output.includes("EOTP") ||
+        output.includes("403 Forbidden") ||
+        output.includes("EPUBLISHCONFLICT") ||
+        output.includes("cannot publish over"))
+    ) {
+      return { ok: false, reason: "auth-or-conflict", output };
     }
     if (output) process.stderr.write(output);
     throw error;
@@ -82,15 +95,18 @@ function publishClawqlMcp(bundleWorkspace) {
 
 let bundleWorkspace = forceBundle;
 
-// Own-cadence packages first (e.g. mcp-grpc-transport@1.0.0) so clawql-mcp peers resolve.
+// Own-cadence packages first (e.g. mcp-grpc-transport@1.0.0) when OIDC/token allows.
+// localPackExtras are for pack-smoke + optional publish — never abort the clawql-mcp release.
 if (!bundleWorkspace) {
   for (const name of extras) {
     console.log(`Publishing ${name} (localPackExtras)…`);
-    const result = tryPublish(name);
+    const result = tryPublish(name, { softFail: true });
     if (!result.ok) {
       console.warn(
-        `WARN: ${name} publish failed (${result.reason}). Continuing with clawql-* packages.`
+        `WARN: ${name} publish failed (${result.reason}). ` +
+          "Skipping (own cadence / not linked for OIDC). Continuing with clawql-* packages.",
       );
+      if (result.output) process.stderr.write(`${result.output}\n`);
     }
   }
 }
@@ -99,12 +115,13 @@ if (!bundleWorkspace) {
   for (const name of packages) {
     if (name === "clawql-mcp") continue;
     console.log(`Publishing ${name}…`);
-    const result = tryPublish(name);
+    const result = tryPublish(name, { softFail: true });
     if (!result.ok) {
       console.warn(
         `WARN: ${name} publish failed (${result.reason}). ` +
           "Falling back to bundled clawql-mcp — add NPM_TOKEN or link trusted publishers on npmjs.com, then re-run to publish workspace packages separately.",
       );
+      if (result.output && result.reason !== "404") process.stderr.write(`${result.output}\n`);
       bundleWorkspace = true;
       break;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`v7.2.0` GitHub release is live, but **npm publish** aborted on `mcp-grpc-transport@1.0.0` with `ENEEDAUTH` (package not OIDC-linked). `localPackExtras` are own-cadence; they must not block `clawql-mcp`.

### Fix

- `scripts/release/npm-publish-workspace.mjs`: soft-fail extras (and clawql-* workspace pkgs) on auth/conflict errors; continue to `clawql-mcp` publish / bundle fallback.

### Release follow-up (after merge)

1. Move `v7.2.0` tag to the merge commit (nothing consumed `clawql-mcp@7.2.0` from npm yet — 404 confirmed).
2. Re-run npm publish on the retagged tip.

### Test plan

- [ ] CI green
- [ ] After merge + retag: `npm view clawql-mcp version` → `7.2.0`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

