### PR TITLE
feat(payments): HATEOAS/HTMX deep links and QR for credits P2P

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -470,6 +470,12 @@
 # CLAWQL_CUCKOO_METRICS=1
 # CLAWQL_MERKLE_ENABLED=1
 
+# Prepaid credits P2P deep links / HTMX (docs/payments/credits-deeplinks.md)
+# CLAWQL_CREDITS_ENABLED=1
+# CLAWQL_CREDITS_HATEOAS_BASE=https://gateway.example   # else CLAWQL_COMPENSATION_APPROVAL_BASE / clawql://tool
+# CLAWQL_COMPENSATION_APPROVAL_BASE=https://gateway.example
+# CLAWQL_PAYMENTS_MCP_TOOLS=1   # includes payments_credits_link
+
 # ─── 11. Sandbox (`sandbox_exec`) — default off; CLAWQL_ENABLE_SANDBOX=1 ──
 # CLAWQL_ENABLE_SANDBOX=1
 # Backend: omit = bridge only. auto = prefer Seatbelt, then Docker CLI, then bridge (when URL+token below).

--- a/docs/payments/credits-ach.md
+++ b/docs/payments/credits-ach.md
@@ -51,6 +51,7 @@ ACH can take **1–3 business days**. Credits settle on `payment_intent.succeede
 | `CLAWQL_CREDITS_RETURN_URL`            | —                                     | Optional return URL for Financial Connections                   |
 | `CLAWQL_CREDITS_TRANSFER_DIRECT`       | off                                   | Skip stage/confirm (break-glass / tests only)                   |
 | `CLAWQL_CREDITS_TRANSFER_REQUIRE_TOTP` | off                                   | Require enrolled TOTP on transfer confirm                       |
+| `CLAWQL_CREDITS_HATEOAS_BASE`          | compensation / `clawql://tool`        | Public origin for pay/request/invite deep links + HTMX          |
 
 ## CLI
 

--- a/docs/payments/credits-deeplinks.md
+++ b/docs/payments/credits-deeplinks.md
@@ -1,0 +1,52 @@
+# Credits deep links (HATEOAS / HTMX / QR)
+
+Shareable pay and money-request links for prepaid P2P — same addressing as `credits pay` / `credits request`, without moving money until stage → confirm.
+
+## URLs
+
+| Kind | Shape |
+| ---- | ----- |
+| Pay (HTTP) | `{base}/credits/pay?to=@bob&amount=10&note=coffee` |
+| Pay (scheme) | `clawql://pay?to=@bob&amount=10` |
+| Request | `{base}/credits/request/{requestId}` |
+| Invite | `{base}/credits/request/invite?request_id=…&token=…` |
+| QR SVG | `{base}/credits/qr.svg?to=…&amount=…` (encodes `clawql://pay?…`) |
+
+`base` comes from **`CLAWQL_CREDITS_HATEOAS_BASE`**, else `CLAWQL_COMPENSATION_APPROVAL_BASE` / gateway URL, else `clawql://tool` (same fallback as compensation approval links).
+
+## Gateway routes
+
+When the MCP HTTP server is up, these are mounted under `/credits/*` with minimal HTMX pages:
+
+- **GET** `/credits/pay` — landing + CLI hint + QR (Accept: HTML or JSON HATEOAS envelope)
+- **GET** `/credits/qr.svg` — payment QR
+- **GET** `/credits/request/invite` — claim form (token-gated)
+- **POST** `/credits/request/invite/claim` — HTMX claim
+- **GET** `/credits/request/:id` — status + accept/decline forms
+- **POST** `…/accept` — stages transfer (still needs `transfer --confirm`)
+- **POST** `…/decline`
+
+Put these behind gateway auth in production; accept only **stages** — confirm (+ optional TOTP) remains the money-moving gate.
+
+## CLI
+
+```bash
+export CLAWQL_CREDITS_HATEOAS_BASE=https://gateway.example
+
+clawql payments credits link --to @bob --amount 10 --note coffee
+clawql payments credits link --request-id UUID
+clawql payments credits link --parse 'clawql://pay?to=@bob&amount=10'
+clawql payments credits qr --to bob@acme.com --amount 5 --out pay.svg
+```
+
+## MCP
+
+`payments_credits_link` when `CLAWQL_PAYMENTS_MCP_TOOLS=1` — returns HATEOAS envelope; optional `includeQrSvg`.
+
+## Env
+
+| Variable | Default | Meaning |
+| -------- | ------- | ------- |
+| `CLAWQL_CREDITS_HATEOAS_BASE` | (compensation / `clawql://tool`) | Public origin for pay/request/invite URLs |
+
+See also: [money requests](./money-requests.md), [activity feed](./activity-feed.md), [consumer roadmap](./p2p-consumer-roadmap.md).

--- a/docs/payments/money-requests.md
+++ b/docs/payments/money-requests.md
@@ -78,5 +78,8 @@ clawql payments credits request decline|cancel --request-id UUID
 | Variable | Default | Meaning |
 | -------- | ------- | ------- |
 | `CLAWQL_CREDITS_REQUEST_TTL_SEC` | 7 days | Request expiry |
+| `CLAWQL_CREDITS_HATEOAS_BASE` | compensation / `clawql://tool` | Public origin for invite / request deep links |
 
-See also: [consumer roadmap](./p2p-consumer-roadmap.md), [credits ACH / P2P](./credits-ach.md).
+Invite URLs use the [deep link](./credits-deeplinks.md) builders (`/credits/request/invite?request_id=…&token=…`). Print the URL for now — outbound email is deferred.
+
+See also: [consumer roadmap](./p2p-consumer-roadmap.md), [credits ACH / P2P](./credits-ach.md), [deep links](./credits-deeplinks.md).

--- a/docs/payments/p2p-consumer-roadmap.md
+++ b/docs/payments/p2p-consumer-roadmap.md
@@ -15,6 +15,7 @@ ClawQL is **not** a consumer bank. Balances are prepaid credits; bank/USDC off-r
 | `credits pay --to email\|@user` | ✅ | Alias over transfer + directory resolve |
 | Request / invoice + email invite | ✅ | [`money-requests.md`](./money-requests.md) |
 | Activity feed | ✅ | [`activity-feed.md`](./activity-feed.md) |
+| QR / deep links (HATEOAS + HTMX) | ✅ | [`credits-deeplinks.md`](./credits-deeplinks.md) |
 | OIDC / MFA policy (gateway) | ✅ (stacked) | [`clawql-auth-oidc-stepup.md`](../security/clawql-auth-oidc-stepup.md) |
 
 ## Addressing model
@@ -31,7 +32,7 @@ Emails are stored only under `$CLAWQL_HOME/Payments/directory.json` (mode `0600`
 
 1. ~~**Request money**~~ — ✅ email invoice + invite — [`money-requests.md`](./money-requests.md)
 2. ~~**Activity feed**~~ — ✅ [`activity-feed.md`](./activity-feed.md)
-3. **QR / deep link** — `clawql://pay/@bob?amount=10` / request invite deep links
+3. ~~**QR / deep link**~~ — ✅ HATEOAS + HTMX + `clawql://pay` — [`credits-deeplinks.md`](./credits-deeplinks.md)
 4. **Contacts** — optional phone → email (customer IdP or verified claim; not a full IdP)
 5. **Hosted mini UI** — one-screen pay/request (brand-first; not a dashboard)
 6. **Outbound email delivery** — optional later (invite URL print is enough for now)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5637,6 +5637,16 @@
                 "pg-types": "^2.2.0"
             }
         },
+        "node_modules/@types/qrcode": {
+            "version": "1.5.6",
+            "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+            "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/qs": {
             "version": "6.15.1",
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
@@ -6475,6 +6485,15 @@
                 "tslib": "^2.0.3"
             }
         },
+        "node_modules/camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/capital-case": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
@@ -6879,6 +6898,15 @@
                 }
             }
         },
