### PR TITLE
feat(landing): add Government industry page (clawql-government)

### DIFF
--- a/landing-page/demo/src/app/industries/government/page.tsx
+++ b/landing-page/demo/src/app/industries/government/page.tsx
@@ -1,0 +1,17 @@
+import { IndustryPage } from '@/components/sections/industry-page'
+import { industriesBySlug } from '@/lib/industries'
+import { pageMetadata } from '@/lib/seo'
+
+const industry = industriesBySlug.government
+
+export const metadata = pageMetadata({
+  title: industry.name,
+  description:
+    "ClawQL's government vertical (clawql-government) provides independently verifiable outcome accountability for bond-funded and public programs — measurable definitions at authorization, immutable baselines, Merkle-chained WORM audit, and Arweave anchoring.",
+  path: '/industries/government',
+  absoluteTitle: 'Government · ClawQL',
+})
+
+export default function Page() {
+  return <IndustryPage industry={industry} />
+}

--- a/landing-page/demo/src/app/industries/page.tsx
+++ b/landing-page/demo/src/app/industries/page.tsx
@@ -17,7 +17,7 @@ function statusLabel(status: (typeof industries)[number]['status'], custom?: str
 export const metadata = pageMetadata({
   title: 'Industries',
   description:
-    'ClawQL vertical packages for lending, real estate, healthcare, and more — agent-native document and API workflows on one Agentic Gateway.',
+    'ClawQL vertical packages for lending, real estate, government, healthcare, and more — agent-native document and API workflows on one Agentic Gateway.',
   path: '/industries',
 })
 
@@ -31,8 +31,9 @@ export default function Page() {
         subheadline={
           <p>
             ClawQL modularization v2.1 defines opt-in vertical packages that share security, memory, audit, and the IDP
-            pipeline. <strong>Lending</strong> and <strong>real estate</strong> have shipped reference workflows today;
-            healthcare, legal, and insurance are on the roadmap.
+            pipeline. <strong>Lending</strong> and <strong>real estate</strong> have shipped reference workflows today;{' '}
+            <strong>government</strong> outcome-accountability tooling is on the roadmap with audit infrastructure
+            available now; healthcare, legal, and insurance follow.
           </p>
         }
         cta={

--- a/landing-page/demo/src/app/layout.tsx
+++ b/landing-page/demo/src/app/layout.tsx
@@ -176,6 +176,7 @@ export default function RootLayout({
                 <FooterCategory title="Industries">
                   <FooterLink href="/industries/lending">Lending</FooterLink>
                   <FooterLink href="/industries/real-estate">Real estate</FooterLink>
+                  <FooterLink href="/industries/government">Government</FooterLink>
                   <FooterLink href="/industries/healthcare">Healthcare</FooterLink>
                   <FooterLink href="/industries/legal">Legal</FooterLink>
                   <FooterLink href="/industries/insurance">Insurance</FooterLink>

--- a/landing-page/demo/src/app/sitemap.ts
+++ b/landing-page/demo/src/app/sitemap.ts
@@ -21,6 +21,7 @@ const ROUTES: Array<{
   { path: '/industries', changeFrequency: 'monthly', priority: 0.75 },
   { path: '/industries/lending', changeFrequency: 'monthly', priority: 0.65 },
   { path: '/industries/real-estate', changeFrequency: 'monthly', priority: 0.65 },
+  { path: '/industries/government', changeFrequency: 'monthly', priority: 0.65 },
   { path: '/industries/healthcare', changeFrequency: 'monthly', priority: 0.65 },
   { path: '/industries/legal', changeFrequency: 'monthly', priority: 0.65 },
   { path: '/industries/insurance', changeFrequency: 'monthly', priority: 0.65 },

--- a/landing-page/demo/src/components/sections/industry-page.tsx
+++ b/landing-page/demo/src/components/sections/industry-page.tsx
@@ -5,7 +5,7 @@ import { ArrowNarrowRightIcon } from '@/components/icons/arrow-narrow-right-icon
 import { CallToActionSimple } from '@/components/sections/call-to-action-simple'
 import { HeroSimpleCentered } from '@/components/sections/hero-simple-centered'
 import { NewsletterForm } from '@/components/sections/footer-with-newsletter-form-categories-and-social-icons'
-import type { Industry } from '@/lib/industries'
+import type { Industry, IndustryStackRow } from '@/lib/industries'
 import { site } from '@/lib/site'
 
 function StatusBadge({ industry }: { industry: Industry }) {
@@ -23,6 +23,17 @@ function StatusBadge({ industry }: { industry: Industry }) {
   )
 }
 
+function HeroEyebrow({ industry }: { industry: Industry }) {
+  if (industry.heroEyebrow) {
+    return (
+      <p className="max-w-3xl text-center text-sm font-medium tracking-wide text-mist-600 uppercase dark:text-mist-400">
+        {industry.heroEyebrow}
+      </p>
+    )
+  }
+  return <StatusBadge industry={industry} />
+}
+
 function DisclaimerNotice({ text }: { text: string }) {
   return (
     <div className="mx-auto max-w-3xl rounded-xl border border-amber-500/25 bg-amber-500/5 px-5 py-4 text-sm/7 text-mist-700 dark:text-mist-300">
@@ -31,7 +42,48 @@ function DisclaimerNotice({ text }: { text: string }) {
   )
 }
 
+function StackTable({
+  rows,
+  systemLabel = 'System',
+  roleLabel = 'Role',
+}: {
+  rows: readonly IndustryStackRow[]
+  systemLabel?: string
+  roleLabel?: string
+}) {
+  const hasProvider = rows.some((row) => row.provider)
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[320px] border-collapse text-left text-sm/7">
+        <thead>
+          <tr className="border-b border-mist-950/10 dark:border-white/10">
+            <th className="py-2 pr-3 font-semibold text-mist-950 dark:text-white">{systemLabel}</th>
+            <th className="py-2 pr-3 font-semibold text-mist-950 dark:text-white">{roleLabel}</th>
+            {hasProvider ? (
+              <th className="py-2 font-semibold text-mist-950 dark:text-white">Who provides it</th>
+            ) : null}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.system} className="border-b border-mist-950/5 dark:border-white/5">
+              <td className="py-2 pr-3 font-medium text-mist-950 dark:text-white">{row.system}</td>
+              <td className="py-2 pr-3 text-mist-700 dark:text-mist-400">{row.role}</td>
+              {hasProvider ? (
+                <td className="py-2 text-mist-700 dark:text-mist-400">{row.provider ?? '—'}</td>
+              ) : null}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
 function ctaSubheadline(industry: Industry) {
+  if (industry.ctaSubheadline) {
+    return <p>{industry.ctaSubheadline}</p>
+  }
   if (industry.status === 'partial' || industry.status === 'shipped') {
     return (
       <p>
@@ -53,7 +105,7 @@ function PlannedIndustryStub({ industry }: { industry: Industry }) {
     <>
       <HeroSimpleCentered
         id="hero"
-        eyebrow={<StatusBadge industry={industry} />}
+        eyebrow={<HeroEyebrow industry={industry} />}
         headline={industry.headline}
         subheadline={<p>{industry.subheadline}</p>}
       />
@@ -115,11 +167,14 @@ export function IndustryPage({ industry }: { industry: Industry }) {
     return <PlannedIndustryStub industry={industry} />
   }
 
+  const secondaryHref = industry.ctaSecondaryHref ?? `${site.urls.docs}/vision/modularization`
+  const secondaryLabel = industry.ctaSecondaryLabel ?? 'Modularization roadmap'
+
   return (
     <>
       <HeroSimpleCentered
         id="hero"
-        eyebrow={<StatusBadge industry={industry} />}
+        eyebrow={<HeroEyebrow industry={industry} />}
         headline={industry.headline}
         subheadline={<p>{industry.subheadline}</p>}
         cta={
@@ -142,7 +197,11 @@ export function IndustryPage({ industry }: { industry: Industry }) {
         </section>
       ) : null}
 
-      <Section id="overview" eyebrow="Overview" headline={`ClawQL for ${industry.name.toLowerCase()}`}>
+      <Section
+        id="overview"
+        eyebrow="Overview"
+        headline={industry.overviewHeadline ?? `ClawQL for ${industry.name.toLowerCase()}`}
+      >
         <p className="max-w-3xl text-sm/7 text-mist-700 dark:text-mist-400">{industry.overview}</p>
         {industry.productionReference ? (
           <p className="mt-4 max-w-3xl text-sm/7 text-mist-600 dark:text-mist-600">{industry.productionReference}</p>
@@ -154,16 +213,21 @@ export function IndustryPage({ industry }: { industry: Industry }) {
           id="market"
           eyebrow="Industry context"
           headline={
-            industry.audiences && industry.audiences.length > 0
+            industry.marketHeadline ??
+            (industry.audiences && industry.audiences.length > 0
               ? 'The gap brokerages and FSBO sellers share'
-              : 'The gap every brokerage stack shares'
+              : 'The gap every brokerage stack shares')
           }
           subheadline={
-            <p>
-              {industry.audiences && industry.audiences.length > 0
-                ? 'CRM and flat-fee listing tools compete on pipeline and MLS access — nobody classifies title commitments or compares buyer offers with grounded citations.'
-                : 'Franchise CRMs compete on lead gen and agent productivity — transaction document intelligence is still unowned.'}
-            </p>
+            industry.marketSubheadline ? (
+              <p>{industry.marketSubheadline}</p>
+            ) : (
+              <p>
+                {industry.audiences && industry.audiences.length > 0
+                  ? 'CRM and flat-fee listing tools compete on pipeline and MLS access — nobody classifies title commitments or compares buyer offers with grounded citations.'
+                  : 'Franchise CRMs compete on lead gen and agent productivity — transaction document intelligence is still unowned.'}
+              </p>
+            )
           }
         >
           <p className="max-w-3xl text-sm/7 text-mist-700 dark:text-mist-400">{industry.marketContext}</p>
@@ -174,11 +238,11 @@ export function IndustryPage({ industry }: { industry: Industry }) {
         <Section
           id="audiences"
           eyebrow="Who it's for"
-          headline="Two audiences, one document engine"
+          headline={industry.audiencesHeadline ?? 'Two audiences, one document engine'}
           subheadline={
             <p>
-              Same classify → extract → recall pipeline — positioned for transaction coordinators at
-              brokerages and for FSBO sellers comparing offers without a coordinator seat.
+              {industry.audiencesSubheadline ??
+                'Same classify → extract → recall pipeline — positioned for transaction coordinators at brokerages and for FSBO sellers comparing offers without a coordinator seat.'}
             </p>
           }
         >
@@ -197,24 +261,11 @@ export function IndustryPage({ industry }: { industry: Industry }) {
                   <p className="text-sm/7 text-mist-700 dark:text-mist-400">{audience.overview}</p>
                 </div>
                 {audience.stackPlacement && audience.stackPlacement.length > 0 ? (
-                  <div className="overflow-x-auto">
-                    <table className="w-full min-w-[320px] border-collapse text-left text-sm/7">
-                      <thead>
-                        <tr className="border-b border-mist-950/10 dark:border-white/10">
-                          <th className="py-2 pr-3 font-semibold text-mist-950 dark:text-white">System</th>
-                          <th className="py-2 font-semibold text-mist-950 dark:text-white">Role</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {audience.stackPlacement.map((row) => (
-                          <tr key={row.system} className="border-b border-mist-950/5 dark:border-white/5">
-                            <td className="py-2 pr-3 font-medium text-mist-950 dark:text-white">{row.system}</td>
-                            <td className="py-2 text-mist-700 dark:text-mist-400">{row.role}</td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
+                  <StackTable
+                    rows={audience.stackPlacement}
+                    systemLabel={audience.stackPlacement.some((r) => r.provider) ? 'Layer' : 'System'}
+                    roleLabel={audience.stackPlacement.some((r) => r.provider) ? 'What it does' : 'Role'}
+                  />
                 ) : null}
                 {audience.useCases && audience.useCases.length > 0 ? (
                   <ul className="flex flex-col gap-3">
@@ -249,24 +300,7 @@ export function IndustryPage({ industry }: { industry: Industry }) {
             </p>
           }
         >
-          <div className="overflow-x-auto">
-            <table className="w-full min-w-[480px] border-collapse text-left text-sm/7">
-              <thead>
-                <tr className="border-b border-mist-950/10 dark:border-white/10">
-                  <th className="py-3 pr-4 font-semibold text-mist-950 dark:text-white">System</th>
-                  <th className="py-3 font-semibold text-mist-950 dark:text-white">Role</th>
-                </tr>
-              </thead>
-              <tbody>
-                {industry.stackPlacement.map((row) => (
-                  <tr key={row.system} className="border-b border-mist-950/5 dark:border-white/5">
-                    <td className="py-3 pr-4 font-medium text-mist-950 dark:text-white">{row.system}</td>
-                    <td className="py-3 text-mist-700 dark:text-mist-400">{row.role}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          <StackTable rows={industry.stackPlacement} />
         </Section>
       ) : null}
 
@@ -288,11 +322,11 @@ export function IndustryPage({ industry }: { industry: Industry }) {
       <Section
         id="pain-points"
         eyebrow="Challenges"
-        headline="Problems agents solve in this vertical"
+        headline={industry.painPointsHeadline ?? 'Problems agents solve in this vertical'}
         subheadline={
           <p>
-            These are the operational friction points {industry.packageName} targets — on top of ClawQL Core search,
-            execute, memory, audit, and the IDP pipeline.
+            {industry.painPointsSubheadline ??
+              `These are the operational friction points ${industry.packageName} targets — on top of ClawQL Core search, execute, memory, audit, and the IDP pipeline.`}
           </p>
         }
       >
@@ -310,7 +344,12 @@ export function IndustryPage({ industry }: { industry: Industry }) {
         id="platform"
         eyebrow="Platform"
         headline="Shared ClawQL capabilities"
-        subheadline={<p>Every vertical package composes these horizontal layers — security, memory, and document intelligence.</p>}
+        subheadline={
+          <p>
+            {industry.platformSubheadline ??
+              'Every vertical package composes these horizontal layers — security, memory, and document intelligence.'}
+          </p>
+        }
       >
         <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           {industry.platformCapabilities.map((item) => (
@@ -331,9 +370,13 @@ export function IndustryPage({ industry }: { industry: Industry }) {
         headline={`Tools from ${industry.packageName}`}
         subheadline={
           <p>
-            Planned or shipping MCP tools from{' '}
-            <Link href="https://docs.clawql.com/vision/modularization">modularization v2.1</Link> — registered when the
-            vertical package is enabled via <code className="text-sm">CLAWQL_ENABLE_*</code> or Operator flags.
+            {industry.domainToolsSubheadline ?? (
+              <>
+                Planned or shipping MCP tools from{' '}
+                <Link href="https://docs.clawql.com/vision/modularization">modularization v2.1</Link> — registered when
+                the vertical package is enabled via <code className="text-sm">CLAWQL_ENABLE_*</code> or Operator flags.
+              </>
+            )}
           </p>
         }
       >
@@ -347,23 +390,60 @@ export function IndustryPage({ industry }: { industry: Industry }) {
         </div>
       </Section>
 
-      <Section
-        id="documents"
-        eyebrow="Document types"
-        headline="What the IDP pipeline processes"
-        subheadline={<p>Representative inputs agents classify, extract, redact, and archive in this vertical.</p>}
-      >
-        <ul className="flex flex-wrap gap-2">
-          {industry.documentTypes.map((docType) => (
-            <li
-              key={docType}
-              className="rounded-full bg-mist-950/5 px-4 py-2 text-sm font-medium text-mist-700 dark:bg-white/10 dark:text-mist-300"
-            >
-              {docType}
-            </li>
-          ))}
-        </ul>
-      </Section>
+      {industry.auditEvents && industry.auditEvents.length > 0 ? (
+        <Section
+          id="audit-events"
+          eyebrow="Audit events"
+          headline="What goes into the permanent record"
+          subheadline={
+            <p>
+              {industry.auditEventsSubheadline ??
+                'Every event appends a hash-chained entry to the WORM audit log. Entries cannot be modified or deleted after writing.'}
+            </p>
+          }
+        >
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[480px] border-collapse text-left text-sm/7">
+              <thead>
+                <tr className="border-b border-mist-950/10 dark:border-white/10">
+                  <th className="py-3 pr-4 font-semibold text-mist-950 dark:text-white">Event</th>
+                  <th className="py-3 font-semibold text-mist-950 dark:text-white">Trigger</th>
+                </tr>
+              </thead>
+              <tbody>
+                {industry.auditEvents.map((row) => (
+                  <tr key={row.event} className="border-b border-mist-950/5 dark:border-white/5">
+                    <td className="py-3 pr-4 font-mono text-sm font-medium text-mist-950 dark:text-white">
+                      {row.event}
+                    </td>
+                    <td className="py-3 text-mist-700 dark:text-mist-400">{row.trigger}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Section>
+      ) : null}
+
+      {industry.documentTypes.length > 0 ? (
+        <Section
+          id="documents"
+          eyebrow="Document types"
+          headline="What the IDP pipeline processes"
+          subheadline={<p>Representative inputs agents classify, extract, redact, and archive in this vertical.</p>}
+        >
+          <ul className="flex flex-wrap gap-2">
+            {industry.documentTypes.map((docType) => (
+              <li
+                key={docType}
+                className="rounded-full bg-mist-950/5 px-4 py-2 text-sm font-medium text-mist-700 dark:bg-white/10 dark:text-mist-300"
+              >
+                {docType}
+              </li>
+            ))}
+          </ul>
+        </Section>
+      ) : null}
 
       <Section
         id="use-cases"
@@ -371,8 +451,12 @@ export function IndustryPage({ industry }: { industry: Industry }) {
         headline={`Why ClawQL for ${industry.name.toLowerCase()}`}
         subheadline={
           <p>
-            Vertical packages extend the same Agentic Gateway — search, execute, memory, IDP, audit — with domain tools from{' '}
-            <code className="text-sm">{industry.packageName}</code>.
+            {industry.useCasesSubheadline ?? (
+              <>
+                Vertical packages extend the same Agentic Gateway — search, execute, memory, IDP, audit — with domain
+                tools from <code className="text-sm">{industry.packageName}</code>.
+              </>
+            )}
           </p>
         }
       >
@@ -386,64 +470,70 @@ export function IndustryPage({ industry }: { industry: Industry }) {
         </div>
       </Section>
 
-      <Section
-        id="examples"
-        eyebrow="Examples"
-        headline="Example agent workflows"
-        subheadline={
-          <p>
-            Representative MCP tool sequences with step-by-step detail — production deployments add tenant classifiers,
-            RBAC, and your compliance policies on top.
-          </p>
-        }
-      >
-        <div className="flex flex-col gap-6">
-          {industry.examples.map((example) => (
-            <article
-              key={example.title}
-              className="flex flex-col gap-5 rounded-xl bg-mist-950/2.5 p-6 sm:p-8 dark:bg-white/5"
-            >
-              <div className="flex flex-col gap-2">
-                <p className="text-xs font-medium tracking-wide text-mist-600 uppercase dark:text-mist-400">
-                  {example.summary}
-                </p>
-                <h3 className="text-base font-semibold text-mist-950 dark:text-white">{example.title}</h3>
-                <p className="text-sm/7 text-mist-700 dark:text-mist-400">{example.body}</p>
-              </div>
-              <ol className="flex flex-col gap-3 border-l border-mist-950/10 pl-5 dark:border-white/10">
-                {example.steps.map((step, index) => (
-                  <li key={step.label} className="relative flex flex-col gap-1">
-                    <span className="absolute -left-[1.375rem] flex size-5 items-center justify-center rounded-full bg-mist-950/10 text-xs font-semibold text-mist-600 dark:bg-white/10 dark:text-mist-300">
-                      {index + 1}
-                    </span>
-                    <span className="text-sm font-semibold text-mist-950 dark:text-white">{step.label}</span>
-                    <span className="text-sm/7 text-mist-700 dark:text-mist-400">{step.detail}</span>
-                  </li>
-                ))}
-              </ol>
-              <div className="flex flex-wrap gap-2">
-                {example.tools.map((tool) => (
-                  <code
-                    key={tool}
-                    className="rounded-md bg-mist-950/5 px-2 py-1 text-xs font-semibold text-mist-800 dark:bg-white/10 dark:text-mist-200"
-                  >
-                    {tool}()
-                  </code>
-                ))}
-              </div>
-            </article>
-          ))}
-        </div>
-      </Section>
+      {industry.examples.length > 0 ? (
+        <Section
+          id="examples"
+          eyebrow="Examples"
+          headline="Example agent workflows"
+          subheadline={
+            <p>
+              Representative MCP tool sequences with step-by-step detail — production deployments add tenant classifiers,
+              RBAC, and your compliance policies on top.
+            </p>
+          }
+        >
+          <div className="flex flex-col gap-6">
+            {industry.examples.map((example) => (
+              <article
+                key={example.title}
+                className="flex flex-col gap-5 rounded-xl bg-mist-950/2.5 p-6 sm:p-8 dark:bg-white/5"
+              >
+                <div className="flex flex-col gap-2">
+                  <p className="text-xs font-medium tracking-wide text-mist-600 uppercase dark:text-mist-400">
+                    {example.summary}
+                  </p>
+                  <h3 className="text-base font-semibold text-mist-950 dark:text-white">{example.title}</h3>
+                  <p className="text-sm/7 text-mist-700 dark:text-mist-400">{example.body}</p>
+                </div>
+                <ol className="flex flex-col gap-3 border-l border-mist-950/10 pl-5 dark:border-white/10">
+                  {example.steps.map((step, index) => (
+                    <li key={step.label} className="relative flex flex-col gap-1">
+                      <span className="absolute -left-[1.375rem] flex size-5 items-center justify-center rounded-full bg-mist-950/10 text-xs font-semibold text-mist-600 dark:bg-white/10 dark:text-mist-300">
+                        {index + 1}
+                      </span>
+                      <span className="text-sm font-semibold text-mist-950 dark:text-white">{step.label}</span>
+                      <span className="text-sm/7 text-mist-700 dark:text-mist-400">{step.detail}</span>
+                    </li>
+                  ))}
+                </ol>
+                <div className="flex flex-wrap gap-2">
+                  {example.tools.map((tool) => (
+                    <code
+                      key={tool}
+                      className="rounded-md bg-mist-950/5 px-2 py-1 text-xs font-semibold text-mist-800 dark:bg-white/10 dark:text-mist-200"
+                    >
+                      {tool}()
+                    </code>
+                  ))}
+                </div>
+              </article>
+            ))}
+          </div>
+        </Section>
+      ) : null}
 
       <Section
         id="compliance"
         eyebrow="Security & compliance"
-        headline="Built for regulated workflows"
+        headline={industry.complianceHeadline ?? 'Built for regulated workflows'}
         subheadline={
           <p>
-            Industry pages summarize platform capabilities — your legal, compliance, and security teams should review{' '}
-            <Link href={`${site.urls.docs}/security`}>docs.clawql.com/security</Link> before production data.
+            {industry.complianceSubheadline ?? (
+              <>
+                Industry pages summarize platform capabilities — your legal, compliance, and security teams should review{' '}
+                <Link href={`${site.urls.docs}/security`}>docs.clawql.com/security</Link> before production data.
+              </>
+            )}
           </p>
         }
       >
@@ -476,19 +566,29 @@ export function IndustryPage({ industry }: { industry: Industry }) {
 
       <CallToActionSimple
         id="cta"
-        headline={`Ready to demo ClawQL for ${industry.name.toLowerCase()}?`}
+        headline={industry.ctaHeadline ?? `Ready to demo ClawQL for ${industry.name.toLowerCase()}?`}
         subheadline={ctaSubheadline(industry)}
         cta={
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
             <ButtonLink href={site.urls.signup} size="lg">
               Book a demo
             </ButtonLink>
-            <PlainButtonLink href={`${site.urls.docs}/vision/modularization`} size="lg">
-              Modularization roadmap <ArrowNarrowRightIcon />
+            <PlainButtonLink href={secondaryHref} size="lg">
+              {secondaryLabel} <ArrowNarrowRightIcon />
             </PlainButtonLink>
           </div>
         }
       />
+
+      {industry.closingNote ? (
+        <section className="pb-16">
+          <div className="px-6">
+            <p className="mx-auto max-w-3xl text-center text-xs/6 text-mist-600 dark:text-mist-500">
+              {industry.closingNote}
+            </p>
+          </div>
+        </section>
+      ) : null}
     </>
   )
 }

--- a/landing-page/demo/src/components/sections/industry-page.tsx
+++ b/landing-page/demo/src/components/sections/industry-page.tsx
@@ -3,8 +3,8 @@ import { Link } from '@/components/elements/link'
 import { Section } from '@/components/elements/section'
 import { ArrowNarrowRightIcon } from '@/components/icons/arrow-narrow-right-icon'
 import { CallToActionSimple } from '@/components/sections/call-to-action-simple'
-import { HeroSimpleCentered } from '@/components/sections/hero-simple-centered'
 import { NewsletterForm } from '@/components/sections/footer-with-newsletter-form-categories-and-social-icons'
+import { HeroSimpleCentered } from '@/components/sections/hero-simple-centered'
 import type { Industry, IndustryStackRow } from '@/lib/industries'
 import { site } from '@/lib/site'
 
@@ -59,9 +59,7 @@ function StackTable({
           <tr className="border-b border-mist-950/10 dark:border-white/10">
             <th className="py-2 pr-3 font-semibold text-mist-950 dark:text-white">{systemLabel}</th>
             <th className="py-2 pr-3 font-semibold text-mist-950 dark:text-white">{roleLabel}</th>
-            {hasProvider ? (
-              <th className="py-2 font-semibold text-mist-950 dark:text-white">Who provides it</th>
-            ) : null}
+            {hasProvider ? <th className="py-2 font-semibold text-mist-950 dark:text-white">Who provides it</th> : null}
           </tr>
         </thead>
         <tbody>
@@ -69,9 +67,7 @@ function StackTable({
             <tr key={row.system} className="border-b border-mist-950/5 dark:border-white/5">
               <td className="py-2 pr-3 font-medium text-mist-950 dark:text-white">{row.system}</td>
               <td className="py-2 pr-3 text-mist-700 dark:text-mist-400">{row.role}</td>
-              {hasProvider ? (
-                <td className="py-2 text-mist-700 dark:text-mist-400">{row.provider ?? '—'}</td>
-              ) : null}
+              {hasProvider ? <td className="py-2 text-mist-700 dark:text-mist-400">{row.provider ?? '—'}</td> : null}
             </tr>
           ))}
         </tbody>
@@ -143,8 +139,8 @@ function PlannedIndustryStub({ industry }: { industry: Industry }) {
         headline="Need lending or document automation today?"
         subheadline={
           <p>
-            Explore the lending vertical or self-host ClawQL Core with the full IDP pipeline while {industry.name}{' '}
-            tools are in development.
+            Explore the lending vertical or self-host ClawQL Core with the full IDP pipeline while {industry.name} tools
+            are in development.
           </p>
         }
         cta={
@@ -251,7 +247,7 @@ export function IndustryPage({ industry }: { industry: Industry }) {
               <article
                 key={audience.id}
                 id={audience.id}
-                className="scroll-mt-24 flex flex-col gap-5 rounded-xl border border-mist-950/10 bg-mist-950/2.5 p-6 dark:border-white/10 dark:bg-white/5"
+                className="flex scroll-mt-24 flex-col gap-5 rounded-xl border border-mist-950/10 bg-mist-950/2.5 p-6 dark:border-white/10 dark:bg-white/5"
               >
                 <div className="flex flex-col gap-2">
                   <p className="text-xs font-medium tracking-wide text-mist-600 uppercase dark:text-mist-400">
@@ -477,8 +473,8 @@ export function IndustryPage({ industry }: { industry: Industry }) {
           headline="Example agent workflows"
           subheadline={
             <p>
-              Representative MCP tool sequences with step-by-step detail — production deployments add tenant classifiers,
-              RBAC, and your compliance policies on top.
+              Representative MCP tool sequences with step-by-step detail — production deployments add tenant
+              classifiers, RBAC, and your compliance policies on top.
             </p>
           }
         >
@@ -530,8 +526,8 @@ export function IndustryPage({ industry }: { industry: Industry }) {
           <p>
             {industry.complianceSubheadline ?? (
               <>
-                Industry pages summarize platform capabilities — your legal, compliance, and security teams should review{' '}
-                <Link href={`${site.urls.docs}/security`}>docs.clawql.com/security</Link> before production data.
+                Industry pages summarize platform capabilities — your legal, compliance, and security teams should
+                review <Link href={`${site.urls.docs}/security`}>docs.clawql.com/security</Link> before production data.
               </>
             )}
           </p>

--- a/landing-page/demo/src/lib/agent-discovery.ts
+++ b/landing-page/demo/src/lib/agent-discovery.ts
@@ -383,7 +383,7 @@ export function getAgentMarkdownMap(origin = getSiteOriginString()): Record<stri
     '/about': `# About ClawQL\n\nClawQL provides the Agentic Gateway as the Foundational Platform for Auditable Production AI.\n\nSee ${origin}/about/ for mission and ecosystem overview.`,
     '/signup': `# Sign up\n\nStart a 14-day Developer trial or join the waitlist.\n\n${origin}/signup/`,
     '/privacy-policy': `# Privacy Policy\n\nSee ${origin}/privacy-policy/ for the full policy.`,
-    '/industries': `# Industries\n\nVertical workflows for lending, real estate, healthcare, legal, insurance, and education.\n\n${origin}/industries/`,
+    '/industries': `# Industries\n\nVertical workflows for lending, real estate, government, healthcare, legal, insurance, and education.\n\n${origin}/industries/`,
     '/inference/gtm': `# Inference-first GTM playbook\n\nClawQL provides the Agentic Gateway as the Foundational Platform for Auditable Production AI — Zero-Trust Agentic Fabric.\n\nSee ${origin}/inference/gtm/.`,
     '/idp': `# Intelligent Document Processing\n\nClawQL IDP — full document lifecycle (ingest → VDR), flat Starter pricing vs ABBYY / Hyperscience / Intralinks, Helm deploy or 14-day trial.\n\nSee ${origin}/idp/.`,
     '/idp/gtm': `# IDP-first GTM playbook\n\nStandalone ClawQL Intelligent Document Processing go-to-market — market reality, honest positioning, sales motion, and landing-page brief vs ABBYY, Hyperscience, and Intralinks.\n\nSee ${origin}/idp/gtm/.`,

--- a/landing-page/demo/src/lib/industries.ts
+++ b/landing-page/demo/src/lib/industries.ts
@@ -1,7 +1,10 @@
 export type {
   Industry,
+  IndustryAudience,
+  IndustryAuditEvent,
   IndustryExample,
   IndustryResource,
+  IndustryStackRow,
   IndustryWorkflowStep,
 } from './industries/types'
 

--- a/landing-page/demo/src/lib/industries/government.ts
+++ b/landing-page/demo/src/lib/industries/government.ts
@@ -12,7 +12,7 @@ export const governmentIndustry: Industry = {
   heroEyebrow: 'Measurable outcomes · immutable baselines · independently verifiable records',
   overviewHeadline: 'ClawQL for government outcome accountability',
   overview:
-    'California has issued about $196 billion in general obligation bonds since 2000, with roughly $81.8 billion still outstanding and nearly $8.6 billion in debt service this fiscal year alone. Schools, water systems, climate programs, housing — voters approved them all. The state can track how bond dollars are spent. It cannot consistently answer whether those investments achieved the outcomes voters were promised. Spending accountability and outcome accountability are not the same thing. Governments have built robust infrastructure for the first and almost nothing for the second. That is not a California problem. It is a government technology problem with a precise technical solution: define measurable outcomes at authorization, record immutable baselines before programs begin, and maintain append-only, externally anchored outcome records that any qualified party can verify without trusting the program being measured. clawql-government composes ClawQL\'s WORM audit, Merkle chaining, and Arweave anchoring into that outcome layer — the same architecture used for AI agent trails and surveillance evidence integrity, under a different authorization surface. The framing that works: financial audit has required immutable baseline records for decades. Outcome measurement deserves the same standard. Programs that cannot be measured cannot be found to have failed — and that incentive is why the infrastructure must push integrity outside the control of the party being measured.',
+    "California has issued about $196 billion in general obligation bonds since 2000, with roughly $81.8 billion still outstanding and nearly $8.6 billion in debt service this fiscal year alone. Schools, water systems, climate programs, housing — voters approved them all. The state can track how bond dollars are spent. It cannot consistently answer whether those investments achieved the outcomes voters were promised. Spending accountability and outcome accountability are not the same thing. Governments have built robust infrastructure for the first and almost nothing for the second. That is not a California problem. It is a government technology problem with a precise technical solution: define measurable outcomes at authorization, record immutable baselines before programs begin, and maintain append-only, externally anchored outcome records that any qualified party can verify without trusting the program being measured. clawql-government composes ClawQL's WORM audit, Merkle chaining, and Arweave anchoring into that outcome layer — the same architecture used for AI agent trails and surveillance evidence integrity, under a different authorization surface. The framing that works: financial audit has required immutable baseline records for decades. Outcome measurement deserves the same standard. Programs that cannot be measured cannot be found to have failed — and that incentive is why the infrastructure must push integrity outside the control of the party being measured.",
   marketHeadline: 'Spending records are not outcome records',
   marketSubheadline:
     'California tracks where bond dollars go. It does not consistently measure whether those investments delivered what voters expected — and new bond measures are still moving without that requirement.',
@@ -91,7 +91,7 @@ export const governmentIndustry: Industry = {
     },
     {
       title: 'Program-controlled logs are not independent evidence',
-      body: 'Operational databases designed for management can be amended, selectively retained, or purged. Outcome integrity requires append-only storage, cryptographic chaining, and an external anchor outside the program\'s control — the same properties that make financial audit trails trustworthy.',
+      body: "Operational databases designed for management can be amended, selectively retained, or purged. Outcome integrity requires append-only storage, cryptographic chaining, and an external anchor outside the program's control — the same properties that make financial audit trails trustworthy.",
     },
     {
       title: 'FOIA and citizen access without a second system of record',
@@ -117,13 +117,11 @@ export const governmentIndustry: Industry = {
     },
     {
       name: 'outcome_baseline_record',
-      description:
-        'Lock an immutable baseline at program inception — hash-chained and scheduled for external anchor.',
+      description: 'Lock an immutable baseline at program inception — hash-chained and scheduled for external anchor.',
     },
     {
       name: 'outcome_measure_ingest',
-      description:
-        'Ingest a timed outcome measurement against the registered definition; append to the WORM chain.',
+      description: 'Ingest a timed outcome measurement against the registered definition; append to the WORM chain.',
     },
     {
       name: 'outcome_verify',
@@ -137,7 +135,8 @@ export const governmentIndustry: Industry = {
     },
     {
       name: 'foia_route',
-      description: 'Classify and route FOIA / public records requests with redaction checkpoints and audit correlation IDs.',
+      description:
+        'Classify and route FOIA / public records requests with redaction checkpoints and audit correlation IDs.',
     },
     {
       name: 'permit_classify',
@@ -197,7 +196,10 @@ export const governmentIndustry: Industry = {
     { event: 'BASELINE_RECORDED', trigger: 'Immutable baseline locked at program inception' },
     { event: 'OUTCOME_MEASURE_INGESTED', trigger: 'Timed outcome measurement appended to the chain' },
     { event: 'OUTCOME_VERIFIED', trigger: 'Verification pass or fail against Merkle chain + anchor' },
-    { event: 'OUTCOME_DEFINITION_REJECTED', trigger: 'Registration blocked — outcome not measurable / baseline missing' },
+    {
+      event: 'OUTCOME_DEFINITION_REJECTED',
+      trigger: 'Registration blocked — outcome not measurable / baseline missing',
+    },
     { event: 'MERKLE_ROOT_COMPUTED', trigger: 'New Merkle root calculated for an outcome window' },
     { event: 'ARWEAVE_ANCHOR_CONFIRMED', trigger: 'Root published to Arweave, transaction ID recorded' },
     { event: 'AUTHORIZATION_COMPLIANCE_VERIFIED', trigger: 'Compliance report generated against model language' },

--- a/landing-page/demo/src/lib/industries/government.ts
+++ b/landing-page/demo/src/lib/industries/government.ts
@@ -1,0 +1,260 @@
+import type { Industry } from './types'
+
+export const governmentIndustry: Industry = {
+  slug: 'government',
+  name: 'Government',
+  headline: 'Outcome accountability for the programs voters fund.',
+  subheadline:
+    "ClawQL's government vertical (clawql-government) turns bond authorizations and public programs into independently verifiable outcome records — measurable definitions at authorization, immutable baselines, Merkle-chained WORM audit, and Arweave anchoring — so spending accountability and outcome accountability finally share the same infrastructure.",
+  packageName: 'clawql-government',
+  status: 'partial',
+  statusLabel: 'Outcome audit infrastructure available · domain package planned',
+  heroEyebrow: 'Measurable outcomes · immutable baselines · independently verifiable records',
+  overviewHeadline: 'ClawQL for government outcome accountability',
+  overview:
+    'California has issued about $196 billion in general obligation bonds since 2000, with roughly $81.8 billion still outstanding and nearly $8.6 billion in debt service this fiscal year alone. Schools, water systems, climate programs, housing — voters approved them all. The state can track how bond dollars are spent. It cannot consistently answer whether those investments achieved the outcomes voters were promised. Spending accountability and outcome accountability are not the same thing. Governments have built robust infrastructure for the first and almost nothing for the second. That is not a California problem. It is a government technology problem with a precise technical solution: define measurable outcomes at authorization, record immutable baselines before programs begin, and maintain append-only, externally anchored outcome records that any qualified party can verify without trusting the program being measured. clawql-government composes ClawQL\'s WORM audit, Merkle chaining, and Arweave anchoring into that outcome layer — the same architecture used for AI agent trails and surveillance evidence integrity, under a different authorization surface. The framing that works: financial audit has required immutable baseline records for decades. Outcome measurement deserves the same standard. Programs that cannot be measured cannot be found to have failed — and that incentive is why the infrastructure must push integrity outside the control of the party being measured.',
+  marketHeadline: 'Spending records are not outcome records',
+  marketSubheadline:
+    'California tracks where bond dollars go. It does not consistently measure whether those investments delivered what voters expected — and new bond measures are still moving without that requirement.',
+  marketContext:
+    'A CalMatters commentary put the gap bluntly: after hundreds of billions in bond authorization, whether outcomes materialized is "surprisingly difficult to answer." Outcome records are harder than spending ledgers because results are distributed, delayed, and contested — but "hard to measure" is not the same as "not measured at all." The current failure mode is structural: bond language often promises goals that cannot survive contact with data, baselines are not recorded immutably before programs start, and operational logs live inside systems controlled by the programs being measured. The Oak Park, Illinois surveillance case is the same pattern at contract scale — cameras paid for on promised crime-reduction outcomes, operated for years without measurement, then found to have played no meaningful role in investigations once an oversight board actually checked. New California measures — including university facilities/housing and a proposed $10 billion housing bond — will again promise outcomes without requiring independently verifiable measurement. The legislative opening is clear: write measurable outcomes and baselines into authorization language, require WORM storage with external anchoring for outcome records, expose public verification APIs, and give auditors a standing mandate to cryptographically verify active programs. clawql-government is the infrastructure that makes those requirements implementable rather than aspirational.',
+  audiencesHeadline: 'Two audiences, one outcome engine',
+  audiencesSubheadline:
+    'Same Merkle-chained WORM audit and Arweave anchoring — positioned for agencies that must prove program results, and for legislators and auditors who need machine-verifiable accountability without trusting program self-reporting.',
+  audiences: [
+    {
+      id: 'agencies',
+      name: 'State and local agencies',
+      headline: 'Prove program outcomes without rewriting every ledger.',
+      overview:
+        'Agencies already generate operational records for program management. clawql-government turns those records into audit-grade outcome trails: baselines locked at inception, measurements appended immutably, Merkle roots anchored externally, and FOIA/public verification paths that do not require trusting the program database alone.',
+      stackPlacement: [
+        {
+          system: 'Bond / program authorization',
+          role: 'Define measurable outcomes, baselines, and measurement periods',
+          provider: 'Legislature / agency',
+        },
+        {
+          system: 'clawql-government',
+          role: 'Record baselines, ingest outcome measures, Merkle-chain + Arweave anchor',
+          provider: 'ClawQL',
+        },
+        {
+          system: 'Program operations systems',
+          role: 'Source operational data (construction, housing units, water events, etc.)',
+          provider: 'Agency / vendors',
+        },
+        {
+          system: 'Auditors & public',
+          role: 'Independently verify integrity via public transaction IDs and APIs',
+          provider: 'Any qualified party',
+        },
+      ],
+    },
+    {
+      id: 'oversight',
+      name: 'Legislators, auditors, and oversight',
+      headline: 'Authorization language that can be enforced in software.',
+      overview:
+        'Outcome accountability fails when it depends on political will alone. Model authorization requirements — measurable outcomes, immutable baselines, WORM + external anchors, public verification, standing cryptographic audit — become enforceable when the infrastructure is already available. clawql-government is that infrastructure.',
+      useCases: [
+        {
+          title: 'Bond authorization checklists',
+          body: 'Require measurable KPI language and baseline capture before proceeds flow — same rigor as spending limits.',
+        },
+        {
+          title: 'Standing State Auditor mandate',
+          body: 'Periodic merkle_verify / anchor status across active bond programs without relying on program self-attestation.',
+        },
+        {
+          title: 'Public verification',
+          body: 'Anyone with an Arweave transaction ID can confirm that published outcome roots have not been altered.',
+        },
+      ],
+    },
+  ],
+  painPointsHeadline: 'Problems clawql-government solves',
+  painPointsSubheadline:
+    'These are the structural gaps the vertical targets — on top of ClawQL Core WORM audit, Arweave anchoring, document IDP, FOIA-oriented redaction, and FedRAMP-ready deployment patterns.',
+  painPoints: [
+    {
+      title: 'Spending trails exist; outcome trails do not',
+      body: 'Bond dollars move through accounts auditors can follow. Outcomes — reduced system failures, housing units delivered, student-capacity targets — are rarely recorded in a form that survives independent scrutiny. clawql-government treats outcome events as first-class WORM audit entries chained to an immutable baseline.',
+    },
+    {
+      title: 'Goals written as slogans cannot be measured',
+      body: '"Improve water systems" is not an outcome definition. "Reduce system failure events 30% within five years against a defined baseline" is. The vertical expects measurable authorization language and rejects blank or non-quantified outcome registrations the way surveillance blocks blank case numbers.',
+    },
+    {
+      title: 'Baselines can be rewritten after the fact',
+      body: 'Without an immutable baseline recorded before the program begins, "improvement" is whatever the program later claims. Baselines are hash-chained at inception and anchored externally so retroactive adjustment is detectable.',
+    },
+    {
+      title: 'Program-controlled logs are not independent evidence',
+      body: 'Operational databases designed for management can be amended, selectively retained, or purged. Outcome integrity requires append-only storage, cryptographic chaining, and an external anchor outside the program\'s control — the same properties that make financial audit trails trustworthy.',
+    },
+    {
+      title: 'FOIA and citizen access without a second system of record',
+      body: 'Public records requests and citizen service routing still need document intelligence — classify, redact, route — on the same gateway that holds outcome trails. clawql-government composes IDP + memory with outcome audit rather than bolting a separate transparency portal onto unverifiable ledgers.',
+    },
+  ],
+  platformSubheadline:
+    'Every vertical package composes these horizontal layers — security, audit, documents, and supply chain integrity.',
+  platformCapabilities: [
+    'WORM forensic audit — Merkle-chained, hash-linked outcome and access events; same architecture as ClawQL inference and payments audit',
+    'Arweave anchoring — external immutable roots for baselines and outcome windows; publicly verifiable; typically under $1/day per program',
+    'IDP pipeline — FOIA packets, permit applications, tax forms, bid documents: classify, extract, redact, archive',
+    'Vault memory — durable program context, authorization language, and prior audit findings across agent sessions',
+    'Supply chain signing — Cosign-signed images, CycloneDX SBOM, startup hash verification via clawql-release',
+    'FedRAMP-oriented defaults — self-hosted deployment patterns for agencies that cannot put program data in unmanaged SaaS',
+  ],
+  domainToolsSubheadline: 'Registered when CLAWQL_GOVERNMENT_ENABLED=1 (planned package enable flag):',
+  domainTools: [
+    {
+      name: 'bond_program_register',
+      description:
+        'Register a bond-funded or authorized program with measurable outcome definitions, baseline references, and measurement periods.',
+    },
+    {
+      name: 'outcome_baseline_record',
+      description:
+        'Lock an immutable baseline at program inception — hash-chained and scheduled for external anchor.',
+    },
+    {
+      name: 'outcome_measure_ingest',
+      description:
+        'Ingest a timed outcome measurement against the registered definition; append to the WORM chain.',
+    },
+    {
+      name: 'outcome_verify',
+      description:
+        'Verify an outcome record against the Merkle chain and Arweave anchor; returns a machine-readable report for auditors.',
+    },
+    {
+      name: 'authorization_compliance_report',
+      description:
+        'Generate a section-by-section compliance report against model bond/program authorization requirements (measurable outcomes, baselines, WORM, public verify, auditor mandate).',
+    },
+    {
+      name: 'foia_route',
+      description: 'Classify and route FOIA / public records requests with redaction checkpoints and audit correlation IDs.',
+    },
+    {
+      name: 'permit_classify',
+      description: 'Classify permitting intake packets and extract structured fields for workflow routing.',
+    },
+    {
+      name: 'record_redact',
+      description: 'Redact PII and exempt material before public release or citizen portal publication.',
+    },
+    {
+      name: 'bid_analyze',
+      description: 'Analyze procurement / bid packages with grounded citations into vault memory.',
+    },
+    {
+      name: 'audit_generate',
+      description: 'Produce an examiner-ready audit package linking spending references to outcome chain proofs.',
+    },
+  ],
+  documentTypes: [
+    'Bond measure text and authorization statutes',
+    'Baseline metric reports and source datasets',
+    'Program outcome dashboards and annual reports',
+    'FOIA / public records request packets',
+    'Permit applications and inspection reports',
+    'Procurement bids and award justifications',
+    'Tax forms and citizen service filings',
+  ],
+  useCasesSubheadline:
+    'Bond programs, housing and facilities measures, infrastructure KPIs, FOIA, and procurement oversight — on one verifiable outcome engine.',
+  useCases: [
+    {
+      title: 'Bond measures with enforceable outcome language',
+      body: 'Before proceeds flow, bond_program_register captures measurable KPIs and outcome_baseline_record locks the pre-program baseline. Later outcome_measure_ingest entries are meaningless without that chain — the authorization becomes software-enforceable, not a PDF promise.',
+    },
+    {
+      title: 'Independent verification for State Auditors',
+      body: 'outcome_verify and merkle_verify return cryptographic proofs and Arweave transaction IDs. Auditors validate integrity without asking the program to "confirm" its own numbers — the same independence standard financial audit already assumes.',
+    },
+    {
+      title: 'Housing and facilities bonds under public scrutiny',
+      body: 'University facilities, student housing, and multifamily housing programs can publish unit-delivery and timeline outcomes as anchored records. Voters and journalists verify progress against the authorization baseline instead of relying on press releases.',
+    },
+    {
+      title: 'Contract-scale outcome failure detection',
+      body: 'Oak Park-style failures happen when promised outcomes are never measured. Mandatory measurement windows and WORM trails surface non-delivery while contracts are still active — not years later when the officials who made the promises have moved on.',
+    },
+    {
+      title: 'FOIA and permitting on the same gateway',
+      body: 'Citizen-facing document workflows (foia_route, permit_classify, record_redact) share audit correlation with outcome trails, so transparency requests and program performance evidence live in one Agentic Gateway rather than disconnected portals.',
+    },
+  ],
+  examples: [],
+  auditEventsSubheadline:
+    'Every government outcome and access event appends a hash-chained entry to the WORM audit log. Entries cannot be modified or deleted after writing. Correlation IDs link agent-assisted processing to the permanent record.',
+  auditEvents: [
+    { event: 'PROGRAM_REGISTERED', trigger: 'Bond or authorized program registered with measurable outcomes' },
+    { event: 'BASELINE_RECORDED', trigger: 'Immutable baseline locked at program inception' },
+    { event: 'OUTCOME_MEASURE_INGESTED', trigger: 'Timed outcome measurement appended to the chain' },
+    { event: 'OUTCOME_VERIFIED', trigger: 'Verification pass or fail against Merkle chain + anchor' },
+    { event: 'OUTCOME_DEFINITION_REJECTED', trigger: 'Registration blocked — outcome not measurable / baseline missing' },
+    { event: 'MERKLE_ROOT_COMPUTED', trigger: 'New Merkle root calculated for an outcome window' },
+    { event: 'ARWEAVE_ANCHOR_CONFIRMED', trigger: 'Root published to Arweave, transaction ID recorded' },
+    { event: 'AUTHORIZATION_COMPLIANCE_VERIFIED', trigger: 'Compliance report generated against model language' },
+    { event: 'FOIA_REQUEST_ROUTED', trigger: 'Public records request classified and routed' },
+    { event: 'RECORD_REDACTED', trigger: 'Exempt/PII material redacted before release' },
+    { event: 'AUDIT_PACKAGE_GENERATED', trigger: 'Examiner package linking spend refs to outcome proofs' },
+    { event: 'UNAUTHORIZED_ACCESS_BLOCKED', trigger: 'Access attempt outside provisioned agency/role scope' },
+  ],
+  complianceHeadline: 'Built for the accountability standard auditors already understand',
+  compliance: [
+    'WORM Merkle audit trail for baselines and outcomes — independently verifiable; same pattern as ClawQL inference and payments',
+    'External immutable anchoring — Arweave transaction IDs publicly accessible without agency cooperation on every request',
+    'Model authorization alignment — measurable outcomes, baselines, WORM storage, public verify API, standing auditor verification',
+    'FOIA / public records tooling — classify, redact, route with structured audit events',
+    'FedRAMP-ready deployment posture — self-hosted Helm/K8s patterns; Cosign + SBOM via clawql-release',
+    'Jurisdiction-aware defaults — data sovereignty and role scoping planned via clawql-auth vertical RLS',
+  ],
+  relatedResources: [
+    {
+      label: 'California bond outcome accountability (PragmaticVectors)',
+      href: 'https://pragmaticvectors.com/posts/california-bond-outcome-accountability/',
+    },
+    {
+      label: 'WORM forensic audit reference',
+      href: 'https://docs.clawql.com/security/audit-trail',
+    },
+    {
+      label: 'Security best practices',
+      href: 'https://docs.clawql.com/security/best-practices',
+    },
+    {
+      label: 'Immutable releases — Arweave',
+      href: 'https://docs.clawql.com/getting-started/immutable-releases',
+    },
+    {
+      label: 'Modularization v2.1 — clawql-government',
+      href: 'https://docs.clawql.com/vision/modularization',
+    },
+    {
+      label: 'Plugin registry — government vertical',
+      href: 'https://docs.clawql.com/plugins?kind=vertical&q=government#registry',
+    },
+    {
+      label: 'Surveillance evidence integrity (same audit architecture)',
+      href: 'https://docs.clawql.com/surveillance/clawql-surveillance',
+    },
+  ],
+  docsHref: 'https://docs.clawql.com/vision/modularization',
+  disclaimer:
+    'clawql-government is infrastructure for agencies, auditors, and oversight bodies. It does not authorize bonds, appropriate funds, or replace statutory audit mandates. Outcome definitions and baselines must be set by the authorizing body; ClawQL provides the immutable measurement and verification layer.',
+  ctaHeadline: 'Ready to demo ClawQL for government outcome accountability?',
+  ctaSubheadline:
+    'Self-host ClawQL Core with WORM audit and Arweave anchoring today, or contact us about clawql-government early access for bond and program outcome pilots.',
+  ctaSecondaryHref: 'https://docs.clawql.com/vision/modularization',
+  ctaSecondaryLabel: 'Modularization roadmap',
+  closingNote:
+    'clawql-government provides outcome-accountability infrastructure. Agencies define measurable outcomes; ClawQL records baselines and results in a form voters, auditors, and courts can independently verify.',
+  demoPitch:
+    'California can already prove where bond dollars went. It still cannot consistently prove whether voters got the outcomes they were promised. clawql-government closes that gap with measurable authorization hooks, immutable baselines, Merkle-chained outcome records, and Arweave anchors — the same independently verifiable audit architecture ClawQL uses for AI agents and evidence integrity, applied to public programs.',
+}

--- a/landing-page/demo/src/lib/industries/index.ts
+++ b/landing-page/demo/src/lib/industries/index.ts
@@ -1,4 +1,5 @@
 import { educationIndustry } from './education'
+import { governmentIndustry } from './government'
 import { healthcareIndustry } from './healthcare'
 import { insuranceIndustry } from './insurance'
 import { legalIndustry } from './legal'
@@ -7,14 +8,18 @@ import { realEstateIndustry } from './real-estate'
 
 export type {
   Industry,
+  IndustryAudience,
+  IndustryAuditEvent,
   IndustryExample,
   IndustryResource,
+  IndustryStackRow,
   IndustryWorkflowStep,
 } from './types'
 
 export const industries = [
   lendingIndustry,
   realEstateIndustry,
+  governmentIndustry,
   healthcareIndustry,
   legalIndustry,
   insuranceIndustry,

--- a/landing-page/demo/src/lib/industries/types.ts
+++ b/landing-page/demo/src/lib/industries/types.ts
@@ -19,6 +19,8 @@ export type IndustryResource = {
 export type IndustryStackRow = {
   system: string
   role: string
+  /** Optional third column (e.g. who provides the layer). */
+  provider?: string
 }
 
 export type IndustryAudience = {
@@ -33,6 +35,11 @@ export type IndustryAudience = {
   useCases?: readonly { title: string; body: string }[]
 }
 
+export type IndustryAuditEvent = {
+  event: string
+  trigger: string
+}
+
 export type Industry = {
   slug: string
   name: string
@@ -42,25 +49,49 @@ export type Industry = {
   status: 'shipped' | 'partial' | 'planned'
   /** Override the default status badge label when partial/shipped/planned is too vague. */
   statusLabel?: string
+  /** Hero eyebrow text — when set, replaces the status badge. */
+  heroEyebrow?: string
+  /** Override Overview section headline. */
+  overviewHeadline?: string
   /** Short production reference — e.g. a vertical product powered by ClawQL. */
   productionReference?: string
   /** How ClawQL fits alongside incumbent systems (CRM, storage, transaction tools). */
   stackPlacement?: readonly IndustryStackRow[]
   /** Industry-wide competitive context — franchise-agnostic framing. */
   marketContext?: string
+  marketHeadline?: string
+  marketSubheadline?: string
   /** One-paragraph pitch for forwarding to prospects or partners. */
   demoPitch?: string
   /** Dual-audience targeting — e.g. brokerages vs FSBO sellers on the same vertical page. */
   audiences?: readonly IndustryAudience[]
+  audiencesHeadline?: string
+  audiencesSubheadline?: string
   overview: string
   painPoints: readonly { title: string; body: string }[]
+  painPointsHeadline?: string
+  painPointsSubheadline?: string
   platformCapabilities: readonly string[]
+  platformSubheadline?: string
   domainTools: readonly { name: string; description: string }[]
+  domainToolsSubheadline?: string
   documentTypes: readonly string[]
   useCases: readonly { title: string; body: string }[]
+  useCasesSubheadline?: string
   examples: readonly IndustryExample[]
+  /** WORM / audit event catalog for verticals with forensic logging. */
+  auditEvents?: readonly IndustryAuditEvent[]
+  auditEventsSubheadline?: string
   compliance: readonly string[]
+  complianceHeadline?: string
+  complianceSubheadline?: string
   relatedResources: readonly IndustryResource[]
   docsHref: string
   disclaimer?: string
+  ctaHeadline?: string
+  ctaSubheadline?: string
+  ctaSecondaryHref?: string
+  ctaSecondaryLabel?: string
+  /** Optional closing note below the CTA (e.g. scope disclaimer). */
+  closingNote?: string
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Government** industry marketing page at `/industries/government`, framed by [California bond outcome accountability](https://pragmaticvectors.com/posts/california-bond-outcome-accountability/) (PragmaticVectors).

## Narrative

California can track bond **spending** but not consistently prove **outcomes**. The page positions `clawql-government` as the infrastructure for:

1. Measurable outcome definitions at authorization  
2. Immutable baselines before programs begin  
3. Merkle-chained WORM outcome records + Arweave external anchors  
4. Public / auditor verification without trusting program self-reporting  

Also covers FOIA, permitting, and procurement on the same Agentic Gateway (aligned with modularization v2.1).

## Changes

- `landing-page/demo/src/lib/industries/government.ts` — full vertical content (audiences, pain points, domain tools, audit events, compliance)
- Route: `/industries/government`
- Extended `Industry` types + `industry-page` section overrides (same pattern as the surveillance vertical PR)
- Wired into industries hub, footer, sitemap, agent-discovery

## Live URL (after merge/deploy)

https://clawql.com/industries/government/

## Related

- Essay: https://pragmaticvectors.com/posts/california-bond-outcome-accountability/
- Surveillance industry PR: https://github.com/danielsmithdevelopment/ClawQL/pull/813
- Surveillance docs PR: https://github.com/danielsmithdevelopment/ClawQL/pull/816

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9b5e-4d74-72e6-90bb-d0c2100f09d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9b5e-4d74-72e6-90bb-d0c2100f09d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

