### PR TITLE
feat(payments): money requests / invoices with email invite

### DIFF
--- a/docs/payments/credits-ach.md
+++ b/docs/payments/credits-ach.md
@@ -143,7 +143,8 @@ Wired into `paymentsServicesLiveLayer()`. Discovery advertises `type: "credits"`
 
 ## Follow-ups
 
-- Request money + activity feed + QR deep links ([consumer roadmap](./p2p-consumer-roadmap.md))
+- Activity feed + QR deep links ([consumer roadmap](./p2p-consumer-roadmap.md))
+- Outbound email delivery of invite URLs (today: print invite for the requester to share)
 - Hosted checkout / Billing Portal bank payment method UX
 - Optional direct Plaid Link only if product needs non-Stripe bank data
 - Valkey Lua hot counter + Postgres durable grants (same DeductionService API)

--- a/docs/payments/money-requests.md
+++ b/docs/payments/money-requests.md
@@ -1,0 +1,82 @@
+# Money requests & invoices
+
+Ask someone to pay prepaid credits — by **email** (default), **`@username`**, or tenant id.
+
+Unknown emails get an **invite URL + one-time token** so they can join ClawQL, claim the directory identity, then accept and pay (same stage → confirm path as `credits pay`).
+
+## Flow
+
+```mermaid
+sequenceDiagram
+  participant A as Requester
+  participant CLI as credits request
+  participant Dir as directory.json
+  participant Req as money-requests.json
+  participant B as Payer
+
+  A->>CLI: request --to newbie@acme.com --amount 25
+  CLI->>Dir: lookup email
+  alt unknown email
+    CLI->>Req: pending + invite token
+    CLI-->>A: inviteUrl
+    B->>CLI: claim-invite --token …
+    CLI->>Dir: claim email (+ optional @username)
+    CLI->>Req: link payerTenantId
+  else on-platform
+    CLI->>Req: pending + payerTenantId
+  end
+  B->>CLI: request accept
+  CLI->>CLI: stageTransfer (payer → requester)
+  B->>CLI: transfer --confirm (+ TOTP)
+  CLI->>Req: status=paid
+```
+
+## CLI
+
+```bash
+export CLAWQL_CREDITS_ENABLED=1
+
+# Invoice someone already on the platform
+clawql payments credits invoice --to bob@acme.com --amount 25 --note "March consulting"
+# alias: credits request --to @bob --amount 25
+
+# Invite someone new by email
+clawql payments credits request --to newbie@acme.com --amount 40 --note "dinner"
+# → share inviteUrl / token once
+
+# Invitee joins + links the request
+clawql payments credits request claim-invite \
+  --request-id UUID --token TOKEN --tenant-id newbie [--handle newb]
+
+# Payer accepts → stages transfer (money not moved yet)
+clawql payments credits request accept --request-id UUID --tenant-id bob
+
+# Confirm (same high-impact step-up as pay)
+clawql payments credits transfer --confirm --action-id … --code … [--totp …]
+
+clawql payments credits request list --tenant-id alice
+clawql payments credits request decline|cancel --request-id UUID
+```
+
+## Storage
+
+- `$CLAWQL_HOME/Payments/money-requests.json` (mode `0600`)
+- Invite tokens stored as **SHA-256 hashes** only; cleartext token returned once at create
+- Emails never written to payment WORM
+
+## MCP (`CLAWQL_PAYMENTS_MCP_TOOLS=1`)
+
+| Tool | Role |
+| ---- | ---- |
+| `payments_credits_request_create` | Create / invite |
+| `payments_credits_request_list` | List |
+| `payments_credits_request_claim_invite` | Join via email invite |
+| `payments_credits_request_accept` | Stage payer → requester transfer |
+
+## Env
+
+| Variable | Default | Meaning |
+| -------- | ------- | ------- |
+| `CLAWQL_CREDITS_REQUEST_TTL_SEC` | 7 days | Request expiry |
+
+See also: [consumer roadmap](./p2p-consumer-roadmap.md), [credits ACH / P2P](./credits-ach.md).

--- a/docs/payments/p2p-consumer-roadmap.md
+++ b/docs/payments/p2p-consumer-roadmap.md
@@ -13,6 +13,7 @@ ClawQL is **not** a consumer bank. Balances are prepaid credits; bank/USDC off-r
 | Stage → confirm (+ optional TOTP) | ✅ | High-impact 2PC |
 | Pay-by-email (default) + optional `@username` | ✅ | `$CLAWQL_HOME/Payments/directory.json` |
 | `credits pay --to email\|@user` | ✅ | Alias over transfer + directory resolve |
+| Request / invoice + email invite | ✅ | [`money-requests.md`](./money-requests.md) |
 | OIDC / MFA policy (gateway) | ✅ (stacked) | [`clawql-auth-oidc-stepup.md`](../security/clawql-auth-oidc-stepup.md) |
 
 ## Addressing model