+        "node_modules/decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -6912,6 +6940,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/dijkstrajs": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+            "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+            "license": "MIT"
         },
         "node_modules/dom-serializer": {
             "version": "2.0.0",
@@ -10448,6 +10482,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -10749,7 +10792,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -10949,6 +10991,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/pngjs": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+            "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.13.0"
             }
         },
         "node_modules/postcss": {
@@ -11224,6 +11275,141 @@
             ],
             "license": "MIT"
         },
+        "node_modules/qrcode": {
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+            "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+            "license": "MIT",
+            "dependencies": {
+                "dijkstrajs": "^1.0.1",
+                "pngjs": "^5.0.0",
+                "yargs": "^15.3.1"
+            },
+            "bin": {
+                "qrcode": "bin/qrcode"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/qrcode/node_modules/cliui": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+            "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^6.2.0"
+            }
+        },
+        "node_modules/qrcode/node_modules/find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/qrcode/node_modules/locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/qrcode/node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "license": "MIT",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/qrcode/node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/qrcode/node_modules/wrap-ansi": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/qrcode/node_modules/y18n": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+            "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+            "license": "ISC"
+        },
+        "node_modules/qrcode/node_modules/yargs": {
+            "version": "15.4.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^6.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^4.1.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^4.2.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^18.1.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/qrcode/node_modules/yargs-parser": {
+            "version": "18.1.3",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+            "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+            "license": "ISC",
+            "dependencies": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/qs": {
             "version": "6.15.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
@@ -11329,6 +11515,12 @@
             "engines": {
                 "node": ">=9.3.0 || >=8.10.0 <9.0.0"
             }
+        },
+        "node_modules/require-main-filename": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+            "license": "ISC"
         },
         "node_modules/resolve-from": {
             "version": "5.0.0",
@@ -11523,6 +11715,12 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
             }
+        },
+        "node_modules/set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+            "license": "ISC"
         },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
@@ -13142,6 +13340,12 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/which-module": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+            "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+            "license": "ISC"
+        },
         "node_modules/why-is-node-running": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -13649,6 +13853,7 @@
                 "effect": "^3.21.4",
                 "nats": "^2.29.3",
                 "pg": "^8.21.0",
+                "qrcode": "^1.5.4",
                 "stripe": "^22.3.2",
                 "zod": "^4.3.6"
             },
@@ -13657,6 +13862,7 @@
             },
             "devDependencies": {
                 "@types/node": "^26.1.1",
+                "@types/qrcode": "^1.5.6",
                 "tsup": "^8.3.0",
                 "typescript": "^6.0.3",
                 "vitest": "^4.1.1"

--- a/packages/clawql-payments/package.json
+++ b/packages/clawql-payments/package.json
@@ -111,6 +111,7 @@
     "effect": "^3.21.4",
     "nats": "^2.29.3",
     "pg": "^8.21.0",
+    "qrcode": "^1.5.4",
     "stripe": "^22.3.2",
     "zod": "^4.3.6"
   },
@@ -120,6 +121,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.1",
+    "@types/qrcode": "^1.5.6",
     "tsup": "^8.3.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.1"

--- a/packages/clawql-payments/src/cli/credits.ts
+++ b/packages/clawql-payments/src/cli/credits.ts
@@ -28,8 +28,20 @@ import {
   publicMoneyRequest,
 } from "../credits/requests.js";
 import { formatActivityLine, getActivityFeed } from "../credits/activity.js";
+import {
+  buildClawqlPayUri,
+  buildPayDeepLink,
+  buildPayQrPayload,
+  buildRequestDeepLink,
+  creditsHateoasBase,
+  parseCreditsDeepLink,
+  payCliHint,
+  payHateoasEnvelope,
+} from "../credits/deeplinks.js";
+import { renderQrSvg } from "../credits/hateoas-html.js";
 import { runPaymentsEffect } from "../runtime/payments-effect-runtime.js";
 import { loadPaymentsConfig } from "../config/store.js";
