### PR TITLE
docs(vision): refresh IDP platform July 2026 investor/architect deck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **IDP platform vision refresh (July 2026)** — [`docs/vision/clawql-idp-platform.md`](docs/vision/clawql-idp-platform.md) rewritten for investor + architect audiences: twelve-layer token efficiency, `mcp-api-adapter`, sovereign fleet / PorTAL / OKF, OpenBench evidence, hybrid Cloudflare→K3s→EKS deployment, and honest competitive gaps.
 - **OpenBench advanced specs + Phase 1 task packs** — B-1…B-6 ledger in [`docs/benchmarks/openbench-advanced-specs.md`](docs/benchmarks/openbench-advanced-specs.md). Offline packs: `codegraph-feature-api-surface` (B-3.1), `memory-conflict-pricing` (B-4.1), `memory-stale-after-update` (B-4.2), `memory-injection-attempt` (B-4.3). Specs only — no live run IDs yet.
 - **IDP NATS agent bridge (#128)** — second JetStream durable `clawql-idp-agent-bridge` on `clawql.document.>` maps `pipeline.completed` / `pipeline.failed` / `coneshare.viewer` into ClawQL MCP `memory_ingest` (+ optional `notify` / `audit`). Runtime-agnostic for Hermes / Pi / OpenClaw. CLI: `npm run nats:agent-bridge`. Helm: `nats.agentBridge.enabled`. Samples: [`deployment/samples/idp-nats-agent/`](deployment/samples/idp-nats-agent/). Runbook: [`docs/runbooks/idp-nats-agent-bridge.md`](docs/runbooks/idp-nats-agent-bridge.md).
 

--- a/docs/vision/clawql-idp-platform.md
+++ b/docs/vision/clawql-idp-platform.md
@@ -1,11 +1,11 @@
 # ClawQL Intelligent Document Processing Platform
 
-**Version:** July 2026 (7.0.0+)  
+**Version:** July 2026 (7.2.0+)  
 **Tagline:** Sovereign • Modular • Production-Ready • Hosted & Self-Hosted
 
 **Audience:** Investors · Developers & architects · Operators
 
-**Related:** [IDP GTM strategy & landing brief](./clawql-idp-gtm.md) · [Public IDP GTM playbook](https://clawql.com/idp/gtm) · [IDP pipeline hub](../providers/idp-pipeline.md) · [Requirements matrix](../roadmap/idp-master-requirements-matrix.md) · [OpenClaw IDP skill profile](../openclaw/openclaw-idp-skill-profile.md) · [Master enablement guide](./clawql-master-enablement-guide.md) · [Deployment guide](../deployment/clawql-deployment-operations-guide.md)
+**Related:** [IDP GTM strategy & landing brief](./clawql-idp-gtm.md) · [Public IDP GTM playbook](https://clawql.com/idp/gtm) · [IDP pipeline hub](../providers/idp-pipeline.md) · [Requirements matrix](../roadmap/idp-master-requirements-matrix.md) · [OpenClaw IDP skill profile](../openclaw/openclaw-idp-skill-profile.md) · [Token efficiency (12 layers)](../architecture/clawql-token-efficiency.md) · [OpenBench advanced specs](../benchmarks/openbench-advanced-specs.md) · [Master enablement guide](./clawql-master-enablement-guide.md) · [Deployment guide](../deployment/clawql-deployment-operations-guide.md)
 
 ---
 
@@ -15,546 +15,517 @@ Understand the market problem, business model, competitive differentiation, and 
 
 ## For Developers & Architects
 
-Deep-dive into architecture decisions, component integrations, deployment topology, and the archive layer design.
+Deep-dive into architecture decisions, token efficiency, component integrations, deployment topology, and the inference fleet.
 
 ---
 
 ## Executive Summary
 
-ClawQL is a sovereign Intelligent Document Processing platform that replaces fragmented SaaS toolchains with a single AI-orchestrated pipeline — from document ingestion to secure external distribution — available both as a self-hosted deployment and as a fully managed hosted service.
+ClawQL is a sovereign Intelligent Document Processing platform and MCP agent operating system. It replaces fragmented SaaS toolchains with a single AI-orchestrated pipeline — from document ingestion to secure external distribution — available both as a self-hosted deployment and as a fully managed hosted service.
 
-Enterprises manage documents across dozens of disconnected tools: OCR vendors, PDF processors, document management systems, knowledge bases, and data room platforms. Each handoff introduces cost, latency, compliance risk, and data exposure. ClawQL collapses this stack into one modular system orchestrated by AI agents, with a clean path to either self-hosted sovereignty or a managed hosted plan.
+Enterprises manage documents across dozens of disconnected tools while their AI agents operate without persistent memory, token efficiency, or semantic search over institutional knowledge. ClawQL collapses both problems: a **twelve-layer** token efficiency architecture for the agent layer, a full document processing pipeline for the document layer, and a sovereign multi-model inference fleet that keeps sensitive data inside the tenant boundary.
 
 ---
 
 ## The Problem
 
-- Document workflows span 5–10+ SaaS products, each with separate billing, compliance postures, and API contracts.
-- Every SaaS touchpoint is a potential breach vector — especially critical for legal, financial, and healthcare documents.
-- AI automation requires deep pipeline integration that fragmented tools cannot provide out of the box.
-- Audit trails are inconsistent or absent across tool boundaries.
-- Virtual Data Room incumbents (Intralinks, Datasite, Ansarada) charge significant per-user and per-GB fees with no pipeline integration.
+- Document workflows span 5–10+ SaaS products with separate billing, compliance postures, and data exposure points.
+- AI agents have no persistent memory — every session starts from zero. Institutional context must be re-explained manually.
+- Naive tool-calling approaches load full API specs into context windows: **2,556,000+ tokens** for three common providers combined.
+- VDR incumbents charge $10,000–$200,000+/year with no pipeline integration. IDP vendors charge $0.50–1.50/page.
+- No competitor provides a sovereign locally-running fine-tuned LLM with verifiable data sovereignty at the infrastructure layer.
 
 ---
 
 ## The ClawQL Solution
 
-- End-to-end IDP pipeline: ingest → convert → redact → archive → semantically index → share — orchestrated by a single MCP server.
-- Two deployment models: self-hosted (full data sovereignty) and managed hosted (zero infrastructure overhead).
-- Cryptographic audit trails via Merkle trees for tamper-evident, per-step processing records.
-- AI agents drive the entire workflow via natural language — no custom integration code required.
-- Modular architecture: adopt components incrementally, swap alternatives where needed.
+- **Twelve-layer token efficiency** reducing input tokens by ~99.8% on average at Layer 1. The nearest MCP gateway competitor implements one layer. Canonical detail: [`clawql-token-efficiency.md`](../architecture/clawql-token-efficiency.md).
+- **End-to-end IDP pipeline:** ingest → convert → redact → archive → semantically index → share — one Helm chart.
+- **Durable cross-session agent memory** (Markdown, local, portable). OKF v0.2 trust signals (`generated`, `verified`, `stale_after`, `status`, `superseded_by`) in vault entries. `memory_ingest` / `memory_recall` tools. See [`okf.md`](../memory/okf.md).
+- **PorTAL** (Ramp Labs, Apache 2.0): Portable Task-specific Adapter Learning via `--format portal-bundle` in the flywheel export pipeline. See [`portal-flywheel.md`](../inference/portal-flywheel.md).
+- **Sovereign multi-model inference fleet:** fine-tuned Qwen3.6-27B + Ornith 35B MoE + Phi-4 14B. Istio-enforced egress block. No tokens leave the tenant boundary.
+- **Defense-in-depth security:** Kata container VM isolation, WORM Merkle audit logs, Panguard ATR fail-closed, model weight integrity verification. Documented at [defense-in-depth](https://docs.clawql.com/security/defense-in-depth).
 
 ---
 
 ## Business Value at a Glance
 
-| Value Driver         | Detail                                                                                                                |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| **Cost Reduction**   | Replaces 5–10 SaaS subscriptions. Self-hosted plan has no per-document or per-user fees beyond infrastructure.        |
-| **Compliance**       | Data processed locally (self-hosted) or in a dedicated tenant (hosted). Cryptographic audit trail for every step.     |
-| **AI Readiness**     | Native MCP integration means AI agents operate the full pipeline without custom code. Improves as models improve.     |
-| **Scalability**      | Kubernetes/Helm deployment scales horizontally. 1,000+ document formats supported.                                    |
-| **VDR Market Entry** | Coneshare delivers Virtual Data Room capabilities at a fraction of incumbent pricing, with full pipeline integration. |
-| **Hosted Revenue**   | Managed hosted plan creates recurring SaaS revenue on top of the open-source self-hosted core.                        |
+| Value Driver                | Detail                                                                                                                                                                                                      |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Token efficiency**        | Twelve compounding layers. ~99.8% average input reduction on Layer 1 alone. Layers 2–12 reduce output, prose, cache cost, repeated calls, history growth, per-task model cost, and flywheel training waste. |
+| **Cost reduction**          | Replaces $8,000–15,000+/month incumbent stacks. ClawQL Dedicated + Sovereign Security Pack: **$799/month** maximum (indicative GTM).                                                                        |
+| **Data sovereignty**        | Provable at the infrastructure layer. Istio AuthorizationPolicies enforce egress blocks — not only a contractual claim.                                                                                     |
+| **Persistent agent memory** | Unique among IDP / VDR / MCP gateway competitors: cross-session vault memory with OKF trust signals.                                                                                                        |
+| **AI readiness**            | MCP-native from day one. Improves as models improve. Token layers mean agent cost drops as usage scales.                                                                                                    |
+| **VDR market entry**        | Coneshare delivers VDR capabilities at a fraction of incumbent pricing, with full pipeline integration.                                                                                                     |
+| **Hosted revenue**          | Managed hosted plan creates recurring SaaS revenue on top of the open-source self-hosted core.                                                                                                              |
 
 ---
 
 ## Deployment Models
 
-ClawQL is available in two deployment configurations. Both run identical pipeline logic; they differ in who manages the infrastructure and where data resides.
+ClawQL is available in configurations that run identical pipeline logic.
 
-|                     | **Self-Hosted**                                                                             | **Managed Hosted**                                                                   |
-| ------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| **Target customer** | Enterprises with existing Kubernetes infrastructure and strict data residency requirements. | Teams who want ClawQL's capabilities without managing infrastructure.                |
-| **Data residency**  | Fully local — no data leaves the operator's environment.                                    | Tenant-isolated; data processed and stored in dedicated infrastructure per customer. |
-| **Infrastructure**  | Customer-managed Kubernetes/Helm. ClawQL provides the chart.                                | Fully managed by ClawQL. Customer connects via API or web UI.                        |
-| **Licensing model** | Apache 2.0 core — free to deploy. Commercial support tiers available.                       | Monthly or annual subscription. Usage-based tiers by document volume and seats.      |
-| **Deployment time** | Hours to days depending on existing Kubernetes maturity.                                    | Minutes. Tenant provisioned automatically on signup.                                 |
-| **Updates**         | Customer-managed via Helm chart upgrades.                                                   | Managed by ClawQL — customers always on latest release.                              |
+| Model                           | Details                                                                                                                  |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| **Self-Hosted ($0)**            | Full OSS stack on your own infrastructure. All bundles self-managed via Helm. Apache 2.0 core. No license fee.           |
+| **Managed Hosted**              | Shared multi-tenant (**$299/mo**) or Dedicated single-tenant (**$599/mo**). Fully managed. Tenant provisioned on signup. |
+| **Enterprise (from $3,500/mo)** | Dedicated node, custom SLA, on-call, HITL, vertical fine-tune adapters, security review assistance, multi-region.        |
 
----
+The GPL-3.0 Paperless-ngx dependency is **removed from the hosted stack**. The ClawQL-native archive layer (Nextcloud + Postgres + Onyx) replaces it. Self-hosted operators who prefer Paperless-ngx can enable it via feature toggle. See [Licensing Summary](#licensing-summary).
 
-## Hosted Plan: Architecture Decisions
-
-The managed hosted plan required one significant architecture change from the self-hosted stack: the removal of Paperless-ngx as the archive layer. This is a deliberate, proactive decision driven by licensing and business model requirements.
-
-Paperless-ngx is licensed under GPL-3.0. In a self-hosted deployment this presents no commercial friction. However, in a hosted/managed SaaS product, distributing a service that bundles GPL-3.0 software triggers license propagation obligations that are incompatible with a closed commercial offering. Paperless-ngx is therefore removed from the hosted plan entirely.
-
-### The ClawQL-Native Archive Layer
-
-Rather than substituting a different GPL-adjacent DMS, ClawQL replaces Paperless-ngx with a purpose-built archive layer assembled from components already in the stack. This results in a cleaner, more capable architecture:
-
-| Component                            | Role in Archive Layer                                                                                                                                                                                                                                      |
-| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Nextcloud**                        | Human-accessible file storage and team UI. Documents are stored here as first-class files, browsable and shareable without any DMS login.                                                                                                                  |
-| **Nextcloud Automated Tagging**      | Rule-based collaborative tags applied on upload/update via the Files Automated Tagging app. Replaces Paperless tag assignment for basic classification.                                                                                                    |
-| **Nextcloud Full-Text Search**       | Elasticsearch-backed full-text search with Tesseract OCR integration indexes all PDFs and Office files. Replaces Paperless search for keyword retrieval.                                                                                                   |
-| **ClawQL Metadata Store (Postgres)** | A lightweight ClawQL-managed Postgres schema stores rich document metadata: correspondent, document type, custom fields, processing history, and Merkle roots. This replaces Paperless's Django metadata model with a schema fully under ClawQL's control. |
-| **Onyx**                             | Semantic search and cross-document knowledge retrieval. Substantially more powerful than Paperless search — supports vector search, citation-backed results, and 40+ connector integrations.                                                               |
-| **Stirling-PDF**                     | OCR is handled here, before archiving, rather than on import. Documents arrive in Nextcloud already OCR'd and text-searchable.                                                                                                                             |
-
-**Net result:** the hosted plan archive layer is more capable than Paperless-ngx in every dimension that matters for enterprise use — richer metadata, superior search (Onyx semantic vs. Paperless keyword), native file access via Nextcloud, and no GPL dependency. The only thing lost is Paperless's dedicated web UI, which is replaced by Nextcloud's file browser and Onyx's search interface.
-
-### Hosted Plan: Tenant Isolation
-
-Each hosted customer receives a dedicated tenant with full isolation at the data and infrastructure layer:
-
-- Dedicated Nextcloud instance per tenant — no shared storage.
-- Dedicated Postgres schema per tenant for the ClawQL metadata store.
-- Dedicated Onyx index per tenant — no cross-tenant knowledge bleed.
-- Coneshare VDR links scoped to the tenant's Nextcloud instance.
-- mTLS between all tenant services via Istio; tenant-scoped secrets in HashiCorp Vault.
-
-### Hosted Plan: Pricing Model (July 2026 — plugin bundles)
-
-Managed hosting is structured around **plugin bundles**, not a single document-volume ladder. Gateway-only customers pay dramatically less than IDP customers. There is **no perpetual free hosted tier** — self-host free forever on Apache 2.0, or start a **14-day Developer trial** (no credit card).
-
-| Tier             | Price          | Plugin bundle           | Included                                                                                                  |
-| ---------------- | -------------- | ----------------------- | --------------------------------------------------------------------------------------------------------- |
-| **Developer**    | $29/mo         | Gateway + memory        | Unlimited executions, 1 user, vault memory — no IDP, no GPU. 14-day free trial available.                 |
-| **Teams**        | $99/mo         | Gateway + memory + Onyx | Unlimited executions, 5 users, full Onyx semantic search — no IDP                                         |
-| **Starter**      | $299/mo        | IDP plugin bundle       | Unlimited executions, 5 users, 5,000 documents/mo, VDR, classify/extract, sovereign inference             |
-| **Business**     | $599/mo        | IDP plugin bundle       | Unlimited executions, 25,000 documents/mo, priority queue, full VDR analytics, 99.5% SLA                  |
-| **Professional** | $1,200/mo      | Full stack              | Unlimited executions, 75,000 documents/mo, dedicated namespace, vertical fine-tune, SSO/SAML              |
-| **Enterprise**   | from $3,500/mo | Full stack + security   | Unlimited executions, dedicated node, custom fine-tune, EU multi-region, Sovereign Security Pack included |
-
-**Unlimited executions on every tier.** ClawQL does not meter Agentic Gateway usage or charge execution overage. Stateless gateway workers scale on spot capacity — usage-based execution pricing would only encourage customers to throttle their agents. Real cost drivers are reserved-pool memory (Onyx, Nextcloud per tenant), GPU inference, and document storage (R2). Those are covered by flat subscription tiers and storage overage. executor.sh caps Team at 250,000 executions/mo with $0.20/1,000 overage; ClawQL does not.
-
-Sovereign Security Pack: **+$200/mo** on any paid tier.
-
-> **Note:** tiers are indicative for GTM positioning. Validate against infrastructure cost modeling before launch.
+Plugin-bundle pricing detail (Developer/Teams/Starter/…): see [Hosted plan pricing](#hosted-plan-pricing-july-2026--plugin-bundles) and [IDP GTM](./clawql-idp-gtm.md).
 
 ---
 
 ## Platform Overview
 
-ClawQL's IDP platform automates the full document lifecycle: ingestion, classification, extraction, enrichment, redaction, archiving, semantic indexing, and secure external sharing — unified under a single AI orchestration layer.
+ClawQL's IDP platform automates the full document lifecycle: ingestion, classification, extraction, enrichment, redaction, archiving, semantic indexing, and secure external sharing — unified under a single AI orchestration layer with twelve-layer token efficiency and persistent agent memory.
 
 ### Core Architecture Principles
 
-- **Local-first:** All processing runs in the operator's environment (self-hosted) or a dedicated tenant (hosted). No document data sent to external SaaS APIs.
-- **Specification-driven:** Every service exposes an OpenAPI spec loaded into ClawQL, enabling uniform agent access via `search()` and `execute()` tools.
-- **Agentic orchestration:** The Ouroboros 5-phase loop (Interview → Seed → Execute → Evaluate → Evolve) handles complex, retryable multi-step workflows automatically.
-- **Cryptographic integrity:** Merkle trees generate per-step audit roots; Cuckoo filters handle deduplication at scale.
-- **Modular deployment:** Adopt the full stack or individual services. Each exposes clean API boundaries.
+- **Twelve-layer token efficiency:** Compounds across input, output, prose, caching, semantic deduplication, history, prompt trimming, model routing, structured-output hints, token budgets, optional prefill, and the fine-tune flywheel.
+- **Local-first:** Processing runs in the operator's environment (self-hosted) or a dedicated tenant (hosted). No document data sent to external SaaS LLM APIs on Dedicated/Enterprise sovereign paths.
+- **Specification-driven:** Every service exposes an OpenAPI (or GraphQL) surface loaded into ClawQL for uniform `search()` / `execute()`. The **`mcp-api-adapter`** package exposes every MCP tool as `POST /{toolName}` (+ GraphQL, `/mcp`, gRPC, `gen-cli`) so HTTP clients and Workers can call tools without speaking MCP wire protocol. Production paths may use gRPC directly.
+- **Persistent memory:** Obsidian vault + `memory_ingest` / `memory_recall` for institutional knowledge across sessions.
+- **Sovereign AI inference:** Fine-tuned model fleet via vLLM inside the tenant boundary; Istio egress block at the mesh layer.
+- **Cryptographic integrity:** Merkle trees per step; WORM storage; Cosign-signed commits where configured.
 
 ### Component Map
 
-| Component                | Role in Platform                                                              |
-| ------------------------ | ----------------------------------------------------------------------------- |
-| **ClawQL Core**          | MCP server and AI orchestration layer (TypeScript, Apache 2.0)                |
-| **Apache Tika**          | Universal document parsing and metadata extraction (1,000+ formats)           |
-| **Gotenberg**            | High-fidelity document-to-PDF conversion (LibreOffice + Chromium)             |
-| **Stirling-PDF**         | PDF manipulation, PII redaction, OCR, and Merkle audit generation             |
-| **ClawQL Archive Layer** | Nextcloud + Postgres metadata store + Onyx. Replaces Paperless-ngx. GPL-free. |
-| **Onyx**                 | Semantic search and knowledge layer with 40+ pre-built connectors             |
-| **Obsidian Vault**       | Durable cross-session agent memory (Markdown, local, portable)                |
-| **Nextcloud**            | Human-accessible file storage, collaboration, and archive UI                  |
-| **Coneshare**            | Secure sharing, Virtual Data Rooms, and engagement analytics (MIT)            |
-
-Paperless-ngx (GPL-3.0) is supported in self-hosted deployments for operators who prefer it. It is not included in the managed hosted plan. The ClawQL-native archive layer described above is the default for all new deployments and all hosted customers.
+| Component                    | Role in Platform                                                                  |
+| ---------------------------- | --------------------------------------------------------------------------------- |
+| **ClawQL Core**              | MCP server, token-efficiency engine, AI orchestration (TypeScript, Apache 2.0)    |
+| **ClawQL Inference Gateway** | Policy-driven model routing; `/v1/chat/completions`; NSV/SGDOP; Layer 8+          |
+| **Apache Tika**              | Universal parsing and metadata (1,000+ formats)                                   |
+| **Gotenberg**                | Document-to-PDF (LibreOffice + Chromium)                                          |
+| **Stirling-PDF**             | PDF ops, PII redaction, OCR, Merkle audit generation                              |
+| **ClawQL Archive Layer**     | Nextcloud + Postgres metadata + Onyx. GPL-free. Replaces Paperless-ngx on hosted. |
+| **Onyx**                     | Semantic search + 40+ connectors                                                  |
+| **Obsidian Vault**           | Durable cross-session agent memory (Markdown)                                     |
+| **Nextcloud**                | Human file storage, collaboration, archive UI                                     |
+| **Coneshare**                | Secure sharing, VDRs, engagement analytics (MIT)                                  |
+| **Qwen3.6-27B (fine-tuned)** | Core document worker; vLLM NVFP4; L4 GPU                                          |
+| **Ornith 1.0 35B MoE**       | Coding specialist; serve as-is (MIT, DeepReinforce AI)                            |
+| **Phi-4 14B (fine-tuned)**   | Utility / memory worker                                                           |
+| **Langfuse**                 | Trace capture, datasets, flywheel observability (LGTM+)                           |
 
 ---
 
 ## ClawQL Core: Orchestration and Agent Interface
 
-**License:** Apache License 2.0 — open-source, commercially permissive.
+**License:** Apache License 2.0.
 
-ClawQL is a TypeScript-based Model Context Protocol (MCP) server published as `clawql-mcp` on npm. It enables AI agents to discover and invoke operations across any REST API, document workflow, or knowledge source using just two tools — keeping agent context lean while providing access to the entire pipeline.
+ClawQL is a TypeScript MCP server published as `clawql-mcp` on npm. Agents discover and invoke operations across REST APIs, document workflows, and knowledge sources using two tools — keeping context lean while accessing the full pipeline through compounding token-efficiency layers.
 
 ### The Two-Tool Pattern
 
-- **`search()`:** Discovers available operations by natural language query across all loaded OpenAPI specs. Agents never need to know the full API surface.
-- **`execute()`:** Invokes a specific operation with parameters. Optional GraphQL projection trims responses for token efficiency.
+- **`search()`** — Discover operations by natural language across loaded specs.
+- **`execute()`** — Invoke a specific operation; optional GraphQL / field projection trims responses (Layer 2).
 
-A single agent prompt — _"Process Q1 invoices, redact PII, cross-reference our pricing knowledge base, archive, create a data room, notify Slack"_ — triggers the entire pipeline automatically through this two-tool interface. No custom integration code. No manual handoffs.
+A single agent prompt — _“Process Q1 invoices, redact PII, cross-reference our pricing knowledge base, archive, create a data room, notify Slack”_ — can drive the pipeline without custom integration code.
+
+### Twelve-Layer Token Efficiency Architecture
+
+Most agent frameworks reduce cost at one point in the lifecycle. ClawQL addresses **twelve** points. Layers 1–8 are the MCP/gateway stack described below; Layers 9–12 are inference-gateway extensions ([canonical reference](../architecture/clawql-token-efficiency.md)). The nearest MCP gateway competitor (executor.sh) implements Layer 1 only.
+
+| Layer                                 | Mechanism and measured impact                                                                                                                         |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1 Code Mode** (always on)           | Two-tool pattern. Full specs stay on the server. Input reduction **97–99.9%** per provider; ~**99.8%** average across Google Cloud, Jira, Cloudflare. |
+| **2 Response trimming** (always on)   | Trim responses to fields the agent code depends on. Example: GKE list **421 → 76** tokens (~82%).                                                     |
+| **3 Prose compression** (always on)   | Strip hedging filler; preserve code/paths/ids. ~50–80% prose reduction.                                                                               |
+| **4 Prompt caching** (one-time setup) | Stabilized prefix enables provider cache reads (~10% of input price where supported).                                                                 |
+| **5 Semantic cache** (on by default)  | Similar requests skip the model; writes always live and invalidate related caches.                                                                    |
+| **6 History compression** (opt-in)    | Distill long transcripts for multi-hour sessions.                                                                                                     |
+| **7 Final prompt trimming** (opt-in)  | 20–40% additional reduction on already-compressed prompts.                                                                                            |
+| **8 Model routing** (gateway)         | Cheapest capable model per sub-task across the sovereign fleet.                                                                                       |
+| **9 Structured output**               | Inference-gateway hints (default on).                                                                                                                 |
+| **10 Token budget signaling**         | Derive budgets from `max_tokens` (default on).                                                                                                        |
+| **11 Prefill opener**                 | Optional assistant prefill (default off).                                                                                                             |
+| **12 Flywheel**                       | Export → fine-tune → frugal tier registration (PorTAL-compatible).                                                                                    |
+
+Layers 1–3 are always on with zero configuration and deliver the large majority of day-one savings. On managed hosted plans, Layers 1–5 and Layer 8 are active by default where credentials allow.
+
+### Universal API Adapter: `mcp-api-adapter`
+
+`mcp-api-adapter` is a standalone TypeScript package that points at any MCP server and exposes **five** surfaces from the same tool catalog. No ClawQL install required. Works with stdio, Streamable HTTP, or gRPC MCP servers.
+
+**Direction matters.** ClawQL Core goes **OpenAPI → MCP** (`search` / `execute`). `mcp-api-adapter` goes the other way: **MCP tools → REST / GraphQL / gRPC / IDE**. Complementary, not competing. Do not market it as an “OpenAPI gateway” — that phrase collides with Core’s inverse direction.
+
+| Surface                | What you get                                                       |
+| ---------------------- | ------------------------------------------------------------------ |
+| OpenAPI / REST         | `POST /{toolName}`; Swagger UI `/docs`; `x-clawql-grpc` extensions |
+| GraphQL                | Per-tool mutations + GraphiQL `/graphiql`                          |
+| Streamable HTTP `/mcp` | Re-export for IDE clients                                          |
+| gRPC                   | `:50051` (forward or local `mcp-grpc-transport`)                   |
+| `gen-cli`              | Thin zero-dependency Node CLI posting to REST                      |
+
+```bash
+npx mcp-api-adapter --mcp-url http://127.0.0.1:8080/mcp
+npx mcp-api-adapter --stdio -- npx -y @modelcontextprotocol/server-everything
+npx mcp-api-adapter --grpc-address 127.0.0.1:50051
+```
+
+Shipped line (indicative): **v0.5.1** current — Streamable HTTP `/mcp` re-export, `gen-cli`, gRPC content normalization for MCP SDK clients.
+
+vs **mcpo** (open-webui): Python / stdio-centric / FastAPI-first. `mcp-api-adapter` is TypeScript-native, transport-agnostic on input, adds GraphQL and `/mcp` re-export. Complementary.
 
 ### Key Capabilities
 
-- MCP server supporting stdio, HTTP, and gRPC transports.
-- Bundled provider specifications: GitHub, Cloudflare, Slack, Sentry, n8n, Linear, Jira, Bitbucket, and all document pipeline services.
-- First-class MCP tools: `memory_ingest`/`recall()`, `knowledge_search_onyx()`, `sandbox_exec()`, `ingest_external_knowledge()`, `notify()`, `cache()`, `audit()`.
-- Ouroboros 5-phase orchestration loop for complex, retryable multi-step workflows.
-- Cuckoo filters for deduplication; Merkle trees for tamper-evident audit trails.
-- Environment-variable feature toggles for optional layers (Onyx, Web3 provenance, Paperless compatibility).
-- Unified Helm chart managing 12+ services in a single deployment.
+- MCP transports: stdio, HTTP (Streamable), gRPC.
+- Bundled provider specs: GitHub, Cloudflare, Slack, Sentry, n8n, Linear, Jira, Bitbucket, and document pipeline services.
+- First-class tools: `memory_ingest` / `memory_recall`, `knowledge_search_onyx`, `sandbox_exec`, `ingest_external_knowledge`, `notify`, `cache`, `audit`, `run_idp_pipeline`, classify/extract/inspect when enabled.
+- **Ouroboros** 5-phase loop for retryable multi-step workflows. Empirically: `ouroboros-oscillation-escape` scores **1.0** (~5 turns, ~78s) vs **0.0** (~167s thrash) on DeepSeek — runs `30863572642`, `30866904277`, `30872913519`.
+- Cuckoo filters for dedup; Merkle trees for tamper-evident audit.
+- Arweave-anchored Layer 0 release manifests + `clawql doctor --smoke` startup hash verification.
+- Integration catalog mirroring to ClawQL-controlled Harbor/R2 before distribution.
+- Env feature toggles for optional layers (Onyx, Web3 provenance, Paperless compatibility).
+- Unified Helm charts managing the supporting services.
 
 ### Production Hardening
 
-- **Golden Image Pipeline:** Trivy + OSV-Scanner vulnerability scanning, SBOM generation, and Cosign image signing on every build.
-- **Istio Service Mesh:** Optional mTLS, L7 traffic policies, and Kiali observability between all services.
-- **HashiCorp Vault:** Secrets and certificate lifecycle management.
-- **Kubernetes/Helm:** Horizontal scaling, rolling updates, and health-check-driven self-healing.
+- Golden Image Pipeline: Trivy + OSV-Scanner, SBOM, Cosign on every build.
+- Optional Istio service mesh (mTLS, L7 policy, Kiali).
+- HashiCorp Vault for secrets / certificates.
+- Kubernetes/Helm: HPA, rolling updates, health-driven healing.
 
 ---
 
 ## Document Processing Pipeline
 
-Documents flow through a sequential, modular pipeline. Each stage is a self-contained service with a clean API boundary, orchestrated by ClawQL agents via MCP tools. Files enter from Nextcloud folders, email, WebDAV, or direct upload.
+```text
+Nextcloud / Email / WebDAV
+  → pdf-inspector / Tika
+  → Gotenberg (as needed)
+  → Docling (complex layouts)
+  → Stirling-PDF (OCR + redact + Merkle)
+  → ClawQL Archive (Nextcloud + Postgres + Onyx)
+  → Coneshare (distribute)
+```
 
-**Pipeline flow:** Nextcloud / Email / WebDAV → Tika (parse + detect) → Gotenberg (convert to PDF) → Stirling-PDF (OCR + redact + Merkle) → ClawQL Archive Layer (store + index) → Onyx (semantic index) → Coneshare (distribute)
+All stages run as Kubernetes workers. Argo Workflows can enforce per-tenant concurrency so one batch cannot saturate the shared pool.
 
-### Stage 1: Apache Tika — Universal Parsing
+### Stage 0: pdf-inspector — Classification and Fast Extraction
 
-**License:** Apache License 2.0 — Apache Software Foundation.
+**License:** MIT (Rust). Millisecond PDF classification (text / scanned / mixed); high-fidelity Markdown from native-text PDFs without model inference. Branches the Argo DAG.
 
-Tika is the intake layer. It determines what a document is and extracts its content regardless of format, using a plugin-based parser architecture covering 1,000+ MIME types.
+### Stage 1: Apache Tika — Universal Format Parsing
 
-**Capabilities**
-
-- Text and metadata extraction from 1,000+ formats: PDF, Office, HTML, email, archives, images, and more.
-- MIME type detection and language identification.
-- Tesseract OCR integration for scanned or image-based documents.
-- Rich metadata preservation: EXIF, Dublin Core, document-specific properties.
-- Streaming and batch processing.
-
-**Integration Role**
-
-ClawQL loads Tika's OpenAPI spec as a bundled provider. Agents invoke it via `execute()` on incoming files, flagging Office documents for Gotenberg conversion and extracting text that seeds Onyx indexing and Ouroboros workflows.
+**License:** Apache 2.0. 1,000+ MIME types; Office/email/HTML/archives/images; Tesseract for image inputs.
 
 ### Stage 2: Gotenberg — Document Conversion
 
-**License:** MIT License — open-source, commercially permissive.
+**License:** MIT. Office/HTML/Markdown → PDF for uniform downstream processing.
 
-Gotenberg is a Docker-based API for converting document formats to PDF. It uses LibreOffice for Office files and Chromium for HTML and Markdown, delivering high-fidelity headless rendering.
+### Stage 3: Docling — Layout Analysis
 
-**Capabilities**
+**License:** MIT (IBM Research). DocLayNet + TableFormer for multi-column, tables, forms, scanned pages. Tracked historically as [#248](https://github.com/danielsmithdevelopment/ClawQL/issues/248).
 
-- Converts DOCX, XLSX, PPTX, HTML, URLs, and Markdown to PDF.
-- PDF merge, split, headers/footers, and compression.
-- RESTful API with JSON configuration.
+### Stage 4: Stirling-PDF — Redaction and Audit
 
-**Integration Role**
+**License:** Open-core. PII redaction, Merkle roots to Postgres, OCR fallback. Sovereign Security Pack adds WORM + Cosign-signed commits.
 
-Receives Office files flagged by Tika. ClawQL calls it via its OpenAPI spec to normalize all documents to PDF. Output feeds directly into Stirling-PDF. Agents orchestrate batch conversion within Ouroboros loops.
+### Stage 5: LangExtract — Schema-Enforced Field Extraction
 
-### Stage 3: Stirling-PDF — Manipulation, OCR, and Redaction
+**License:** Apache 2.0 (Google). Character-offset grounding + confidence; low-confidence → HITL. Tracked as [#246](https://github.com/danielsmithdevelopment/ClawQL/issues/246). MCP: `extract_document`.
 
-**License:** Open-core. Base OSS functionality used in ClawQL. Advanced enterprise features available in paid Stirling tiers.
+### Stage 6: ClawQL Archive Layer
 
-Stirling-PDF is the most capability-dense stage in the pipeline. All compliance-critical operations — OCR, PII redaction, and cryptographic audit generation — occur here.
+**License:** Assembled from Apache 2.0 / AGPL / MIT components — **no GPL dependency** on hosted.
 
-**Capabilities**
+| Paperless-ngx feature | ClawQL archive equivalent                          |
+| --------------------- | -------------------------------------------------- |
+| Consumption inbox     | Nextcloud folder watch + webhook → NATS / pipeline |
+| Auto-tagging          | Nextcloud Automated Tagging + agent tags           |
+| Correspondent / type  | Postgres metadata store (+ Onyx classification)    |
+| Full-text search      | Nextcloud Elasticsearch + Onyx semantic            |
+| OCR on import         | Stirling OCR upstream                              |
+| REST API              | ClawQL MCP tools                                   |
+| Archive UI            | Nextcloud browser + Onyx search UI                 |
 
-- High-accuracy OCR on scanned documents (runs before archiving, so stored documents are always text-searchable).
-- PII redaction with pattern matching: SSNs, account numbers, emails, and custom regex rules.
-- Merkle tree generation: cryptographic audit hash per redaction step, verifiable independently of ClawQL.
-- PDF merge, split, rotate, page reorganization.
-- Digital signing, certification, compression, and form handling.
-- Batch processing support.
+Self-hosted operators may still enable Paperless-ngx via toggle; hosted defaults to the native layer.
 
-**Integration Role**
+### Pipeline Routing Summary
 
-Receives converted PDFs from Gotenberg. ClawQL invokes redaction rules via `execute()` and stores resulting Merkle roots in Postgres. This is the compliance enforcement point for the entire pipeline.
+1. Document arrives (Nextcloud watch, R2 upload / Argo Events, or API).
+2. pdf-inspector classifies.
+3. **Text PDF:** Markdown → Stirling → optional LangExtract → archive.
+4. **Scanned/complex PDF:** Docling → Stirling → optional LangExtract → archive.
+5. **Office:** Tika → Gotenberg → Docling → Stirling → optional LangExtract → archive.
+6. **Other:** Tika → Stirling as needed → optional LangExtract → archive.
+7. All paths: Onyx index, vault update, Merkle root commit; Coneshare for external distribution.
 
-> **Investor note:** Stirling-PDF's open-core model means ClawQL delivers strong base capabilities with a clear upgrade path to enterprise Stirling features for customers requiring advanced compliance tooling.
+---
 
-### Stage 4: ClawQL Archive Layer — Storage, Metadata, and Retrieval
+## Knowledge Layer: Onyx
 
-**License:** Assembled from Apache 2.0, AGPL, and MIT licensed components. No GPL dependency. Hosted-plan safe.
+Semantic retrieval with citations across pipeline outputs + 40+ connectors. Real-time indexing (Flink where deployed). Permission-aware hybrid search. Exposed as `knowledge_search_onyx()`.
 
-The ClawQL archive layer replaces Paperless-ngx with a purpose-built combination of components already present in the stack. It stores documents, records rich metadata, and makes the archive queryable — without introducing any GPL licensing constraints.
+---
 
-**Architecture**
+## Durable Agent Memory: Obsidian Vault
 
-- **Nextcloud:** Primary document store. Files land here after Stirling-PDF processing, fully OCR'd and redacted. Team members access documents via Nextcloud's familiar file browser.
-- **Nextcloud Automated Tagging:** Rule-based tags applied on upload: document type classification, correspondent assignment, and workflow routing — configured via the Nextcloud admin UI or API.
-- **Nextcloud Full-Text Search + Elasticsearch:** Indexes all PDF and Office content with Tesseract OCR for keyword search across the archive. Provides the same search capability as Paperless-ngx for basic retrieval.
-- **ClawQL Metadata Store (Postgres):** A ClawQL-managed schema records all document metadata: correspondent, document type, custom fields, processing timestamps, Merkle roots, and redaction logs. Fully queryable by agents via MCP tools. Replaces Paperless's Django metadata model with a schema under complete ClawQL control.
+Plain Markdown vaults — portable, no license restrictions on data. `memory_ingest` / `memory_recall` with OKF v0.2 trust signals. Vaults can sync to Nextcloud for human review. Roadmap: deeper in-vault semantic recall (sqlite-vec) where not already covered by Memory Stack 2.0.
 
-**What This Replaces from Paperless-ngx**
+---
 
-| Paperless-ngx Feature            | ClawQL Archive Equivalent                                                   |
-| -------------------------------- | --------------------------------------------------------------------------- |
-| Consumption inbox (watch folder) | Nextcloud folder watch + ClawQL webhook trigger                             |
-| Auto-tagging on import           | Nextcloud Automated Tagging app + ClawQL agent tag assignment via Ouroboros |
-| Correspondent tracking           | ClawQL Postgres metadata store (correspondent field)                        |
-| Document type classification     | ClawQL Postgres metadata store + Onyx semantic classification               |
-| Full-text search                 | Nextcloud Elasticsearch full-text search (keyword) + Onyx (semantic)        |
-| OCR on import                    | Stirling-PDF OCR upstream — documents are pre-OCR'd before archiving        |
-| REST API                         | ClawQL MCP tools expose metadata store and Nextcloud API uniformly          |
-| Archive web UI                   | Nextcloud file browser (human access) + Onyx search UI (semantic access)    |
+## Storage and Collaboration: Nextcloud
 
-The ClawQL archive layer is more capable than Paperless-ngx in every dimension relevant to enterprise use: richer metadata (Postgres vs. Django ORM), superior search (Onyx semantic + Elasticsearch keyword vs. Paperless keyword-only), native file collaboration (Nextcloud), and zero GPL dependency.
+**License:** AGPL-3.0 (self-hosted); commercial licenses from Nextcloud GmbH. Entry point and delivery destination for processed files; WebDAV/REST for agents; Automated Tagging; Elasticsearch FTS; retention apps; guest ACLs.
 
-Self-hosted operators who prefer Paperless-ngx can continue to use it via environment-variable toggle. The ClawQL metadata store runs alongside it and picks up processed documents via post-import webhooks.
+---
 
-### Knowledge and Semantic Layer: Onyx
+## Secure Sharing and VDRs: Coneshare
 
-**License:** Open-source enterprise search — commercially permissive core. Review current repository for enterprise licensing terms.
+**License:** MIT. Passworded / expiring links, VDRs, page-level analytics, watermarks, file requests, Slack/webhooks. Every deal room can carry a `deal_id` linked into the WORM trail. Viewer events can resume Argo / notify / update memory (NATS document consumers).
 
-Onyx transforms the document archive from a static repository into a live, queryable knowledge graph. It provides semantic retrieval with citation-backed results across all documents processed by the pipeline, plus 40+ external connectors.
-
-**Capabilities**
-
-- Semantic search with citation-backed results — agents know not just what was found, but where and why.
-- 40+ pre-built connectors: Slack, Confluence, Drive, Jira, GitHub, email, and more.
-- Real-time indexing via Apache Flink — indexes stay current as documents are processed.
-- Permission-aware retrieval — agents surface only content the requesting user is authorized to see.
-- Hybrid search combining keyword and vector methods for high recall and precision.
-
-**Integration Role**
-
-Onyx indexes content from the ClawQL archive, Nextcloud files, and Ouroboros workflow outputs. ClawQL exposes `knowledge_search_onyx()` as a first-class MCP tool, allowing agents to cross-reference institutional knowledge mid-workflow — for example, pulling pricing data from Slack during invoice processing. Post-processing results flow back into Onyx, creating a continuously enriching knowledge loop.
-
-**Business value:** every invoice, contract, or report processed by ClawQL immediately becomes searchable and referenceable by AI agents in future workflows. Onyx is the memory that makes the system smarter over time.
-
-### Durable Agent Memory: Obsidian Vault
-
-**License:** Obsidian application: proprietary (free personal use). Vault file format: plain Markdown — fully open, portable, no license restrictions.
-
-ClawQL uses Obsidian-style Markdown vaults for durable, cross-session agent memory. Unlike in-context memory that vanishes when a session ends, vault memory persists decisions, citations, Merkle roots, redaction logs, and workflow summaries across deployments and agent sessions.
-
-**Integration Role**
-
-The `memory_ingest()` and `memory_recall()` MCP tools write and retrieve from the vault. After each Ouroboros cycle, outputs, citations, audit hashes, and decisions are stored. This gives ClawQL genuine long-term institutional memory — a key differentiator from stateless AI pipelines that require re-explanation of context on every session.
-
-- Vaults sync to Nextcloud for human review and team access.
-- Roadmap: sqlite-vec integration for in-vault semantic recall (planned, not yet in production).
-
-### Storage and Collaboration: Nextcloud
-
-**License:** AGPL-3.0 — self-hosted. Nextcloud GmbH offers commercial enterprise licensing and support.
-
-Nextcloud is the primary human-accessible storage, collaboration, and archive interface. It serves as both the entry point for documents into the pipeline and the delivery destination for processed outputs. It carries additional responsibility in ClawQL's architecture as the backbone of the native archive layer.
-
-**Capabilities**
-
-- File sync and sharing with granular, role-based permissions.
-- Real-time collaboration via OnlyOffice or Collabora Office integration.
-- WebDAV and REST API access for programmatic use by ClawQL agents.
-- Automated Tagging app for rule-based file classification on upload.
-- Full-text search framework (Elasticsearch + Tesseract) for keyword search across PDFs and Office files.
-- Files Retention app for policy-based archival and deletion rules.
-- Guest accounts and advanced access control for external collaborators.
-
-**Integration Role**
-
-Documents arrive in Nextcloud folders watched by ClawQL pipeline triggers. Processed outputs return to Nextcloud after Stirling-PDF, becoming the human-browsable archive. ClawQL agents interact via WebDAV or Nextcloud API. Coneshare layers on top of Nextcloud storage to add secure external sharing without file migration.
-
-### Secure Sharing and Virtual Data Rooms: Coneshare
-
-**License:** MIT License — open-source, commercially permissive. Self-hosted.
-
-Coneshare is an open-source, self-hosted platform that adds secure sharing, engagement tracking, and workflow automation as a layer directly on top of Nextcloud storage. It is the external distribution endpoint of the IDP pipeline — the point at which processed, redacted, audited documents are shared with investors, legal counterparties, customers, or regulators.
-
-**Capabilities**
-
-- Secure share links with password protection, expiration dates, and email verification.
-- Virtual Data Rooms (VDRs) with granular folder- and file-level permissions.
-- Page-level engagement analytics: views, time spent per page, downloads, and revisit tracking.
-- Dynamic watermarking to deter unauthorized distribution.
-- File request capabilities for collecting documents from external parties.
-- Webhook and Slack integrations for automated follow-up on viewer activity.
-
-**Integration Role**
-
-After ClawQL processes and indexes documents, agents or users create VDRs or share links via Coneshare APIs exposed through ClawQL's MCP tools. Viewer activity triggers webhooks back into Ouroboros — automatically firing Slack notifications, updating memory vaults, filing follow-up tasks, or escalating based on engagement signals. This closes the IDP loop from document ingestion to trackable external distribution.
-
-> **Investor note:** Coneshare directly targets the Virtual Data Room market historically served by Intralinks, Datasite, and Ansarada — platforms charging $1,000–$5,000+ per deal. ClawQL delivers equivalent VDR capabilities self-hosted or via the hosted plan, with the added advantage of deep pipeline integration no standalone VDR product can match.
+Investor note: targets Intralinks / Datasite / Ansarada economics with pipeline-native provenance those standalone VDRs lack.
 
 ---
 
 ## Security, Audit, and Resilience
 
-ClawQL is designed around a zero-trust security model. Every processing step is auditable, every service boundary is authenticated, and no document data leaves the operator's control. The hosted plan extends this model with tenant isolation and managed key management.
+Zero-trust posture: auditable steps, authenticated service boundaries, operator-controlled data. Hosted adds tenant isolation and managed KMS patterns.
 
 ### Security Architecture
 
-- **Zero-Trust Networking:** Optional Istio service mesh with mTLS, L7 traffic policies, and Kiali observability between all services.
-- **Secrets Management:** HashiCorp Vault for credential and certificate lifecycle management. Per-tenant vault namespaces in hosted deployments.
-- **Image Security:** Golden Image Pipeline: Trivy + OSV-Scanner scanning, SBOM generation, and Cosign signing on every container before deployment.
-- **Data Sovereignty:** Self-hosted: all processing is local. Hosted: dedicated per-tenant infrastructure; no cross-tenant data access.
+- Optional Istio mTLS + AuthorizationPolicies + Kiali.
+- HashiCorp Vault (per-tenant namespaces on hosted).
+- Golden images: Trivy, OSV, SBOM, Cosign.
+- **Two-layer sovereignty:** (1) processing inside tenant boundary; (2) open-weight models you control — no closed-provider activation steering / undisclosed PEFT between your app and weights.
 
 ### Audit and Integrity
 
-- **Merkle Trees:** Each processing step generates a cryptographic hash. Roots are stored in Postgres and verifiable independently. Tampering with any intermediate step invalidates the chain.
-- **Cuckoo Filters:** Probabilistic deduplication at scale — documents are not double-processed without full database scans.
-- **Audit Tool:** The `audit()` MCP tool gives agents direct access to processing logs and verification endpoints.
-- **ClawQL Metadata Store:** Complete processing history per document stored in Postgres: who triggered it, which steps ran, timestamps, Merkle roots, and redaction records.
+- Merkle trees per step; roots in Postgres.
+- Cuckoo filters for dedup at scale.
+- `audit()` MCP tool for agent-accessible verification.
+- ClawQL metadata store: who triggered, stages, timestamps, Merkle roots, redaction records, LangExtract offsets, HITL decisions.
 
-### Roadmap: On-Chain Provenance
+### Model Substrate Security
 
-Hyperledger Fabric integration is planned for permissioned blockchain-based document provenance — providing tamper-evident distributed history for regulated industries. This is a future capability.
+Before registering fine-tuned adapters in `tier-map.json`, model prep runs: refusal ablation → desperation ablation → custom policy / LoRA / PorTAL alignment (order matters). Open-weight serving eliminates closed-API intervention surfaces.
 
-> **Roadmap items:** On-chain provenance (Hyperledger Fabric) and in-vault semantic search (sqlite-vec) are planned features. All other capabilities in this document are available in the April 2026 release.
+### Prompt Integrity Monitoring
+
+When closed APIs are used: Unicode normalization checks, date-separator anomalies, behavioral baseline drift probes. WORM entries include prompt/response hashes and integrity verdicts.
+
+Roadmap (not claimed as shipped here): Hyperledger Fabric on-chain provenance for regulated industries.
 
 ---
 
 ## End-to-End Workflow Example
 
-The following illustrates a complete IDP workflow triggered by a single agent instruction: _"Process Q1 invoices, redact PII, cross-reference our pricing knowledge base, archive, create a data room, and notify the team."_
+Instruction: _“Process Q1 invoices, redact PII, cross-reference pricing knowledge, archive, create a data room, notify the team.”_
 
-1. Document arrives in a Nextcloud folder (or via email/WebDAV). ClawQL detects it via folder watch or webhook.
-2. ClawQL agent invokes Tika via `execute()`: MIME detection, text extraction, metadata extraction.
-3. Gotenberg converts Office files to PDF for uniform downstream processing.
-4. Stirling-PDF applies OCR, PII redaction rules, and generates a Merkle verification hash per step.
-5. Processed, OCR'd, redacted PDF is written to Nextcloud. ClawQL Metadata Store records correspondent, document type, Merkle roots, and processing history in Postgres.
-6. Nextcloud Automated Tagging applies classification tags. Onyx indexes the document for semantic search.
-7. Agent queries Onyx via `knowledge_search_onyx()` to cross-reference pricing data from Slack.
-8. Workflow outputs, citations, Merkle roots, and decisions ingested into Obsidian vault via `memory_ingest()`.
-9. Coneshare creates a trackable VDR link with expiry, password, and watermarking.
-10. Viewer engagement triggers Ouroboros webhook: Slack notification sent, memory updated, follow-up task filed.
+1. Document arrives in Nextcloud (or email/WebDAV); webhook / watch fires.
+2. Agent `execute`s Tika (or pdf-inspector branch) for detect/extract.
+3. Gotenberg converts Office → PDF when needed.
+4. Stirling OCR/redact + Merkle hashes.
+5. Processed PDF → Nextcloud; Postgres records metadata + roots.
+6. Tags + Onyx index.
+7. `knowledge_search_onyx` for pricing cross-ref.
+8. `memory_ingest` for decisions / citations / hashes.
+9. Coneshare VDR link (expiry, password, watermark).
+10. Viewer engagement → NATS / Ouroboros / Slack / vault follow-up.
 
-The entire sequence above runs from a single natural-language agent prompt. No custom integration code. No manual handoffs. Full cryptographic audit trail from step 1 through step 10.
+Full cryptographic trail from step 1 through 10.
 
 ---
 
-## Competitive Positioning
+## Competitive Positioning, Pricing, and Verticals
 
-ClawQL is an **Foundational Platform for Auditable Production AI**, not a single SKU. Sales focus follows **plugin bundles** — gateway and memory first (Developer/Teams), IDP and VDR when explicitly opted in (Starter+). The surface area is large; buyers activate layers they need rather than purchasing four products at once.
+### MCP Gateway: executor.sh — One Layer vs Twelve
 
-**First buyers:** document-heavy teams of 20–200 people in legal, M&A diligence, healthcare operations, and lending — organizations already spending $500–2k/mo on SaaS who need agent memory and document intelligence. Gateway-only developers evaluating MCP infrastructure start on Developer or Teams.
+| ClawQL capability               | executor.sh                                 |
+| ------------------------------- | ------------------------------------------- |
+| 12-layer token efficiency       | Layer 1 only                                |
+| Layers 2–12                     | None                                        |
+| Persistent vault memory         | None                                        |
+| Onyx semantic search            | None                                        |
+| Full IDP + Merkle audit         | None                                        |
+| Coneshare VDR                   | None                                        |
+| Sovereign LLM fleet             | None                                        |
+| NSV/SGDOP ensemble coordination | None                                        |
+| Defense-in-depth docs           | Secrets + basic policy; no equivalent depth |
+| GitHub stars                    | Ahead on adoption timing — not capability   |
 
-**Current state:** the open-source MCP core is production-ready and self-hostable today (npm, Helm, published case studies, Kubernetes operator). Managed gateway hosting is in early access with a 14-day Developer trial. IDP hosted tenants onboard with founder-led setup. Architecture earns trust over time — we do not claim compliance certifications or long vendor histories we do not have yet.
+executor.sh is a **stateless tool router**. ClawQL is a **stateful agent operating system**.
 
-ClawQL competes across four adjacent markets — price each plugin bundle against the right incumbent:
+### Hosted Plan Pricing (July 2026 — plugin bundles)
 
-| Competitor Category                                                           | ClawQL tier                                                | ClawQL differentiation                                                                                                                                                                                                                           |
-| ----------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Agent routers** ([executor.sh](https://executor.sh/), emerging MCP routers) | Developer ($29/mo), Teams ($99/mo)                         | executor.sh is a **tool** with a head start on developer marketing. ClawQL is the **Foundational Platform**: unlimited executions, twelve efficiency layers, vault memory, Onyx search, optional IDP — more capability at lower gateway pricing. |
-| **SaaS IDP vendors** (Hyperscience, Kofax, ABBYY)                             | Starter–Professional (IDP bundle)                          | Cloud-hosted; per-document pricing at scale. No native MCP/agent interface. ClawQL: tenant-isolated hosted or self-hosted, flat IDP tiers, MCP-native from day one.                                                                              |
-| **VDR incumbents** (Intralinks, Datasite, Ansarada)                           | Starter+ (IDP bundle includes Coneshare)                   | Hosted VDRs with no document processing pipeline. High per-user/per-GB/per-deal licensing. ClawQL: full pipeline integration, Coneshare VDR included in IDP subscription.                                                                        |
-| **Vertical CRMs** (REsimpli, franchise transaction tools)                     | Teams ($99/mo) for agent memory; Starter ($299/mo) for IDP | CRMs track pipeline; Drive folders hold files. ClawQL connects CRM APIs + storage via MCP, indexes documents in Onyx, threads deal context in vault — without replacing Command, Dotloop, or SkySlope.                                           |
+| Tier                    | Price          | Notes                                                                                             |
+| ----------------------- | -------------- | ------------------------------------------------------------------------------------------------- |
+| Self-hosted             | $0             | Full OSS; self-managed                                                                            |
+| Developer (planned)     | $29–99/mo      | Gateway + memory (+ Onyx on Teams); no IDP/GPU                                                    |
+| Shared                  | $299/mo        | Full IDP + Onyx + VDR + vault                                                                     |
+| Dedicated               | $599/mo        | Single-tenant; sovereign AI bundle; SSO/RBAC                                                      |
+| Enterprise              | from $3,500/mo | SLA, HITL, vertical adapters, multi-region                                                        |
+| Sovereign Security Pack | +$200/mo       | Kata, weight integrity, WORM Merkle, Panguard, YubiKey signing, Presidio pre-log, monthly posture |
 
-### Real estate vertical
+> Indicative GTM numbers — validate against infrastructure cost modeling before launch. See also [clawql-idp-gtm.md](./clawql-idp-gtm.md) for Starter/Business ladder variants.
 
-Brokerages on Keller Williams Command, eXp BoldTrail, Follow Up Boss, or Compass share a structural gap: **CRM knows the deal, Drive holds the files** — no semantic link between contacts and transaction PDFs.
+### Full Stack Replacement Value
 
-| Need                                                             | Recommended tier                  | Why                                                                                                   |
-| ---------------------------------------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| Connect Command + Drive, semantic search, deal memory            | **Teams ($99/mo)**                | Agentic Gateway + Onyx + vault — no IDP overhead for teams that do not process documents daily        |
-| Title commitment classify/extract, Coneshare VDR for disclosures | **Starter ($299/mo)**             | IDP plugin bundle — explicitly opted in                                                               |
-| REsimpli comparison                                              | Teams vs REsimpli Basic ($149/mo) | REsimpli is CRM-only for investors; ClawQL unifies CRM integration, document search, and agent memory |
+Representative: 25 users, 25k docs/mo, VDR + compliance.
 
-ClawQL does **not** replace Dotloop (forms, e-sign, broker compliance) or MLS listing platforms. It is the intelligent document layer on top.
+| Component       | Incumbent vs ClawQL Dedicated                                    |
+| --------------- | ---------------------------------------------------------------- |
+| IDP             | Hyperscience / ABBYY five–six figures → **included**             |
+| VDR             | Intralinks/Datasite/Ansarada → **included**                      |
+| Semantic search | Algolia/Coveo/Glean → **included**                               |
+| Merkle audit    | Custom build → **included**                                      |
+| Sovereign LLM   | Not available elsewhere → **included on Dedicated**              |
+| **Total**       | $8k–15k+/mo incumbents vs **≤$799/mo** Dedicated + Security Pack |
 
-### Market 1: executor.sh (vs Agentic Gateway)
+### Verticals
 
-executor.sh is the closest direct competitor to ClawQL's Agentic Gateway entry layer. **It is a tool; ClawQL is the Foundational Platform.** executor.sh routes tool calls well — that is its job. ClawQL adds memory, search, security depth, document pipeline, and optional sovereign inference behind one Agentic Gateway endpoint.
+**Real estate / Keller Williams Command + Drive:** MCP + memory + Onyx at Teams price; Coneshare for disclosure packages; classify/extract for TC workflows.
 
-**Where executor.sh leads:** developer mindshare, YC-backed go-to-market, and community velocity in the MCP router category. That is real and we state it plainly.
+**Software / technology:** One gateway for GitHub/Linear/Jira/Sentry/Slack; vault for eng decisions; Onyx over Notion/Confluence; Panguard + audit for governed tool use. Competes with executor.sh Team while adding memory + security depth.
 
-**Collaboration:** before publishing head-to-head comparisons, we approached executor.sh about collaboration and shared MCP ecosystem work. Those overtures were not engaged. We document positioning directly for buyers making infrastructure decisions.
+### Where Competitors Have Genuine Advantages
 
-| Dimension          | executor.sh                                            | ClawQL                                                                                                   |
-| ------------------ | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
-| Category           | Tool — routes MCP calls, injects secrets, meters usage | Foundational Platform — Agentic Gateway, memory, search, security, IDP, sovereign inference              |
-| Developer adoption | Head start on marketing and community mindshare        | Later entrant; deeper stack, open-source core, published case studies                                    |
-| Token efficiency   | One layer: search-and-execute only                     | Twelve compounding layers on top of search/execute                                                       |
-| Agent memory       | None — every session starts from zero                  | Obsidian vault with memory_ingest / memory_recall                                                        |
-| Semantic search    | None                                                   | Onyx — 40+ connectors, hybrid search, citations                                                          |
-| Security           | Host-side secrets, basic audit log                     | Kata isolation, WORM Merkle logs, Panguard fail-closed, documented defense-in-depth                      |
-| Document pipeline  | None                                                   | Tika → Gotenberg → Stirling → archive → Onyx                                                             |
-| VDR                | None                                                   | Coneshare included from IDP Starter                                                                      |
-| Sovereign LLM      | None                                                   | Fine-tuned Qwen inside tenant boundary (IDP tiers) — vertical adapters early; maturity risk named openly |
-| Execution pricing  | 250K cap + $0.20/1K overage on Team                    | Unlimited on every tier — no caps, no overage bills                                                      |
-| Gateway pricing    | Team $150/org/mo — metered routing                     | Developer $29/mo · Teams $99/mo with memory + search · unlimited executions                              |
-
-On infrastructure dimensions that matter — memory, security, token efficiency depth, document pipeline, sovereign inference — ClawQL delivers more at lower gateway pricing. executor.sh's advantage is awareness and adoption velocity, not platform depth.
-
-### Shipped vs roadmap (honest scope)
-
-| Capability                                                | Status                                                                                                        |
-| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| ClawQL Core (search, execute, audit, cache)               | **Shipped** — open source, case studies                                                                       |
-| Vault memory, Onyx search, IDP pipeline                   | **Shipped** — self-host and early hosted tenants                                                              |
-| Ouroboros evolutionary loop library                       | **Shipped** — `clawql-ouroboros` package                                                                      |
-| DAOS swarm coordination (NSV, SGDOP, Diversity Dividends) | **Roadmap** — specified in [DAOS build plan](../ouroboros/daos-build-plan-v2.7.1.md); not production-hardened |
-| Tenant-bound fine-tuned models (Qwen3.6 family)           | **Early** — deliberate bet; newer than incumbent cloud APIs; name maturity risk in regulated evaluations      |
-
-ClawQL's MCP-native architecture benefits from improvements in frontier model capabilities. Tenant-bound fine-tunes are a differentiation bet with explicit maturity risk — regulated buyers should weigh architecture against reference history.
+| Gap                             | Honest assessment                                                              |
+| ------------------------------- | ------------------------------------------------------------------------------ |
+| Certifications (SOC 2, FedRAMP) | Controls architecturally present; audit process remaining.                     |
+| Pre-trained skill libraries     | ABBYY’s catalog is larger; ClawQL vertical adapters are deeper where shipped.  |
+| M&A brand                       | Intralinks embedded in IB relationships — references required.                 |
+| executor.sh DX / stars          | Strong developer experience; answer is Developer/Teams tier + memory/security. |
 
 ---
 
 ## Deployment Architecture
 
-ClawQL deploys via a unified Helm chart that provisions the full stack. All services expose OpenAPI specifications auto-loaded as ClawQL bundled providers on startup.
+Hybrid: **Cloudflare edge** (Developer/Teams) → **AWS K3s** (first IDP customers) → **EKS + Karpenter** (scale). Customer endpoint: `gateway.clawql.app` Worker routes by tenant tier.
 
-### Self-Hosted Stack
+### Shared vs Per-Tenant Services
 
-- Unified Helm chart: deploys ClawQL core and 12+ supporting services in a single `helm install`.
-- Kubernetes with optional Istio Ambient or sidecar mesh.
-- Nextcloud (AIO or standard) with folder watches for pipeline ingestion.
-- Coneshare deployed alongside Nextcloud, directly integrated with its storage layer.
-- Persistent volumes for Obsidian vaults, Nextcloud files, Onyx indexes, and Postgres.
-- Paperless-ngx available via feature toggle for operators who prefer it (self-hosted only).
+| Tier                            | Services                                                                         |
+| ------------------------------- | -------------------------------------------------------------------------------- |
+| Shared cluster-wide (stateless) | Tika, Gotenberg, Stirling — one pool, fair queues                                |
+| Shared with tenant scope        | ES (per-tenant index), Postgres (per-tenant schema), Argo, Istio policies, LGTM+ |
+| Strictly per-tenant             | Onyx, Nextcloud, R2 bucket, Coneshare, Vault namespace                           |
 
-### Hosted infrastructure model
+Marginal cost per tenant is primarily Onyx + Nextcloud; workers scale with volume, not headcount of tenants.
 
-Managed hosting uses a **hybrid model** aligned to plugin bundles — without changing the customer-facing MCP endpoint:
+### Path 1: Bootstrap — K3s on EC2
 
-| Tier class                                      | Infrastructure                          | What the customer gets                                                                             |
-| ----------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| **Developer, Teams**                            | Regional Hub + object storage for vault | Agentic Gateway, memory vault, cache, audit. Unlimited executions. Low-latency endpoint worldwide. |
-| **Starter, Business, Professional, Enterprise** | Dedicated tenant (Kubernetes)           | Full IDP pipeline, Onyx at scale, Nextcloud archive, Coneshare VDR, sovereign inference.           |
+K3s on r7i.2xlarge; R2 per-tenant buckets; Istio sidecar; Argo CD from day one; Ouroboros/job queue → Argo Workflows at scale; ingress-nginx; LGTM+.
 
-A single routing layer dispatches each request by tenant tier. **Vault documents live in shared object storage** accessible from both gateway and IDP backends — upgrading from Teams to Starter retains full agent memory history without migration. The customer's MCP URL and auth token do not change on upgrade.
+### Path 2: Scale — EKS + Karpenter + Istio Ambient + Argo Suite
 
-AWS (EKS + Karpenter) provisions **only when the first IDP customer signs** — not at gateway-tier launch. This keeps bootstrap burn minimal while gateway tiers validate product-market fit.
+- **Reserved pool:** stateful (Onyx, Nextcloud, Postgres, ES, core).
+- **Spot pool:** Tika/Gotenberg/Stirling/Argo pods.
+- **Istio Ambient** for ephemeral workers.
+- **Argo CD / Workflows / Events / Rollouts** for GitOps, DAGs, R2 triggers, canaries.
 
-### Hosted Stack (per tenant — IDP tiers)
+Migration is incremental: same Helm charts, Argo CD on both clusters, no application rewrite.
 
-- Dedicated Nextcloud instance, Postgres schema, and Onyx index per tenant.
-- Shared ClawQL core and processing services (Tika, Gotenberg, Stirling-PDF) with tenant-scoped job queues.
-- Istio mTLS enforced between all tenant services.
-- Per-tenant secrets in HashiCorp Vault namespaces.
-- Paperless-ngx not deployed — ClawQL-native archive layer only.
+### Self-Hosted Customer Deployments
 
-### Scaling Characteristics
+Same Helm chart; feature flags (`ENABLE_ONYX`, `ENABLE_CONESHARE`, `ENABLE_ISTIO`, `ENABLE_ARGO`, `ENABLE_PAPERLESS` self-hosted only). Minimum viable: Tika + Gotenberg + Stirling + Nextcloud + Postgres on a single VM.
 
-- Stateless ClawQL core and processing workers (Tika, Gotenberg, Stirling-PDF) scale horizontally.
-- Postgres and Nextcloud scale vertically or via read replicas for larger deployments.
-- Onyx indexes scale independently via Flink pipeline parallelism.
-- Minimum viable deployment (no Istio, no Onyx, no Coneshare) available via environment-variable toggles for evaluation.
+---
+
+## Sovereign AI: Multi-Model Fleet
+
+Hosted Dedicated/Enterprise run a sovereign fleet inside the tenant boundary. Harnesses call **one** OpenAI-compatible Gateway endpoint; routing, NSV/SGDOP, prompts, and Langfuse emission live in one place.
+
+### Role-Based Models
+
+| Model                  | Role                                                      |
+| ---------------------- | --------------------------------------------------------- |
+| Qwen3.6-27B FT (NVFP4) | Document worker — tool sequencing, Ouroboros, Merkle, VDR |
+| Ornith 35B MoE (as-is) | Coding specialist — do **not** LoRA away self-scaffolding |
+| Phi-4 14B FT           | Utility / memory / metadata                               |
+| Gemma 4 31B            | NSV/SGDOP diversity only                                  |
+
+Mistral Devstral 2 (123B) excluded from initial fleet on cost; reconsider when revenue justifies.
+
+### Model Escalation vs Agent Coordination
+
+- **Escalation:** Frugal → Standard → Frontier on outcome failure (never skip tiers); WORM-logged.
+- **Coordination:** `combined_drift` > 0.3 → Hermes MoA fan-out with NSV/SGDOP — independent of escalation.
+
+J-space / imaginary-direction hypotheses are research notes, not product claims. Contact: hello@clawql.com.
+
+### Gateway Routing (summary)
+
+Identity → preset → SGDOP → NSV → harness-aware Ornith selection → canonical system prompt → vLLM → Langfuse/Loki/Tempo. Policy YAML presets: `worker-tool-use`, `coding-specialist`, `utility-quick`, `moa-diversity`.
+
+### Data Sovereignty Layer
+
+Presidio before LLM; Istio egress block on vLLM pods; local vLLM; tenant-scoped Langfuse; WORM routing decisions in Merkle chain.
+
+### Fine-Tuning / PorTAL Flywheel
+
+WORM call store is the primary training source (`verdict`, `verdict_source`, exclude `cache_hit`). Export with Presidio scrub + TrainingLineage manifest. Train on RTX 5090 (Unsloth QLoRA) → NVFP4 → `finetune register` → Argo Rollouts canary. PorTAL task-latent + per-base alignment makes adapters portable across base models ([portal-flywheel.md](../inference/portal-flywheel.md)).
+
+---
+
+## OpenBench: Live A/B Benchmark Results
+
+Claims are verified with live agent A/B on GitHub Actions using frugal DeepSeek via OpenRouter. Graders require real `tool:clawql_*` evidence.
+
+See also: [openbench.md](../benchmarks/openbench.md) · [openbench-advanced-specs.md](../benchmarks/openbench-advanced-specs.md) (B-1…B-6 Phase 1 packs) · in-repo `openbench/`.
+
+### Proven claims (indicative July 2026)
+
+| Claim                              | Result                            | Run                                   |
+| ---------------------------------- | --------------------------------- | ------------------------------------- |
+| Ouroboros convergence              | on 1.0 (~78s) / off 0.0 (~167s)   | 30863572642, 30866904277, 30872913519 |
+| Memory continuation (seed removed) | on 1.0 / off 0.333                | 30872913516                           |
+| Token-budget constrained           | on 1.0 / off 0.0                  | 30872437811                           |
+| Memory roundtrip                   | on 1.0 / off 0.0                  | 30872913516                           |
+| Search-first discovery             | on 1.0 / off 0.0                  | 30872913516                           |
+| Execute-verify loop                | on 1.0 / off 0.0                  | 30872913516                           |
+| Audit checkpoints                  | on 1.0 / off 0.0                  | 30872437811                           |
+| Policy-deny execute                | on 1.0 / off 0.0                  | 30872913516                           |
+| Multi-provider workflow            | on 1.0 / off 0.75 (noisier later) | 30868287877                           |
+
+Infrastructure timeouts (OpenCode hang, no tools) are noise, not claim failures. Most cells are n=1 — raise n≥3 before statistical confidence (advanced ledger Phase 1+).
+
+### Reasoning Trace Protocol (RTP)
+
+OpenBenchTrace (outer envelope) + RTP (inner reasoning structure) are complementary. NSV/SGDOP used for schema governance in RTP and runtime ensemble coordination in ClawQL — same math, two scales.
 
 ---
 
 ## Licensing Summary
 
-All components in the default ClawQL stack operate under licenses permissive for commercial deployment and SaaS distribution. Paperless-ngx (GPL-3.0) is available as an optional self-hosted toggle but is not part of the hosted plan or the default stack.
+| Component                | License & notes                                     |
+| ------------------------ | --------------------------------------------------- |
+| ClawQL Core              | Apache 2.0                                          |
+| Coneshare                | MIT                                                 |
+| Apache Tika              | Apache 2.0                                          |
+| Gotenberg                | MIT                                                 |
+| Stirling-PDF             | Open-core                                           |
+| Nextcloud                | AGPL-3.0 (+ commercial options)                     |
+| Onyx                     | Open-source core — review current repo terms        |
+| Obsidian vault format    | Plain Markdown — open data                          |
+| Paperless-ngx (optional) | GPL-3.0 — **self-hosted only**, not in hosted stack |
 
-| Component                    | License & Commercial Notes                                                                                                                                                                                                                           |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **ClawQL Core**              | Apache 2.0 — permissive, commercial use and SaaS distribution allowed.                                                                                                                                                                               |
-| **Coneshare**                | MIT — permissive, commercial use and SaaS distribution allowed.                                                                                                                                                                                      |
-| **Apache Tika**              | Apache 2.0 — permissive, commercial use allowed.                                                                                                                                                                                                     |
-| **Gotenberg**                | MIT — permissive, commercial use allowed.                                                                                                                                                                                                            |
-| **Stirling-PDF**             | Open-core. Base features open-source. Enterprise tiers commercially licensed by Stirling.                                                                                                                                                            |
-| **Nextcloud**                | AGPL-3.0. Self-hosted use is unrestricted. Nextcloud GmbH offers commercial enterprise licensing. AGPL requires source disclosure of modifications if distributed, but does not propagate to ClawQL or applications using Nextcloud via API/network. |
-| **Onyx**                     | Open-source core. Review current repository license for enterprise commercial terms.                                                                                                                                                                 |
-| **Obsidian Vault Format**    | Plain Markdown — fully open, no license restrictions on vault data.                                                                                                                                                                                  |
-| **Paperless-ngx (optional)** | GPL-3.0. Self-hosted deployments only. Not included in hosted plan. Operators should review GPL obligations before distributing derivative products.                                                                                                 |
-
-The managed hosted plan is built entirely on Apache 2.0, MIT, and AGPL-licensed components. No GPL dependencies are present in the hosted stack. Legal review of AGPL network use clauses is recommended but standard for SaaS products built on AGPL software.
+Hosted plan avoids GPL dependencies. Legal review of AGPL network clauses recommended for SaaS.
 
 ---
 
 ## Roadmap
 
-The following outlines planned capabilities beyond the April 2026 release. Roadmap items are subject to change based on customer feedback and engineering priorities.
+### Near-term (1–3 months)
 
-### Near-Term (Next 1–3 Months)
+- Hosted beta: Developer/Teams on Cloudflare Workers; 14-day trial.
+- Inference Gateway v1 + pdf-inspector Stage 0 + Docling + LangExtract + HITL Label Studio.
+- Qwen3.6-27B ClawQL-general fine-tune v1 + Istio egress + Presidio.
+- `mcp-api-adapter` 0.5.x line (shipped).
+- OpenBench expansion — advanced Phase 1 packs landed; live cells next.
 
-- Hosted plan beta launch with 14-day Developer trial and Starter tiers.
-- ClawQL Metadata Store REST API for direct metadata query without MCP client.
-- Nextcloud app for in-browser document processing trigger (no agent client required).
-- Automated tenant provisioning and onboarding flow for hosted customers.
+### Medium-term (3–6 months)
 
-### Medium-Term (3–6 Months)
+- Privacy filter [#245], document-type classifier, See The Greens vertical FT, observability [#252], Argo HITL suspend/resume [#254], HITL→few-shot feedback, Business/Enterprise hosted, EU multi-region.
 
-- sqlite-vec integration in Obsidian vault for semantic recall over agent memory.
-- Business and Enterprise hosted tiers with SLA and SSO/SAML support.
-- Coneshare analytics dashboard integration into ClawQL MCP tools (view engagement data via agent query).
-- Multi-region hosted deployments for EU data residency requirements.
+### Longer-term (6–12 months)
 
-### Longer-Term (6–12 Months)
-
-- Hyperledger Fabric integration for on-chain document provenance in regulated industries.
-- ClawQL-native document review UI — lightweight alternative to the Nextcloud file browser for archive access.
-- White-label hosted option for resellers and system integrators.
-- Connector marketplace for community-contributed OpenAPI specs and Onyx connectors.
+- Vertical packs [#251], KEDA [#257], handwriting/ICR, chart/figure VLM, cross-document entity resolution, continuous active learning, Hyperledger Fabric provenance, white-label hosted.
 
 ---
 
@@ -562,44 +533,22 @@ The following outlines planned capabilities beyond the April 2026 release. Roadm
 
 ### For Investors
 
-**How does ClawQL generate revenue?**
+**How does ClawQL generate revenue?** Managed hosted subscriptions (primary); commercial support for self-hosted (secondary). OSS core drives adoption and conversion.
 
-The managed hosted plan is the primary revenue vehicle — monthly and annual subscriptions tiered by document volume and seats. Secondary revenue comes from commercial support contracts for self-hosted enterprise deployments. The open-source core drives adoption and inbound pipeline for both.
+**Why not DocSend / Intralinks alone?** Distribution-only. No redact/convert/semantic index/agent integration. ClawQL VDR is the last mile of a processing + provenance pipeline; unlimited VDRs within subscription vs per-deal five-figure fees.
 
-**Why won't customers just use DocSend or Intralinks?**
+**What is the moat?** (1) Pipeline depth across IDP + API integration; (2) MCP-native architecture; (3) WORM call-store flywheel + PorTAL; (4) Merkle / Arweave / `deal_id` evidence chains.
 
-DocSend and Intralinks are distribution-only tools. They cannot redact PII, convert documents, semantically index content, or integrate with AI agents. ClawQL's VDR (Coneshare) is the last mile of a complete processing pipeline — you can't replicate that by adding a VDR on top of a disconnected stack. Additionally, per-deal VDR pricing from incumbents can reach $5,000+ for a single transaction; ClawQL's hosted plan covers unlimited VDRs within a subscription.
-
-**What is the moat?**
-
-Three layers: (1) **Pipeline depth** — the integration between ingestion, redaction, archive, semantic search, and VDR distribution is not replicable by bolting together point tools. (2) **MCP-native architecture** — as AI agents become the default interface for enterprise workflows, ClawQL is natively positioned to benefit without code changes. (3) **Cryptographic audit trail** — Merkle-verified processing records are a compliance differentiator in regulated industries that SaaS alternatives cannot easily replicate.
-
-**Is the open-source core a threat to the hosted business?**
-
-No — it is the growth engine. Self-hosted users who hit operational complexity (scaling, updates, security patches) convert to hosted. The open-source core also drives developer community adoption and reduces sales friction: customers evaluate the product on their own infrastructure before committing to hosted plans.
+**Does OSS threaten hosted?** No — it is the growth engine and evaluation path.
 
 ### For Developers
 
-**Can I use ClawQL without the full stack?**
+**Can I use ClawQL without the full stack?** Yes — feature toggles; minimal Tika + Gotenberg + Stirling + Nextcloud is viable.
 
-Yes. Each pipeline stage is independently deployable. The Helm chart supports feature toggles to enable or disable Onyx, Coneshare, Paperless-ngx compatibility, Web3 features, and Istio. A minimal deployment (Tika + Gotenberg + Stirling-PDF + Nextcloud) is viable for straightforward document processing without semantic search or VDR.
+**How does Ouroboros handle failures?** Retryable phases; Evaluate/Evolve re-route or HITL via `notify`; Merkle commit on success only.
 
-**How does the Ouroboros loop handle failures?**
-
-Each phase in the Ouroboros loop (Interview → Seed → Execute → Evaluate → Evolve) is retryable. Failed `execute()` calls are logged with full context in the ClawQL metadata store. The Evaluate phase detects failures and the Evolve phase can re-route, retry with modified parameters, or escalate to a human via `notify()`. Merkle roots are only committed on successful step completion.
-
-**How is the Nextcloud archive layer different from just using Nextcloud normally?**
-
-Standard Nextcloud has no document metadata model, no correspondent tracking, and no processing history. The ClawQL archive layer adds a Postgres-backed metadata store that records full processing context per document, integrates with Onyx for semantic search, and exposes everything via MCP tools so agents can query the archive programmatically. Think of it as Nextcloud plus a document intelligence layer — not a replacement for Nextcloud's file management capabilities.
+**How is the archive different from “just Nextcloud”?** Postgres metadata + Onyx semantic + MCP-queryable processing history on top of Nextcloud files.
 
 ---
 
-## Operator references
-
-| Doc                                                                     | Purpose                                              |
-| ----------------------------------------------------------------------- | ---------------------------------------------------- |
-| [IDP pipeline hub](../providers/idp-pipeline.md)                        | Bundled providers, env, Helm, `DEFAULT_IDP_PIPELINE` |
-| [Requirements matrix](../roadmap/idp-master-requirements-matrix.md)     | Shipped vs gap tracking                              |
-| [OpenClaw IDP skill profile](../openclaw/openclaw-idp-skill-profile.md) | Agent + dashboard contract                           |
-| [Agent chat contract](../dashboard/agent-chat.md)                       | Rich IDP UI JSON                                     |
-| [Helm chart](../../charts/clawql-mcp/README.md)                         | Co-deploy document stack                             |
+_Confidential — July 2026. GTM figures are indicative until launch cost models are locked._

--- a/website/src/generated/clawql-idp-platform-body.mdx
+++ b/website/src/generated/clawql-idp-platform-body.mdx
@@ -1,11 +1,11 @@
 # ClawQL Intelligent Document Processing Platform
 
-**Version:** July 2026 (7.0.0+)  
+**Version:** July 2026 (7.2.0+)  
 **Tagline:** Sovereign • Modular • Production-Ready • Hosted & Self-Hosted
 
 **Audience:** Investors · Developers & architects · Operators
 
-**Related:** [IDP pipeline hub](/learn/document-pipeline) · [Requirements matrix](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/roadmap/idp-master-requirements-matrix.md) · [OpenClaw IDP skill profile](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/openclaw/openclaw-idp-skill-profile.md) · [Master enablement guide](/architecture) · [Deployment guide](/deployment/operations-guide)
+**Related:** [IDP GTM strategy & landing brief](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/vision/clawql-idp-gtm.md) · [Public IDP GTM playbook](https://clawql.com/idp/gtm) · [IDP pipeline hub](/learn/document-pipeline) · [Requirements matrix](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/roadmap/idp-master-requirements-matrix.md) · [OpenClaw IDP skill profile](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/openclaw/openclaw-idp-skill-profile.md) · [Token efficiency (12 layers)](/architecture/token-efficiency) · [OpenBench advanced specs](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/benchmarks/openbench-advanced-specs.md) · [Master enablement guide](/architecture) · [Deployment guide](/deployment/operations-guide)
 
 ---
 
@@ -15,546 +15,517 @@ Understand the market problem, business model, competitive differentiation, and 
 
 ## For Developers & Architects
 
-Deep-dive into architecture decisions, component integrations, deployment topology, and the archive layer design.
+Deep-dive into architecture decisions, token efficiency, component integrations, deployment topology, and the inference fleet.
 
 ---
 
 ## Executive Summary
 
-ClawQL is a sovereign Intelligent Document Processing platform that replaces fragmented SaaS toolchains with a single AI-orchestrated pipeline — from document ingestion to secure external distribution — available both as a self-hosted deployment and as a fully managed hosted service.
+ClawQL is a sovereign Intelligent Document Processing platform and MCP agent operating system. It replaces fragmented SaaS toolchains with a single AI-orchestrated pipeline — from document ingestion to secure external distribution — available both as a self-hosted deployment and as a fully managed hosted service.
 
-Enterprises manage documents across dozens of disconnected tools: OCR vendors, PDF processors, document management systems, knowledge bases, and data room platforms. Each handoff introduces cost, latency, compliance risk, and data exposure. ClawQL collapses this stack into one modular system orchestrated by AI agents, with a clean path to either self-hosted sovereignty or a managed hosted plan.
+Enterprises manage documents across dozens of disconnected tools while their AI agents operate without persistent memory, token efficiency, or semantic search over institutional knowledge. ClawQL collapses both problems: a **twelve-layer** token efficiency architecture for the agent layer, a full document processing pipeline for the document layer, and a sovereign multi-model inference fleet that keeps sensitive data inside the tenant boundary.
 
 ---
 
 ## The Problem
 
-- Document workflows span 5–10+ SaaS products, each with separate billing, compliance postures, and API contracts.
-- Every SaaS touchpoint is a potential breach vector — especially critical for legal, financial, and healthcare documents.
-- AI automation requires deep pipeline integration that fragmented tools cannot provide out of the box.
-- Audit trails are inconsistent or absent across tool boundaries.
-- Virtual Data Room incumbents (Intralinks, Datasite, Ansarada) charge significant per-user and per-GB fees with no pipeline integration.
+- Document workflows span 5–10+ SaaS products with separate billing, compliance postures, and data exposure points.
+- AI agents have no persistent memory — every session starts from zero. Institutional context must be re-explained manually.
+- Naive tool-calling approaches load full API specs into context windows: **2,556,000+ tokens** for three common providers combined.
+- VDR incumbents charge $10,000–$200,000+/year with no pipeline integration. IDP vendors charge $0.50–1.50/page.
+- No competitor provides a sovereign locally-running fine-tuned LLM with verifiable data sovereignty at the infrastructure layer.
 
 ---
 
 ## The ClawQL Solution
 
-- End-to-end IDP pipeline: ingest → convert → redact → archive → semantically index → share — orchestrated by a single MCP server.
-- Two deployment models: self-hosted (full data sovereignty) and managed hosted (zero infrastructure overhead).
-- Cryptographic audit trails via Merkle trees for tamper-evident, per-step processing records.
-- AI agents drive the entire workflow via natural language — no custom integration code required.
-- Modular architecture: adopt components incrementally, swap alternatives where needed.
+- **Twelve-layer token efficiency** reducing input tokens by ~99.8% on average at Layer 1. The nearest MCP gateway competitor implements one layer. Canonical detail: [`clawql-token-efficiency.md`](/architecture/token-efficiency).
+- **End-to-end IDP pipeline:** ingest → convert → redact → archive → semantically index → share — one Helm chart.
+- **Durable cross-session agent memory** (Markdown, local, portable). OKF v0.2 trust signals (`generated`, `verified`, `stale_after`, `status`, `superseded_by`) in vault entries. `memory_ingest` / `memory_recall` tools. See [`okf.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/memory/okf.md).
+- **PorTAL** (Ramp Labs, Apache 2.0): Portable Task-specific Adapter Learning via `--format portal-bundle` in the flywheel export pipeline. See [`portal-flywheel.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/inference/portal-flywheel.md).
+- **Sovereign multi-model inference fleet:** fine-tuned Qwen3.6-27B + Ornith 35B MoE + Phi-4 14B. Istio-enforced egress block. No tokens leave the tenant boundary.
+- **Defense-in-depth security:** Kata container VM isolation, WORM Merkle audit logs, Panguard ATR fail-closed, model weight integrity verification. Documented at [defense-in-depth](https://docs.clawql.com/security/defense-in-depth).
 
 ---
 
 ## Business Value at a Glance
 
-| Value Driver         | Detail                                                                                                                |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| **Cost Reduction**   | Replaces 5–10 SaaS subscriptions. Self-hosted plan has no per-document or per-user fees beyond infrastructure.        |
-| **Compliance**       | Data processed locally (self-hosted) or in a dedicated tenant (hosted). Cryptographic audit trail for every step.     |
-| **AI Readiness**     | Native MCP integration means AI agents operate the full pipeline without custom code. Improves as models improve.     |
-| **Scalability**      | Kubernetes/Helm deployment scales horizontally. 1,000+ document formats supported.                                    |
-| **VDR Market Entry** | Coneshare delivers Virtual Data Room capabilities at a fraction of incumbent pricing, with full pipeline integration. |
-| **Hosted Revenue**   | Managed hosted plan creates recurring SaaS revenue on top of the open-source self-hosted core.                        |
+| Value Driver                | Detail                                                                                                                                                                                                      |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Token efficiency**        | Twelve compounding layers. ~99.8% average input reduction on Layer 1 alone. Layers 2–12 reduce output, prose, cache cost, repeated calls, history growth, per-task model cost, and flywheel training waste. |
+| **Cost reduction**          | Replaces $8,000–15,000+/month incumbent stacks. ClawQL Dedicated + Sovereign Security Pack: **$799/month** maximum (indicative GTM).                                                                        |
+| **Data sovereignty**        | Provable at the infrastructure layer. Istio AuthorizationPolicies enforce egress blocks — not only a contractual claim.                                                                                     |
+| **Persistent agent memory** | Unique among IDP / VDR / MCP gateway competitors: cross-session vault memory with OKF trust signals.                                                                                                        |
+| **AI readiness**            | MCP-native from day one. Improves as models improve. Token layers mean agent cost drops as usage scales.                                                                                                    |
+| **VDR market entry**        | Coneshare delivers VDR capabilities at a fraction of incumbent pricing, with full pipeline integration.                                                                                                     |
+| **Hosted revenue**          | Managed hosted plan creates recurring SaaS revenue on top of the open-source self-hosted core.                                                                                                              |
 
 ---
 
 ## Deployment Models
 
-ClawQL is available in two deployment configurations. Both run identical pipeline logic; they differ in who manages the infrastructure and where data resides.
+ClawQL is available in configurations that run identical pipeline logic.
 
-|                     | **Self-Hosted**                                                                             | **Managed Hosted**                                                                   |
-| ------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| **Target customer** | Enterprises with existing Kubernetes infrastructure and strict data residency requirements. | Teams who want ClawQL's capabilities without managing infrastructure.                |
-| **Data residency**  | Fully local — no data leaves the operator's environment.                                    | Tenant-isolated; data processed and stored in dedicated infrastructure per customer. |
-| **Infrastructure**  | Customer-managed Kubernetes/Helm. ClawQL provides the chart.                                | Fully managed by ClawQL. Customer connects via API or web UI.                        |
-| **Licensing model** | Apache 2.0 core — free to deploy. Commercial support tiers available.                       | Monthly or annual subscription. Usage-based tiers by document volume and seats.      |
-| **Deployment time** | Hours to days depending on existing Kubernetes maturity.                                    | Minutes. Tenant provisioned automatically on signup.                                 |
-| **Updates**         | Customer-managed via Helm chart upgrades.                                                   | Managed by ClawQL — customers always on latest release.                              |
+| Model                           | Details                                                                                                                  |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| **Self-Hosted ($0)**            | Full OSS stack on your own infrastructure. All bundles self-managed via Helm. Apache 2.0 core. No license fee.           |
+| **Managed Hosted**              | Shared multi-tenant (**$299/mo**) or Dedicated single-tenant (**$599/mo**). Fully managed. Tenant provisioned on signup. |
+| **Enterprise (from $3,500/mo)** | Dedicated node, custom SLA, on-call, HITL, vertical fine-tune adapters, security review assistance, multi-region.        |
 
----
+The GPL-3.0 Paperless-ngx dependency is **removed from the hosted stack**. The ClawQL-native archive layer (Nextcloud + Postgres + Onyx) replaces it. Self-hosted operators who prefer Paperless-ngx can enable it via feature toggle. See [Licensing Summary](#licensing-summary).
 
-## Hosted Plan: Architecture Decisions
-
-The managed hosted plan required one significant architecture change from the self-hosted stack: the removal of Paperless-ngx as the archive layer. This is a deliberate, proactive decision driven by licensing and business model requirements.
-
-Paperless-ngx is licensed under GPL-3.0. In a self-hosted deployment this presents no commercial friction. However, in a hosted/managed SaaS product, distributing a service that bundles GPL-3.0 software triggers license propagation obligations that are incompatible with a closed commercial offering. Paperless-ngx is therefore removed from the hosted plan entirely.
-
-### The ClawQL-Native Archive Layer
-
-Rather than substituting a different GPL-adjacent DMS, ClawQL replaces Paperless-ngx with a purpose-built archive layer assembled from components already in the stack. This results in a cleaner, more capable architecture:
-
-| Component                            | Role in Archive Layer                                                                                                                                                                                                                                      |
-| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Nextcloud**                        | Human-accessible file storage and team UI. Documents are stored here as first-class files, browsable and shareable without any DMS login.                                                                                                                  |
-| **Nextcloud Automated Tagging**      | Rule-based collaborative tags applied on upload/update via the Files Automated Tagging app. Replaces Paperless tag assignment for basic classification.                                                                                                    |
-| **Nextcloud Full-Text Search**       | Elasticsearch-backed full-text search with Tesseract OCR integration indexes all PDFs and Office files. Replaces Paperless search for keyword retrieval.                                                                                                   |
-| **ClawQL Metadata Store (Postgres)** | A lightweight ClawQL-managed Postgres schema stores rich document metadata: correspondent, document type, custom fields, processing history, and Merkle roots. This replaces Paperless's Django metadata model with a schema fully under ClawQL's control. |
-| **Onyx**                             | Semantic search and cross-document knowledge retrieval. Substantially more powerful than Paperless search — supports vector search, citation-backed results, and 40+ connector integrations.                                                               |
-| **Stirling-PDF**                     | OCR is handled here, before archiving, rather than on import. Documents arrive in Nextcloud already OCR'd and text-searchable.                                                                                                                             |
-
-**Net result:** the hosted plan archive layer is more capable than Paperless-ngx in every dimension that matters for enterprise use — richer metadata, superior search (Onyx semantic vs. Paperless keyword), native file access via Nextcloud, and no GPL dependency. The only thing lost is Paperless's dedicated web UI, which is replaced by Nextcloud's file browser and Onyx's search interface.
-
-### Hosted Plan: Tenant Isolation
-
-Each hosted customer receives a dedicated tenant with full isolation at the data and infrastructure layer:
-
-- Dedicated Nextcloud instance per tenant — no shared storage.
-- Dedicated Postgres schema per tenant for the ClawQL metadata store.
-- Dedicated Onyx index per tenant — no cross-tenant knowledge bleed.
-- Coneshare VDR links scoped to the tenant's Nextcloud instance.
-- mTLS between all tenant services via Istio; tenant-scoped secrets in HashiCorp Vault.
-
-### Hosted Plan: Pricing Model (July 2026 — plugin bundles)
-
-Managed hosting is structured around **plugin bundles**, not a single document-volume ladder. Gateway-only customers pay dramatically less than IDP customers. There is **no perpetual free hosted tier** — self-host free forever on Apache 2.0, or start a **14-day Developer trial** (no credit card).
-
-| Tier             | Price          | Plugin bundle           | Included                                                                                                  |
-| ---------------- | -------------- | ----------------------- | --------------------------------------------------------------------------------------------------------- |
-| **Developer**    | $29/mo         | Gateway + memory        | Unlimited executions, 1 user, vault memory — no IDP, no GPU. 14-day free trial available.                 |
-| **Teams**        | $99/mo         | Gateway + memory + Onyx | Unlimited executions, 5 users, full Onyx semantic search — no IDP                                         |
-| **Starter**      | $299/mo        | IDP plugin bundle       | Unlimited executions, 5 users, 5,000 documents/mo, VDR, classify/extract, sovereign inference             |
-| **Business**     | $599/mo        | IDP plugin bundle       | Unlimited executions, 25,000 documents/mo, priority queue, full VDR analytics, 99.5% SLA                  |
-| **Professional** | $1,200/mo      | Full stack              | Unlimited executions, 75,000 documents/mo, dedicated namespace, vertical fine-tune, SSO/SAML              |
-| **Enterprise**   | from $3,500/mo | Full stack + security   | Unlimited executions, dedicated node, custom fine-tune, EU multi-region, Sovereign Security Pack included |
-
-**Unlimited executions on every tier.** ClawQL does not meter Agentic Gateway usage or charge execution overage. Stateless gateway workers scale on spot capacity — usage-based execution pricing would only encourage customers to throttle their agents. Real cost drivers are reserved-pool memory (Onyx, Nextcloud per tenant), GPU inference, and document storage (R2). Those are covered by flat subscription tiers and storage overage. executor.sh caps Team at 250,000 executions/mo with $0.20/1,000 overage; ClawQL does not.
-
-Sovereign Security Pack: **+$200/mo** on any paid tier.
-
-> **Note:** tiers are indicative for GTM positioning. Validate against infrastructure cost modeling before launch.
+Plugin-bundle pricing detail (Developer/Teams/Starter/…): see [Hosted plan pricing](#hosted-plan-pricing-july-2026--plugin-bundles) and [IDP GTM](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/vision/clawql-idp-gtm.md).
 
 ---
 
 ## Platform Overview
 
-ClawQL's IDP platform automates the full document lifecycle: ingestion, classification, extraction, enrichment, redaction, archiving, semantic indexing, and secure external sharing — unified under a single AI orchestration layer.
+ClawQL's IDP platform automates the full document lifecycle: ingestion, classification, extraction, enrichment, redaction, archiving, semantic indexing, and secure external sharing — unified under a single AI orchestration layer with twelve-layer token efficiency and persistent agent memory.
 
 ### Core Architecture Principles
 
-- **Local-first:** All processing runs in the operator's environment (self-hosted) or a dedicated tenant (hosted). No document data sent to external SaaS APIs.
-- **Specification-driven:** Every service exposes an OpenAPI spec loaded into ClawQL, enabling uniform agent access via `search()` and `execute()` tools.
-- **Agentic orchestration:** The Ouroboros 5-phase loop (Interview → Seed → Execute → Evaluate → Evolve) handles complex, retryable multi-step workflows automatically.
-- **Cryptographic integrity:** Merkle trees generate per-step audit roots; Cuckoo filters handle deduplication at scale.
-- **Modular deployment:** Adopt the full stack or individual services. Each exposes clean API boundaries.
+- **Twelve-layer token efficiency:** Compounds across input, output, prose, caching, semantic deduplication, history, prompt trimming, model routing, structured-output hints, token budgets, optional prefill, and the fine-tune flywheel.
+- **Local-first:** Processing runs in the operator's environment (self-hosted) or a dedicated tenant (hosted). No document data sent to external SaaS LLM APIs on Dedicated/Enterprise sovereign paths.
+- **Specification-driven:** Every service exposes an OpenAPI (or GraphQL) surface loaded into ClawQL for uniform `search()` / `execute()`. The **`mcp-api-adapter`** package exposes every MCP tool as `POST /\{toolName\}` (+ GraphQL, `/mcp`, gRPC, `gen-cli`) so HTTP clients and Workers can call tools without speaking MCP wire protocol. Production paths may use gRPC directly.
+- **Persistent memory:** Obsidian vault + `memory_ingest` / `memory_recall` for institutional knowledge across sessions.
+- **Sovereign AI inference:** Fine-tuned model fleet via vLLM inside the tenant boundary; Istio egress block at the mesh layer.
+- **Cryptographic integrity:** Merkle trees per step; WORM storage; Cosign-signed commits where configured.
 
 ### Component Map
 
-| Component                | Role in Platform                                                              |
-| ------------------------ | ----------------------------------------------------------------------------- |
-| **ClawQL Core**          | MCP server and AI orchestration layer (TypeScript, Apache 2.0)                |
-| **Apache Tika**          | Universal document parsing and metadata extraction (1,000+ formats)           |
-| **Gotenberg**            | High-fidelity document-to-PDF conversion (LibreOffice + Chromium)             |
-| **Stirling-PDF**         | PDF manipulation, PII redaction, OCR, and Merkle audit generation             |
-| **ClawQL Archive Layer** | Nextcloud + Postgres metadata store + Onyx. Replaces Paperless-ngx. GPL-free. |
-| **Onyx**                 | Semantic search and knowledge layer with 40+ pre-built connectors             |
-| **Obsidian Vault**       | Durable cross-session agent memory (Markdown, local, portable)                |
-| **Nextcloud**            | Human-accessible file storage, collaboration, and archive UI                  |
-| **Coneshare**            | Secure sharing, Virtual Data Rooms, and engagement analytics (MIT)            |
-
-Paperless-ngx (GPL-3.0) is supported in self-hosted deployments for operators who prefer it. It is not included in the managed hosted plan. The ClawQL-native archive layer described above is the default for all new deployments and all hosted customers.
+| Component                    | Role in Platform                                                                  |
+| ---------------------------- | --------------------------------------------------------------------------------- |
+| **ClawQL Core**              | MCP server, token-efficiency engine, AI orchestration (TypeScript, Apache 2.0)    |
+| **ClawQL Inference Gateway** | Policy-driven model routing; `/v1/chat/completions`; NSV/SGDOP; Layer 8+          |
+| **Apache Tika**              | Universal parsing and metadata (1,000+ formats)                                   |
+| **Gotenberg**                | Document-to-PDF (LibreOffice + Chromium)                                          |
+| **Stirling-PDF**             | PDF ops, PII redaction, OCR, Merkle audit generation                              |
+| **ClawQL Archive Layer**     | Nextcloud + Postgres metadata + Onyx. GPL-free. Replaces Paperless-ngx on hosted. |
+| **Onyx**                     | Semantic search + 40+ connectors                                                  |
+| **Obsidian Vault**           | Durable cross-session agent memory (Markdown)                                     |
+| **Nextcloud**                | Human file storage, collaboration, archive UI                                     |
+| **Coneshare**                | Secure sharing, VDRs, engagement analytics (MIT)                                  |
+| **Qwen3.6-27B (fine-tuned)** | Core document worker; vLLM NVFP4; L4 GPU                                          |
+| **Ornith 1.0 35B MoE**       | Coding specialist; serve as-is (MIT, DeepReinforce AI)                            |
+| **Phi-4 14B (fine-tuned)**   | Utility / memory worker                                                           |
+| **Langfuse**                 | Trace capture, datasets, flywheel observability (LGTM+)                           |
 
 ---
 
 ## ClawQL Core: Orchestration and Agent Interface
 
-**License:** Apache License 2.0 — open-source, commercially permissive.
+**License:** Apache License 2.0.
 
-ClawQL is a TypeScript-based Model Context Protocol (MCP) server published as `clawql-mcp` on npm. It enables AI agents to discover and invoke operations across any REST API, document workflow, or knowledge source using just two tools — keeping agent context lean while providing access to the entire pipeline.
+ClawQL is a TypeScript MCP server published as `clawql-mcp` on npm. Agents discover and invoke operations across REST APIs, document workflows, and knowledge sources using two tools — keeping context lean while accessing the full pipeline through compounding token-efficiency layers.
 
 ### The Two-Tool Pattern
 
-- **`search()`:** Discovers available operations by natural language query across all loaded OpenAPI specs. Agents never need to know the full API surface.
-- **`execute()`:** Invokes a specific operation with parameters. Optional GraphQL projection trims responses for token efficiency.
+- **`search()`** — Discover operations by natural language across loaded specs.
+- **`execute()`** — Invoke a specific operation; optional GraphQL / field projection trims responses (Layer 2).
 
-A single agent prompt — _"Process Q1 invoices, redact PII, cross-reference our pricing knowledge base, archive, create a data room, notify Slack"_ — triggers the entire pipeline automatically through this two-tool interface. No custom integration code. No manual handoffs.
+A single agent prompt — _“Process Q1 invoices, redact PII, cross-reference our pricing knowledge base, archive, create a data room, notify Slack”_ — can drive the pipeline without custom integration code.
+
+### Twelve-Layer Token Efficiency Architecture
+
+Most agent frameworks reduce cost at one point in the lifecycle. ClawQL addresses **twelve** points. Layers 1–8 are the MCP/gateway stack described below; Layers 9–12 are inference-gateway extensions ([canonical reference](/architecture/token-efficiency)). The nearest MCP gateway competitor (executor.sh) implements Layer 1 only.
+
+| Layer                                 | Mechanism and measured impact                                                                                                                         |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1 Code Mode** (always on)           | Two-tool pattern. Full specs stay on the server. Input reduction **97–99.9%** per provider; ~**99.8%** average across Google Cloud, Jira, Cloudflare. |
+| **2 Response trimming** (always on)   | Trim responses to fields the agent code depends on. Example: GKE list **421 → 76** tokens (~82%).                                                     |
+| **3 Prose compression** (always on)   | Strip hedging filler; preserve code/paths/ids. ~50–80% prose reduction.                                                                               |
+| **4 Prompt caching** (one-time setup) | Stabilized prefix enables provider cache reads (~10% of input price where supported).                                                                 |
+| **5 Semantic cache** (on by default)  | Similar requests skip the model; writes always live and invalidate related caches.                                                                    |
+| **6 History compression** (opt-in)    | Distill long transcripts for multi-hour sessions.                                                                                                     |
+| **7 Final prompt trimming** (opt-in)  | 20–40% additional reduction on already-compressed prompts.                                                                                            |
+| **8 Model routing** (gateway)         | Cheapest capable model per sub-task across the sovereign fleet.                                                                                       |
+| **9 Structured output**               | Inference-gateway hints (default on).                                                                                                                 |
+| **10 Token budget signaling**         | Derive budgets from `max_tokens` (default on).                                                                                                        |
+| **11 Prefill opener**                 | Optional assistant prefill (default off).                                                                                                             |
+| **12 Flywheel**                       | Export → fine-tune → frugal tier registration (PorTAL-compatible).                                                                                    |
+
+Layers 1–3 are always on with zero configuration and deliver the large majority of day-one savings. On managed hosted plans, Layers 1–5 and Layer 8 are active by default where credentials allow.
+
+### Universal API Adapter: `mcp-api-adapter`
+
+`mcp-api-adapter` is a standalone TypeScript package that points at any MCP server and exposes **five** surfaces from the same tool catalog. No ClawQL install required. Works with stdio, Streamable HTTP, or gRPC MCP servers.
+
+**Direction matters.** ClawQL Core goes **OpenAPI → MCP** (`search` / `execute`). `mcp-api-adapter` goes the other way: **MCP tools → REST / GraphQL / gRPC / IDE**. Complementary, not competing. Do not market it as an “OpenAPI gateway” — that phrase collides with Core’s inverse direction.
+
+| Surface                | What you get                                                         |
+| ---------------------- | -------------------------------------------------------------------- |
+| OpenAPI / REST         | `POST /\{toolName\}`; Swagger UI `/docs`; `x-clawql-grpc` extensions |
+| GraphQL                | Per-tool mutations + GraphiQL `/graphiql`                            |
+| Streamable HTTP `/mcp` | Re-export for IDE clients                                            |
+| gRPC                   | `:50051` (forward or local `mcp-grpc-transport`)                     |
+| `gen-cli`              | Thin zero-dependency Node CLI posting to REST                        |
+
+```bash
+npx mcp-api-adapter --mcp-url http://127.0.0.1:8080/mcp
+npx mcp-api-adapter --stdio -- npx -y @modelcontextprotocol/server-everything
+npx mcp-api-adapter --grpc-address 127.0.0.1:50051
+```
+
+Shipped line (indicative): **v0.5.1** current — Streamable HTTP `/mcp` re-export, `gen-cli`, gRPC content normalization for MCP SDK clients.
+
+vs **mcpo** (open-webui): Python / stdio-centric / FastAPI-first. `mcp-api-adapter` is TypeScript-native, transport-agnostic on input, adds GraphQL and `/mcp` re-export. Complementary.
 
 ### Key Capabilities
 
-- MCP server supporting stdio, HTTP, and gRPC transports.
-- Bundled provider specifications: GitHub, Cloudflare, Slack, Sentry, n8n, Linear, Jira, Bitbucket, and all document pipeline services.
-- First-class MCP tools: `memory_ingest`/`recall()`, `knowledge_search_onyx()`, `sandbox_exec()`, `ingest_external_knowledge()`, `notify()`, `cache()`, `audit()`.
-- Ouroboros 5-phase orchestration loop for complex, retryable multi-step workflows.
-- Cuckoo filters for deduplication; Merkle trees for tamper-evident audit trails.
-- Environment-variable feature toggles for optional layers (Onyx, Web3 provenance, Paperless compatibility).
-- Unified Helm chart managing 12+ services in a single deployment.
+- MCP transports: stdio, HTTP (Streamable), gRPC.
+- Bundled provider specs: GitHub, Cloudflare, Slack, Sentry, n8n, Linear, Jira, Bitbucket, and document pipeline services.
+- First-class tools: `memory_ingest` / `memory_recall`, `knowledge_search_onyx`, `sandbox_exec`, `ingest_external_knowledge`, `notify`, `cache`, `audit`, `run_idp_pipeline`, classify/extract/inspect when enabled.
+- **Ouroboros** 5-phase loop for retryable multi-step workflows. Empirically: `ouroboros-oscillation-escape` scores **1.0** (~5 turns, ~78s) vs **0.0** (~167s thrash) on DeepSeek — runs `30863572642`, `30866904277`, `30872913519`.
+- Cuckoo filters for dedup; Merkle trees for tamper-evident audit.
+- Arweave-anchored Layer 0 release manifests + `clawql doctor --smoke` startup hash verification.
+- Integration catalog mirroring to ClawQL-controlled Harbor/R2 before distribution.
+- Env feature toggles for optional layers (Onyx, Web3 provenance, Paperless compatibility).
+- Unified Helm charts managing the supporting services.
 
 ### Production Hardening
 
-- **Golden Image Pipeline:** Trivy + OSV-Scanner vulnerability scanning, SBOM generation, and Cosign image signing on every build.
-- **Istio Service Mesh:** Optional mTLS, L7 traffic policies, and Kiali observability between all services.
-- **HashiCorp Vault:** Secrets and certificate lifecycle management.
-- **Kubernetes/Helm:** Horizontal scaling, rolling updates, and health-check-driven self-healing.
+- Golden Image Pipeline: Trivy + OSV-Scanner, SBOM, Cosign on every build.
+- Optional Istio service mesh (mTLS, L7 policy, Kiali).
+- HashiCorp Vault for secrets / certificates.
+- Kubernetes/Helm: HPA, rolling updates, health-driven healing.
 
 ---
 
 ## Document Processing Pipeline
 
-Documents flow through a sequential, modular pipeline. Each stage is a self-contained service with a clean API boundary, orchestrated by ClawQL agents via MCP tools. Files enter from Nextcloud folders, email, WebDAV, or direct upload.
+```text
+Nextcloud / Email / WebDAV
+  → pdf-inspector / Tika
+  → Gotenberg (as needed)
+  → Docling (complex layouts)
+  → Stirling-PDF (OCR + redact + Merkle)
+  → ClawQL Archive (Nextcloud + Postgres + Onyx)
+  → Coneshare (distribute)
+```
 
-**Pipeline flow:** Nextcloud / Email / WebDAV → Tika (parse + detect) → Gotenberg (convert to PDF) → Stirling-PDF (OCR + redact + Merkle) → ClawQL Archive Layer (store + index) → Onyx (semantic index) → Coneshare (distribute)
+All stages run as Kubernetes workers. Argo Workflows can enforce per-tenant concurrency so one batch cannot saturate the shared pool.
 
-### Stage 1: Apache Tika — Universal Parsing
+### Stage 0: pdf-inspector — Classification and Fast Extraction
 
-**License:** Apache License 2.0 — Apache Software Foundation.
+**License:** MIT (Rust). Millisecond PDF classification (text / scanned / mixed); high-fidelity Markdown from native-text PDFs without model inference. Branches the Argo DAG.
 
-Tika is the intake layer. It determines what a document is and extracts its content regardless of format, using a plugin-based parser architecture covering 1,000+ MIME types.
+### Stage 1: Apache Tika — Universal Format Parsing
 
-**Capabilities**
-
-- Text and metadata extraction from 1,000+ formats: PDF, Office, HTML, email, archives, images, and more.
-- MIME type detection and language identification.
-- Tesseract OCR integration for scanned or image-based documents.
-- Rich metadata preservation: EXIF, Dublin Core, document-specific properties.
-- Streaming and batch processing.
-
-**Integration Role**
-
-ClawQL loads Tika's OpenAPI spec as a bundled provider. Agents invoke it via `execute()` on incoming files, flagging Office documents for Gotenberg conversion and extracting text that seeds Onyx indexing and Ouroboros workflows.
+**License:** Apache 2.0. 1,000+ MIME types; Office/email/HTML/archives/images; Tesseract for image inputs.
 
 ### Stage 2: Gotenberg — Document Conversion
 
-**License:** MIT License — open-source, commercially permissive.
+**License:** MIT. Office/HTML/Markdown → PDF for uniform downstream processing.
 
-Gotenberg is a Docker-based API for converting document formats to PDF. It uses LibreOffice for Office files and Chromium for HTML and Markdown, delivering high-fidelity headless rendering.
+### Stage 3: Docling — Layout Analysis
 
-**Capabilities**
+**License:** MIT (IBM Research). DocLayNet + TableFormer for multi-column, tables, forms, scanned pages. Tracked historically as [#248](https://github.com/danielsmithdevelopment/ClawQL/issues/248).
 
-- Converts DOCX, XLSX, PPTX, HTML, URLs, and Markdown to PDF.
-- PDF merge, split, headers/footers, and compression.
-- RESTful API with JSON configuration.
+### Stage 4: Stirling-PDF — Redaction and Audit
 
-**Integration Role**
+**License:** Open-core. PII redaction, Merkle roots to Postgres, OCR fallback. Sovereign Security Pack adds WORM + Cosign-signed commits.
 
-Receives Office files flagged by Tika. ClawQL calls it via its OpenAPI spec to normalize all documents to PDF. Output feeds directly into Stirling-PDF. Agents orchestrate batch conversion within Ouroboros loops.
+### Stage 5: LangExtract — Schema-Enforced Field Extraction
 
-### Stage 3: Stirling-PDF — Manipulation, OCR, and Redaction
+**License:** Apache 2.0 (Google). Character-offset grounding + confidence; low-confidence → HITL. Tracked as [#246](https://github.com/danielsmithdevelopment/ClawQL/issues/246). MCP: `extract_document`.
 
-**License:** Open-core. Base OSS functionality used in ClawQL. Advanced enterprise features available in paid Stirling tiers.
+### Stage 6: ClawQL Archive Layer
 
-Stirling-PDF is the most capability-dense stage in the pipeline. All compliance-critical operations — OCR, PII redaction, and cryptographic audit generation — occur here.
+**License:** Assembled from Apache 2.0 / AGPL / MIT components — **no GPL dependency** on hosted.
 
-**Capabilities**
+| Paperless-ngx feature | ClawQL archive equivalent                          |
+| --------------------- | -------------------------------------------------- |
+| Consumption inbox     | Nextcloud folder watch + webhook → NATS / pipeline |
+| Auto-tagging          | Nextcloud Automated Tagging + agent tags           |
+| Correspondent / type  | Postgres metadata store (+ Onyx classification)    |
+| Full-text search      | Nextcloud Elasticsearch + Onyx semantic            |
+| OCR on import         | Stirling OCR upstream                              |
+| REST API              | ClawQL MCP tools                                   |
+| Archive UI            | Nextcloud browser + Onyx search UI                 |
 
-- High-accuracy OCR on scanned documents (runs before archiving, so stored documents are always text-searchable).
-- PII redaction with pattern matching: SSNs, account numbers, emails, and custom regex rules.
-- Merkle tree generation: cryptographic audit hash per redaction step, verifiable independently of ClawQL.
-- PDF merge, split, rotate, page reorganization.
-- Digital signing, certification, compression, and form handling.
-- Batch processing support.
+Self-hosted operators may still enable Paperless-ngx via toggle; hosted defaults to the native layer.
 
-**Integration Role**
+### Pipeline Routing Summary
 
-Receives converted PDFs from Gotenberg. ClawQL invokes redaction rules via `execute()` and stores resulting Merkle roots in Postgres. This is the compliance enforcement point for the entire pipeline.
+1. Document arrives (Nextcloud watch, R2 upload / Argo Events, or API).
+2. pdf-inspector classifies.
+3. **Text PDF:** Markdown → Stirling → optional LangExtract → archive.
+4. **Scanned/complex PDF:** Docling → Stirling → optional LangExtract → archive.
+5. **Office:** Tika → Gotenberg → Docling → Stirling → optional LangExtract → archive.
+6. **Other:** Tika → Stirling as needed → optional LangExtract → archive.
+7. All paths: Onyx index, vault update, Merkle root commit; Coneshare for external distribution.
 
-> **Investor note:** Stirling-PDF's open-core model means ClawQL delivers strong base capabilities with a clear upgrade path to enterprise Stirling features for customers requiring advanced compliance tooling.
+---
 
-### Stage 4: ClawQL Archive Layer — Storage, Metadata, and Retrieval
+## Knowledge Layer: Onyx
 
-**License:** Assembled from Apache 2.0, AGPL, and MIT licensed components. No GPL dependency. Hosted-plan safe.
+Semantic retrieval with citations across pipeline outputs + 40+ connectors. Real-time indexing (Flink where deployed). Permission-aware hybrid search. Exposed as `knowledge_search_onyx()`.
 
-The ClawQL archive layer replaces Paperless-ngx with a purpose-built combination of components already present in the stack. It stores documents, records rich metadata, and makes the archive queryable — without introducing any GPL licensing constraints.
+---
 
-**Architecture**
+## Durable Agent Memory: Obsidian Vault
 
-- **Nextcloud:** Primary document store. Files land here after Stirling-PDF processing, fully OCR'd and redacted. Team members access documents via Nextcloud's familiar file browser.
-- **Nextcloud Automated Tagging:** Rule-based tags applied on upload: document type classification, correspondent assignment, and workflow routing — configured via the Nextcloud admin UI or API.
-- **Nextcloud Full-Text Search + Elasticsearch:** Indexes all PDF and Office content with Tesseract OCR for keyword search across the archive. Provides the same search capability as Paperless-ngx for basic retrieval.
-- **ClawQL Metadata Store (Postgres):** A ClawQL-managed schema records all document metadata: correspondent, document type, custom fields, processing timestamps, Merkle roots, and redaction logs. Fully queryable by agents via MCP tools. Replaces Paperless's Django metadata model with a schema under complete ClawQL control.
+Plain Markdown vaults — portable, no license restrictions on data. `memory_ingest` / `memory_recall` with OKF v0.2 trust signals. Vaults can sync to Nextcloud for human review. Roadmap: deeper in-vault semantic recall (sqlite-vec) where not already covered by Memory Stack 2.0.
 
-**What This Replaces from Paperless-ngx**
+---
 
-| Paperless-ngx Feature            | ClawQL Archive Equivalent                                                   |
-| -------------------------------- | --------------------------------------------------------------------------- |
-| Consumption inbox (watch folder) | Nextcloud folder watch + ClawQL webhook trigger                             |
-| Auto-tagging on import           | Nextcloud Automated Tagging app + ClawQL agent tag assignment via Ouroboros |
-| Correspondent tracking           | ClawQL Postgres metadata store (correspondent field)                        |
-| Document type classification     | ClawQL Postgres metadata store + Onyx semantic classification               |
-| Full-text search                 | Nextcloud Elasticsearch full-text search (keyword) + Onyx (semantic)        |
-| OCR on import                    | Stirling-PDF OCR upstream — documents are pre-OCR'd before archiving        |
-| REST API                         | ClawQL MCP tools expose metadata store and Nextcloud API uniformly          |
-| Archive web UI                   | Nextcloud file browser (human access) + Onyx search UI (semantic access)    |
+## Storage and Collaboration: Nextcloud
 
-The ClawQL archive layer is more capable than Paperless-ngx in every dimension relevant to enterprise use: richer metadata (Postgres vs. Django ORM), superior search (Onyx semantic + Elasticsearch keyword vs. Paperless keyword-only), native file collaboration (Nextcloud), and zero GPL dependency.
+**License:** AGPL-3.0 (self-hosted); commercial licenses from Nextcloud GmbH. Entry point and delivery destination for processed files; WebDAV/REST for agents; Automated Tagging; Elasticsearch FTS; retention apps; guest ACLs.
 
-Self-hosted operators who prefer Paperless-ngx can continue to use it via environment-variable toggle. The ClawQL metadata store runs alongside it and picks up processed documents via post-import webhooks.
+---
 
-### Knowledge and Semantic Layer: Onyx
+## Secure Sharing and VDRs: Coneshare
 
-**License:** Open-source enterprise search — commercially permissive core. Review current repository for enterprise licensing terms.
+**License:** MIT. Passworded / expiring links, VDRs, page-level analytics, watermarks, file requests, Slack/webhooks. Every deal room can carry a `deal_id` linked into the WORM trail. Viewer events can resume Argo / notify / update memory (NATS document consumers).
 
-Onyx transforms the document archive from a static repository into a live, queryable knowledge graph. It provides semantic retrieval with citation-backed results across all documents processed by the pipeline, plus 40+ external connectors.
-
-**Capabilities**
-
-- Semantic search with citation-backed results — agents know not just what was found, but where and why.
-- 40+ pre-built connectors: Slack, Confluence, Drive, Jira, GitHub, email, and more.
-- Real-time indexing via Apache Flink — indexes stay current as documents are processed.
-- Permission-aware retrieval — agents surface only content the requesting user is authorized to see.
-- Hybrid search combining keyword and vector methods for high recall and precision.
-
-**Integration Role**
-
-Onyx indexes content from the ClawQL archive, Nextcloud files, and Ouroboros workflow outputs. ClawQL exposes `knowledge_search_onyx()` as a first-class MCP tool, allowing agents to cross-reference institutional knowledge mid-workflow — for example, pulling pricing data from Slack during invoice processing. Post-processing results flow back into Onyx, creating a continuously enriching knowledge loop.
-
-**Business value:** every invoice, contract, or report processed by ClawQL immediately becomes searchable and referenceable by AI agents in future workflows. Onyx is the memory that makes the system smarter over time.
-
-### Durable Agent Memory: Obsidian Vault
-
-**License:** Obsidian application: proprietary (free personal use). Vault file format: plain Markdown — fully open, portable, no license restrictions.
-
-ClawQL uses Obsidian-style Markdown vaults for durable, cross-session agent memory. Unlike in-context memory that vanishes when a session ends, vault memory persists decisions, citations, Merkle roots, redaction logs, and workflow summaries across deployments and agent sessions.
-
-**Integration Role**
-
-The `memory_ingest()` and `memory_recall()` MCP tools write and retrieve from the vault. After each Ouroboros cycle, outputs, citations, audit hashes, and decisions are stored. This gives ClawQL genuine long-term institutional memory — a key differentiator from stateless AI pipelines that require re-explanation of context on every session.
-
-- Vaults sync to Nextcloud for human review and team access.
-- Roadmap: sqlite-vec integration for in-vault semantic recall (planned, not yet in production).
-
-### Storage and Collaboration: Nextcloud
-
-**License:** AGPL-3.0 — self-hosted. Nextcloud GmbH offers commercial enterprise licensing and support.
-
-Nextcloud is the primary human-accessible storage, collaboration, and archive interface. It serves as both the entry point for documents into the pipeline and the delivery destination for processed outputs. It carries additional responsibility in ClawQL's architecture as the backbone of the native archive layer.
-
-**Capabilities**
-
-- File sync and sharing with granular, role-based permissions.
-- Real-time collaboration via OnlyOffice or Collabora Office integration.
-- WebDAV and REST API access for programmatic use by ClawQL agents.
-- Automated Tagging app for rule-based file classification on upload.
-- Full-text search framework (Elasticsearch + Tesseract) for keyword search across PDFs and Office files.
-- Files Retention app for policy-based archival and deletion rules.
-- Guest accounts and advanced access control for external collaborators.
-
-**Integration Role**
-
-Documents arrive in Nextcloud folders watched by ClawQL pipeline triggers. Processed outputs return to Nextcloud after Stirling-PDF, becoming the human-browsable archive. ClawQL agents interact via WebDAV or Nextcloud API. Coneshare layers on top of Nextcloud storage to add secure external sharing without file migration.
-
-### Secure Sharing and Virtual Data Rooms: Coneshare
-
-**License:** MIT License — open-source, commercially permissive. Self-hosted.
-
-Coneshare is an open-source, self-hosted platform that adds secure sharing, engagement tracking, and workflow automation as a layer directly on top of Nextcloud storage. It is the external distribution endpoint of the IDP pipeline — the point at which processed, redacted, audited documents are shared with investors, legal counterparties, customers, or regulators.
-
-**Capabilities**
-
-- Secure share links with password protection, expiration dates, and email verification.
-- Virtual Data Rooms (VDRs) with granular folder- and file-level permissions.
-- Page-level engagement analytics: views, time spent per page, downloads, and revisit tracking.
-- Dynamic watermarking to deter unauthorized distribution.
-- File request capabilities for collecting documents from external parties.
-- Webhook and Slack integrations for automated follow-up on viewer activity.
-
-**Integration Role**
-
-After ClawQL processes and indexes documents, agents or users create VDRs or share links via Coneshare APIs exposed through ClawQL's MCP tools. Viewer activity triggers webhooks back into Ouroboros — automatically firing Slack notifications, updating memory vaults, filing follow-up tasks, or escalating based on engagement signals. This closes the IDP loop from document ingestion to trackable external distribution.
-
-> **Investor note:** Coneshare directly targets the Virtual Data Room market historically served by Intralinks, Datasite, and Ansarada — platforms charging $1,000–$5,000+ per deal. ClawQL delivers equivalent VDR capabilities self-hosted or via the hosted plan, with the added advantage of deep pipeline integration no standalone VDR product can match.
+Investor note: targets Intralinks / Datasite / Ansarada economics with pipeline-native provenance those standalone VDRs lack.
 
 ---
 
 ## Security, Audit, and Resilience
 
-ClawQL is designed around a zero-trust security model. Every processing step is auditable, every service boundary is authenticated, and no document data leaves the operator's control. The hosted plan extends this model with tenant isolation and managed key management.
+Zero-trust posture: auditable steps, authenticated service boundaries, operator-controlled data. Hosted adds tenant isolation and managed KMS patterns.
 
 ### Security Architecture
 
-- **Zero-Trust Networking:** Optional Istio service mesh with mTLS, L7 traffic policies, and Kiali observability between all services.
-- **Secrets Management:** HashiCorp Vault for credential and certificate lifecycle management. Per-tenant vault namespaces in hosted deployments.
-- **Image Security:** Golden Image Pipeline: Trivy + OSV-Scanner scanning, SBOM generation, and Cosign signing on every container before deployment.
-- **Data Sovereignty:** Self-hosted: all processing is local. Hosted: dedicated per-tenant infrastructure; no cross-tenant data access.
+- Optional Istio mTLS + AuthorizationPolicies + Kiali.
+- HashiCorp Vault (per-tenant namespaces on hosted).
+- Golden images: Trivy, OSV, SBOM, Cosign.
+- **Two-layer sovereignty:** (1) processing inside tenant boundary; (2) open-weight models you control — no closed-provider activation steering / undisclosed PEFT between your app and weights.
 
 ### Audit and Integrity
 
-- **Merkle Trees:** Each processing step generates a cryptographic hash. Roots are stored in Postgres and verifiable independently. Tampering with any intermediate step invalidates the chain.
-- **Cuckoo Filters:** Probabilistic deduplication at scale — documents are not double-processed without full database scans.
-- **Audit Tool:** The `audit()` MCP tool gives agents direct access to processing logs and verification endpoints.
-- **ClawQL Metadata Store:** Complete processing history per document stored in Postgres: who triggered it, which steps ran, timestamps, Merkle roots, and redaction records.
+- Merkle trees per step; roots in Postgres.
+- Cuckoo filters for dedup at scale.
+- `audit()` MCP tool for agent-accessible verification.
+- ClawQL metadata store: who triggered, stages, timestamps, Merkle roots, redaction records, LangExtract offsets, HITL decisions.
 
-### Roadmap: On-Chain Provenance
+### Model Substrate Security
 
-Hyperledger Fabric integration is planned for permissioned blockchain-based document provenance — providing tamper-evident distributed history for regulated industries. This is a future capability.
+Before registering fine-tuned adapters in `tier-map.json`, model prep runs: refusal ablation → desperation ablation → custom policy / LoRA / PorTAL alignment (order matters). Open-weight serving eliminates closed-API intervention surfaces.
 
-> **Roadmap items:** On-chain provenance (Hyperledger Fabric) and in-vault semantic search (sqlite-vec) are planned features. All other capabilities in this document are available in the April 2026 release.
+### Prompt Integrity Monitoring
+
+When closed APIs are used: Unicode normalization checks, date-separator anomalies, behavioral baseline drift probes. WORM entries include prompt/response hashes and integrity verdicts.
+
+Roadmap (not claimed as shipped here): Hyperledger Fabric on-chain provenance for regulated industries.
 
 ---
 
 ## End-to-End Workflow Example
 
-The following illustrates a complete IDP workflow triggered by a single agent instruction: _"Process Q1 invoices, redact PII, cross-reference our pricing knowledge base, archive, create a data room, and notify the team."_
+Instruction: _“Process Q1 invoices, redact PII, cross-reference pricing knowledge, archive, create a data room, notify the team.”_
 
-1. Document arrives in a Nextcloud folder (or via email/WebDAV). ClawQL detects it via folder watch or webhook.
-2. ClawQL agent invokes Tika via `execute()`: MIME detection, text extraction, metadata extraction.
-3. Gotenberg converts Office files to PDF for uniform downstream processing.
-4. Stirling-PDF applies OCR, PII redaction rules, and generates a Merkle verification hash per step.
-5. Processed, OCR'd, redacted PDF is written to Nextcloud. ClawQL Metadata Store records correspondent, document type, Merkle roots, and processing history in Postgres.
-6. Nextcloud Automated Tagging applies classification tags. Onyx indexes the document for semantic search.
-7. Agent queries Onyx via `knowledge_search_onyx()` to cross-reference pricing data from Slack.
-8. Workflow outputs, citations, Merkle roots, and decisions ingested into Obsidian vault via `memory_ingest()`.
-9. Coneshare creates a trackable VDR link with expiry, password, and watermarking.
-10. Viewer engagement triggers Ouroboros webhook: Slack notification sent, memory updated, follow-up task filed.
+1. Document arrives in Nextcloud (or email/WebDAV); webhook / watch fires.
+2. Agent `execute`s Tika (or pdf-inspector branch) for detect/extract.
+3. Gotenberg converts Office → PDF when needed.
+4. Stirling OCR/redact + Merkle hashes.
+5. Processed PDF → Nextcloud; Postgres records metadata + roots.
+6. Tags + Onyx index.
+7. `knowledge_search_onyx` for pricing cross-ref.
+8. `memory_ingest` for decisions / citations / hashes.
+9. Coneshare VDR link (expiry, password, watermark).
+10. Viewer engagement → NATS / Ouroboros / Slack / vault follow-up.
 
-The entire sequence above runs from a single natural-language agent prompt. No custom integration code. No manual handoffs. Full cryptographic audit trail from step 1 through step 10.
+Full cryptographic trail from step 1 through 10.
 
 ---
 
-## Competitive Positioning
+## Competitive Positioning, Pricing, and Verticals
 
-ClawQL is an **Foundational Platform for Auditable Production AI**, not a single SKU. Sales focus follows **plugin bundles** — gateway and memory first (Developer/Teams), IDP and VDR when explicitly opted in (Starter+). The surface area is large; buyers activate layers they need rather than purchasing four products at once.
+### MCP Gateway: executor.sh — One Layer vs Twelve
 
-**First buyers:** document-heavy teams of 20–200 people in legal, M&A diligence, healthcare operations, and lending — organizations already spending $500–2k/mo on SaaS who need agent memory and document intelligence. Gateway-only developers evaluating MCP infrastructure start on Developer or Teams.
+| ClawQL capability               | executor.sh                                 |
+| ------------------------------- | ------------------------------------------- |
+| 12-layer token efficiency       | Layer 1 only                                |
+| Layers 2–12                     | None                                        |
+| Persistent vault memory         | None                                        |
+| Onyx semantic search            | None                                        |
+| Full IDP + Merkle audit         | None                                        |
+| Coneshare VDR                   | None                                        |
+| Sovereign LLM fleet             | None                                        |
+| NSV/SGDOP ensemble coordination | None                                        |
+| Defense-in-depth docs           | Secrets + basic policy; no equivalent depth |
+| GitHub stars                    | Ahead on adoption timing — not capability   |
 
-**Current state:** the open-source MCP core is production-ready and self-hostable today (npm, Helm, published case studies, Kubernetes operator). Managed gateway hosting is in early access with a 14-day Developer trial. IDP hosted tenants onboard with founder-led setup. Architecture earns trust over time — we do not claim compliance certifications or long vendor histories we do not have yet.
+executor.sh is a **stateless tool router**. ClawQL is a **stateful agent operating system**.
 
-ClawQL competes across four adjacent markets — price each plugin bundle against the right incumbent:
+### Hosted Plan Pricing (July 2026 — plugin bundles)
 
-| Competitor Category                                                           | ClawQL tier                                                | ClawQL differentiation                                                                                                                                                                                                                           |
-| ----------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Agent routers** ([executor.sh](https://executor.sh/), emerging MCP routers) | Developer ($29/mo), Teams ($99/mo)                         | executor.sh is a **tool** with a head start on developer marketing. ClawQL is the **Foundational Platform**: unlimited executions, twelve efficiency layers, vault memory, Onyx search, optional IDP — more capability at lower gateway pricing. |
-| **SaaS IDP vendors** (Hyperscience, Kofax, ABBYY)                             | Starter–Professional (IDP bundle)                          | Cloud-hosted; per-document pricing at scale. No native MCP/agent interface. ClawQL: tenant-isolated hosted or self-hosted, flat IDP tiers, MCP-native from day one.                                                                              |
-| **VDR incumbents** (Intralinks, Datasite, Ansarada)                           | Starter+ (IDP bundle includes Coneshare)                   | Hosted VDRs with no document processing pipeline. High per-user/per-GB/per-deal licensing. ClawQL: full pipeline integration, Coneshare VDR included in IDP subscription.                                                                        |
-| **Vertical CRMs** (REsimpli, franchise transaction tools)                     | Teams ($99/mo) for agent memory; Starter ($299/mo) for IDP | CRMs track pipeline; Drive folders hold files. ClawQL connects CRM APIs + storage via MCP, indexes documents in Onyx, threads deal context in vault — without replacing Command, Dotloop, or SkySlope.                                           |
+| Tier                    | Price          | Notes                                                                                             |
+| ----------------------- | -------------- | ------------------------------------------------------------------------------------------------- |
+| Self-hosted             | $0             | Full OSS; self-managed                                                                            |
+| Developer (planned)     | $29–99/mo      | Gateway + memory (+ Onyx on Teams); no IDP/GPU                                                    |
+| Shared                  | $299/mo        | Full IDP + Onyx + VDR + vault                                                                     |
+| Dedicated               | $599/mo        | Single-tenant; sovereign AI bundle; SSO/RBAC                                                      |
+| Enterprise              | from $3,500/mo | SLA, HITL, vertical adapters, multi-region                                                        |
+| Sovereign Security Pack | +$200/mo       | Kata, weight integrity, WORM Merkle, Panguard, YubiKey signing, Presidio pre-log, monthly posture |
 
-### Real estate vertical
+> Indicative GTM numbers — validate against infrastructure cost modeling before launch. See also [clawql-idp-gtm.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/vision/clawql-idp-gtm.md) for Starter/Business ladder variants.
 
-Brokerages on Keller Williams Command, eXp BoldTrail, Follow Up Boss, or Compass share a structural gap: **CRM knows the deal, Drive holds the files** — no semantic link between contacts and transaction PDFs.
+### Full Stack Replacement Value
 
-| Need                                                             | Recommended tier                  | Why                                                                                                   |
-| ---------------------------------------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| Connect Command + Drive, semantic search, deal memory            | **Teams ($99/mo)**                | Agentic Gateway + Onyx + vault — no IDP overhead for teams that do not process documents daily        |
-| Title commitment classify/extract, Coneshare VDR for disclosures | **Starter ($299/mo)**             | IDP plugin bundle — explicitly opted in                                                               |
-| REsimpli comparison                                              | Teams vs REsimpli Basic ($149/mo) | REsimpli is CRM-only for investors; ClawQL unifies CRM integration, document search, and agent memory |
+Representative: 25 users, 25k docs/mo, VDR + compliance.
 
-ClawQL does **not** replace Dotloop (forms, e-sign, broker compliance) or MLS listing platforms. It is the intelligent document layer on top.
+| Component       | Incumbent vs ClawQL Dedicated                                    |
+| --------------- | ---------------------------------------------------------------- |
+| IDP             | Hyperscience / ABBYY five–six figures → **included**             |
+| VDR             | Intralinks/Datasite/Ansarada → **included**                      |
+| Semantic search | Algolia/Coveo/Glean → **included**                               |
+| Merkle audit    | Custom build → **included**                                      |
+| Sovereign LLM   | Not available elsewhere → **included on Dedicated**              |
+| **Total**       | $8k–15k+/mo incumbents vs **≤$799/mo** Dedicated + Security Pack |
 
-### Market 1: executor.sh (vs Agentic Gateway)
+### Verticals
 
-executor.sh is the closest direct competitor to ClawQL's Agentic Gateway entry layer. **It is a tool; ClawQL is the Foundational Platform.** executor.sh routes tool calls well — that is its job. ClawQL adds memory, search, security depth, document pipeline, and optional sovereign inference behind one Agentic Gateway endpoint.
+**Real estate / Keller Williams Command + Drive:** MCP + memory + Onyx at Teams price; Coneshare for disclosure packages; classify/extract for TC workflows.
 
-**Where executor.sh leads:** developer mindshare, YC-backed go-to-market, and community velocity in the MCP router category. That is real and we state it plainly.
+**Software / technology:** One gateway for GitHub/Linear/Jira/Sentry/Slack; vault for eng decisions; Onyx over Notion/Confluence; Panguard + audit for governed tool use. Competes with executor.sh Team while adding memory + security depth.
 
-**Collaboration:** before publishing head-to-head comparisons, we approached executor.sh about collaboration and shared MCP ecosystem work. Those overtures were not engaged. We document positioning directly for buyers making infrastructure decisions.
+### Where Competitors Have Genuine Advantages
 
-| Dimension          | executor.sh                                            | ClawQL                                                                                                   |
-| ------------------ | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
-| Category           | Tool — routes MCP calls, injects secrets, meters usage | Foundational Platform — Agentic Gateway, memory, search, security, IDP, sovereign inference              |
-| Developer adoption | Head start on marketing and community mindshare        | Later entrant; deeper stack, open-source core, published case studies                                    |
-| Token efficiency   | One layer: search-and-execute only                     | Twelve compounding layers on top of search/execute                                                       |
-| Agent memory       | None — every session starts from zero                  | Obsidian vault with memory_ingest / memory_recall                                                        |
-| Semantic search    | None                                                   | Onyx — 40+ connectors, hybrid search, citations                                                          |
-| Security           | Host-side secrets, basic audit log                     | Kata isolation, WORM Merkle logs, Panguard fail-closed, documented defense-in-depth                      |
-| Document pipeline  | None                                                   | Tika → Gotenberg → Stirling → archive → Onyx                                                             |
-| VDR                | None                                                   | Coneshare included from IDP Starter                                                                      |
-| Sovereign LLM      | None                                                   | Fine-tuned Qwen inside tenant boundary (IDP tiers) — vertical adapters early; maturity risk named openly |
-| Execution pricing  | 250K cap + $0.20/1K overage on Team                    | Unlimited on every tier — no caps, no overage bills                                                      |
-| Gateway pricing    | Team $150/org/mo — metered routing                     | Developer $29/mo · Teams $99/mo with memory + search · unlimited executions                              |
-
-On infrastructure dimensions that matter — memory, security, token efficiency depth, document pipeline, sovereign inference — ClawQL delivers more at lower gateway pricing. executor.sh's advantage is awareness and adoption velocity, not platform depth.
-
-### Shipped vs roadmap (honest scope)
-
-| Capability                                                | Status                                                                                                                                                                     |
-| --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ClawQL Core (search, execute, audit, cache)               | **Shipped** — open source, case studies                                                                                                                                    |
-| Vault memory, Onyx search, IDP pipeline                   | **Shipped** — self-host and early hosted tenants                                                                                                                           |
-| Ouroboros evolutionary loop library                       | **Shipped** — `clawql-ouroboros` package                                                                                                                                   |
-| DAOS swarm coordination (NSV, SGDOP, Diversity Dividends) | **Roadmap** — specified in [DAOS build plan](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/ouroboros/daos-build-plan-v2.7.1.md); not production-hardened |
-| Tenant-bound fine-tuned models (Qwen3.6 family)           | **Early** — deliberate bet; newer than incumbent cloud APIs; name maturity risk in regulated evaluations                                                                   |
-
-ClawQL's MCP-native architecture benefits from improvements in frontier model capabilities. Tenant-bound fine-tunes are a differentiation bet with explicit maturity risk — regulated buyers should weigh architecture against reference history.
+| Gap                             | Honest assessment                                                              |
+| ------------------------------- | ------------------------------------------------------------------------------ |
+| Certifications (SOC 2, FedRAMP) | Controls architecturally present; audit process remaining.                     |
+| Pre-trained skill libraries     | ABBYY’s catalog is larger; ClawQL vertical adapters are deeper where shipped.  |
+| M&A brand                       | Intralinks embedded in IB relationships — references required.                 |
+| executor.sh DX / stars          | Strong developer experience; answer is Developer/Teams tier + memory/security. |
 
 ---
 
 ## Deployment Architecture
 
-ClawQL deploys via a unified Helm chart that provisions the full stack. All services expose OpenAPI specifications auto-loaded as ClawQL bundled providers on startup.
+Hybrid: **Cloudflare edge** (Developer/Teams) → **AWS K3s** (first IDP customers) → **EKS + Karpenter** (scale). Customer endpoint: `gateway.clawql.app` Worker routes by tenant tier.
 
-### Self-Hosted Stack
+### Shared vs Per-Tenant Services
 
-- Unified Helm chart: deploys ClawQL core and 12+ supporting services in a single `helm install`.
-- Kubernetes with optional Istio Ambient or sidecar mesh.
-- Nextcloud (AIO or standard) with folder watches for pipeline ingestion.
-- Coneshare deployed alongside Nextcloud, directly integrated with its storage layer.
-- Persistent volumes for Obsidian vaults, Nextcloud files, Onyx indexes, and Postgres.
-- Paperless-ngx available via feature toggle for operators who prefer it (self-hosted only).
+| Tier                            | Services                                                                         |
+| ------------------------------- | -------------------------------------------------------------------------------- |
+| Shared cluster-wide (stateless) | Tika, Gotenberg, Stirling — one pool, fair queues                                |
+| Shared with tenant scope        | ES (per-tenant index), Postgres (per-tenant schema), Argo, Istio policies, LGTM+ |
+| Strictly per-tenant             | Onyx, Nextcloud, R2 bucket, Coneshare, Vault namespace                           |
 
-### Hosted infrastructure model
+Marginal cost per tenant is primarily Onyx + Nextcloud; workers scale with volume, not headcount of tenants.
 
-Managed hosting uses a **hybrid model** aligned to plugin bundles — without changing the customer-facing MCP endpoint:
+### Path 1: Bootstrap — K3s on EC2
 
-| Tier class                                      | Infrastructure                          | What the customer gets                                                                             |
-| ----------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| **Developer, Teams**                            | Regional Hub + object storage for vault | Agentic Gateway, memory vault, cache, audit. Unlimited executions. Low-latency endpoint worldwide. |
-| **Starter, Business, Professional, Enterprise** | Dedicated tenant (Kubernetes)           | Full IDP pipeline, Onyx at scale, Nextcloud archive, Coneshare VDR, sovereign inference.           |
+K3s on r7i.2xlarge; R2 per-tenant buckets; Istio sidecar; Argo CD from day one; Ouroboros/job queue → Argo Workflows at scale; ingress-nginx; LGTM+.
 
-A single routing layer dispatches each request by tenant tier. **Vault documents live in shared object storage** accessible from both gateway and IDP backends — upgrading from Teams to Starter retains full agent memory history without migration. The customer's MCP URL and auth token do not change on upgrade.
+### Path 2: Scale — EKS + Karpenter + Istio Ambient + Argo Suite
 
-AWS (EKS + Karpenter) provisions **only when the first IDP customer signs** — not at gateway-tier launch. This keeps bootstrap burn minimal while gateway tiers validate product-market fit.
+- **Reserved pool:** stateful (Onyx, Nextcloud, Postgres, ES, core).
+- **Spot pool:** Tika/Gotenberg/Stirling/Argo pods.
+- **Istio Ambient** for ephemeral workers.
+- **Argo CD / Workflows / Events / Rollouts** for GitOps, DAGs, R2 triggers, canaries.
 
-### Hosted Stack (per tenant — IDP tiers)
+Migration is incremental: same Helm charts, Argo CD on both clusters, no application rewrite.
 
-- Dedicated Nextcloud instance, Postgres schema, and Onyx index per tenant.
-- Shared ClawQL core and processing services (Tika, Gotenberg, Stirling-PDF) with tenant-scoped job queues.
-- Istio mTLS enforced between all tenant services.
-- Per-tenant secrets in HashiCorp Vault namespaces.
-- Paperless-ngx not deployed — ClawQL-native archive layer only.
+### Self-Hosted Customer Deployments
 
-### Scaling Characteristics
+Same Helm chart; feature flags (`ENABLE_ONYX`, `ENABLE_CONESHARE`, `ENABLE_ISTIO`, `ENABLE_ARGO`, `ENABLE_PAPERLESS` self-hosted only). Minimum viable: Tika + Gotenberg + Stirling + Nextcloud + Postgres on a single VM.
 
-- Stateless ClawQL core and processing workers (Tika, Gotenberg, Stirling-PDF) scale horizontally.
-- Postgres and Nextcloud scale vertically or via read replicas for larger deployments.
-- Onyx indexes scale independently via Flink pipeline parallelism.
-- Minimum viable deployment (no Istio, no Onyx, no Coneshare) available via environment-variable toggles for evaluation.
+---
+
+## Sovereign AI: Multi-Model Fleet
+
+Hosted Dedicated/Enterprise run a sovereign fleet inside the tenant boundary. Harnesses call **one** OpenAI-compatible Gateway endpoint; routing, NSV/SGDOP, prompts, and Langfuse emission live in one place.
+
+### Role-Based Models
+
+| Model                  | Role                                                      |
+| ---------------------- | --------------------------------------------------------- |
+| Qwen3.6-27B FT (NVFP4) | Document worker — tool sequencing, Ouroboros, Merkle, VDR |
+| Ornith 35B MoE (as-is) | Coding specialist — do **not** LoRA away self-scaffolding |
+| Phi-4 14B FT           | Utility / memory / metadata                               |
+| Gemma 4 31B            | NSV/SGDOP diversity only                                  |
+
+Mistral Devstral 2 (123B) excluded from initial fleet on cost; reconsider when revenue justifies.
+
+### Model Escalation vs Agent Coordination
+
+- **Escalation:** Frugal → Standard → Frontier on outcome failure (never skip tiers); WORM-logged.
+- **Coordination:** `combined_drift` > 0.3 → Hermes MoA fan-out with NSV/SGDOP — independent of escalation.
+
+J-space / imaginary-direction hypotheses are research notes, not product claims. Contact: hello@clawql.com.
+
+### Gateway Routing (summary)
+
+Identity → preset → SGDOP → NSV → harness-aware Ornith selection → canonical system prompt → vLLM → Langfuse/Loki/Tempo. Policy YAML presets: `worker-tool-use`, `coding-specialist`, `utility-quick`, `moa-diversity`.
+
+### Data Sovereignty Layer
+
+Presidio before LLM; Istio egress block on vLLM pods; local vLLM; tenant-scoped Langfuse; WORM routing decisions in Merkle chain.
+
+### Fine-Tuning / PorTAL Flywheel
+
+WORM call store is the primary training source (`verdict`, `verdict_source`, exclude `cache_hit`). Export with Presidio scrub + TrainingLineage manifest. Train on RTX 5090 (Unsloth QLoRA) → NVFP4 → `finetune register` → Argo Rollouts canary. PorTAL task-latent + per-base alignment makes adapters portable across base models ([portal-flywheel.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/inference/portal-flywheel.md)).
+
+---
+
+## OpenBench: Live A/B Benchmark Results
+
+Claims are verified with live agent A/B on GitHub Actions using frugal DeepSeek via OpenRouter. Graders require real `tool:clawql_*` evidence.
+
+See also: [openbench.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/benchmarks/openbench.md) · [openbench-advanced-specs.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/benchmarks/openbench-advanced-specs.md) (B-1…B-6 Phase 1 packs) · in-repo `openbench/`.
+
+### Proven claims (indicative July 2026)
+
+| Claim                              | Result                            | Run                                   |
+| ---------------------------------- | --------------------------------- | ------------------------------------- |
+| Ouroboros convergence              | on 1.0 (~78s) / off 0.0 (~167s)   | 30863572642, 30866904277, 30872913519 |
+| Memory continuation (seed removed) | on 1.0 / off 0.333                | 30872913516                           |
+| Token-budget constrained           | on 1.0 / off 0.0                  | 30872437811                           |
+| Memory roundtrip                   | on 1.0 / off 0.0                  | 30872913516                           |
+| Search-first discovery             | on 1.0 / off 0.0                  | 30872913516                           |
+| Execute-verify loop                | on 1.0 / off 0.0                  | 30872913516                           |
+| Audit checkpoints                  | on 1.0 / off 0.0                  | 30872437811                           |
+| Policy-deny execute                | on 1.0 / off 0.0                  | 30872913516                           |
+| Multi-provider workflow            | on 1.0 / off 0.75 (noisier later) | 30868287877                           |
+
+Infrastructure timeouts (OpenCode hang, no tools) are noise, not claim failures. Most cells are n=1 — raise n≥3 before statistical confidence (advanced ledger Phase 1+).
+
+### Reasoning Trace Protocol (RTP)
+
+OpenBenchTrace (outer envelope) + RTP (inner reasoning structure) are complementary. NSV/SGDOP used for schema governance in RTP and runtime ensemble coordination in ClawQL — same math, two scales.
 
 ---
 
 ## Licensing Summary
 
-All components in the default ClawQL stack operate under licenses permissive for commercial deployment and SaaS distribution. Paperless-ngx (GPL-3.0) is available as an optional self-hosted toggle but is not part of the hosted plan or the default stack.
+| Component                | License & notes                                     |
+| ------------------------ | --------------------------------------------------- |
+| ClawQL Core              | Apache 2.0                                          |
+| Coneshare                | MIT                                                 |
+| Apache Tika              | Apache 2.0                                          |
+| Gotenberg                | MIT                                                 |
+| Stirling-PDF             | Open-core                                           |
+| Nextcloud                | AGPL-3.0 (+ commercial options)                     |
+| Onyx                     | Open-source core — review current repo terms        |
+| Obsidian vault format    | Plain Markdown — open data                          |
+| Paperless-ngx (optional) | GPL-3.0 — **self-hosted only**, not in hosted stack |
 
-| Component                    | License & Commercial Notes                                                                                                                                                                                                                           |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **ClawQL Core**              | Apache 2.0 — permissive, commercial use and SaaS distribution allowed.                                                                                                                                                                               |
-| **Coneshare**                | MIT — permissive, commercial use and SaaS distribution allowed.                                                                                                                                                                                      |
-| **Apache Tika**              | Apache 2.0 — permissive, commercial use allowed.                                                                                                                                                                                                     |
-| **Gotenberg**                | MIT — permissive, commercial use allowed.                                                                                                                                                                                                            |
-| **Stirling-PDF**             | Open-core. Base features open-source. Enterprise tiers commercially licensed by Stirling.                                                                                                                                                            |
-| **Nextcloud**                | AGPL-3.0. Self-hosted use is unrestricted. Nextcloud GmbH offers commercial enterprise licensing. AGPL requires source disclosure of modifications if distributed, but does not propagate to ClawQL or applications using Nextcloud via API/network. |
-| **Onyx**                     | Open-source core. Review current repository license for enterprise commercial terms.                                                                                                                                                                 |
-| **Obsidian Vault Format**    | Plain Markdown — fully open, no license restrictions on vault data.                                                                                                                                                                                  |
-| **Paperless-ngx (optional)** | GPL-3.0. Self-hosted deployments only. Not included in hosted plan. Operators should review GPL obligations before distributing derivative products.                                                                                                 |
-
-The managed hosted plan is built entirely on Apache 2.0, MIT, and AGPL-licensed components. No GPL dependencies are present in the hosted stack. Legal review of AGPL network use clauses is recommended but standard for SaaS products built on AGPL software.
+Hosted plan avoids GPL dependencies. Legal review of AGPL network clauses recommended for SaaS.
 
 ---
 
 ## Roadmap
 
-The following outlines planned capabilities beyond the April 2026 release. Roadmap items are subject to change based on customer feedback and engineering priorities.
+### Near-term (1–3 months)
 
-### Near-Term (Next 1–3 Months)
+- Hosted beta: Developer/Teams on Cloudflare Workers; 14-day trial.
+- Inference Gateway v1 + pdf-inspector Stage 0 + Docling + LangExtract + HITL Label Studio.
+- Qwen3.6-27B ClawQL-general fine-tune v1 + Istio egress + Presidio.
+- `mcp-api-adapter` 0.5.x line (shipped).
+- OpenBench expansion — advanced Phase 1 packs landed; live cells next.
 
-- Hosted plan beta launch with 14-day Developer trial and Starter tiers.
-- ClawQL Metadata Store REST API for direct metadata query without MCP client.
-- Nextcloud app for in-browser document processing trigger (no agent client required).
-- Automated tenant provisioning and onboarding flow for hosted customers.
+### Medium-term (3–6 months)
 
-### Medium-Term (3–6 Months)
+- Privacy filter [#245], document-type classifier, See The Greens vertical FT, observability [#252], Argo HITL suspend/resume [#254], HITL→few-shot feedback, Business/Enterprise hosted, EU multi-region.
 
-- sqlite-vec integration in Obsidian vault for semantic recall over agent memory.
-- Business and Enterprise hosted tiers with SLA and SSO/SAML support.
-- Coneshare analytics dashboard integration into ClawQL MCP tools (view engagement data via agent query).
-- Multi-region hosted deployments for EU data residency requirements.
+### Longer-term (6–12 months)
 
-### Longer-Term (6–12 Months)
-
-- Hyperledger Fabric integration for on-chain document provenance in regulated industries.
-- ClawQL-native document review UI — lightweight alternative to the Nextcloud file browser for archive access.
-- White-label hosted option for resellers and system integrators.
-- Connector marketplace for community-contributed OpenAPI specs and Onyx connectors.
+- Vertical packs [#251], KEDA [#257], handwriting/ICR, chart/figure VLM, cross-document entity resolution, continuous active learning, Hyperledger Fabric provenance, white-label hosted.
 
 ---
 
@@ -562,47 +533,25 @@ The following outlines planned capabilities beyond the April 2026 release. Roadm
 
 ### For Investors
 
-**How does ClawQL generate revenue?**
+**How does ClawQL generate revenue?** Managed hosted subscriptions (primary); commercial support for self-hosted (secondary). OSS core drives adoption and conversion.
 
-The managed hosted plan is the primary revenue vehicle — monthly and annual subscriptions tiered by document volume and seats. Secondary revenue comes from commercial support contracts for self-hosted enterprise deployments. The open-source core drives adoption and inbound pipeline for both.
+**Why not DocSend / Intralinks alone?** Distribution-only. No redact/convert/semantic index/agent integration. ClawQL VDR is the last mile of a processing + provenance pipeline; unlimited VDRs within subscription vs per-deal five-figure fees.
 
-**Why won't customers just use DocSend or Intralinks?**
+**What is the moat?** (1) Pipeline depth across IDP + API integration; (2) MCP-native architecture; (3) WORM call-store flywheel + PorTAL; (4) Merkle / Arweave / `deal_id` evidence chains.
 
-DocSend and Intralinks are distribution-only tools. They cannot redact PII, convert documents, semantically index content, or integrate with AI agents. ClawQL's VDR (Coneshare) is the last mile of a complete processing pipeline — you can't replicate that by adding a VDR on top of a disconnected stack. Additionally, per-deal VDR pricing from incumbents can reach $5,000+ for a single transaction; ClawQL's hosted plan covers unlimited VDRs within a subscription.
-
-**What is the moat?**
-
-Three layers: (1) **Pipeline depth** — the integration between ingestion, redaction, archive, semantic search, and VDR distribution is not replicable by bolting together point tools. (2) **MCP-native architecture** — as AI agents become the default interface for enterprise workflows, ClawQL is natively positioned to benefit without code changes. (3) **Cryptographic audit trail** — Merkle-verified processing records are a compliance differentiator in regulated industries that SaaS alternatives cannot easily replicate.
-
-**Is the open-source core a threat to the hosted business?**
-
-No — it is the growth engine. Self-hosted users who hit operational complexity (scaling, updates, security patches) convert to hosted. The open-source core also drives developer community adoption and reduces sales friction: customers evaluate the product on their own infrastructure before committing to hosted plans.
+**Does OSS threaten hosted?** No — it is the growth engine and evaluation path.
 
 ### For Developers
 
-**Can I use ClawQL without the full stack?**
+**Can I use ClawQL without the full stack?** Yes — feature toggles; minimal Tika + Gotenberg + Stirling + Nextcloud is viable.
 
-Yes. Each pipeline stage is independently deployable. The Helm chart supports feature toggles to enable or disable Onyx, Coneshare, Paperless-ngx compatibility, Web3 features, and Istio. A minimal deployment (Tika + Gotenberg + Stirling-PDF + Nextcloud) is viable for straightforward document processing without semantic search or VDR.
+**How does Ouroboros handle failures?** Retryable phases; Evaluate/Evolve re-route or HITL via `notify`; Merkle commit on success only.
 
-**How does the Ouroboros loop handle failures?**
-
-Each phase in the Ouroboros loop (Interview → Seed → Execute → Evaluate → Evolve) is retryable. Failed `execute()` calls are logged with full context in the ClawQL metadata store. The Evaluate phase detects failures and the Evolve phase can re-route, retry with modified parameters, or escalate to a human via `notify()`. Merkle roots are only committed on successful step completion.
-
-**How is the Nextcloud archive layer different from just using Nextcloud normally?**
-
-Standard Nextcloud has no document metadata model, no correspondent tracking, and no processing history. The ClawQL archive layer adds a Postgres-backed metadata store that records full processing context per document, integrates with Onyx for semantic search, and exposes everything via MCP tools so agents can query the archive programmatically. Think of it as Nextcloud plus a document intelligence layer — not a replacement for Nextcloud's file management capabilities.
+**How is the archive different from “just Nextcloud”?** Postgres metadata + Onyx semantic + MCP-queryable processing history on top of Nextcloud files.
 
 ---
 
-## Operator references
-
-| Doc                                                                                                                                  | Purpose                                              |
-| ------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
-| [IDP pipeline hub](/learn/document-pipeline)                                                                                         | Bundled providers, env, Helm, `DEFAULT_IDP_PIPELINE` |
-| [Requirements matrix](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/roadmap/idp-master-requirements-matrix.md)     | Shipped vs gap tracking                              |
-| [OpenClaw IDP skill profile](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/openclaw/openclaw-idp-skill-profile.md) | Agent + dashboard contract                           |
-| [Agent chat contract](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/dashboard/agent-chat.md)                       | Rich IDP UI JSON                                     |
-| [Helm chart](https://github.com/danielsmithdevelopment/ClawQL/blob/main/charts/clawql-mcp/README.md)                                 | Co-deploy document stack                             |
+_Confidential — July 2026. GTM figures are indicative until launch cost models are locked._
 
 export function wrapper({ children }) {
   return children


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rewrites the canonical IDP platform vision doc from the July 2026 investor/architect deck.

### Updates in [`docs/vision/clawql-idp-platform.md`](docs/vision/clawql-idp-platform.md)

- Twelve-layer token efficiency (aligned with [`clawql-token-efficiency.md`](docs/architecture/clawql-token-efficiency.md); Layers 9–12 called out)
- `mcp-api-adapter` five-surface adapter (direction vs Core clarified)
- Sovereign fleet / PorTAL / OKF memory trust signals
- OpenBench live evidence + links to advanced B-1…B-6 specs
- Hybrid deploy topology (Cloudflare → K3s → EKS/Karpenter/Argo)
- Honest competitive gaps vs executor.sh / ABBYY / Intralinks
- Hosted GPL-free archive layer narrative preserved

Website `/vision/idp-platform` regenerates via `sync-clawql-idp-platform-doc.mjs` on prebuild.

### Test plan

- [x] Prettier on vision doc
- [ ] CI green
- [ ] Spot-check rendered docs page after merge deploy
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5a07-15ee-7a2a-828a-9ad0a5c8763c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5a07-15ee-7a2a-828a-9ad0a5c8763c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