@@ -27,11 +28,12 @@ Emails are stored only under `$CLAWQL_HOME/Payments/directory.json` (mode `0600`
 
 ## Next bits (suggested order)
 
-1. **Request money** — inert request record `@alice` asks `@bob` for $X; bob confirms → same transfer path
+1. ~~**Request money**~~ — ✅ email invoice + invite — [`money-requests.md`](./money-requests.md)
 2. **Activity feed** — recent sent/received/requests for a handle (read model over ledger + directory)
-3. **QR / deep link** — `clawql://pay/@bob?amount=10` for mobile / agent handoff
-4. **Contacts** — optional phone/email → handle (customer IdP or verified claim; not a full IdP)
+3. **QR / deep link** — `clawql://pay/@bob?amount=10` / request invite deep links
+4. **Contacts** — optional phone → email (customer IdP or verified claim; not a full IdP)
 5. **Hosted mini UI** — one-screen pay/request (brand-first; not a dashboard)
+6. **Outbound email delivery** — actually send the invite (SendGrid/SES); today CLI prints inviteUrl
 
 ## Explicit non-goals (for now)
 

--- a/docs/plugins/payments.md
+++ b/docs/plugins/payments.md
@@ -30,7 +30,7 @@ ClawQL is the only Agentic Gateway with native **Stripe + x402 + MPP + AP2 + ACP
 | **PayPal**         | Human wallet Orders v2 create/capture                                                  |
 | **Adyen**          | Enterprise Checkout sessions, payments, HMAC-verified webhooks                         |
 | **Payouts / Ramp** | Creator bank + Base USDC; Ramp agent cards; Moonpay/Transak off-ramp                   |
-| **Credits**        | Prepaid ledger + ACH/FC top-up + P2P email/`@username` pay (stage/confirm + TOTP) |
+| **Credits**        | Prepaid ledger + ACH/FC + P2P pay/request (email invite) + stage/confirm TOTP |
 | **Compensation**   | Agent deposit / cash-out with DAOS-aligned 2PC staging                                 |
 | **Accounting**     | Period subledger CSV/JSON/QB/Xero; tax profile gate; year-end evidence pack            |
 

--- a/packages/clawql-payments/src/cli/credits.ts
+++ b/packages/clawql-payments/src/cli/credits.ts
@@ -17,6 +17,16 @@ import {
   releaseHandle,
   resolveRecipient,
 } from "../credits/directory.js";
+import {
+  acceptMoneyRequest,
+  cancelMoneyRequest,
+  claimMoneyRequestInvite,
+  createMoneyRequest,
+  declineMoneyRequest,
+  getMoneyRequest,
+  listMoneyRequests,
+  publicMoneyRequest,
+} from "../credits/requests.js";
 import { runPaymentsEffect } from "../runtime/payments-effect-runtime.js";
 import { loadPaymentsConfig } from "../config/store.js";
 
@@ -552,6 +562,309 @@ export async function runPaymentsCreditsStepUpShow(
     `Transfer TOTP gate: ${isCreditsTransferTotpRequired() ? "ON" : "off (set CLAWQL_CREDITS_TRANSFER_REQUIRE_TOTP=1)"}`
   );
   return 0;
+}
+
+export type PaymentsCreditsRequestOptions = {
+  fromTenantId?: string;
+  /** Requester tenant (alias of fromTenantId for request create). */
+  tenantId?: string;
+  payTo?: string;
+  toHandle?: string;
+  toTenantId?: string;
+  amountUsd?: number;
+  note?: string;
+  correlationId?: string;
+  requestId?: string;
+  inviteToken?: string;
+  handle?: string;
+  email?: string;
+  displayName?: string;
+  role?: "requester" | "payer" | "any";
+  status?: string;
+  json?: boolean;
+};
+
+export async function runPaymentsCreditsRequestCreate(
+  options: PaymentsCreditsRequestOptions = {}
+): Promise<number> {
+  if (!isCreditsEnabled()) {
+    console.error("Credits disabled — set CLAWQL_CREDITS_ENABLED=1");
+    return 1;
+  }
+  const config = await loadPaymentsConfig();
+  const requesterTenantId =
+    options.fromTenantId?.trim() || options.tenantId?.trim() || config.tenantId || "default";
+  const to =
+    options.payTo?.trim() ||
+    options.toHandle?.trim() ||
+    options.toTenantId?.trim() ||
+    options.email?.trim();
+  const amountUsd = options.amountUsd;
+  if (!to || amountUsd === undefined || !Number.isFinite(amountUsd) || amountUsd <= 0) {
+    console.error(
+      "Usage: clawql payments credits request --to newbie@acme.com|--to @bob --amount 25 [--note invoice]\n" +
+        "       clawql payments credits invoice …  (alias)"
+    );
+    return 1;
+  }
+  try {
+    const result = await createMoneyRequest({
+      requesterTenantId,
+      to,
+      amountCents: Math.round(amountUsd * 100),
+      note: options.note,
+      correlationId: options.correlationId,
+    });
+    if (options.json) {
+      console.log(
+        JSON.stringify(
+          {
+            ...publicMoneyRequest(result.request),
+            invite: result.invite,
+            inviteToken: result.inviteToken,
+          },
+          null,
+          2
+        )
+      );
+      return 0;
+    }
+    const r = result.request;
+    console.log(
+      `Request ${r.requestId}: $${(r.amountCents / 100).toFixed(2)} from ${requesterTenantId} → ${
+        r.payerHandle ? `@${r.payerHandle}` : r.payerEmail || r.payerTenantId || to
+      }`
+    );
+    if (r.note) console.log(`Note: ${r.note}`);
+    console.log(`Status: ${r.status} (expires ${r.expiresAt})`);
+    if (result.invite) {
+      console.log("Payer is not on ClawQL yet — share this invite:");
+      console.log(`  ${r.inviteUrl}`);
+      console.log(
+        `  clawql payments credits request claim-invite --request-id ${r.requestId} --token ${result.inviteToken} --tenant-id <new> [--handle …]`
+      );
+    } else {
+      console.log(
+        `Payer accepts: clawql payments credits request accept --request-id ${r.requestId} --tenant-id ${r.payerTenantId}`
+      );
+    }
+    return 0;
+  } catch (err) {
+    console.error(formatErr(err));
+    return 1;
+  }
+}
+
+/** Alias for request create (invoice language). */
+export async function runPaymentsCreditsInvoice(
+  options: PaymentsCreditsRequestOptions = {}
+): Promise<number> {
+  return runPaymentsCreditsRequestCreate(options);
+}
+
+export async function runPaymentsCreditsRequestList(
+  options: PaymentsCreditsRequestOptions = {}
+): Promise<number> {
+  const config = await loadPaymentsConfig();
+  const tenantId = options.tenantId?.trim() || config.tenantId;
+  const role = options.role ?? "any";
+  const status = options.status?.trim() as
+    | "pending"
+    | "accepted"
+    | "paid"
+    | "declined"
+    | "cancelled"
+    | "expired"
+    | undefined;
+  const rows = await listMoneyRequests({ tenantId, role, status });
+  if (options.json) {
+    console.log(JSON.stringify(rows.map(publicMoneyRequest), null, 2));
+    return 0;
+  }
+  if (rows.length === 0) {
+    console.log("No money requests.");
+    return 0;
+  }
+  for (const r of rows) {
+    const who = r.payerHandle
+      ? `@${r.payerHandle}`
+      : r.payerEmail || r.payerTenantId || "(invite)";
+    console.log(
+      `${r.requestId.slice(0, 8)}…  $${(r.amountCents / 100).toFixed(2).padStart(8)}  ${r.status.padEnd(10)}  ${r.requesterTenantId} ← ${who}${r.note ? `  (${r.note})` : ""}`
+    );
+  }
+  return 0;
+}
+
+export async function runPaymentsCreditsRequestShow(
+  options: PaymentsCreditsRequestOptions = {}
+): Promise<number> {
+  const requestId = options.requestId?.trim();
+  if (!requestId) {
+    console.error("Usage: clawql payments credits request show --request-id UUID");
+    return 1;
+  }
+  const req = await getMoneyRequest(requestId);
+  if (!req) {
+    console.error("Unknown request id");
+    return 1;
+  }
+  if (options.json) {
+    console.log(JSON.stringify(publicMoneyRequest(req), null, 2));
+    return 0;
+  }
+  const pub = publicMoneyRequest(req);
+  console.log(JSON.stringify(pub, null, 2));
+  return 0;
+}
+
+export async function runPaymentsCreditsRequestClaimInvite(
+  options: PaymentsCreditsRequestOptions = {}
+): Promise<number> {
+  const requestId = options.requestId?.trim();
+  const token = options.inviteToken?.trim();
+  const tenantId = options.tenantId?.trim();
+  if (!requestId || !token || !tenantId) {
+    console.error(
+      "Usage: clawql payments credits request claim-invite --request-id UUID --token TOKEN --tenant-id ID [--email …] [--handle …]"
+    );
+    return 1;
+  }
+  try {
+    const { request, directoryCreated } = await claimMoneyRequestInvite({
+      requestId,
+      token,
+      tenantId,
+      email: options.email,
+      handle: options.handle,
+      displayName: options.displayName,
+    });
+    if (options.json) {
+      console.log(JSON.stringify({ request: publicMoneyRequest(request), directoryCreated }, null, 2));
+      return 0;
+    }
+    console.log(
+      directoryCreated
+        ? `Joined ClawQL as tenant ${tenantId} (directory created)`
+        : `Linked invite to tenant ${tenantId}`
+    );
+    if (request.payerEmail) console.log(`Email: ${request.payerEmail}`);
+    if (request.payerHandle) console.log(`Username: @${request.payerHandle}`);
+    console.log(
+      `Accept & pay: clawql payments credits request accept --request-id ${request.requestId} --tenant-id ${tenantId}`
+    );
+    return 0;
+  } catch (err) {
+    console.error(formatErr(err));
+    return 1;
+  }
+}
+
+export async function runPaymentsCreditsRequestAccept(
+  options: PaymentsCreditsRequestOptions = {}
+): Promise<number> {
+  if (!isCreditsEnabled()) {
+    console.error("Credits disabled — set CLAWQL_CREDITS_ENABLED=1");
+    return 1;
+  }
+  const config = await loadPaymentsConfig();
+  const requestId = options.requestId?.trim();
+  const payerTenantId =
+    options.tenantId?.trim() || options.fromTenantId?.trim() || config.tenantId || "default";
+  if (!requestId) {
+    console.error(
+      "Usage: clawql payments credits request accept --request-id UUID [--tenant-id payer]"
+    );
+    return 1;
+  }
+  try {
+    const { request, staged } = await acceptMoneyRequest(
+      { requestId, payerTenantId },
+      async (input) =>
+        runPaymentsEffect(
+          Effect.gen(function* () {
+            const credits = yield* CreditsService;
+            return yield* credits.stageTransfer({
+              fromTenantId: input.fromTenantId,
+              toTenantId: input.toTenantId,
+              amountCents: input.amountCents,
+              note: input.note,
+              correlationId: input.correlationId,
+              requestId: input.requestId,
+            });
+          })
+        )
+    );
+    if (options.json) {
+      console.log(JSON.stringify({ request: publicMoneyRequest(request), staged }, null, 2));
+      return 0;
+    }
+    console.log(
+      `Accepted request ${request.requestId} — staged $${staged.amountUsd.toFixed(2)} ${staged.fromTenantId} → ${staged.toTenantId}`
+    );
+    console.log(`action_id: ${staged.actionId}`);
+    console.log(`confirmation_code: ${staged.confirmationCode}`);
+    if (staged.totpRequired || isCreditsTransferTotpRequired()) {
+      console.log("TOTP required on confirm");
+    }
+    console.log(
+      `Confirm: clawql payments credits transfer --confirm --action-id ${staged.actionId} --code ${staged.confirmationCode}${staged.totpRequired ? " --totp NNNNNN" : ""}`
+    );
+    return 0;
+  } catch (err) {
+    console.error(formatErr(err));
+    return 1;
+  }
+}
+
+export async function runPaymentsCreditsRequestDecline(
+  options: PaymentsCreditsRequestOptions = {}
+): Promise<number> {
+  const config = await loadPaymentsConfig();
+  const requestId = options.requestId?.trim();
+  const payerTenantId =
+    options.tenantId?.trim() || options.fromTenantId?.trim() || config.tenantId || "default";
+  if (!requestId) {
+    console.error("Usage: clawql payments credits request decline --request-id UUID");
+    return 1;
+  }
+  try {
+    const req = await declineMoneyRequest({ requestId, payerTenantId });
+    if (options.json) {
+      console.log(JSON.stringify(publicMoneyRequest(req), null, 2));
+      return 0;
+    }
+    console.log(`Declined request ${req.requestId}`);
+    return 0;
+  } catch (err) {
+    console.error(formatErr(err));
+    return 1;
+  }
+}
+
+export async function runPaymentsCreditsRequestCancel(
+  options: PaymentsCreditsRequestOptions = {}
+): Promise<number> {
+  const config = await loadPaymentsConfig();
+  const requestId = options.requestId?.trim();
+  const requesterTenantId =
+    options.tenantId?.trim() || options.fromTenantId?.trim() || config.tenantId || "default";
+  if (!requestId) {
+    console.error("Usage: clawql payments credits request cancel --request-id UUID");
+    return 1;
+  }
+  try {
+    const req = await cancelMoneyRequest({ requestId, requesterTenantId });
+    if (options.json) {
+      console.log(JSON.stringify(publicMoneyRequest(req), null, 2));
+      return 0;
+    }
+    console.log(`Cancelled request ${req.requestId}`);
+    return 0;
+  } catch (err) {
+    console.error(formatErr(err));
+    return 1;
+  }
 }
 
 function formatErr(err: unknown): string {

--- a/packages/clawql-payments/src/cli/index.ts
+++ b/packages/clawql-payments/src/cli/index.ts
@@ -71,6 +71,14 @@ export {
   runPaymentsCreditsDirectoryShow,
   runPaymentsCreditsDirectoryList,
   runPaymentsCreditsDirectoryRelease,
+  runPaymentsCreditsRequestCreate,
+  runPaymentsCreditsInvoice,
+  runPaymentsCreditsRequestList,
+  runPaymentsCreditsRequestShow,
+  runPaymentsCreditsRequestClaimInvite,
+  runPaymentsCreditsRequestAccept,
+  runPaymentsCreditsRequestDecline,
+  runPaymentsCreditsRequestCancel,
   runPaymentsCreditsStepUpEnroll,
   runPaymentsCreditsStepUpShow,
   type PaymentsCreditsShowOptions,
@@ -78,6 +86,7 @@ export {
   type PaymentsCreditsTopupOptions,
   type PaymentsCreditsTransferOptions,
   type PaymentsCreditsDirectoryOptions,
+  type PaymentsCreditsRequestOptions,
   type PaymentsCreditsStepUpOptions,
 } from "./credits.js";
 export {

--- a/packages/clawql-payments/src/config/paths.ts
+++ b/packages/clawql-payments/src/config/paths.ts
@@ -54,3 +54,8 @@ export function resolvePendingActionsDir(env: NodeJS.ProcessEnv = process.env): 
 export function resolveDeductionOutboxPath(env: NodeJS.ProcessEnv = process.env): string {
   return join(resolvePaymentsDir(env), "deduction-outbox.jsonl");
 }
+
+/** Money requests / invoices (file-backed; invite tokens for off-platform email). */
+export function resolveMoneyRequestsPath(env: NodeJS.ProcessEnv = process.env): string {
+  return join(resolvePaymentsDir(env), "money-requests.json");
+}

--- a/packages/clawql-payments/src/credits/credits-service.ts
+++ b/packages/clawql-payments/src/credits/credits-service.ts
@@ -32,6 +32,7 @@ import {
   type CreditTransferResult,
 } from "./ledger.js";
 import { requireStepUpTotp } from "./step-up.js";
+import { markMoneyRequestPaid } from "./requests.js";
 
 export const CREDITS_TRANSFER_STAGE_TOOL = "payments_credits_transfer_stage";
 export const CREDITS_TRANSFER_CONFIRM_TOOL = "payments_credits_transfer_confirm";
@@ -102,6 +103,8 @@ export class CreditsService extends Context.Tag("clawql/CreditsService")<
       idempotencyKey?: string;
       correlationId?: string;
       note?: string;
+      /** When set, confirm marks the money request paid. */
+      requestId?: string;
     }) => Effect.Effect<StagedCreditTransfer, CreditsError>;
     /** Confirm staged transfer; optional TOTP when CLAWQL_CREDITS_TRANSFER_REQUIRE_TOTP=1. */
     readonly confirmTransfer: (input: {
@@ -321,6 +324,7 @@ export function creditsLiveLayer(
         idempotencyKey?: string;
         correlationId?: string;
         note?: string;
+        requestId?: string;
       }) =>
         Effect.gen(function* () {
           if (!isCreditsEnabled(env)) {
@@ -359,6 +363,7 @@ export function creditsLiveLayer(
                     amountCents: Math.round(input.amountCents),
                     idempotencyKey: input.idempotencyKey,
                     note: input.note,
+                    requestId: input.requestId?.trim() || undefined,
                   },
                 },
                 env
@@ -475,6 +480,22 @@ export function creditsLiveLayer(
                 cause,
               }),
           });
+
+          const requestId =
+            typeof record.args.requestId === "string" ? record.args.requestId.trim() : "";
+          if (requestId) {
+            yield* Effect.promise(async () => {
+              try {
+                await markMoneyRequestPaid(
+                  { requestId, transferId: result.transferId },
+                  env
+                );
+              } catch {
+                /* best-effort — transfer already succeeded */
+              }
+            });
+          }
+
           return result;
         });
 