+import { writeFile } from "node:fs/promises";
 
 export type PaymentsCreditsShowOptions = {
   tenantId?: string;
@@ -905,6 +917,150 @@ export async function runPaymentsCreditsRequestCancel(
       return 0;
     }
     console.log(`Cancelled request ${req.requestId}`);
+    return 0;
+  } catch (err) {
+    console.error(formatErr(err));
+    return 1;
+  }
+}
+
+export type PaymentsCreditsLinkOptions = {
+  /** Payee for a pay link: email | @handle | tenant. */
+  payTo?: string;
+  toHandle?: string;
+  amountUsd?: number;
+  note?: string;
+  fromTenantId?: string;
+  /** Emit a request deep link instead of pay. */
+  requestId?: string;
+  /** Parse an existing deep link / clawql:// URI and print CLI hint. */
+  parse?: string;
+  /** Write QR SVG to this path (implies qr mode when used with `qr` command). */
+  out?: string;
+  json?: boolean;
+};
+
+function resolvePayeeForLink(options: PaymentsCreditsLinkOptions): string | undefined {
+  return options.payTo?.trim() || options.toHandle?.trim();
+}
+
+/** Print HATEOAS / clawql:// pay (or request) deep links. */
+export async function runPaymentsCreditsLink(
+  options: PaymentsCreditsLinkOptions = {}
+): Promise<number> {
+  if (options.parse?.trim()) {
+    const parsed = parseCreditsDeepLink(options.parse);
+    if (!parsed.ok) {
+      console.error(parsed.error);
+      return 1;
+    }
+    const { ok: _ok, ...pay } = parsed;
+    if (options.json) {
+      console.log(JSON.stringify(payHateoasEnvelope(pay), null, 2));
+      return 0;
+    }
+    console.log(payCliHint(pay));
+    console.log(buildPayDeepLink(pay));
+    console.log(buildClawqlPayUri(pay));
+    return 0;
+  }
+
+  const requestId = options.requestId?.trim();
+  if (requestId) {
+    const url = buildRequestDeepLink({ requestId });
+    if (options.json) {
+      console.log(
+        JSON.stringify(
+          {
+            ok: true,
+            kind: "credits.request",
+            links: { self: url, approval_url: url },
+            approval_url: url,
+            base: creditsHateoasBase(),
+          },
+          null,
+          2
+        )
+      );
+      return 0;
+    }
+    console.log(url);
+    return 0;
+  }
+
+  const to = resolvePayeeForLink(options);
+  if (!to) {
+    console.error(
+      "Usage: clawql payments credits link --to bob@acme.com|--to @bob [--amount 10] [--note …]\n" +
+        "       clawql payments credits link --request-id UUID\n" +
+        "       clawql payments credits link --parse 'clawql://pay?to=@bob&amount=10'"
+    );
+    return 1;
+  }
+  const pay = {
+    to,
+    amountUsd: options.amountUsd,
+    note: options.note,
+    fromTenantId: options.fromTenantId,
+  };
+  const envelope = payHateoasEnvelope(pay);
+  if (options.json) {
+    console.log(JSON.stringify(envelope, null, 2));
+    return 0;
+  }
+  console.log(envelope.links.self);
+  console.log(envelope.links.clawql);
+  console.log(`CLI: ${envelope.links.cli}`);
+  console.log(`HATEOAS base: ${creditsHateoasBase()}`);
+  return 0;
+}
+
+/** Generate a pay QR (SVG) to stdout or --out file. */
+export async function runPaymentsCreditsQr(
+  options: PaymentsCreditsLinkOptions = {}
+): Promise<number> {
+  const to = resolvePayeeForLink(options);
+  if (!to) {
+    console.error(
+      "Usage: clawql payments credits qr --to bob@acme.com|--to @bob [--amount 10] [--note …] [--out pay.svg]"
+    );
+    return 1;
+  }
+  const pay = {
+    to,
+    amountUsd: options.amountUsd,
+    note: options.note,
+    fromTenantId: options.fromTenantId,
+  };
+  const payload = buildPayQrPayload(pay);
+  try {
+    const svg = await renderQrSvg(payload);
+    const out = options.out?.trim();
+    if (out) {
+      await writeFile(out, svg, "utf8");
+      if (!options.json) {
+        console.log(`Wrote QR for ${payload} → ${out}`);
+      }
+    } else if (!options.json) {
+      process.stdout.write(svg);
+      if (!svg.endsWith("\n")) process.stdout.write("\n");
+    }
+    if (options.json) {
+      console.log(
+        JSON.stringify(
+          {
+            ok: true,
+            payload,
+            http: buildPayDeepLink(pay),
+            clawql: buildClawqlPayUri(pay),
+            out: out ?? null,
+            svg: out ? undefined : svg,
+          },
+          null,
+          2
+        )
+      );
+    }
     return 0;
   } catch (err) {
     console.error(formatErr(err));

--- a/packages/clawql-payments/src/cli/index.ts
+++ b/packages/clawql-payments/src/cli/index.ts
@@ -80,6 +80,8 @@ export {
   runPaymentsCreditsRequestAccept,
   runPaymentsCreditsRequestDecline,
   runPaymentsCreditsRequestCancel,
+  runPaymentsCreditsLink,
+  runPaymentsCreditsQr,
   runPaymentsCreditsStepUpEnroll,
   runPaymentsCreditsStepUpShow,
   type PaymentsCreditsShowOptions,
@@ -89,6 +91,7 @@ export {
   type PaymentsCreditsActivityOptions,
   type PaymentsCreditsDirectoryOptions,
   type PaymentsCreditsRequestOptions,
+  type PaymentsCreditsLinkOptions,
   type PaymentsCreditsStepUpOptions,
 } from "./credits.js";
 export {

--- a/packages/clawql-payments/src/credits/deeplinks.test.ts
+++ b/packages/clawql-payments/src/credits/deeplinks.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildClawqlPayUri,
+  buildInviteDeepLink,
+  buildPayDeepLink,
+  buildPayQrPayload,
+  buildRequestDeepLink,
+  creditsHateoasBase,
+  isHttpCreditsHateoasBase,
+  parseCreditsDeepLink,
+  payCliHint,
+  payHateoasEnvelope,
+} from "./deeplinks.js";
+
+describe("credits deeplinks", () => {
+  const prev = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...prev };
+  });
+
+  it("falls back to compensation / clawql://tool base", () => {
+    delete process.env.CLAWQL_CREDITS_HATEOAS_BASE;
+    delete process.env.CLAWQL_COMPENSATION_APPROVAL_BASE;
+    delete process.env.CLAWQL_OUROBOROS_GATEWAY_URL;
+    expect(creditsHateoasBase()).toBe("clawql://tool");
+    expect(isHttpCreditsHateoasBase()).toBe(false);
+  });
+
+  it("builds http pay + invite links when base is set", () => {
+    process.env.CLAWQL_CREDITS_HATEOAS_BASE = "https://pay.example/";
+    expect(isHttpCreditsHateoasBase()).toBe(true);
+    expect(
+      buildPayDeepLink({ to: "@bob", amountUsd: 10, note: "coffee" })
+    ).toBe("https://pay.example/credits/pay?to=%40bob&amount=10&note=coffee");
+    expect(buildRequestDeepLink({ requestId: "req-1" })).toBe(
+      "https://pay.example/credits/request/req-1"
+    );
+    expect(buildInviteDeepLink({ requestId: "req-1", token: "tok" })).toMatch(
+      /https:\/\/pay\.example\/credits\/request\/invite\?request_id=req-1&token=tok/
+    );
+  });
+
+  it("builds clawql:// pay URI and QR payload", () => {
+    const uri = buildClawqlPayUri({ to: "bob@acme.com", amountUsd: 5 });
+    expect(uri).toBe("clawql://pay?to=bob%40acme.com&amount=5");
+    expect(buildPayQrPayload({ to: "@bob", amountUsd: 1 })).toBe(
+      "clawql://pay?to=%40bob&amount=1"
+    );
+  });
+
+  it("parses clawql and http pay links", () => {
+    const a = parseCreditsDeepLink("clawql://pay?to=@bob&amount=10&note=hi");
+    expect(a).toMatchObject({ ok: true, to: "@bob", amountUsd: 10, note: "hi" });
+    process.env.CLAWQL_CREDITS_HATEOAS_BASE = "https://pay.example";
+    const b = parseCreditsDeepLink(
+      buildPayDeepLink({ to: "alice@acme.com", amountUsd: 2.5 })
+    );
+    expect(b).toMatchObject({ ok: true, to: "alice@acme.com", amountUsd: 2.5 });
+  });
+
+  it("payCliHint and envelope include HATEOAS links", () => {
+    process.env.CLAWQL_CREDITS_HATEOAS_BASE = "https://pay.example";
+    const pay = { to: "@bob", amountUsd: 10 };
+    expect(payCliHint(pay)).toContain("credits pay");
+    expect(payCliHint(pay)).toContain("--to @bob");
+    const env = payHateoasEnvelope(pay);
+    expect(env.links.self).toContain("/credits/pay?");
+    expect(env.links.clawql).toMatch(/^clawql:\/\/pay\?/);
+    expect(env.approval_url).toBe(env.links.self);
+  });
+});

--- a/packages/clawql-payments/src/credits/deeplinks.ts
+++ b/packages/clawql-payments/src/credits/deeplinks.ts
@@ -1,0 +1,199 @@
+/**
+ * HATEOAS deep links for prepaid P2P (pay / request / invite).
+ * Base matches compensation approval URLs so HTMX/gateway can host GET-safe views.
+ */
+
+import { compensationApprovalBaseUrl } from "../compensation/config.js";
+
+export function creditsHateoasBase(env: NodeJS.ProcessEnv = process.env): string {
+  return (
+    env.CLAWQL_CREDITS_HATEOAS_BASE?.trim() ||
+    compensationApprovalBaseUrl(env)
+  ).replace(/\/$/, "");
+}
+
+/** True when the configured HATEOAS base is an http(s) origin (mountable HTML). */
+export function isHttpCreditsHateoasBase(env: NodeJS.ProcessEnv = process.env): boolean {
+  const base = creditsHateoasBase(env);
+  return /^https?:\/\//i.test(base);
+}
+
+export type PayDeepLink = {
+  to: string;
+  amountUsd?: number;
+  note?: string;
+  fromTenantId?: string;
+};
+
+export type RequestDeepLink = {
+  requestId: string;
+};
+
+export type InviteDeepLink = {
+  requestId: string;
+  token: string;
+};
+
+export function buildPayDeepLink(
+  input: PayDeepLink,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const base = creditsHateoasBase(env);
+  const q = new URLSearchParams();
+  q.set("to", input.to.trim());
+  if (input.amountUsd !== undefined && Number.isFinite(input.amountUsd)) {
+    q.set("amount", String(input.amountUsd));
+  }
+  if (input.note?.trim()) q.set("note", input.note.trim());
+  if (input.fromTenantId?.trim()) q.set("from", input.fromTenantId.trim());
+  return `${base}/credits/pay?${q.toString()}`;
+}
+
+export function buildRequestDeepLink(
+  input: RequestDeepLink,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const base = creditsHateoasBase(env);
+  return `${base}/credits/request/${encodeURIComponent(input.requestId.trim())}`;
+}
+
+export function buildInviteDeepLink(
+  input: InviteDeepLink,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const base = creditsHateoasBase(env);
+  const q = new URLSearchParams({
+    request_id: input.requestId.trim(),
+    token: input.token.trim(),
+  });
+  return `${base}/credits/request/invite?${q.toString()}`;
+}
+
+/** clawql:// convenience alias (always scheme-based, ignores HTTP base). */
+export function buildClawqlPayUri(input: PayDeepLink): string {
+  const q = new URLSearchParams();
+  q.set("to", input.to.trim());
+  if (input.amountUsd !== undefined && Number.isFinite(input.amountUsd)) {
+    q.set("amount", String(input.amountUsd));
+  }
+  if (input.note?.trim()) q.set("note", input.note.trim());
+  if (input.fromTenantId?.trim()) q.set("from", input.fromTenantId.trim());
+  return `clawql://pay?${q.toString()}`;
+}
+
+/** Payload preferred for QR codes — scheme URI so scanners work without an HTTP host. */
+export function buildPayQrPayload(input: PayDeepLink): string {
+  return buildClawqlPayUri(input);
+}
+
+export function parsePayDeepLinkQuery(
+  query: Record<string, string | string[] | undefined>
+): PayDeepLink {
+  const get = (k: string) => {
+    const v = query[k];
+    return Array.isArray(v) ? v[0] : v;
+  };
+  const to = get("to")?.trim();
+  if (!to) throw new Error("Missing to= payee");
+  const amountRaw = get("amount");
+  const amountUsd =
+    amountRaw && Number.isFinite(Number(amountRaw)) ? Number(amountRaw) : undefined;
+  return {
+    to,
+    amountUsd,
+    note: get("note")?.trim() || undefined,
+    fromTenantId: get("from")?.trim() || undefined,
+  };
+}
+
+/**
+ * Parse `clawql://pay?…`, absolute HATEOAS pay URLs, or bare query strings.
+ */
+export function parseCreditsDeepLink(raw: string):
+  | ({ ok: true } & PayDeepLink)
+  | { ok: false; error: string } {
+  const trimmed = raw.trim();
+  if (!trimmed) return { ok: false, error: "Empty deep link" };
+  try {
+    let query: Record<string, string | string[] | undefined>;
+    if (trimmed.startsWith("clawql://pay")) {
+      const u = new URL(trimmed.replace(/^clawql:/, "http:"));
+      query = Object.fromEntries(u.searchParams.entries());
+    } else if (trimmed.includes("://") || trimmed.startsWith("/")) {
+      const u = new URL(trimmed, "http://local.invalid");
+      if (!u.pathname.includes("/credits/pay")) {
+        return { ok: false, error: "Not a credits pay deep link" };
+      }
+      query = Object.fromEntries(u.searchParams.entries());
+    } else if (trimmed.includes("=")) {
+      query = Object.fromEntries(new URLSearchParams(trimmed).entries());
+    } else {
+      return { ok: false, error: "Unrecognized deep link format" };
+    }
+    return { ok: true, ...parsePayDeepLinkQuery(query) };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+export function payCliHint(input: PayDeepLink): string {
+  const parts = ["clawql payments credits pay", `--to ${shellQuote(input.to)}`];
+  if (input.amountUsd !== undefined) parts.push(`--amount ${input.amountUsd}`);
+  if (input.note) parts.push(`--note ${shellQuote(input.note)}`);
+  if (input.fromTenantId) parts.push(`--from-tenant ${shellQuote(input.fromTenantId)}`);
+  return parts.join(" ");
+}
+
+function shellQuote(s: string): string {
+  if (/^[a-zA-Z0-9@._+-]+$/.test(s)) return s;
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+export type HateoasLinkMap = {
+  self: string;
+  cli?: string;
+  qr?: string;
+  invite?: string;
+  accept?: string;
+  decline?: string;
+  claim?: string;
+  clawql?: string;
+  /** Next step (DAOS-style approval_url thread). */
+  approval_url?: string | null;
+};
+
+export type HateoasEnvelope = {
+  ok: boolean;
+  kind: string;
+  summary: string;
+  data: Record<string, unknown>;
+  links: HateoasLinkMap;
+  approval_url: string | null;
+};
+
+export function payHateoasEnvelope(
+  input: PayDeepLink,
+  env: NodeJS.ProcessEnv = process.env
+): HateoasEnvelope {
+  const self = buildPayDeepLink(input, env);
+  const clawql = buildClawqlPayUri(input);
+  const cli = payCliHint(input);
+  return {
+    ok: true,
+    kind: "credits.pay",
+    summary: `Pay ${input.amountUsd != null ? `$${input.amountUsd}` : "credits"} to ${input.to}`,
+    data: { ...input },
+    links: {
+      self,
+      clawql,
+      cli,
+      qr: `${creditsHateoasBase(env)}/credits/qr.svg?${new URLSearchParams({
+        to: input.to,
+        ...(input.amountUsd != null ? { amount: String(input.amountUsd) } : {}),
+        ...(input.note ? { note: input.note } : {}),
+      }).toString()}`,
+      approval_url: self,
+    },
+    approval_url: self,
+  };
+}

--- a/packages/clawql-payments/src/credits/hateoas-html.ts
+++ b/packages/clawql-payments/src/credits/hateoas-html.ts
@@ -1,0 +1,120 @@
+/**
+ * Minimal HTMX-friendly HTML for credits HATEOAS views (GET-safe by default).
+ */
+
+import QRCode from "qrcode";
+import type { HateoasEnvelope } from "./deeplinks.js";
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export function escapeHtml(s: string): string {
+  return esc(s);
+}
+
+export async function renderQrSvg(payload: string): Promise<string> {
+  return QRCode.toString(payload, {
+    type: "svg",
+    errorCorrectionLevel: "M",
+    margin: 2,
+    width: 256,
+  });
+}
+
+export function renderHateoasHtml(input: {
+  title: string;
+  summary: string;
+  envelope: HateoasEnvelope;
+  bodyHtml: string;
+}): string {
+  const links = Object.entries(input.envelope.links)
+    .filter(([, v]) => v)
+    .map(
+      ([rel, href]) =>
+        `<li><a rel="${esc(rel)}" href="${esc(String(href))}">${esc(rel)}</a></li>`
+    )
+    .join("\n");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${esc(input.title)} · ClawQL</title>
+  <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LPqG9RFHx" crossorigin="anonymous"></script>
+  <style>
+    :root { --ink:#0f172a; --muted:#475569; --line:#e2e8f0; --bg:#f8fafc; --accent:#0f766e; --err:#b91c1c; }
+    body { margin:0; font-family: ui-sans-serif, system-ui, sans-serif; color:var(--ink); background:linear-gradient(180deg,#ecfeff 0%, var(--bg) 40%); min-height:100vh; }
+    main { max-width:36rem; margin:0 auto; padding:2rem 1.25rem 3rem; }
+    h1 { font-size:1.5rem; letter-spacing:-0.02em; margin:0 0 .35rem; }
+    .brand { font-weight:700; color:var(--accent); font-size:.85rem; text-transform:uppercase; letter-spacing:.08em; }
+    .summary { color:var(--muted); margin:0 0 1.25rem; line-height:1.45; }
+    .panel { background:#fff; border:1px solid var(--line); border-radius:12px; padding:1.1rem 1.2rem; margin-bottom:1rem; }
+    label { display:block; font-size:.8rem; color:var(--muted); margin:.65rem 0 .25rem; }
+    input { width:100%; box-sizing:border-box; padding:.55rem .65rem; border:1px solid var(--line); border-radius:8px; font:inherit; }
+    button, .btn { display:inline-block; margin-top:.9rem; margin-right:.5rem; background:var(--accent); color:#fff; border:0; border-radius:8px; padding:.55rem .9rem; font:inherit; cursor:pointer; text-decoration:none; }
+    .btn.secondary { background:#fff; color:var(--ink); border:1px solid var(--line); }
+    code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size:.8rem; }
+    pre { background:#0f172a; color:#e2e8f0; padding:.75rem; border-radius:8px; overflow:auto; }
+    ul.links { padding-left:1.1rem; color:var(--muted); }
+    .meta { font-size:.85rem; color:var(--muted); }
+    .muted { color:var(--muted); }
+    .err { color:var(--err); }
+    dt { font-size:.75rem; color:var(--muted); margin-top:.5rem; }
+    dd { margin:0 0 .25rem; }
+  </style>
+</head>
+<body>
+  <main>
+    <div class="brand">ClawQL Payments</div>
+    <h1>${esc(input.title)}</h1>
+    <p class="summary">${esc(input.summary)}</p>
+    <div id="view" class="panel">
+      ${input.bodyHtml}
+    </div>
+    <div class="panel">
+      <div class="meta">HATEOAS links</div>
+      <ul class="links">${links || "<li>(none)</li>"}</ul>
+    </div>
+  </main>
+</body>
+</html>`;
+}
+
+/** Convenience wrapper when you only need title + body (empty link map). */
+export function renderCreditsHateoasPage(input: {
+  title: string;
+  heading?: string;
+  summary?: string;
+  bodyHtml: string;
+  envelope?: HateoasEnvelope;
+}): string {
+  const envelope =
+    input.envelope ??
+    ({
+      ok: true,
+      kind: "credits.view",
+      summary: input.summary ?? input.heading ?? input.title,
+      data: {},
+      links: { self: "#" },
+      approval_url: null,
+    } satisfies HateoasEnvelope);
+  return renderHateoasHtml({
+    title: input.heading ?? input.title,
+    summary: input.summary ?? envelope.summary,
+    envelope,
+    bodyHtml: input.bodyHtml,
+  });
+}
+
+export function wantsHtml(acceptHeader: string | undefined): boolean {
+  const a = (acceptHeader ?? "").toLowerCase();
+  if (a.includes("application/json") && !a.includes("text/html")) return false;
+  if (a.includes("text/html")) return true;
+  return a.includes("mozilla");
+}

--- a/packages/clawql-payments/src/credits/hateoas-http.test.ts
+++ b/packages/clawql-payments/src/credits/hateoas-http.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import express from "express";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { attachCreditsHateoasRoutes } from "./hateoas-http.js";
+import { claimDirectory, resetDirectoryForTests } from "./directory.js";
+import { createMoneyRequest, resetMoneyRequestsForTests } from "./requests.js";
+
+async function withApp(run: (base: string) => Promise<void>): Promise<void> {
+  const app = express();
+  app.use(express.json());
+  app.use("/credits", express.urlencoded({ extended: false }));
+  attachCreditsHateoasRoutes(app);
+  const server = await new Promise<import("node:http").Server>((resolve) => {
+    const s = app.listen(0, "127.0.0.1", () => resolve(s));
+  });
+  const addr = server.address();
+  if (!addr || typeof addr === "string") throw new Error("no listen address");
+  const base = `http://127.0.0.1:${addr.port}`;
+  try {
+    await run(base);
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve()))
+    );
+  }
+}
+
+describe("credits hateoas http", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "clawql-credits-hateoas-"));
+    process.env.CLAWQL_HOME = home;
+    process.env.CLAWQL_CREDITS_ENABLED = "1";
+    process.env.CLAWQL_CREDITS_HATEOAS_BASE = "http://127.0.0.1:9";
+    await resetDirectoryForTests(process.env);
+    await resetMoneyRequestsForTests(process.env);
+  });
+
+  afterEach(async () => {
+    delete process.env.CLAWQL_CREDITS_HATEOAS_BASE;
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("GET /credits/pay returns HTML and JSON", async () => {
+    await withApp(async (base) => {
+      const html = await fetch(`${base}/credits/pay?to=%40bob&amount=10`, {
+        headers: { Accept: "text/html" },
+      });
+      expect(html.status).toBe(200);
+      const body = await html.text();
+      expect(body).toContain("Send credits");
+      expect(body).toContain("@bob");
+      expect(body).toContain("htmx.org");
+
+      const json = await fetch(`${base}/credits/pay?to=%40bob&amount=10`, {
+        headers: { Accept: "application/json" },
+      });
+      expect(json.status).toBe(200);
+      const envelope = (await json.json()) as { kind: string; links: { clawql: string } };
+      expect(envelope.kind).toBe("credits.pay");
+      expect(envelope.links.clawql).toContain("clawql://pay?");
+    });
+  });
+
+  it("GET /credits/qr.svg returns SVG", async () => {
+    await withApp(async (base) => {
+      const res = await fetch(`${base}/credits/qr.svg?to=bob%40acme.com&amount=5`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toMatch(/svg/);
+      const svg = await res.text();
+      expect(svg).toContain("<svg");
+    });
+  });
+
+  it("invite page + claim via HTMX form post", async () => {
+    await claimDirectory({ email: "alice@acme.com", tenantId: "alice" });
+    const { request, inviteToken } = await createMoneyRequest({
+      requesterTenantId: "alice",
+      to: "newbie@acme.com",
+      amountCents: 2500,
+    });
+    expect(inviteToken).toBeTruthy();
+
+    await withApp(async (base) => {
+      const page = await fetch(
+        `${base}/credits/request/invite?request_id=${request.requestId}&token=${inviteToken}`
+      );
+      expect(page.status).toBe(200);
+      expect(await page.text()).toContain("Claim invite");
+
+      const claim = await fetch(`${base}/credits/request/invite/claim`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          token: inviteToken!,
+          requestId: request.requestId,
+          tenantId: "newbie",
+          handle: "newb",
+        }).toString(),
+      });
+      expect(claim.status).toBe(200);
+      const claimBody = await claim.text();
+      expect(claimBody).toContain("Claimed");
+      expect(claimBody).toContain("newbie");
+
+      const reqPage = await fetch(`${base}/credits/request/${request.requestId}`, {
+        headers: { Accept: "application/json" },
+      });
+      expect(reqPage.status).toBe(200);
+      const data = (await reqPage.json()) as { data: { payerTenantId: string } };
+      expect(data.data.payerTenantId).toBe("newbie");
+    });
+  });
+});

--- a/packages/clawql-payments/src/credits/hateoas-http.ts
+++ b/packages/clawql-payments/src/credits/hateoas-http.ts
@@ -1,0 +1,304 @@
+/**
+ * Minimal HTMX/HATEOAS HTTP surface for credits pay + request deep links.
+ * Mount with {@link attachCreditsHateoasRoutes} on the MCP HTTP gateway.
+ *
+ * Money movement still requires stage → confirm (accept only stages).
+ * These routes are for deep-link landing + local/dev HTMX; put them behind
+ * gateway auth in production.
+ */
+
+import { Effect } from "effect";
+import type { Express, Request, Response } from "express";
+import { runPaymentsEffect } from "../runtime/payments-effect-runtime.js";
+import { CreditsService } from "./credits-service.js";
+import {
+  buildClawqlPayUri,
+  buildPayDeepLink,
+  buildPayQrPayload,
+  buildRequestDeepLink,
+  parsePayDeepLinkQuery,
+  payCliHint,
+  payHateoasEnvelope,
+  type PayDeepLink,
+} from "./deeplinks.js";
+import { escapeHtml, renderCreditsHateoasPage, renderQrSvg, wantsHtml } from "./hateoas-html.js";
+import {
+  acceptMoneyRequest,
+  claimMoneyRequestInvite,
+  declineMoneyRequest,
+  getMoneyRequest,
+  publicMoneyRequest,
+  type MoneyRequest,
+} from "./requests.js";
+
+const esc = escapeHtml;
+
+function payPageHtml(pay: PayDeepLink): string {
+  const envelope = payHateoasEnvelope(pay);
+  const cli = payCliHint(pay);
+  const clawql = buildClawqlPayUri(pay);
+  const qrQs = new URLSearchParams({
+    to: pay.to,
+    ...(pay.amountUsd != null ? { amount: String(pay.amountUsd) } : {}),
+    ...(pay.note ? { note: pay.note } : {}),
+  }).toString();
+
+  const body = `
+    <p class="muted">Confirm this payment in the CLI (stage → confirm). This page does not move money.</p>
+    <dl>
+      <dt>To</dt><dd>${esc(pay.to)}</dd>
+      <dt>Amount (USD)</dt><dd>${esc(pay.amountUsd != null ? String(pay.amountUsd) : "—")}</dd>
+      <dt>Note</dt><dd>${esc(pay.note ?? "—")}</dd>
+    </dl>
+    <p><strong>CLI</strong></p>
+    <pre>${esc(cli)}</pre>
+    <p class="muted">Scheme URI (QR payload): <code>${esc(clawql)}</code></p>
+    <p><img alt="Payment QR" width="200" height="200" src="/credits/qr.svg?${esc(qrQs)}" /></p>
+  `;
+  return renderCreditsHateoasPage({
+    title: "Pay with ClawQL credits",
+    heading: "Send credits",
+    summary: envelope.summary,
+    bodyHtml: body,
+    envelope,
+  });
+}
+
+function invitePageHtml(token: string, requestId: string): string {
+  const body = `
+    <p class="muted">Claim this invite to link the request to your directory identity, then accept to stage payment.</p>
+    <p>Request: <code>${esc(requestId)}</code></p>
+    <form hx-post="/credits/request/invite/claim" hx-target="#result" hx-swap="innerHTML">
+      <input type="hidden" name="token" value="${esc(token)}" />
+      <input type="hidden" name="requestId" value="${esc(requestId)}" />
+      <label>Tenant id <input name="tenantId" required autocomplete="username" placeholder="your-tenant" /></label>
+      <label>Email <input name="email" type="email" autocomplete="email" placeholder="optional if invite email known" /></label>
+      <label>Optional @username <input name="handle" type="text" autocomplete="nickname" placeholder="optional" /></label>
+      <button type="submit">Claim invite</button>
+    </form>
+    <div id="result"></div>
+  `;
+  return renderCreditsHateoasPage({
+    title: "Credits invite",
+    heading: "Money request invite",
+    summary: "Join ClawQL and link this request to your tenant.",
+    bodyHtml: body,
+  });
+}
+
+function requestPageHtml(reqRow: MoneyRequest): string {
+  const amountUsd = (reqRow.amountCents / 100).toFixed(2);
+  const self = buildRequestDeepLink({ requestId: reqRow.requestId });
+  const body = `
+    <dl>
+      <dt>Status</dt><dd>${esc(reqRow.status)}</dd>
+      <dt>Amount (USD)</dt><dd>${esc(amountUsd)}</dd>
+      <dt>From (requester)</dt><dd>${esc(reqRow.requesterTenantId)}</dd>
+      <dt>To (payer)</dt><dd>${esc(reqRow.payerTenantId ?? "— (invite pending)")}</dd>
+      <dt>Note</dt><dd>${esc(reqRow.note ?? "—")}</dd>
+      ${
+        reqRow.stagedTransferActionId
+          ? `<dt>Staged transfer</dt><dd><code>${esc(reqRow.stagedTransferActionId)}</code></dd>`
+          : ""
+      }
+    </dl>
+    ${
+      reqRow.status === "pending"
+        ? `
+    <form hx-post="/credits/request/${esc(reqRow.requestId)}/accept" hx-target="#result" hx-swap="innerHTML">
+      <label>Payer tenant id <input name="payerTenantId" value="${esc(reqRow.payerTenantId ?? "")}" required /></label>
+      <button type="submit">Accept (stage payment)</button>
+    </form>
+    <form hx-post="/credits/request/${esc(reqRow.requestId)}/decline" hx-target="#result" hx-swap="innerHTML" style="margin-top:0.75rem">
+      <label>Payer tenant id <input name="payerTenantId" value="${esc(reqRow.payerTenantId ?? "")}" required /></label>
+      <button type="submit" class="btn secondary">Decline</button>
+    </form>`
+        : ""
+    }
+    <div id="result"></div>
+    <p class="muted">After accept: <code>clawql payments credits transfer --confirm --action-id … --code …</code></p>
+  `;
+  return renderCreditsHateoasPage({
+    title: `Request ${reqRow.requestId}`,
+    heading: "Money request",
+    summary: `$${amountUsd} · ${reqRow.status}`,
+    bodyHtml: body,
+    envelope: {
+      ok: true,
+      kind: "credits.request",
+      summary: `Request ${reqRow.requestId}`,
+      data: publicMoneyRequest(reqRow) as unknown as Record<string, unknown>,
+      links: { self, approval_url: self },
+      approval_url: self,
+    },
+  });
+}
+
+function sendJsonOrHtml(
+  req: Request,
+  res: Response,
+  html: string,
+  json: unknown,
+  status = 200
+): void {
+  if (wantsHtml(req.get("accept") ?? undefined)) {
+    res.status(status).type("html").send(html);
+    return;
+  }
+  res.status(status).json(json);
+}
+
+/**
+ * Attach GET/POST routes under `/credits/*` for deep-link landing + HTMX actions.
+ */
+export function attachCreditsHateoasRoutes(app: Express): void {
+  app.get("/credits/pay", (req: Request, res: Response) => {
+    try {
+      const pay = parsePayDeepLinkQuery(req.query as Record<string, string | undefined>);
+      const html = payPageHtml(pay);
+      sendJsonOrHtml(req, res, html, payHateoasEnvelope(pay));
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      res.status(400).type("text/plain").send(msg);
+    }
+  });
+
+  app.get("/credits/qr.svg", async (req: Request, res: Response) => {
+    try {
+      const pay = parsePayDeepLinkQuery(req.query as Record<string, string | undefined>);
+      const svg = await renderQrSvg(buildPayQrPayload(pay));
+      res.type("image/svg+xml").send(svg);
+    } catch (e) {
+      res.status(400).type("text/plain").send(e instanceof Error ? e.message : String(e));
+    }
+  });
+
+  app.get("/credits/request/invite", (req: Request, res: Response) => {
+    const token = String(req.query.token ?? "").trim();
+    const requestId = String(
+      req.query.request_id ?? req.query.requestId ?? ""
+    ).trim();
+    if (!token || !requestId) {
+      res.status(400).type("html").send(
+        renderCreditsHateoasPage({
+          title: "Invite",
+          heading: "Missing parameters",
+          bodyHtml:
+            "<p>Add <code>?request_id=…&amp;token=…</code> from your invite URL.</p>",
+        }),
+      );
+      return;
+    }
+    res.type("html").send(invitePageHtml(token, requestId));
+  });
+
+  app.get("/credits/request/:requestId", async (req: Request, res: Response) => {
+    const requestId = String(req.params.requestId ?? "").trim();
+    const row = await getMoneyRequest(requestId);
+    if (!row) {
+      res.status(404).type("html").send(
+        renderCreditsHateoasPage({
+          title: "Not found",
+          heading: "Request not found",
+          bodyHtml: `<p>No request <code>${esc(requestId)}</code>.</p>`,
+        }),
+      );
+      return;
+    }
+    const html = requestPageHtml(row);
+    sendJsonOrHtml(req, res, html, {
+      ok: true,
+      kind: "credits.request",
+      data: publicMoneyRequest(row),
+      links: { self: buildRequestDeepLink({ requestId }) },
+      approval_url: buildRequestDeepLink({ requestId }),
+    });
+  });
+
+  app.post("/credits/request/invite/claim", async (req: Request, res: Response) => {
+    try {
+      const token = String(req.body?.token ?? "").trim();
+      const requestId = String(req.body?.requestId ?? req.body?.request_id ?? "").trim();
+      const tenantId = String(req.body?.tenantId ?? "").trim();
+      const email = String(req.body?.email ?? "").trim();
+      const handleRaw = String(req.body?.handle ?? "").trim();
+      const result = await claimMoneyRequestInvite({
+        requestId,
+        token,
+        tenantId,
+        ...(email ? { email } : {}),
+        ...(handleRaw ? { handle: handleRaw } : {}),
+      });
+      const next = buildRequestDeepLink({ requestId: result.request.requestId });
+      res.type("html").send(`
+        <p>Claimed${result.directoryCreated ? " (directory created)" : ""}.</p>
+        <p>Status: <strong>${esc(result.request.status)}</strong> · tenant <code>${esc(result.request.payerTenantId ?? "")}</code></p>
+        <p><a href="${esc(next)}">Open request</a></p>
+        <p class="muted">CLI: <code>clawql payments credits request accept --request-id ${esc(result.request.requestId)} --tenant-id ${esc(tenantId)}</code></p>
+      `);
+    } catch (e) {
+      res
+        .status(400)
+        .type("html")
+        .send(`<p class="err">${esc(e instanceof Error ? e.message : String(e))}</p>`);
+    }
+  });
+
+  app.post("/credits/request/:requestId/accept", async (req: Request, res: Response) => {
+    try {
+      const requestId = String(req.params.requestId ?? "").trim();
+      const payerTenantId = String(req.body?.payerTenantId ?? "").trim();
+      const { request, staged } = await acceptMoneyRequest(
+        { requestId, payerTenantId },
+        async (input) =>
+          runPaymentsEffect(
+            Effect.gen(function* () {
+              const credits = yield* CreditsService;
+              return yield* credits.stageTransfer({
+                fromTenantId: input.fromTenantId,
+                toTenantId: input.toTenantId,
+                amountCents: input.amountCents,
+                note: input.note,
+                correlationId: input.correlationId,
+                requestId: input.requestId,
+              });
+            })
+          )
+      );
+      res.type("html").send(`
+        <p>Accepted — transfer staged (money not moved yet).</p>
+        <p>action_id: <code>${esc(staged.actionId)}</code></p>
+        <p>confirmation_code: <code>${esc(staged.confirmationCode)}</code></p>
+        <pre>clawql payments credits transfer --confirm --action-id ${esc(staged.actionId)} --code ${esc(staged.confirmationCode)}${staged.totpRequired ? " --totp NNNNNN" : ""}</pre>
+        <p class="muted">Request status: ${esc(request.status)}</p>
+      `);
+    } catch (e) {
+      res
+        .status(400)
+        .type("html")
+        .send(`<p class="err">${esc(e instanceof Error ? e.message : String(e))}</p>`);
+    }
+  });
+
+  app.post("/credits/request/:requestId/decline", async (req: Request, res: Response) => {
+    try {
+      const requestId = String(req.params.requestId ?? "").trim();
+      const payerTenantId = String(req.body?.payerTenantId ?? "").trim();
+      const result = await declineMoneyRequest({ requestId, payerTenantId });
+      res.type("html").send(`<p>Declined. Status: <strong>${esc(result.status)}</strong></p>`);
+    } catch (e) {
+      res
+        .status(400)
+        .type("html")
+        .send(`<p class="err">${esc(e instanceof Error ? e.message : String(e))}</p>`);
+    }
+  });
+}
+
+/** @deprecated Use attachCreditsHateoasRoutes — kept for discoverability. */
+export function creditsPayDeepLinkPath(input: PayDeepLink): string {
+  return buildPayDeepLink(input).replace(/^[^?]*/, (p) => {
+    const idx = p.indexOf("/credits/");
+    return idx >= 0 ? p.slice(idx) : "/credits/pay";
+  });
+}

--- a/packages/clawql-payments/src/credits/index.ts
+++ b/packages/clawql-payments/src/credits/index.ts
@@ -71,6 +71,32 @@ export {
   type StageTransferFn,
 } from "./requests.js";
 export {
+  buildClawqlPayUri,
+  buildInviteDeepLink,
+  buildPayDeepLink,
+  buildPayQrPayload,
+  buildRequestDeepLink,
+  creditsHateoasBase,
+  isHttpCreditsHateoasBase,
+  parseCreditsDeepLink,
+  parsePayDeepLinkQuery,
+  payCliHint,
+  payHateoasEnvelope,
+  type HateoasEnvelope,
+  type HateoasLinkMap,
+  type InviteDeepLink,
+  type PayDeepLink,
+  type RequestDeepLink,
+} from "./deeplinks.js";
+export {
+  escapeHtml,
+  renderCreditsHateoasPage,
+  renderHateoasHtml,
+  renderQrSvg,
+  wantsHtml,
+} from "./hateoas-html.js";
+export { attachCreditsHateoasRoutes } from "./hateoas-http.js";
+export {
   appendCreditEntry,
   captureHold,
   getCreditAccount,

--- a/packages/clawql-payments/src/credits/requests.ts
+++ b/packages/clawql-payments/src/credits/requests.ts
@@ -9,7 +9,6 @@
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
-import { compensationApprovalBaseUrl } from "../compensation/config.js";
 import { resolveMoneyRequestsPath } from "../config/paths.js";
 import {
   claimDirectory,
@@ -18,6 +17,7 @@ import {
   normalizeEmail,
   resolveRecipient,
 } from "./directory.js";
+import { buildInviteDeepLink } from "./deeplinks.js";
 
 export type MoneyRequestStatus =
   | "pending"
@@ -85,8 +85,7 @@ export function buildRequestInviteUrl(
   token: string,
   env: NodeJS.ProcessEnv = process.env
 ): string {
-  const base = compensationApprovalBaseUrl(env);
-  return `${base}/credits/request/invite?request_id=${encodeURIComponent(requestId)}&token=${encodeURIComponent(token)}`;
+  return buildInviteDeepLink({ requestId, token }, env);
 }
 
 async function loadFile(env: NodeJS.ProcessEnv): Promise<RequestsFile> {

--- a/packages/clawql-payments/src/plugin/payments-tools-plugin.test.ts
+++ b/packages/clawql-payments/src/plugin/payments-tools-plugin.test.ts
@@ -25,6 +25,7 @@ describe("payments tools MCP plugin", () => {
       "payments_credits_directory_resolve",
       "payments_credits_directory_list",
       "payments_credits_activity",
+      "payments_credits_link",
       "payments_credits_request_create",
       "payments_credits_request_list",
       "payments_credits_request_claim_invite",

--- a/packages/clawql-payments/src/plugin/payments-tools-plugin.ts
+++ b/packages/clawql-payments/src/plugin/payments-tools-plugin.ts
@@ -30,6 +30,14 @@ import {
   publicMoneyRequest,
 } from "../credits/requests.js";
 import { getActivityFeed } from "../credits/activity.js";
+import {
+  buildClawqlPayUri,
+  buildPayDeepLink,
+  buildPayQrPayload,
+  buildRequestDeepLink,
+  payHateoasEnvelope,
+} from "../credits/deeplinks.js";
+import { renderQrSvg } from "../credits/hateoas-html.js";
 import { Ap2MandateService } from "../ap2/ap2-mandate-service.js";
 import { isAp2Enabled } from "../ap2/config.js";
 
@@ -451,6 +459,62 @@ export function createPaymentsToolsPlugin(env: NodeJS.ProcessEnv = process.env):
               env
             );
             return textResult(feed);
+          },
+        });
+
+        yield* api.registerMcpTool({
+          name: "payments_credits_link",
+          description:
+            "Build HATEOAS / clawql:// deep links for pay or a money request (QR-friendly; does not move money).",
+          schema: {
+            to: z.string().optional().describe("Payee email, @username, or tenant id"),
+            amountUsd: z.number().positive().optional(),
+            note: z.string().optional(),
+            fromTenantId: z.string().optional(),
+            requestId: z.string().optional().describe("When set, emit a request deep link instead of pay"),
+            includeQrSvg: z
+              .boolean()
+              .optional()
+              .describe("When true with a pay link, include an SVG QR payload"),
+          },
+          handler: async (args) => {
+            const a = args as {
+              to?: string;
+              amountUsd?: number;
+              note?: string;
+              fromTenantId?: string;
+              requestId?: string;
+              includeQrSvg?: boolean;
+            };
+            const requestId = a.requestId?.trim();
+            if (requestId) {
+              const url = buildRequestDeepLink({ requestId }, env);
+              return textResult({
+                ok: true,
+                kind: "credits.request",
+                links: { self: url, approval_url: url },
+                approval_url: url,
+              });
+            }
+            const to = a.to?.trim();
+            if (!to) throw new Error("Provide to= (payee) or requestId");
+            const pay = {
+              to,
+              amountUsd: a.amountUsd,
+              note: a.note,
+              fromTenantId: a.fromTenantId,
+            };
+            const envelope = payHateoasEnvelope(pay, env);
+            let qrSvg: string | undefined;
+            if (a.includeQrSvg) {
+              qrSvg = await renderQrSvg(buildPayQrPayload(pay));
+            }
+            return textResult({
+              ...envelope,
+              clawql: buildClawqlPayUri(pay),
+              http: buildPayDeepLink(pay, env),
+              qrSvg,
+            });
           },
         });
 

--- a/src/onboarding/cli.ts
+++ b/src/onboarding/cli.ts
@@ -97,6 +97,8 @@ import {
   runPaymentsCreditsTransferCmd,
   runPaymentsCreditsPayCmd,
   runPaymentsCreditsActivityCmd,
+  runPaymentsCreditsLinkCmd,
+  runPaymentsCreditsQrCmd,
   runPaymentsCreditsDirectoryClaimCmd,
   runPaymentsCreditsDirectoryShowCmd,
   runPaymentsCreditsDirectoryListCmd,
@@ -326,6 +328,7 @@ function parse(argv: string[]): {
     else if (a === "--from-tenant") flags.fromTenantId = argv[++i] ?? "";
     else if (a === "--idempotency-key") flags.idempotencyKey = argv[++i] ?? "";
     else if (a === "--note") flags.note = argv[++i] ?? "";
+    else if (a === "--parse") flags.parseDeepLink = argv[++i] ?? "";
     else if (a === "--totp") flags.totp = argv[++i] ?? "";
     else if (a === "--direct") flags.direct = true;
     else if (a.startsWith("--image-digest=")) {
@@ -422,6 +425,8 @@ Usage:
   clawql payments credits directory claim --email you@acme.com [--handle alice] [--name Alice]
   clawql payments credits directory show|list|release --email … | --handle @alice
   clawql payments credits pay --to you@acme.com|--to @alice --amount 10 [--note coffee]
+  clawql payments credits link --to @alice|--to you@acme.com [--amount 10] | --request-id UUID | --parse URI
+  clawql payments credits qr --to @alice [--amount 10] [--out pay.svg]
   clawql payments credits activity [--tenant-id ID] [--limit 25] [--filter money|transfers|requests|all]
   clawql payments credits request|invoice --to newbie@acme.com|--to @bob --amount 25 [--note …]
   clawql payments credits request list|show|accept|decline|cancel|claim-invite …
@@ -1189,6 +1194,8 @@ async function main(): Promise<void> {
       note: typeof flags.note === "string" ? flags.note : undefined,
       totp: typeof flags.totp === "string" ? flags.totp : undefined,
       direct: Boolean(flags.direct),
+      parseDeepLink: typeof flags.parseDeepLink === "string" ? flags.parseDeepLink : undefined,
+      out: typeof flags.out === "string" ? flags.out : undefined,
     };
 
     if (subcmd === "plan") {
@@ -1389,6 +1396,14 @@ async function main(): Promise<void> {
       }
       if (creditsAction === "activity") {
         process.exitCode = await runPaymentsCreditsActivityCmd(paymentsOpts);
+        return;
+      }
+      if (creditsAction === "link") {
+        process.exitCode = await runPaymentsCreditsLinkCmd(paymentsOpts);
+        return;
+      }
+      if (creditsAction === "qr") {
+        process.exitCode = await runPaymentsCreditsQrCmd(paymentsOpts);
         return;
       }
       if (creditsAction === "request" || creditsAction === "invoice") {

--- a/src/onboarding/payments-cli.ts
+++ b/src/onboarding/payments-cli.ts
@@ -48,6 +48,8 @@ import {
   runPaymentsCreditsRequestAccept,
   runPaymentsCreditsRequestDecline,
   runPaymentsCreditsRequestCancel,
+  runPaymentsCreditsLink,
+  runPaymentsCreditsQr,
   runPaymentsCreditsStepUpEnroll,
   runPaymentsCreditsStepUpShow,
   runPaymentsCompensationBalance,
@@ -148,6 +150,10 @@ export type PaymentsCliOptions = {
   source?: "credits" | "funds";
   assetKind?: "credits" | "funds";
   confirm?: boolean;
+  /** Parse an existing credits deep link / clawql:// URI. */
+  parseDeepLink?: string;
+  /** Output path for QR SVG (`credits qr --out`). */
+  out?: string;
 };
 
 export async function runPaymentsPlanShowCmd(options: PaymentsCliOptions = {}): Promise<number> {
@@ -500,6 +506,35 @@ export async function runPaymentsCreditsActivityCmd(
     tenantId: options.tenantId ?? options.fromTenantId,
     limit: options.limit,
     filter: options.activityFilter,
+    json: options.json,
+  });
+}
+
+export async function runPaymentsCreditsLinkCmd(
+  options: PaymentsCliOptions = {}
+): Promise<number> {
+  return runPaymentsCreditsLink({
+    payTo: options.payTo,
+    toHandle: options.toHandle ?? options.handle,
+    amountUsd: options.amount,
+    note: options.note,
+    fromTenantId: options.fromTenantId ?? options.tenantId,
+    requestId: options.requestId,
+    parse: options.parseDeepLink,
+    json: options.json,
+  });
+}
+
+export async function runPaymentsCreditsQrCmd(
+  options: PaymentsCliOptions = {}
+): Promise<number> {
+  return runPaymentsCreditsQr({
+    payTo: options.payTo,
+    toHandle: options.toHandle ?? options.handle,
+    amountUsd: options.amount,
+    note: options.note,
+    fromTenantId: options.fromTenantId ?? options.tenantId,
+    out: options.out ?? options.output,
     json: options.json,
   });
 }

--- a/src/server-http.ts
+++ b/src/server-http.ts
@@ -51,6 +51,7 @@ import {
   type GatewayAuthConfig,
 } from "clawql-auth";
 import { validateVirtualKey } from "clawql-inference";
+import { attachCreditsHateoasRoutes } from "clawql-payments";
 import { attachPaymentsWellKnownRoutes } from "clawql-payments/discovery";
 import { attachMppOpenApiRoutes, isMppOpenApiEnabled } from "clawql-payments/mpp";
 import {
@@ -219,6 +220,9 @@ export async function createMcpHttpApp(options: CreateMcpHttpAppOptions = {}): P
   app.use(applyCorsIfConfigured);
 
   attachPaymentsWellKnownRoutes(app, { serverName: "ClawQL MCP" });
+  // HTMX forms on /credits/* (invite claim / accept / decline)
+  app.use("/credits", express.urlencoded({ extended: false }));
+  attachCreditsHateoasRoutes(app);
   if (isMppOpenApiEnabled(process.env)) {
     attachMppOpenApiRoutes(app, { serverName: "ClawQL MCP" });
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Venmo-style shareable deep links for prepaid credits P2P, wired into the existing compensation-style HATEOAS base and a minimal HTMX surface on the MCP HTTP gateway.

Stacked on `#829` (`cursor/payments-credits-activity-611b`).

### What shipped
- **Deep links:** `{base}/credits/pay?…`, request + invite URLs, plus `clawql://pay?…` for QR scanners
- **Gateway routes:** GET pay / QR SVG / request / invite; HTMX POST claim / accept (stage only) / decline
- **CLI:** `credits link`, `credits qr [--out pay.svg]`, `--parse`
- **MCP:** `payments_credits_link` (optional SVG)
- **Docs:** [`docs/payments/credits-deeplinks.md`](docs/payments/credits-deeplinks.md); roadmap bit checked off

### Config
- `CLAWQL_CREDITS_HATEOAS_BASE` (falls back to compensation approval base / `clawql://tool`)

### Safety
- Landing pages do not move money; accept only **stages**; confirm (+ optional TOTP) remains the gate
- Invite claim stays token-gated; put `/credits/*` behind gateway auth in production

## Test plan
- [x] `vitest` deeplinks + hateoas-http + requests + payments-tools-plugin
- [x] `clawql-payments` typecheck
- [ ] Manual: set `CLAWQL_CREDITS_HATEOAS_BASE`, `credits link --to @bob --amount 10`, open pay HTML, scan QR SVG
- [ ] Manual: request invite URL → HTMX claim → accept → transfer confirm
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