--- a/packages/clawql-payments/src/credits/index.ts
+++ b/packages/clawql-payments/src/credits/index.ts
@@ -43,6 +43,26 @@ export {
   type ResolvedRecipient,
 } from "./directory.js";
 export {
+  acceptMoneyRequest,
+  buildRequestInviteUrl,
+  cancelMoneyRequest,
+  claimMoneyRequestInvite,
+  createMoneyRequest,
+  declineMoneyRequest,
+  getMoneyRequest,
+  listMoneyRequests,
+  markMoneyRequestAccepted,
+  markMoneyRequestPaid,
+  moneyRequestTtlSec,
+  publicMoneyRequest,
+  resetMoneyRequestsForTests,
+  type CreateMoneyRequestInput,
+  type CreateMoneyRequestResult,
+  type MoneyRequest,
+  type MoneyRequestStatus,
+  type StageTransferFn,
+} from "./requests.js";
+export {
   appendCreditEntry,
   captureHold,
   getCreditAccount,

--- a/packages/clawql-payments/src/credits/requests.test.ts
+++ b/packages/clawql-payments/src/credits/requests.test.ts
@@ -1,0 +1,186 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect, Layer } from "effect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AuditLive } from "clawql-core";
+import { paymentAuditLiveLayer } from "../plugin/payment-audit-service.js";
+import { resetPaymentAuditStoreForTests } from "../audit/worm.js";
+import { resetPaymentsEffectRuntimeForTests } from "../runtime/payments-effect-runtime.js";
+import { appendCreditEntry, resetCreditsLedgerForTests } from "./ledger.js";
+import { claimDirectory, resetDirectoryForTests } from "./directory.js";
+import { CreditsService, creditsLiveLayer } from "./credits-service.js";
+import {
+  acceptMoneyRequest,
+  cancelMoneyRequest,
+  claimMoneyRequestInvite,
+  createMoneyRequest,
+  declineMoneyRequest,
+  getMoneyRequest,
+  listMoneyRequests,
+  publicMoneyRequest,
+  resetMoneyRequestsForTests,
+} from "./requests.js";
+
+describe("money requests / invoices", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "clawql-req-"));
+    process.env.CLAWQL_HOME = home;
+    process.env.CLAWQL_PAYMENTS_AUDIT_STORE = "memory";
+    process.env.CLAWQL_CREDITS_ENABLED = "1";
+    delete process.env.CLAWQL_CREDITS_TRANSFER_DIRECT;
+    delete process.env.CLAWQL_CREDITS_TRANSFER_REQUIRE_TOTP;
+    resetPaymentsEffectRuntimeForTests();
+    await resetPaymentAuditStoreForTests(process.env);
+    await resetCreditsLedgerForTests(process.env);
+    await resetDirectoryForTests(process.env);
+    await resetMoneyRequestsForTests(process.env);
+  });
+
+  afterEach(async () => {
+    resetPaymentsEffectRuntimeForTests();
+    delete process.env.CLAWQL_HOME;
+    delete process.env.CLAWQL_PAYMENTS_AUDIT_STORE;
+    delete process.env.CLAWQL_CREDITS_ENABLED;
+    delete process.env.CLAWQL_CREDITS_TRANSFER_DIRECT;
+    await rm(home, { recursive: true, force: true });
+  });
+
+  const layer = () => {
+    const audit = paymentAuditLiveLayer(process.env).pipe(Layer.provide(AuditLive));
+    return creditsLiveLayer(process.env).pipe(Layer.provide(audit));
+  };
+
+  it("creates request to on-platform email", async () => {
+    await claimDirectory({ email: "alice@acme.com", tenantId: "alice" });
+    await claimDirectory({ email: "bob@acme.com", tenantId: "bob", handle: "bob" });
+
+    const { request, invite } = await createMoneyRequest({
+      requesterTenantId: "alice",
+      to: "bob@acme.com",
+      amountCents: 2500,
+      note: "lunch",
+    });
+    expect(invite).toBe(false);
+    expect(request.payerTenantId).toBe("bob");
+    expect(request.payerHandle).toBe("bob");
+    expect(request.status).toBe("pending");
+    expect(publicMoneyRequest(request).invitePending).toBe(false);
+  });
+
+  it("creates invite when email unknown and claim-invite joins platform", async () => {
+    await claimDirectory({ email: "alice@acme.com", tenantId: "alice" });
+
+    const { request, invite, inviteToken } = await createMoneyRequest({
+      requesterTenantId: "alice",
+      to: "newbie@acme.com",
+      amountCents: 1000,
+    });
+    expect(invite).toBe(true);
+    expect(inviteToken).toBeTruthy();
+    expect(request.payerTenantId).toBeUndefined();
+    expect(request.inviteUrl).toMatch(/request\/invite/);
+    expect(publicMoneyRequest(request).invitePending).toBe(true);
+
+    const claimed = await claimMoneyRequestInvite({
+      requestId: request.requestId,
+      token: inviteToken!,
+      tenantId: "newbie",
+      handle: "newb",
+    });
+    expect(claimed.directoryCreated).toBe(true);
+    expect(claimed.request.payerTenantId).toBe("newbie");
+    expect(claimed.request.payerHandle).toBe("newb");
+    expect(claimed.request.inviteTokenHash).toBeUndefined();
+  });
+
+  it("accept stages transfer and confirm marks request paid", async () => {
+    await claimDirectory({ email: "alice@acme.com", tenantId: "alice" });
+    await claimDirectory({ email: "bob@acme.com", tenantId: "bob" });
+    await appendCreditEntry({
+      tenantId: "bob",
+      kind: "topup_settled",
+      deltaCents: 10_000,
+      grantSource: "topup",
+      note: "seed",
+    });
+
+    const { request } = await createMoneyRequest({
+      requesterTenantId: "alice",
+      to: "bob@acme.com",
+      amountCents: 1500,
+      note: "invoice-1",
+    });
+
+    const accepted = await Effect.runPromise(
+      Effect.gen(function* () {
+        const credits = yield* CreditsService;
+        return yield* Effect.promise(() =>
+          acceptMoneyRequest({ requestId: request.requestId, payerTenantId: "bob" }, (input) =>
+            Effect.runPromise(
+              credits.stageTransfer({
+                fromTenantId: input.fromTenantId,
+                toTenantId: input.toTenantId,
+                amountCents: input.amountCents,
+                note: input.note,
+                correlationId: input.correlationId,
+                requestId: input.requestId,
+              })
+            )
+          )
+        );
+      }).pipe(Effect.provide(layer()))
+    );
+
+    expect(accepted.request.status).toBe("accepted");
+    expect(accepted.staged.actionId).toBeTruthy();
+
+    const paid = await Effect.runPromise(
+      Effect.gen(function* () {
+        const credits = yield* CreditsService;
+        return yield* credits.confirmTransfer({
+          actionId: accepted.staged.actionId,
+          code: accepted.staged.confirmationCode,
+        });
+      }).pipe(Effect.provide(layer()))
+    );
+
+    expect(paid.amountCents).toBe(1500);
+    const after = await getMoneyRequest(request.requestId);
+    expect(after?.status).toBe("paid");
+    expect(after?.paidTransferId).toBe(paid.transferId);
+
+    const alice = await Effect.runPromise(
+      Effect.gen(function* () {
+        const credits = yield* CreditsService;
+        return yield* credits.getBalance("alice");
+      }).pipe(Effect.provide(layer()))
+    );
+    expect(alice.balanceCents).toBe(1500);
+  });
+
+  it("decline, cancel, and list", async () => {
+    await claimDirectory({ email: "a@x.com", tenantId: "a" });
+    await claimDirectory({ email: "b@x.com", tenantId: "b" });
+    const { request: r1 } = await createMoneyRequest({
+      requesterTenantId: "a",
+      to: "b@x.com",
+      amountCents: 500,
+    });
+    await declineMoneyRequest({ requestId: r1.requestId, payerTenantId: "b" });
+    expect((await getMoneyRequest(r1.requestId))?.status).toBe("declined");
+
+    const { request: r2 } = await createMoneyRequest({
+      requesterTenantId: "a",
+      to: "b@x.com",
+      amountCents: 700,
+    });
+    await cancelMoneyRequest({ requestId: r2.requestId, requesterTenantId: "a" });
+    expect((await getMoneyRequest(r2.requestId))?.status).toBe("cancelled");
+
+    const listed = await listMoneyRequests({ tenantId: "a", role: "requester" });
+    expect(listed.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/clawql-payments/src/credits/requests.ts
+++ b/packages/clawql-payments/src/credits/requests.ts
@@ -1,0 +1,534 @@
+/**
+ * Money requests / invoices — ask someone to pay prepaid credits.
+ *
+ * Addressing: email (default, can invite off-platform), @username, or tenant id.
+ * Accept → stages a credits transfer (same 2PC + optional TOTP as pay).
+ * Emails / invite tokens never go in payment WORM.
+ */
+
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { compensationApprovalBaseUrl } from "../compensation/config.js";
+import { resolveMoneyRequestsPath } from "../config/paths.js";
+import {
+  claimDirectory,
+  getTenantEntry,
+  looksLikeEmail,
+  normalizeEmail,
+  resolveRecipient,
+} from "./directory.js";
+
+export type MoneyRequestStatus =
+  | "pending"
+  | "accepted"
+  | "paid"
+  | "declined"
+  | "cancelled"
+  | "expired";
+
+export type MoneyRequest = {
+  readonly requestId: string;
+  readonly requesterTenantId: string;
+  readonly requesterEmail?: string;
+  readonly requesterHandle?: string;
+  /** Set when payer is already on the platform (or after invite claim). */
+  payerTenantId?: string;
+  /** Always set when requesting by email / for invites. */
+  readonly payerEmail?: string;
+  readonly payerHandle?: string;
+  readonly amountCents: number;
+  readonly note?: string;
+  status: MoneyRequestStatus;
+  /** Present when payer was not in the directory at create time. */
+  readonly inviteTokenHash?: string;
+  readonly inviteUrl?: string;
+  readonly createdAt: string;
+  readonly expiresAt: string;
+  readonly correlationId?: string;
+  stagedTransferActionId?: string;
+  paidTransferId?: string;
+  updatedAt: string;
+};
+
+type RequestsFile = {
+  version: 1;
+  requests: Record<string, MoneyRequest>;
+};
+
+function emptyFile(): RequestsFile {
+  return { version: 1, requests: {} };
+}
+
+function hashToken(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+function tokensEqual(a: string, b: string): boolean {
+  const ba = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ba.length !== bb.length) {
+    timingSafeEqual(ba, ba);
+    return false;
+  }
+  return timingSafeEqual(ba, bb);
+}
+
+export function moneyRequestTtlSec(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.CLAWQL_CREDITS_REQUEST_TTL_SEC?.trim();
+  if (raw && Number.isFinite(Number(raw)) && Number(raw) > 0) return Math.floor(Number(raw));
+  return 7 * 24 * 60 * 60; // 7 days
+}
+
+export function buildRequestInviteUrl(
+  requestId: string,
+  token: string,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const base = compensationApprovalBaseUrl(env);
+  return `${base}/credits/request/invite?request_id=${encodeURIComponent(requestId)}&token=${encodeURIComponent(token)}`;
+}
+
+async function loadFile(env: NodeJS.ProcessEnv): Promise<RequestsFile> {
+  try {
+    const raw = await readFile(resolveMoneyRequestsPath(env), "utf8");
+    const parsed = JSON.parse(raw) as RequestsFile;
+    if (!parsed || typeof parsed !== "object" || !parsed.requests) return emptyFile();
+    return { version: 1, requests: parsed.requests };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return emptyFile();
+    throw err;
+  }
+}
+
+async function saveFile(file: RequestsFile, env: NodeJS.ProcessEnv): Promise<void> {
+  const path = resolveMoneyRequestsPath(env);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
+}
+
+function touchExpired(req: MoneyRequest): MoneyRequest {
+  if (req.status !== "pending" && req.status !== "accepted") return req;
+  if (Date.parse(req.expiresAt) > Date.now()) return req;
+  return { ...req, status: "expired", updatedAt: new Date().toISOString() };
+}
+
+export async function getMoneyRequest(
+  requestId: string,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<MoneyRequest | undefined> {
+  const file = await loadFile(env);
+  const raw = file.requests[requestId.trim()];
+  if (!raw) return undefined;
+  const req = touchExpired(raw);
+  if (req !== raw) {
+    file.requests[req.requestId] = req;
+    await saveFile(file, env);
+  }
+  return req;
+}
+
+export async function listMoneyRequests(
+  options: {
+    tenantId?: string;
+    role?: "requester" | "payer" | "any";
+    status?: MoneyRequestStatus;
+  } = {},
+  env: NodeJS.ProcessEnv = process.env
+): Promise<MoneyRequest[]> {
+  const file = await loadFile(env);
+  let dirty = false;
+  const out: MoneyRequest[] = [];
+  for (const [id, raw] of Object.entries(file.requests)) {
+    const req = touchExpired(raw);
+    if (req !== raw) {
+      file.requests[id] = req;
+      dirty = true;
+    }
+    out.push(req);
+  }
+  if (dirty) await saveFile(file, env);
+
+  const tenantId = options.tenantId?.trim();
+  const role = options.role ?? "any";
+  return out
+    .filter((r) => {
+      if (options.status && r.status !== options.status) return false;
+      if (!tenantId) return true;
+      if (role === "requester") return r.requesterTenantId === tenantId;
+      if (role === "payer") return r.payerTenantId === tenantId;
+      return r.requesterTenantId === tenantId || r.payerTenantId === tenantId;
+    })
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+export type CreateMoneyRequestInput = {
+  requesterTenantId: string;
+  /** Payee addressing: email, @username, or tenant id (same as pay --to). */
+  to: string;
+  amountCents: number;
+  note?: string;
+  correlationId?: string;
+};
+
+export type CreateMoneyRequestResult = {
+  request: MoneyRequest;
+  /** Cleartext invite token — only returned at create time (never stored). */
+  inviteToken?: string;
+  /** True when payer email is not yet on the platform. */
+  invite: boolean;
+};
+
+/**
+ * Create a money request / invoice.
+ * If `to` is an unknown email, attaches an invite URL so they can join and pay.
+ */
+export async function createMoneyRequest(
+  input: CreateMoneyRequestInput,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<CreateMoneyRequestResult> {
+  const requesterTenantId = input.requesterTenantId.trim();
+  if (!requesterTenantId) throw new Error("requesterTenantId required");
+  if (!Number.isFinite(input.amountCents) || input.amountCents <= 0) {
+    throw new Error("amountCents must be > 0");
+  }
+
+  const to = input.to.trim();
+  if (!to) throw new Error("Recipient required (--to email | @user | tenant)");
+
+  const requester = await getTenantEntry(requesterTenantId, env);
+
+  let payerTenantId: string | undefined;
+  let payerEmail: string | undefined;
+  let payerHandle: string | undefined;
+  let invite = false;
+
+  if (looksLikeEmail(to)) {
+    payerEmail = normalizeEmail(to);
+    try {
+      const resolved = await resolveRecipient(to, env, { forceEmail: true });
+      payerTenantId = resolved.tenantId;
+      payerHandle = resolved.handle;
+    } catch {
+      invite = true;
+    }
+  } else {
+    const resolved = await resolveRecipient(to, env, {
+      forceHandle: to.startsWith("@"),
+    });
+    payerTenantId = resolved.tenantId;
+    payerEmail = resolved.email;
+    payerHandle = resolved.handle;
+    if (!payerEmail && looksLikeEmail(to)) {
+      payerEmail = normalizeEmail(to);
+    }
+  }
+
+  if (payerTenantId && payerTenantId === requesterTenantId) {
+    throw new Error("Cannot request money from yourself");
+  }
+
+  const requestId = randomUUID();
+  const now = new Date().toISOString();
+  const expiresAt = new Date(Date.now() + moneyRequestTtlSec(env) * 1000).toISOString();
+
+  let inviteToken: string | undefined;
+  let inviteTokenHash: string | undefined;
+  let inviteUrl: string | undefined;
+  if (invite) {
+    if (!payerEmail) throw new Error("Invite requires a payer email");
+    inviteToken = randomBytes(24).toString("base64url");
+    inviteTokenHash = hashToken(inviteToken);
+    inviteUrl = buildRequestInviteUrl(requestId, inviteToken, env);
+  }
+
+  const request: MoneyRequest = {
+    requestId,
+    requesterTenantId,
+    requesterEmail: requester?.email,
+    requesterHandle: requester?.handle,
+    payerTenantId,
+    payerEmail,
+    payerHandle,
+    amountCents: Math.round(input.amountCents),
+    note: input.note?.trim() || undefined,
+    status: "pending",
+    inviteTokenHash,
+    inviteUrl,
+    createdAt: now,
+    expiresAt,
+    correlationId: input.correlationId,
+    updatedAt: now,
+  };
+
+  const file = await loadFile(env);
+  file.requests[requestId] = request;
+  await saveFile(file, env);
+
+  return { request, inviteToken, invite: invite };
+}
+
+/** Public view — never exposes inviteTokenHash. */
+export function publicMoneyRequest(req: MoneyRequest): Omit<MoneyRequest, "inviteTokenHash"> & {
+  invitePending: boolean;
+} {
+  const { inviteTokenHash: _, ...rest } = req;
+  return {
+    ...rest,
+    invitePending: Boolean(req.inviteTokenHash) && !req.payerTenantId && req.status === "pending",
+  };
+}
+
+export async function claimMoneyRequestInvite(
+  input: {
+    requestId: string;
+    token: string;
+    tenantId: string;
+    /** Defaults to request.payerEmail */
+    email?: string;
+    handle?: string;
+    displayName?: string;
+  },
+  env: NodeJS.ProcessEnv = process.env
+): Promise<{ request: MoneyRequest; directoryCreated: boolean }> {
+  const file = await loadFile(env);
+  let req = file.requests[input.requestId.trim()];
+  if (!req) throw new Error("Unknown request id");
+  req = touchExpired(req);
+  if (req.status === "expired") {
+    file.requests[req.requestId] = req;
+    await saveFile(file, env);
+    throw new Error("Request expired");
+  }
+  if (req.status !== "pending") throw new Error(`Request is ${req.status}`);
+  if (!req.inviteTokenHash) throw new Error("Request has no invite (payer already on platform)");
+  if (!tokensEqual(hashToken(input.token.trim()), req.inviteTokenHash)) {
+    throw new Error("Invalid invite token");
+  }
+
+  const email = input.email?.trim() || req.payerEmail;
+  if (!email) throw new Error("Email required to claim invite");
+
+  const { entry, created } = await claimDirectory(
+    {
+      email,
+      handle: input.handle,
+      tenantId: input.tenantId.trim(),
+      displayName: input.displayName,
+    },
+    env
+  );
+
+  const updated: MoneyRequest = {
+    requestId: req.requestId,
+    requesterTenantId: req.requesterTenantId,
+    requesterEmail: req.requesterEmail,
+    requesterHandle: req.requesterHandle,
+    payerTenantId: entry.tenantId,
+    payerEmail: entry.email ?? normalizeEmail(email),
+    payerHandle: entry.handle ?? req.payerHandle,
+    amountCents: req.amountCents,
+    note: req.note,
+    status: "pending",
+    createdAt: req.createdAt,
+    expiresAt: req.expiresAt,
+    correlationId: req.correlationId,
+    updatedAt: new Date().toISOString(),
+  };
+
+  file.requests[updated.requestId] = updated;
+  await saveFile(file, env);
+  return { request: updated, directoryCreated: created };
+}
+
+export async function declineMoneyRequest(
+  input: { requestId: string; payerTenantId: string },
+  env: NodeJS.ProcessEnv = process.env
+): Promise<MoneyRequest> {
+  return updateAsPayer(input.requestId, input.payerTenantId, "declined", env);
+}
+
+export async function cancelMoneyRequest(
+  input: { requestId: string; requesterTenantId: string },
+  env: NodeJS.ProcessEnv = process.env
+): Promise<MoneyRequest> {
+  const file = await loadFile(env);
+  let req = file.requests[input.requestId.trim()];
+  if (!req) throw new Error("Unknown request id");
+  req = touchExpired(req);
+  if (req.requesterTenantId !== input.requesterTenantId.trim()) {
+    throw new Error("Only the requester can cancel this request");
+  }
+  if (req.status !== "pending" && req.status !== "accepted") {
+    throw new Error(`Cannot cancel request in status ${req.status}`);
+  }
+  const updated: MoneyRequest = {
+    ...req,
+    status: "cancelled",
+    updatedAt: new Date().toISOString(),
+  };
+  file.requests[updated.requestId] = updated;
+  await saveFile(file, env);
+  return updated;
+}
+
+async function updateAsPayer(
+  requestId: string,
+  payerTenantId: string,
+  status: "declined",
+  env: NodeJS.ProcessEnv
+): Promise<MoneyRequest> {
+  const file = await loadFile(env);
+  let req = file.requests[requestId.trim()];
+  if (!req) throw new Error("Unknown request id");
+  req = touchExpired(req);
+  if (req.status === "expired") {
+    file.requests[req.requestId] = req;
+    await saveFile(file, env);
+    throw new Error("Request expired");
+  }
+  if (req.status !== "pending") throw new Error(`Request is ${req.status}`);
+  if (!req.payerTenantId) {
+    throw new Error(
+      "Payer has not joined yet — claim the invite first: clawql payments credits request claim-invite …"
+    );
+  }
+  if (req.payerTenantId !== payerTenantId.trim()) {
+    throw new Error("Only the payer can decline this request");
+  }
+  const updated: MoneyRequest = {
+    ...req,
+    status,
+    updatedAt: new Date().toISOString(),
+  };
+  file.requests[updated.requestId] = updated;
+  await saveFile(file, env);
+  return updated;
+}
+
+/** Mark request accepted and attach staged transfer action id. */
+export async function markMoneyRequestAccepted(
+  input: {
+    requestId: string;
+    payerTenantId: string;
+    stagedTransferActionId: string;
+  },
+  env: NodeJS.ProcessEnv = process.env
+): Promise<MoneyRequest> {
+  const file = await loadFile(env);
+  let req = file.requests[input.requestId.trim()];
+  if (!req) throw new Error("Unknown request id");
+  req = touchExpired(req);
+  if (req.status === "expired") {
+    file.requests[req.requestId] = req;
+    await saveFile(file, env);
+    throw new Error("Request expired");
+  }
+  if (req.status !== "pending") throw new Error(`Request is ${req.status}`);
+  if (!req.payerTenantId) {
+    throw new Error(
+      "Payer has not joined yet — claim the invite first: clawql payments credits request claim-invite …"
+    );
+  }
+  if (req.payerTenantId !== input.payerTenantId.trim()) {
+    throw new Error("Only the payer can accept this request");
+  }
+  const updated: MoneyRequest = {
+    ...req,
+    status: "accepted",
+    stagedTransferActionId: input.stagedTransferActionId,
+    updatedAt: new Date().toISOString(),
+  };
+  file.requests[updated.requestId] = updated;
+  await saveFile(file, env);
+  return updated;
+}
+
+export type StageTransferFn = (input: {
+  fromTenantId: string;
+  toTenantId: string;
+  amountCents: number;
+  note?: string;
+  correlationId?: string;
+  requestId?: string;
+}) => Promise<{
+  actionId: string;
+  confirmationCode: string;
+  expiresAt: string;
+  totpRequired: boolean;
+  amountUsd: number;
+  fromTenantId: string;
+  toTenantId: string;
+}>;
+
+/**
+ * Payer accepts: stages a credits transfer (payer → requester).
+ * Then confirm with the usual transfer --confirm path (+ optional TOTP).
+ */
+export async function acceptMoneyRequest(
+  input: { requestId: string; payerTenantId: string },
+  stageTransfer: StageTransferFn,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<{
+  request: MoneyRequest;
+  staged: Awaited<ReturnType<StageTransferFn>>;
+}> {
+  const req = await getMoneyRequest(input.requestId, env);
+  if (!req) throw new Error("Unknown request id");
+  if (req.status === "expired") throw new Error("Request expired");
+  if (req.status !== "pending") throw new Error(`Request is ${req.status}`);
+  if (!req.payerTenantId) {
+    throw new Error(
+      "Payer has not joined yet — claim the invite first: clawql payments credits request claim-invite …"
+    );
+  }
+  if (req.payerTenantId !== input.payerTenantId.trim()) {
+    throw new Error("Only the payer can accept this request");
+  }
+
+  const staged = await stageTransfer({
+    fromTenantId: req.payerTenantId,
+    toTenantId: req.requesterTenantId,
+    amountCents: req.amountCents,
+    note: req.note ?? `Payment for request ${req.requestId}`,
+    correlationId: req.correlationId,
+    requestId: req.requestId,
+  });
+
+  const updated = await markMoneyRequestAccepted(
+    {
+      requestId: req.requestId,
+      payerTenantId: input.payerTenantId,
+      stagedTransferActionId: staged.actionId,
+    },
+    env
+  );
+
+  return { request: updated, staged };
+}
+
+/** Called after credits transfer confirm when args.requestId is set. */
+export async function markMoneyRequestPaid(
+  input: { requestId: string; transferId: string },
+  env: NodeJS.ProcessEnv = process.env
+): Promise<MoneyRequest | undefined> {
+  const file = await loadFile(env);
+  const req = file.requests[input.requestId.trim()];
+  if (!req) return undefined;
+  if (req.status === "paid") return req;
+  const updated: MoneyRequest = {
+    ...req,
+    status: "paid",
+    paidTransferId: input.transferId,
+    updatedAt: new Date().toISOString(),
+  };
+  file.requests[updated.requestId] = updated;
+  await saveFile(file, env);
+  return updated;
+}
+
+export async function resetMoneyRequestsForTests(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<void> {
+  await saveFile(emptyFile(), env);
+}

--- a/packages/clawql-payments/src/index.ts
+++ b/packages/clawql-payments/src/index.ts
@@ -30,4 +30,5 @@ export {
   resolveAgentAccountsPath,
   resolvePendingActionsDir,
   resolveDeductionOutboxPath,
+  resolveMoneyRequestsPath,
 } from "./config/paths.js";

--- a/packages/clawql-payments/src/plugin/payments-tools-plugin.test.ts
+++ b/packages/clawql-payments/src/plugin/payments-tools-plugin.test.ts
@@ -24,6 +24,10 @@ describe("payments tools MCP plugin", () => {
       "payments_credits_directory_claim",
       "payments_credits_directory_resolve",
       "payments_credits_directory_list",
+      "payments_credits_request_create",
+      "payments_credits_request_list",
+      "payments_credits_request_claim_invite",
+      "payments_credits_request_accept",
       "payments_credits_transfer_stage",
       "payments_credits_transfer_confirm",
       "agent_compensation_deposit_stage",
@@ -32,7 +36,8 @@ describe("payments tools MCP plugin", () => {
       "agent_compensation_cashout_confirm",
     ]);
     expect(descriptions.get("payments_credits_transfer_stage")).toMatch(/Safe entry point/i);
-    expect(descriptions.get("payments_credits_directory_claim")).toMatch(/email/i);
+    expect(descriptions.get("payments_credits_request_create")).toMatch(/invoice|request|invite/i);
+
     expect(descriptions.get("payments_credits_transfer_confirm")).toMatch(/High-impact/i);
     expect(descriptions.get("agent_compensation_deposit_stage")).toMatch(/Safe entry point/i);
     expect(descriptions.get("agent_compensation_deposit_confirm")).toMatch(/High-impact/i);

--- a/packages/clawql-payments/src/plugin/payments-tools-plugin.ts
+++ b/packages/clawql-payments/src/plugin/payments-tools-plugin.ts
@@ -22,6 +22,13 @@ import {
   listDirectory,
   resolveRecipient,
 } from "../credits/directory.js";
+import {
+  acceptMoneyRequest,
+  claimMoneyRequestInvite,
+  createMoneyRequest,
+  listMoneyRequests,
+  publicMoneyRequest,
+} from "../credits/requests.js";
 import { Ap2MandateService } from "../ap2/ap2-mandate-service.js";
 import { isAp2Enabled } from "../ap2/config.js";
 
@@ -191,6 +198,29 @@ const creditsDirectoryResolveSchema = {
     .describe("Email, @username, or tenant id"),
   email: z.string().optional(),
   handle: z.string().optional().describe("Username e.g. @alice"),
+};
+
+const creditsRequestCreateSchema = {
+  to: z.string().describe("Payer email (invites if unknown), @username, or tenant id"),
+  amountUsd: z.number().positive(),
+  fromTenantId: z.string().optional().describe("Requester tenant"),
+  note: z.string().optional().describe("Invoice memo"),
+  mandateJwt: z.string().optional(),
+};
+
+const creditsRequestAcceptSchema = {
+  requestId: z.string(),
+  payerTenantId: z.string().optional(),
+  mandateJwt: z.string().optional(),
+};
+
+const creditsRequestClaimInviteSchema = {
+  requestId: z.string(),
+  token: z.string().describe("Invite token from create response (shown once)"),
+  tenantId: z.string().describe("New or existing tenant id for the invitee"),
+  email: z.string().optional(),
+  handle: z.string().optional(),
+  displayName: z.string().optional(),
 };
 
 /** High-impact: confirm staged P2P transfer (+ optional TOTP). */
@@ -394,6 +424,130 @@ export function createPaymentsToolsPlugin(env: NodeJS.ProcessEnv = process.env):
           description: "List payments directory profiles (email + optional @username).",
           schema: {},
           handler: async () => textResult({ profiles: await listDirectory() }),
+        });
+
+        yield* api.registerMcpTool({
+          name: "payments_credits_request_create",
+          description:
+            "Create a money request / invoice. Prefer email — unknown emails get an invite URL to join ClawQL and pay.",
+          schema: creditsRequestCreateSchema,
+          handler: async (args) => {
+            const a = args as {
+              to: string;
+              amountUsd: number;
+              fromTenantId?: string;
+              note?: string;
+              mandateJwt?: string;
+            };
+            await assertAp2IfRequired(env, a.mandateJwt);
+            const result = await createMoneyRequest(
+              {
+                requesterTenantId: a.fromTenantId?.trim() || "default",
+                to: a.to,
+                amountCents: Math.round(a.amountUsd * 100),
+                note: a.note,
+              },
+              env
+            );
+            return textResult({
+              ...publicMoneyRequest(result.request),
+              invite: result.invite,
+              inviteToken: result.inviteToken,
+              next: result.invite
+                ? "Share inviteUrl / inviteToken; payer runs claim-invite then accept."
+                : "Payer: payments_credits_request_accept with requestId.",
+            });
+          },
+        });
+
+        yield* api.registerMcpTool({
+          name: "payments_credits_request_list",
+          description: "List money requests / invoices for a tenant.",
+          schema: {
+            tenantId: z.string().optional(),
+            role: z.enum(["requester", "payer", "any"]).optional(),
+          },
+          handler: async (args) => {
+            const a = args as { tenantId?: string; role?: "requester" | "payer" | "any" };
+            const rows = await listMoneyRequests(
+              { tenantId: a.tenantId, role: a.role ?? "any" },
+              env
+            );
+            return textResult({ requests: rows.map(publicMoneyRequest) });
+          },
+        });
+
+        yield* api.registerMcpTool({
+          name: "payments_credits_request_claim_invite",
+          description:
+            "Claim an email invite from a money request: registers directory identity and links payer tenant.",
+          schema: creditsRequestClaimInviteSchema,
+          handler: async (args) => {
+            const a = args as {
+              requestId: string;
+              token: string;
+              tenantId: string;
+              email?: string;
+              handle?: string;
+              displayName?: string;
+            };
+            const result = await claimMoneyRequestInvite(
+              {
+                requestId: a.requestId,
+                token: a.token,
+                tenantId: a.tenantId,
+                email: a.email,
+                handle: a.handle,
+                displayName: a.displayName,
+              },
+              env
+            );
+            return textResult({
+              request: publicMoneyRequest(result.request),
+              directoryCreated: result.directoryCreated,
+              next: "Call payments_credits_request_accept to stage payment.",
+            });
+          },
+        });
+
+        yield* api.registerMcpTool({
+          name: "payments_credits_request_accept",
+          description:
+            "Payer accepts a money request: stages a credits transfer (confirm with payments_credits_transfer_confirm).",
+          schema: creditsRequestAcceptSchema,
+          handler: async (args) => {
+            const a = args as {
+              requestId: string;
+              payerTenantId?: string;
+              mandateJwt?: string;
+            };
+            await assertAp2IfRequired(env, a.mandateJwt);
+            const payerTenantId = a.payerTenantId?.trim() || "default";
+            const { request, staged } = await acceptMoneyRequest(
+              { requestId: a.requestId, payerTenantId },
+              async (input) =>
+                runPaymentsEffect(
+                  Effect.gen(function* () {
+                    const credits = yield* CreditsService;
+                    return yield* credits.stageTransfer({
+                      fromTenantId: input.fromTenantId,
+                      toTenantId: input.toTenantId,
+                      amountCents: input.amountCents,
+                      note: input.note,
+                      correlationId: input.correlationId,
+                      requestId: input.requestId,
+                    });
+                  }),
+                  env
+                ),
+              env
+            );
+            return textResult({
+              request: publicMoneyRequest(request),
+              staged,
+              next: "High-impact: payments_credits_transfer_confirm with actionId + code (+ totp if required).",
+            });
+          },
         });
 
         yield* api.registerMcpTool({

--- a/src/onboarding/cli.ts
+++ b/src/onboarding/cli.ts
@@ -100,6 +100,14 @@ import {
   runPaymentsCreditsDirectoryShowCmd,
   runPaymentsCreditsDirectoryListCmd,
   runPaymentsCreditsDirectoryReleaseCmd,
+  runPaymentsCreditsRequestCreateCmd,
+  runPaymentsCreditsInvoiceCmd,
+  runPaymentsCreditsRequestListCmd,
+  runPaymentsCreditsRequestShowCmd,
+  runPaymentsCreditsRequestClaimInviteCmd,
+  runPaymentsCreditsRequestAcceptCmd,
+  runPaymentsCreditsRequestDeclineCmd,
+  runPaymentsCreditsRequestCancelCmd,
   runPaymentsCreditsStepUpEnrollCmd,
   runPaymentsCreditsStepUpShowCmd,
   runPaymentsCompensationBalanceCmd,
@@ -304,6 +312,10 @@ function parse(argv: string[]): {
     }
     else if (a === "--to-handle" || a === "--handle") flags.toHandle = argv[++i] ?? "";
     else if (a === "--display-name") flags.displayName = argv[++i] ?? "";
+    else if (a === "--request-id") flags.requestId = argv[++i] ?? "";
+    else if (a === "--token" || a === "--invite-token") flags.inviteToken = argv[++i] ?? "";
+    else if (a === "--role") flags.requestRole = argv[++i] ?? "";
+    else if (a === "--status") flags.requestStatus = argv[++i] ?? "";
     else if (a === "--tax-year") flags.taxYear = argv[++i] ?? "";
     else if (a === "--party-id") flags.partyId = argv[++i] ?? "";
     else if (a === "--tax-form") flags.taxForm = argv[++i] ?? "";
@@ -409,6 +421,8 @@ Usage:
   clawql payments credits directory claim --email you@acme.com [--handle alice] [--name Alice]
   clawql payments credits directory show|list|release --email … | --handle @alice
   clawql payments credits pay --to you@acme.com|--to @alice --amount 10 [--note coffee]
+  clawql payments credits request|invoice --to newbie@acme.com|--to @bob --amount 25 [--note …]
+  clawql payments credits request list|show|accept|decline|cancel|claim-invite …
   clawql payments credits transfer --to-tenant other-tenant --amount 10
   clawql payments credits transfer --confirm --action-id UUID --code HEX [--totp NNNNNN]
   clawql payments credits step-up enroll|show [--tenant-id ID] [--show-secrets]
@@ -1154,6 +1168,16 @@ async function main(): Promise<void> {
           : typeof flags.name === "string"
             ? flags.name
             : undefined,
+      requestId: typeof flags.requestId === "string" ? flags.requestId : undefined,
+      inviteToken: typeof flags.inviteToken === "string" ? flags.inviteToken : undefined,
+      requestRole:
+        typeof flags.requestRole === "string" &&
+        (flags.requestRole === "requester" ||
+          flags.requestRole === "payer" ||
+          flags.requestRole === "any")
+          ? flags.requestRole
+          : undefined,
+      requestStatus: typeof flags.requestStatus === "string" ? flags.requestStatus : undefined,
       idempotencyKey: typeof flags.idempotencyKey === "string" ? flags.idempotencyKey : undefined,
       note: typeof flags.note === "string" ? flags.note : undefined,
       totp: typeof flags.totp === "string" ? flags.totp : undefined,
@@ -1356,6 +1380,48 @@ async function main(): Promise<void> {
         process.exitCode = await runPaymentsCreditsPayCmd(paymentsOpts);
         return;
       }
+      if (creditsAction === "request" || creditsAction === "invoice") {
+        const known = new Set([
+          "create",
+          "list",
+          "show",
+          "accept",
+          "decline",
+          "cancel",
+          "claim-invite",
+        ]);
+        const action =
+          rest[1] && known.has(rest[1]) ? rest[1] : "create";
+        if (action === "list") {
+          process.exitCode = await runPaymentsCreditsRequestListCmd(paymentsOpts);
+          return;
+        }
+        if (action === "show") {
+          process.exitCode = await runPaymentsCreditsRequestShowCmd(paymentsOpts);
+          return;
+        }
+        if (action === "claim-invite") {
+          process.exitCode = await runPaymentsCreditsRequestClaimInviteCmd(paymentsOpts);
+          return;
+        }
+        if (action === "accept") {
+          process.exitCode = await runPaymentsCreditsRequestAcceptCmd(paymentsOpts);
+          return;
+        }
+        if (action === "decline") {
+          process.exitCode = await runPaymentsCreditsRequestDeclineCmd(paymentsOpts);
+          return;
+        }
+        if (action === "cancel") {
+          process.exitCode = await runPaymentsCreditsRequestCancelCmd(paymentsOpts);
+          return;
+        }
+        process.exitCode =
+          creditsAction === "invoice"
+            ? await runPaymentsCreditsInvoiceCmd(paymentsOpts)
+            : await runPaymentsCreditsRequestCreateCmd(paymentsOpts);
+        return;
+      }
       if (creditsAction === "directory") {
         const dirAction = rest[1] ?? "list";
         if (dirAction === "claim") {
@@ -1383,7 +1449,7 @@ async function main(): Promise<void> {
         return;
       }
       console.error(
-        "Usage: clawql payments credits show | bank-link | topup | pay | transfer | directory | step-up"
+        "Usage: clawql payments credits show | bank-link | topup | pay | transfer | request|invoice | directory | step-up"
       );
       process.exitCode = 1;
       return;

--- a/src/onboarding/payments-cli.ts
+++ b/src/onboarding/payments-cli.ts
@@ -39,6 +39,14 @@ import {
   runPaymentsCreditsDirectoryShow,
   runPaymentsCreditsDirectoryList,
   runPaymentsCreditsDirectoryRelease,
+  runPaymentsCreditsRequestCreate,
+  runPaymentsCreditsInvoice,
+  runPaymentsCreditsRequestList,
+  runPaymentsCreditsRequestShow,
+  runPaymentsCreditsRequestClaimInvite,
+  runPaymentsCreditsRequestAccept,
+  runPaymentsCreditsRequestDecline,
+  runPaymentsCreditsRequestCancel,
   runPaymentsCreditsStepUpEnroll,
   runPaymentsCreditsStepUpShow,
   runPaymentsCompensationBalance,
@@ -85,6 +93,10 @@ export type PaymentsCliOptions = {
   /** Venmo-style payee from context-aware --to */
   payTo?: string;
   displayName?: string;
+  requestId?: string;
+  inviteToken?: string;
+  requestRole?: "requester" | "payer" | "any";
+  requestStatus?: string;
   idempotencyKey?: string;
   note?: string;
   totp?: string;
@@ -516,6 +528,104 @@ export async function runPaymentsCreditsDirectoryReleaseCmd(
   return runPaymentsCreditsDirectoryRelease({
     handle: options.handle ?? options.toHandle,
     email: options.directoryEmail ?? options.email,
+    json: options.json,
+  });
+}
+
+export async function runPaymentsCreditsRequestCreateCmd(
+  options: PaymentsCliOptions = {}
+): Promise<number> {
+  return runPaymentsCreditsRequestCreate({
+    fromTenantId: options.fromTenantId,
+    tenantId: options.tenantId,
+    payTo: options.payTo,
+    toHandle: options.toHandle ?? options.handle,
+    toTenantId: options.toTenantId,
+    email: options.directoryEmail ?? options.email,
+    amountUsd: options.amount,
+    note: options.note,
+    correlationId: options.correlationId,
+    json: options.json,
+  });
+}
+
+export async function runPaymentsCreditsInvoiceCmd(
+  options: PaymentsCliOptions = {}
+): Promise<number> {
+  return runPaymentsCreditsInvoice({
+    fromTenantId: options.fromTenantId,
+    tenantId: options.tenantId,
+    payTo: options.payTo,
+    toHandle: options.toHandle ?? options.handle,
+    toTenantId: options.toTenantId,
+    email: options.directoryEmail ?? options.email,
+    amountUsd: options.amount,
+    note: options.note,
+    correlationId: options.correlationId,
+    json: options.json,
+  });
+}
+
+export async function runPaymentsCreditsRequestListCmd(
+  options: PaymentsCliOptions = {}
+): Promise<number> {
+  return runPaymentsCreditsRequestList({
+    tenantId: options.tenantId ?? options.fromTenantId,
+    role: options.requestRole,
+    status: options.requestStatus,
+    json: options.json,
+  });
+}
+
+export async function runPaymentsCreditsRequestShowCmd(
+  options: PaymentsCliOptions = {}
+): Promise<number> {
+  return runPaymentsCreditsRequestShow({
+    requestId: options.requestId,
+    json: options.json,
+  });
+}
+
+export async function runPaymentsCreditsRequestClaimInviteCmd(
+  options: PaymentsCliOptions = {}
+): Promise<number> {
+  return runPaymentsCreditsRequestClaimInvite({
+    requestId: options.requestId,
+    inviteToken: options.inviteToken,
+    tenantId: options.tenantId,
+    email: options.directoryEmail ?? options.email,
+    handle: options.handle ?? options.toHandle,
+    displayName: options.displayName ?? options.name,
+    json: options.json,
+  });
+}
+
+export async function runPaymentsCreditsRequestAcceptCmd(
+  options: PaymentsCliOptions = {}
+): Promise<number> {
+  return runPaymentsCreditsRequestAccept({
+    requestId: options.requestId,
+    tenantId: options.tenantId ?? options.fromTenantId,
+    json: options.json,
+  });
+}
+
+export async function runPaymentsCreditsRequestDeclineCmd(
+  options: PaymentsCliOptions = {}
+): Promise<number> {
+  return runPaymentsCreditsRequestDecline({
+    requestId: options.requestId,
+    tenantId: options.tenantId ?? options.fromTenantId,
+    json: options.json,
+  });
+}
+
+export async function runPaymentsCreditsRequestCancelCmd(
+  options: PaymentsCliOptions = {}
+): Promise<number> {
+  return runPaymentsCreditsRequestCancel({
+    requestId: options.requestId,
+    tenantId: options.tenantId ?? options.fromTenantId,
     json: options.json,
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Request money / invoice others — especially **by email**, with an **invite** when they’re not on ClawQL yet.

Accept stages a normal credits transfer (same confirm + optional TOTP as `pay`). Alias: `credits invoice`.

## Stacked on

[#824](https://github.com/danielsmithdevelopment/ClawQL/pull/824) (directory email + `@username` + pay).

## Flow

1. `credits request --to newbie@acme.com --amount 25` (or `@bob` / on-platform email)
2. If unknown email → **invite URL + one-time token** (SHA-256 stored; cleartext once)
3. Invitee: `request claim-invite --token … --tenant-id …` → directory claim
4. Payer: `request accept` → stages transfer
5. `transfer --confirm` → money moves; request marked **paid**

## Surface

| Surface | Detail |
| ------- | ------ |
| Store | `$CLAWQL_HOME/Payments/money-requests.json` (`0600`) |
| CLI | `request` / `invoice` create, list, show, accept, decline, cancel, claim-invite |
| MCP | `payments_credits_request_{create,list,claim_invite,accept}` |
| Docs | [`docs/payments/money-requests.md`](docs/payments/money-requests.md) |

## Not in this PR

- Actually **sending** the invite email (SES/SendGrid) — CLI prints `inviteUrl` for now
- Activity feed / QR / hosted UI

## Test plan

- [x] `requests.test.ts` (invite, accept→paid, decline/cancel)
- [x] directory / transfer / tools plugin
- [x] payments typecheck
- [ ] CI green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

