### PR TITLE
feat(payments): dry-run-first outbound email for money-request invites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -470,13 +470,20 @@
 # CLAWQL_CUCKOO_METRICS=1
 # CLAWQL_MERKLE_ENABLED=1
 
-# Prepaid credits P2P deep links / HTMX / contacts (docs/payments/credits-deeplinks.md, credits-contacts.md)
+# Prepaid credits P2P deep links / HTMX / contacts / invite email
 # CLAWQL_CREDITS_ENABLED=1
 # CLAWQL_CREDITS_HATEOAS_BASE=https://gateway.example   # else CLAWQL_COMPENSATION_APPROVAL_BASE / clawql://tool
 # CLAWQL_COMPENSATION_APPROVAL_BASE=https://gateway.example
 # CLAWQL_CREDITS_PHONE_REQUIRE_VERIFIED=1   # phone claims need --verified (customer IdP assertion)
 # CLAWQL_CREDITS_PHONE_DEFAULT_CC=1
-# CLAWQL_PAYMENTS_MCP_TOOLS=1   # includes payments_credits_link + contacts tools
+# Invite email (docs/payments/credits-invite-email.md) — dry-run until DRY_RUN=0
+# CLAWQL_CREDITS_INVITE_EMAIL=1
+# CLAWQL_CREDITS_INVITE_EMAIL_DRY_RUN=1
+# CLAWQL_CREDITS_INVITE_EMAIL_PROVIDER=resend   # or webhook
+# CLAWQL_CREDITS_INVITE_EMAIL_FROM=ClawQL Payments <pay@yourdomain.com>
+# CLAWQL_CREDITS_INVITE_EMAIL_RESEND_API_KEY=re_…
+# CLAWQL_CREDITS_INVITE_EMAIL_WEBHOOK_URL=https://hooks.example/invite
+# CLAWQL_PAYMENTS_MCP_TOOLS=1   # includes payments_credits_link + contacts + send_invite
 
 # ─── 11. Sandbox (`sandbox_exec`) — default off; CLAWQL_ENABLE_SANDBOX=1 ──
 # CLAWQL_ENABLE_SANDBOX=1

--- a/docs/payments/credits-invite-email.md
+++ b/docs/payments/credits-invite-email.md
@@ -1,0 +1,82 @@
+# Invite email delivery
+
+Optional outbound email for money-request invites. **Print/share the invite URL remains the default** — email is opt-in and **dry-run by default**.
+
+Tokens and recipient emails are never written to payment WORM.
+
+## Quick start (safe)
+
+```bash
+export CLAWQL_CREDITS_ENABLED=1
+# Create invite + print URL (no email)
+clawql payments credits request --to newbie@acme.com --amount 40 --note dinner
+
+# Preview the email body (still no network send)
+clawql payments credits request --to newbie@acme.com --amount 40 --send-email --email-dry-run
+# or enable auto-preview on create:
+export CLAWQL_CREDITS_INVITE_EMAIL=1   # still dry-runs until DRY_RUN=0
+```
+
+## Live send (opt-in)
+
+```bash
+export CLAWQL_CREDITS_INVITE_EMAIL=1
+export CLAWQL_CREDITS_INVITE_EMAIL_DRY_RUN=0
+export CLAWQL_CREDITS_INVITE_EMAIL_FROM="ClawQL Payments <pay@yourdomain.com>"
+
+# Option A — Resend
+export CLAWQL_CREDITS_INVITE_EMAIL_PROVIDER=resend
+export CLAWQL_CREDITS_INVITE_EMAIL_RESEND_API_KEY=re_…
+
+# Option B — generic webhook (Zapier / your mailer)
+export CLAWQL_CREDITS_INVITE_EMAIL_PROVIDER=webhook
+export CLAWQL_CREDITS_INVITE_EMAIL_WEBHOOK_URL=https://hooks.example/invite
+# optional: CLAWQL_CREDITS_INVITE_EMAIL_WEBHOOK_TOKEN=…
+
+clawql payments credits request --to newbie@acme.com --amount 40 --send-email
+```
+
+Resend later (needs the cleartext token from create):
+
+```bash
+clawql payments credits request send-invite \
+  --request-id UUID --token TOKEN [--email override@acme.com] [--email-dry-run]
+```
+
+## Providers
+
+| Provider | Behavior |
+| -------- | -------- |
+| `dry-run` (default) | Returns subject + text preview; no network |
+| `webhook` | `POST` JSON `{ type, to, from, subject, text, html, meta }` |
+| `resend` | Resend HTTP API `POST /emails` |
+
+## CLI / MCP
+
+| Surface | Role |
+| ------- | ---- |
+| `request --send-email` | Create + attempt delivery |
+| `request send-invite` | Preview/send for existing invite |
+| `payments_credits_request_create` (`sendEmail`) | MCP create + optional email |
+| `payments_credits_request_send_invite` | MCP preview/send |
+
+## Env
+
+| Variable | Default | Meaning |
+| -------- | ------- | ------- |
+| `CLAWQL_CREDITS_INVITE_EMAIL` | off | Auto-attempt on create when invite |
+| `CLAWQL_CREDITS_INVITE_EMAIL_DRY_RUN` | on | Preview only until `0` |
+| `CLAWQL_CREDITS_INVITE_EMAIL_PROVIDER` | auto | `dry-run` \| `webhook` \| `resend` |
+| `CLAWQL_CREDITS_INVITE_EMAIL_FROM` | local placeholder | From header |
+| `CLAWQL_CREDITS_INVITE_EMAIL_SUBJECT` | derived | Subject override |
+| `CLAWQL_CREDITS_INVITE_EMAIL_WEBHOOK_URL` | — | Webhook endpoint |
+| `CLAWQL_CREDITS_INVITE_EMAIL_WEBHOOK_TOKEN` | — | Optional Bearer token |
+| `CLAWQL_CREDITS_INVITE_EMAIL_RESEND_API_KEY` | — | Resend API key |
+
+## Non-goals
+
+- Full marketing ESP / bounce handling / spam reputation ops
+- Storing cleartext invite tokens for later resend (keep the token from create)
+- Replacing Slack `notify` (ops channel stays separate)
+
+See also: [money requests](./money-requests.md), [consumer roadmap](./p2p-consumer-roadmap.md).

--- a/docs/payments/money-requests.md
+++ b/docs/payments/money-requests.md
@@ -43,6 +43,9 @@ clawql payments credits invoice --to bob@acme.com --amount 25 --note "March cons
 # Invite someone new by email
 clawql payments credits request --to newbie@acme.com --amount 40 --note "dinner"
 # → share inviteUrl / token once
+# Optional email preview / send (dry-run by default):
+# clawql payments credits request --to newbie@acme.com --amount 40 --send-email
+# clawql payments credits request send-invite --request-id UUID --token TOKEN
 
 # Invitee joins + links the request
 clawql payments credits request claim-invite \
@@ -79,7 +82,8 @@ clawql payments credits request decline|cancel --request-id UUID
 | -------- | ------- | ------- |
 | `CLAWQL_CREDITS_REQUEST_TTL_SEC` | 7 days | Request expiry |
 | `CLAWQL_CREDITS_HATEOAS_BASE` | compensation / `clawql://tool` | Public origin for invite / request deep links |
+| `CLAWQL_CREDITS_INVITE_EMAIL` | off | Attempt invite email on create (still dry-runs by default) |
 
-Invite URLs use the [deep link](./credits-deeplinks.md) builders (`/credits/request/invite?request_id=…&token=…`). Print the URL for now — outbound email is deferred.
+Invite URLs use the [deep link](./credits-deeplinks.md) builders (`/credits/request/invite?request_id=…&token=…`). Outbound delivery: [invite email](./credits-invite-email.md).
 
-See also: [consumer roadmap](./p2p-consumer-roadmap.md), [credits ACH / P2P](./credits-ach.md), [deep links](./credits-deeplinks.md).
+See also: [consumer roadmap](./p2p-consumer-roadmap.md), [credits ACH / P2P](./credits-ach.md), [deep links](./credits-deeplinks.md), [invite email](./credits-invite-email.md).

--- a/docs/payments/p2p-consumer-roadmap.md
+++ b/docs/payments/p2p-consumer-roadmap.md
@@ -18,6 +18,7 @@ ClawQL is **not** a consumer bank. Balances are prepaid credits; bank/USDC off-r
 | QR / deep links (HATEOAS + HTMX) | ✅ | [`credits-deeplinks.md`](./credits-deeplinks.md) |
 | Contacts + phone alias | ✅ | [`credits-contacts.md`](./credits-contacts.md) |
 | Hosted mini UI | ✅ | `/credits` brand-first compose + pay landing — [`credits-deeplinks.md`](./credits-deeplinks.md) |
+| Invite email (dry-run first) | ✅ | [`credits-invite-email.md`](./credits-invite-email.md) |
 | OIDC / MFA policy (gateway) | ✅ (stacked) | [`clawql-auth-oidc-stepup.md`](../security/clawql-auth-oidc-stepup.md) |
 
 ## Addressing model
@@ -39,7 +40,7 @@ Emails and phones are stored only under `$CLAWQL_HOME/Payments/` (mode `0600`) �
 3. ~~**QR / deep link**~~ — ✅ HATEOAS + HTMX + `clawql://pay` — [`credits-deeplinks.md`](./credits-deeplinks.md)
 4. ~~**Contacts**~~ — ✅ phone alias + contacts book — [`credits-contacts.md`](./credits-contacts.md)
 5. ~~**Hosted mini UI**~~ — ✅ brand-first `/credits` — [`credits-deeplinks.md`](./credits-deeplinks.md)
-6. **Outbound email delivery** — optional later (invite URL print is enough for now)
+6. ~~**Outbound email delivery**~~ — ✅ dry-run-first invite email — [`credits-invite-email.md`](./credits-invite-email.md)
 
 ## Explicit non-goals (for now)
 

--- a/packages/clawql-payments/src/cli/credits.ts
+++ b/packages/clawql-payments/src/cli/credits.ts
@@ -19,6 +19,7 @@ import {
   getEmailEntry,
   getHandleEntry,
   getPhoneEntry,
+  getTenantEntry,
   listDirectory,
   looksLikePhone,
   maskEmail,
@@ -38,6 +39,10 @@ import {
   listMoneyRequests,
   publicMoneyRequest,
 } from "../credits/requests.js";
+import {
+  sendMoneyRequestInviteEmail,
+  shouldSendInviteEmailOnCreate,
+} from "../credits/invite-email.js";
 import { formatActivityLine, getActivityFeed } from "../credits/activity.js";
 import {
   buildClawqlPayUri,
@@ -700,6 +705,10 @@ export type PaymentsCreditsRequestOptions = {
   displayName?: string;
   role?: "requester" | "payer" | "any";
   status?: string;
+  /** Attempt invite email on create (dry-run by default). */
+  sendEmail?: boolean;
+  /** Force dry-run preview even if live provider configured. */
+  emailDryRun?: boolean;
   json?: boolean;
 };
 
@@ -734,6 +743,36 @@ export async function runPaymentsCreditsRequestCreate(
       note: options.note,
       correlationId: options.correlationId,
     });
+
+    let emailResult: Awaited<ReturnType<typeof sendMoneyRequestInviteEmail>> | undefined;
+    if (
+      result.invite &&
+      result.inviteToken &&
+      result.request.inviteUrl &&
+      result.request.payerEmail &&
+      shouldSendInviteEmailOnCreate({ sendEmail: options.sendEmail })
+    ) {
+      const requester = await getTenantEntry(requesterTenantId);
+      emailResult = await sendMoneyRequestInviteEmail(
+        {
+          toEmail: result.request.payerEmail,
+          inviteUrl: result.request.inviteUrl,
+          requestId: result.request.requestId,
+          amountCents: result.request.amountCents,
+          note: result.request.note,
+          fromLabel:
+            requester?.displayName ||
+            (requester?.handle ? `@${requester.handle}` : undefined) ||
+            requester?.email ||
+            requesterTenantId,
+          inviteToken: result.inviteToken,
+          expiresAt: result.request.expiresAt,
+        },
+        process.env,
+        { dryRun: options.emailDryRun === true ? true : options.emailDryRun }
+      );
+    }
+
     if (options.json) {
       console.log(
         JSON.stringify(
@@ -741,12 +780,13 @@ export async function runPaymentsCreditsRequestCreate(
             ...publicMoneyRequest(result.request),
             invite: result.invite,
             inviteToken: result.inviteToken,
+            email: emailResult,
           },
           null,
           2
         )
       );
-      return 0;
+      return emailResult && !emailResult.ok ? 1 : 0;
     }
     const r = result.request;
     console.log(
@@ -762,6 +802,32 @@ export async function runPaymentsCreditsRequestCreate(
       console.log(
         `  clawql payments credits request claim-invite --request-id ${r.requestId} --token ${result.inviteToken} --tenant-id <new> [--handle …]`
       );
+      if (emailResult) {
+        if (emailResult.dryRun) {
+          console.log(
+            `\nInvite email dry-run → ${emailResult.to} (${emailResult.provider})`
+          );
+          console.log(`Subject: ${emailResult.subject}`);
+          console.log("---");
+          console.log(emailResult.previewText);
+          console.log("---");
+          console.log(
+            "Set CLAWQL_CREDITS_INVITE_EMAIL_DRY_RUN=0 + provider to send for real."
+          );
+        } else if (emailResult.ok) {
+          console.log(
+            `Invite email sent via ${emailResult.provider} → ${emailResult.to}` +
+              (emailResult.messageId ? ` (id ${emailResult.messageId})` : "")
+          );
+        } else {
+          console.error(`Invite email failed: ${emailResult.error}`);
+          return 1;
+        }
+      } else {
+        console.log(
+          "(Email not sent — pass --send-email or set CLAWQL_CREDITS_INVITE_EMAIL=1; default is dry-run)"
+        );
+      }
     } else {
       console.log(
         `Payer accepts: clawql payments credits request accept --request-id ${r.requestId} --tenant-id ${r.payerTenantId}`
@@ -779,6 +845,85 @@ export async function runPaymentsCreditsInvoice(
   options: PaymentsCreditsRequestOptions = {}
 ): Promise<number> {
   return runPaymentsCreditsRequestCreate(options);
+}
+
+/**
+ * Preview or (re)send an invite email for an existing request.
+ * Requires the cleartext token (only available at create time unless operator still has it).
+ */
+export async function runPaymentsCreditsRequestSendInvite(
+  options: PaymentsCreditsRequestOptions = {}
+): Promise<number> {
+  const requestId = options.requestId?.trim();
+  const token = options.inviteToken?.trim();
+  if (!requestId || !token) {
+    console.error(
+      "Usage: clawql payments credits request send-invite --request-id UUID --token TOKEN [--email …] [--dry-run]"
+    );
+    return 1;
+  }
+  try {
+    const req = await getMoneyRequest(requestId);
+    if (!req) {
+      console.error("Unknown request id");
+      return 1;
+    }
+    if (!req.inviteUrl && !req.inviteTokenHash) {
+      console.error("Request has no invite (payer already on platform)");
+      return 1;
+    }
+    const toEmail = options.email?.trim() || req.payerEmail;
+    if (!toEmail) {
+      console.error("No payer email — pass --email");
+      return 1;
+    }
+    // Rebuild invite URL if missing from storage (URL may have been stored at create).
+    const { buildRequestInviteUrl } = await import("../credits/requests.js");
+    const inviteUrl = req.inviteUrl || buildRequestInviteUrl(requestId, token);
+    const requester = await getTenantEntry(req.requesterTenantId);
+    const emailResult = await sendMoneyRequestInviteEmail(
+      {
+        toEmail,
+        inviteUrl,
+        requestId,
+        amountCents: req.amountCents,
+        note: req.note,
+        fromLabel:
+          requester?.displayName ||
+          (requester?.handle ? `@${requester.handle}` : undefined) ||
+          requester?.email ||
+          req.requesterTenantId,
+        inviteToken: token,
+        expiresAt: req.expiresAt,
+      },
+      process.env,
+      { dryRun: options.emailDryRun === true ? true : options.emailDryRun }
+    );
+    if (options.json) {
+      console.log(JSON.stringify(emailResult, null, 2));
+      return emailResult.ok ? 0 : 1;
+    }
+    if (emailResult.dryRun) {
+      console.log(`Invite email dry-run → ${emailResult.to}`);
+      console.log(`Subject: ${emailResult.subject}`);
+      console.log("---");
+      console.log(emailResult.previewText);
+      console.log("---");
+      return 0;
+    }
+    if (!emailResult.ok) {
+      console.error(`Invite email failed: ${emailResult.error}`);
+      return 1;
+    }
+    console.log(
+      `Invite email sent via ${emailResult.provider} → ${emailResult.to}` +
+        (emailResult.messageId ? ` (id ${emailResult.messageId})` : "")
+    );
+    return 0;
+  } catch (err) {
+    console.error(formatErr(err));
+    return 1;
+  }
 }
 
 export async function runPaymentsCreditsRequestList(

--- a/packages/clawql-payments/src/cli/index.ts
+++ b/packages/clawql-payments/src/cli/index.ts
@@ -84,6 +84,7 @@ export {
   runPaymentsCreditsRequestAccept,
   runPaymentsCreditsRequestDecline,
   runPaymentsCreditsRequestCancel,
+  runPaymentsCreditsRequestSendInvite,
   runPaymentsCreditsLink,
   runPaymentsCreditsQr,
   runPaymentsCreditsStepUpEnroll,

--- a/packages/clawql-payments/src/credits/index.ts
+++ b/packages/clawql-payments/src/credits/index.ts
@@ -118,6 +118,20 @@ export {
 } from "./hateoas-html.js";
 export { attachCreditsHateoasRoutes } from "./hateoas-http.js";
 export {
+  buildMoneyRequestInviteEmail,
+  creditsInviteEmailFrom,
+  creditsInviteEmailProvider,
+  isCreditsInviteEmailDryRun,
+  isCreditsInviteEmailEnabled,
+  sendMoneyRequestInviteEmail,
+  shouldSendInviteEmailOnCreate,
+  type InviteEmailPayload,
+  type InviteEmailProvider,
+  type InviteEmailResult,
+  type MoneyRequestInviteEmailInput,
+  type SendInviteEmailOptions,
+} from "./invite-email.js";
+export {
   appendCreditEntry,
   captureHold,
   getCreditAccount,

--- a/packages/clawql-payments/src/credits/invite-email.test.ts
+++ b/packages/clawql-payments/src/credits/invite-email.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildMoneyRequestInviteEmail,
+  creditsInviteEmailProvider,
+  isCreditsInviteEmailDryRun,
+  isCreditsInviteEmailEnabled,
+  sendMoneyRequestInviteEmail,
+  shouldSendInviteEmailOnCreate,
+} from "./invite-email.js";
+
+describe("credits invite email", () => {
+  it("defaults to dry-run provider", () => {
+    const env = {};
+    expect(isCreditsInviteEmailEnabled(env)).toBe(false);
+    expect(isCreditsInviteEmailDryRun(env)).toBe(true);
+    expect(creditsInviteEmailProvider(env)).toBe("dry-run");
+  });
+
+  it("builds invite payload with link and CLI hint", () => {
+    const payload = buildMoneyRequestInviteEmail(
+      {
+        toEmail: "Newbie@Acme.com",
+        inviteUrl: "https://pay.example/credits/request/invite?request_id=r1&token=tok",
+        requestId: "r1",
+        amountCents: 2500,
+        note: "dinner",
+        fromLabel: "@alice",
+        inviteToken: "tok",
+        expiresAt: "2030-01-01T00:00:00.000Z",
+      },
+      { CLAWQL_CREDITS_INVITE_EMAIL_FROM: "ClawQL <pay@example.com>" }
+    );
+    expect(payload.to).toBe("newbie@acme.com");
+    expect(payload.from).toContain("pay@example.com");
+    expect(payload.subject).toMatch(/\$25\.00/);
+    expect(payload.text).toContain("https://pay.example/credits/request/invite");
+    expect(payload.text).toContain("claim-invite --request-id r1 --token tok");
+    expect(payload.html).toContain("Open invite");
+    expect(payload.meta.dryRun).toBe(true);
+  });
+
+  it("dry-runs by default even when invite email enabled", async () => {
+    const result = await sendMoneyRequestInviteEmail(
+      {
+        toEmail: "n@x.com",
+        inviteUrl: "https://x/invite",
+        requestId: "r",
+        amountCents: 100,
+      },
+      { CLAWQL_CREDITS_INVITE_EMAIL: "1" }
+    );
+    expect(result.ok).toBe(true);
+    expect(result.dryRun).toBe(true);
+    expect(result.provider).toBe("dry-run");
+    expect(result.previewText).toContain("https://x/invite");
+  });
+
+  it("posts to webhook provider when live", async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ id: "wh-1" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+    const result = await sendMoneyRequestInviteEmail(
+      {
+        toEmail: "n@x.com",
+        inviteUrl: "https://x/invite",
+        requestId: "r",
+        amountCents: 500,
+        fromLabel: "Alice",
+      },
+      {
+        CLAWQL_CREDITS_INVITE_EMAIL_DRY_RUN: "0",
+        CLAWQL_CREDITS_INVITE_EMAIL_PROVIDER: "webhook",
+        CLAWQL_CREDITS_INVITE_EMAIL_WEBHOOK_URL: "https://hooks.example/invite",
+        CLAWQL_CREDITS_INVITE_EMAIL_WEBHOOK_TOKEN: "secret",
+      },
+      { fetchImpl: fetchImpl as unknown as typeof fetch }
+    );
+    expect(result.ok).toBe(true);
+    expect(result.dryRun).toBe(false);
+    expect(result.provider).toBe("webhook");
+    expect(result.messageId).toBe("wh-1");
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(call[0]).toBe("https://hooks.example/invite");
+    expect(call[1].headers).toMatchObject({
+      authorization: "Bearer secret",
+    });
+    const body = JSON.parse(String(call[1].body));
+    expect(body.type).toBe("credits.money_request.invite");
+    expect(body.to).toBe("n@x.com");
+    expect(body.subject).toMatch(/Alice/);
+  });
+
+  it("posts to Resend when configured", async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ id: "re_123" }), { status: 200 })
+    );
+    const result = await sendMoneyRequestInviteEmail(
+      {
+        toEmail: "n@x.com",
+        inviteUrl: "https://x/invite",
+        requestId: "r",
+        amountCents: 1000,
+      },
+      {
+        CLAWQL_CREDITS_INVITE_EMAIL_DRY_RUN: "0",
+        CLAWQL_CREDITS_INVITE_EMAIL_PROVIDER: "resend",
+        CLAWQL_CREDITS_INVITE_EMAIL_RESEND_API_KEY: "re_test",
+        CLAWQL_CREDITS_INVITE_EMAIL_FROM: "ClawQL <pay@example.com>",
+      },
+      { fetchImpl: fetchImpl as unknown as typeof fetch }
+    );
+    expect(result.ok).toBe(true);
+    expect(result.messageId).toBe("re_123");
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(call[0]).toBe("https://api.resend.com/emails");
+    expect(call[1].headers).toMatchObject({
+      authorization: "Bearer re_test",
+    });
+  });
+
+  it("returns error on webhook failure", async () => {
+    const fetchImpl = vi.fn(async () => new Response("nope", { status: 500 }));
+    const result = await sendMoneyRequestInviteEmail(
+      {
+        toEmail: "n@x.com",
+        inviteUrl: "https://x/invite",
+        requestId: "r",
+        amountCents: 100,
+      },
+      {
+        CLAWQL_CREDITS_INVITE_EMAIL_DRY_RUN: "0",
+        CLAWQL_CREDITS_INVITE_EMAIL_PROVIDER: "webhook",
+        CLAWQL_CREDITS_INVITE_EMAIL_WEBHOOK_URL: "https://hooks.example/invite",
+      },
+      { fetchImpl: fetchImpl as unknown as typeof fetch }
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/HTTP 500/);
+  });
+
+  it("shouldSendInviteEmailOnCreate respects flag and explicit override", () => {
+    expect(shouldSendInviteEmailOnCreate({}, {})).toBe(false);
+    expect(
+      shouldSendInviteEmailOnCreate({}, { CLAWQL_CREDITS_INVITE_EMAIL: "1" })
+    ).toBe(true);
+    expect(shouldSendInviteEmailOnCreate({ sendEmail: true }, {})).toBe(true);
+    expect(
+      shouldSendInviteEmailOnCreate(
+        { sendEmail: false },
+        { CLAWQL_CREDITS_INVITE_EMAIL: "1" }
+      )
+    ).toBe(false);
+  });
+});

--- a/packages/clawql-payments/src/credits/invite-email.ts
+++ b/packages/clawql-payments/src/credits/invite-email.ts
@@ -1,0 +1,307 @@
+/**
+ * Outbound email for money-request invites.
+ *
+ * Default is dry-run (preview only) — print/share the invite URL remains enough.
+ * Real delivery is opt-in via CLAWQL_CREDITS_INVITE_EMAIL=1 and a provider.
+ * Invite tokens / emails are never written to payment WORM.
+ */
+
+function parseTruthy(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const n = value.trim().toLowerCase();
+  return n === "1" || n === "true" || n === "yes" || n === "on";
+}
+
+function parseFalsey(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const n = value.trim().toLowerCase();
+  return n === "0" || n === "false" || n === "no" || n === "off";
+}
+
+export type InviteEmailProvider = "dry-run" | "webhook" | "resend";
+
+/** Master enable for auto-send / send-invite (still dry-runs unless provider is live). */
+export function isCreditsInviteEmailEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return parseTruthy(env.CLAWQL_CREDITS_INVITE_EMAIL);
+}
+
+/**
+ * Dry-run unless explicitly disabled.
+ * Even with CLAWQL_CREDITS_INVITE_EMAIL=1, keep dry-run until CLAWQL_CREDITS_INVITE_EMAIL_DRY_RUN=0.
+ */
+export function isCreditsInviteEmailDryRun(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (parseFalsey(env.CLAWQL_CREDITS_INVITE_EMAIL_DRY_RUN)) return false;
+  if (parseTruthy(env.CLAWQL_CREDITS_INVITE_EMAIL_DRY_RUN)) return true;
+  // Default: dry-run on (safe).
+  return true;
+}
+
+export function creditsInviteEmailProvider(
+  env: NodeJS.ProcessEnv = process.env
+): InviteEmailProvider {
+  if (isCreditsInviteEmailDryRun(env)) return "dry-run";
+  const raw = (env.CLAWQL_CREDITS_INVITE_EMAIL_PROVIDER ?? "").trim().toLowerCase();
+  if (raw === "webhook" || raw === "resend" || raw === "dry-run") return raw;
+  if (env.CLAWQL_CREDITS_INVITE_EMAIL_RESEND_API_KEY?.trim()) return "resend";
+  if (env.CLAWQL_CREDITS_INVITE_EMAIL_WEBHOOK_URL?.trim()) return "webhook";
+  return "dry-run";
+}
+
+export function creditsInviteEmailFrom(env: NodeJS.ProcessEnv = process.env): string {
+  return (
+    env.CLAWQL_CREDITS_INVITE_EMAIL_FROM?.trim() ||
+    "ClawQL Payments <noreply@clawql.local>"
+  );
+}
+
+export type MoneyRequestInviteEmailInput = {
+  toEmail: string;
+  inviteUrl: string;
+  requestId: string;
+  amountCents: number;
+  note?: string;
+  fromLabel?: string;
+  /** Cleartext invite token — only for email body / claim CLI hint; never persist. */
+  inviteToken?: string;
+  expiresAt?: string;
+};
+
+export type InviteEmailPayload = {
+  to: string;
+  from: string;
+  subject: string;
+  text: string;
+  html: string;
+  meta: {
+    requestId: string;
+    inviteUrl: string;
+    amountUsd: number;
+    provider: InviteEmailProvider;
+    dryRun: boolean;
+  };
+};
+
+export type InviteEmailResult = {
+  ok: boolean;
+  provider: InviteEmailProvider;
+  dryRun: boolean;
+  to: string;
+  subject: string;
+  /** Preview of text body (always returned for CLI/MCP). */
+  previewText: string;
+  messageId?: string;
+  error?: string;
+};
+
+export function buildMoneyRequestInviteEmail(
+  input: MoneyRequestInviteEmailInput,
+  env: NodeJS.ProcessEnv = process.env
+): InviteEmailPayload {
+  const amountUsd = input.amountCents / 100;
+  const fromLabel = input.fromLabel?.trim() || "Someone";
+  const subject =
+    env.CLAWQL_CREDITS_INVITE_EMAIL_SUBJECT?.trim() ||
+    `${fromLabel} requested $${amountUsd.toFixed(2)} via ClawQL`;
+
+  const lines = [
+    `${fromLabel} requested $${amountUsd.toFixed(2)} in ClawQL prepaid credits.`,
+    input.note?.trim() ? `Note: ${input.note.trim()}` : undefined,
+    input.expiresAt ? `Expires: ${input.expiresAt}` : undefined,
+    "",
+    "Open this invite link to join and pay:",
+    input.inviteUrl,
+    "",
+    "Or claim in the CLI:",
+    `clawql payments credits request claim-invite --request-id ${input.requestId}${
+      input.inviteToken ? ` --token ${input.inviteToken}` : " --token <TOKEN>"
+    } --tenant-id <your-id>`,
+    "",
+    "Money only moves after you accept and confirm (stage → confirm + optional TOTP).",
+    "— ClawQL Payments",
+  ].filter((l): l is string => l !== undefined);
+
+  const text = lines.join("\n");
+  const html = `
+<!DOCTYPE html>
+<html><body style="font-family:Georgia,serif;color:#0b1f1c;background:#f4fbf8;padding:24px">
+  <h1 style="font-size:1.4rem;margin:0 0 8px">ClawQL</h1>
+  <p>${escapeHtml(fromLabel)} requested <strong>$${amountUsd.toFixed(2)}</strong> in prepaid credits.</p>
+  ${input.note?.trim() ? `<p style="color:#3d5a54">Note: ${escapeHtml(input.note.trim())}</p>` : ""}
+  <p><a href="${escapeHtml(input.inviteUrl)}" style="display:inline-block;background:#0d6e62;color:#fff;padding:10px 16px;text-decoration:none;border-radius:4px">Open invite</a></p>
+  <p style="font-size:0.85rem;color:#3d5a54;word-break:break-all">${escapeHtml(input.inviteUrl)}</p>
+  <p style="font-size:0.8rem;color:#3d5a54">Money moves only after stage → confirm (+ optional TOTP).</p>
+</body></html>`.trim();
+
+  const provider = creditsInviteEmailProvider(env);
+  return {
+    to: input.toEmail.trim().toLowerCase(),
+    from: creditsInviteEmailFrom(env),
+    subject,
+    text,
+    html,
+    meta: {
+      requestId: input.requestId,
+      inviteUrl: input.inviteUrl,
+      amountUsd,
+      provider,
+      dryRun: provider === "dry-run" || isCreditsInviteEmailDryRun(env),
+    },
+  };
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export type SendInviteEmailOptions = {
+  /** Force dry-run regardless of env. */
+  dryRun?: boolean;
+  /** Override provider. */
+  provider?: InviteEmailProvider;
+  fetchImpl?: typeof fetch;
+};
+
+/**
+ * Deliver (or dry-run) a money-request invite email.
+ * Does not throw on provider HTTP errors — returns `{ ok: false, error }`.
+ */
+export async function sendMoneyRequestInviteEmail(
+  input: MoneyRequestInviteEmailInput,
+  env: NodeJS.ProcessEnv = process.env,
+  options: SendInviteEmailOptions = {}
+): Promise<InviteEmailResult> {
+  const payload = buildMoneyRequestInviteEmail(input, env);
+  const dryRun =
+    options.dryRun === true ||
+    (options.dryRun !== false && (payload.meta.dryRun || options.provider === "dry-run"));
+  const provider: InviteEmailProvider = dryRun
+    ? "dry-run"
+    : options.provider ?? creditsInviteEmailProvider(env);
+
+  const base: InviteEmailResult = {
+    ok: true,
+    provider,
+    dryRun: provider === "dry-run",
+    to: payload.to,
+    subject: payload.subject,
+    previewText: payload.text,
+  };
+
+  if (provider === "dry-run") {
+    return { ...base, messageId: `dry-run-${input.requestId}` };
+  }
+
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  if (typeof fetchImpl !== "function") {
+    return { ...base, ok: false, error: "fetch is not available in this runtime" };
+  }
+
+  try {
+    if (provider === "webhook") {
+      const url = env.CLAWQL_CREDITS_INVITE_EMAIL_WEBHOOK_URL?.trim();
+      if (!url) {
+        return { ...base, ok: false, error: "CLAWQL_CREDITS_INVITE_EMAIL_WEBHOOK_URL not set" };
+      }
+      const res = await fetchImpl(url, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...(env.CLAWQL_CREDITS_INVITE_EMAIL_WEBHOOK_TOKEN?.trim()
+            ? {
+                authorization: `Bearer ${env.CLAWQL_CREDITS_INVITE_EMAIL_WEBHOOK_TOKEN.trim()}`,
+              }
+            : {}),
+        },
+        body: JSON.stringify({
+          type: "credits.money_request.invite",
+          to: payload.to,
+          from: payload.from,
+          subject: payload.subject,
+          text: payload.text,
+          html: payload.html,
+          meta: payload.meta,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        return {
+          ...base,
+          ok: false,
+          error: `webhook HTTP ${res.status}${body ? `: ${body.slice(0, 200)}` : ""}`,
+        };
+      }
+      let messageId: string | undefined;
+      try {
+        const json = (await res.json()) as { id?: string; messageId?: string };
+        messageId = json.messageId ?? json.id;
+      } catch {
+        /* optional */
+      }
+      return { ...base, messageId: messageId ?? `webhook-${input.requestId}` };
+    }
+
+    if (provider === "resend") {
+      const apiKey = env.CLAWQL_CREDITS_INVITE_EMAIL_RESEND_API_KEY?.trim();
+      if (!apiKey) {
+        return {
+          ...base,
+          ok: false,
+          error: "CLAWQL_CREDITS_INVITE_EMAIL_RESEND_API_KEY not set",
+        };
+      }
+      const res = await fetchImpl("https://api.resend.com/emails", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          from: payload.from,
+          to: [payload.to],
+          subject: payload.subject,
+          text: payload.text,
+          html: payload.html,
+        }),
+      });
+      const bodyText = await res.text();
+      if (!res.ok) {
+        return {
+          ...base,
+          ok: false,
+          error: `resend HTTP ${res.status}: ${bodyText.slice(0, 200)}`,
+        };
+      }
+      let messageId: string | undefined;
+      try {
+        messageId = (JSON.parse(bodyText) as { id?: string }).id;
+      } catch {
+        /* optional */
+      }
+      return { ...base, messageId };
+    }
+
+    return { ...base, ok: false, error: `Unknown provider ${provider}` };
+  } catch (e) {
+    return {
+      ...base,
+      ok: false,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+/**
+ * Whether create/invoice should attempt delivery (enabled flag, or explicit CLI --send-email).
+ */
+export function shouldSendInviteEmailOnCreate(
+  options: { sendEmail?: boolean } = {},
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  if (options.sendEmail === false) return false;
+  if (options.sendEmail === true) return true;
+  return isCreditsInviteEmailEnabled(env);
+}

--- a/packages/clawql-payments/src/plugin/payments-tools-plugin.test.ts
+++ b/packages/clawql-payments/src/plugin/payments-tools-plugin.test.ts
@@ -31,6 +31,7 @@ describe("payments tools MCP plugin", () => {
       "payments_credits_activity",
       "payments_credits_link",
       "payments_credits_request_create",
+      "payments_credits_request_send_invite",
       "payments_credits_request_list",
       "payments_credits_request_claim_invite",
       "payments_credits_request_accept",

--- a/packages/clawql-payments/src/plugin/payments-tools-plugin.ts
+++ b/packages/clawql-payments/src/plugin/payments-tools-plugin.ts
@@ -26,6 +26,7 @@ import {
   getEmailEntry,
   getHandleEntry,
   getPhoneEntry,
+  getTenantEntry,
   listDirectory,
   resolveRecipient,
 } from "../credits/directory.js";
@@ -36,6 +37,10 @@ import {
   listMoneyRequests,
   publicMoneyRequest,
 } from "../credits/requests.js";
+import {
+  sendMoneyRequestInviteEmail,
+  shouldSendInviteEmailOnCreate,
+} from "../credits/invite-email.js";
 import { getActivityFeed } from "../credits/activity.js";
 import {
   buildClawqlPayUri,
@@ -230,6 +235,11 @@ const creditsRequestCreateSchema = {
   amountUsd: z.number().positive(),
   fromTenantId: z.string().optional().describe("Requester tenant"),
   note: z.string().optional().describe("Invoice memo"),
+  sendEmail: z
+    .boolean()
+    .optional()
+    .describe("Send invite email (dry-run by default; set CLAWQL_CREDITS_INVITE_EMAIL=1)"),
+  emailDryRun: z.boolean().optional().describe("Force email dry-run preview"),
   mandateJwt: z.string().optional(),
 };
 
@@ -619,7 +629,7 @@ export function createPaymentsToolsPlugin(env: NodeJS.ProcessEnv = process.env):
         yield* api.registerMcpTool({
           name: "payments_credits_request_create",
           description:
-            "Create a money request / invoice. Prefer email — unknown emails get an invite URL to join ClawQL and pay.",
+            "Create a money request / invoice. Prefer email — unknown emails get an invite URL to join ClawQL and pay. Optional invite email (dry-run by default).",
           schema: creditsRequestCreateSchema,
           handler: async (args) => {
             const a = args as {
@@ -627,26 +637,110 @@ export function createPaymentsToolsPlugin(env: NodeJS.ProcessEnv = process.env):
               amountUsd: number;
               fromTenantId?: string;
               note?: string;
+              sendEmail?: boolean;
+              emailDryRun?: boolean;
               mandateJwt?: string;
             };
             await assertAp2IfRequired(env, a.mandateJwt);
+            const fromTenantId = a.fromTenantId?.trim() || "default";
             const result = await createMoneyRequest(
               {
-                requesterTenantId: a.fromTenantId?.trim() || "default",
+                requesterTenantId: fromTenantId,
                 to: a.to,
                 amountCents: Math.round(a.amountUsd * 100),
                 note: a.note,
               },
               env
             );
+            let email:
+              | Awaited<ReturnType<typeof sendMoneyRequestInviteEmail>>
+              | undefined;
+            if (
+              result.invite &&
+              result.inviteToken &&
+              result.request.inviteUrl &&
+              result.request.payerEmail &&
+              shouldSendInviteEmailOnCreate({ sendEmail: a.sendEmail }, env)
+            ) {
+              const requester = await getTenantEntry(fromTenantId, env);
+              email = await sendMoneyRequestInviteEmail(
+                {
+                  toEmail: result.request.payerEmail,
+                  inviteUrl: result.request.inviteUrl,
+                  requestId: result.request.requestId,
+                  amountCents: result.request.amountCents,
+                  note: result.request.note,
+                  fromLabel:
+                    requester?.displayName ||
+                    (requester?.handle ? `@${requester.handle}` : undefined) ||
+                    requester?.email ||
+                    fromTenantId,
+                  inviteToken: result.inviteToken,
+                  expiresAt: result.request.expiresAt,
+                },
+                env,
+                { dryRun: a.emailDryRun === true ? true : a.emailDryRun }
+              );
+            }
             return textResult({
               ...publicMoneyRequest(result.request),
               invite: result.invite,
               inviteToken: result.inviteToken,
+              email,
               next: result.invite
-                ? "Share inviteUrl / inviteToken; payer runs claim-invite then accept."
+                ? "Share inviteUrl / inviteToken (or use email preview); payer runs claim-invite then accept."
                 : "Payer: payments_credits_request_accept with requestId.",
             });
+          },
+        });
+
+        yield* api.registerMcpTool({
+          name: "payments_credits_request_send_invite",
+          description:
+            "Preview or send the money-request invite email (needs cleartext token from create). Dry-run by default.",
+          schema: {
+            requestId: z.string(),
+            token: z.string().describe("Cleartext invite token from create"),
+            email: z.string().optional().describe("Override recipient email"),
+            emailDryRun: z.boolean().optional(),
+          },
+          handler: async (args) => {
+            const a = args as {
+              requestId: string;
+              token: string;
+              email?: string;
+              emailDryRun?: boolean;
+            };
+            const { getMoneyRequest, buildRequestInviteUrl } = await import(
+              "../credits/requests.js"
+            );
+            const req = await getMoneyRequest(a.requestId, env);
+            if (!req) throw new Error("Unknown request id");
+            const toEmail = a.email?.trim() || req.payerEmail;
+            if (!toEmail) throw new Error("No payer email — pass email");
+            const inviteUrl =
+              req.inviteUrl || buildRequestInviteUrl(a.requestId, a.token, env);
+            const requester = await getTenantEntry(req.requesterTenantId, env);
+            return textResult(
+              await sendMoneyRequestInviteEmail(
+                {
+                  toEmail,
+                  inviteUrl,
+                  requestId: a.requestId,
+                  amountCents: req.amountCents,
+                  note: req.note,
+                  fromLabel:
+                    requester?.displayName ||
+                    (requester?.handle ? `@${requester.handle}` : undefined) ||
+                    requester?.email ||
+                    req.requesterTenantId,
+                  inviteToken: a.token,
+                  expiresAt: req.expiresAt,
+                },
+                env,
+                { dryRun: a.emailDryRun === true ? true : a.emailDryRun }
+              )
+            );
           },
         });
 

--- a/src/onboarding/cli.ts
+++ b/src/onboarding/cli.ts
@@ -115,6 +115,7 @@ import {
   runPaymentsCreditsRequestAcceptCmd,
   runPaymentsCreditsRequestDeclineCmd,
   runPaymentsCreditsRequestCancelCmd,
+  runPaymentsCreditsRequestSendInviteCmd,
   runPaymentsCreditsStepUpEnrollCmd,
   runPaymentsCreditsStepUpShowCmd,
   runPaymentsCompensationBalanceCmd,
@@ -337,6 +338,8 @@ function parse(argv: string[]): {
     else if (a === "--verified") flags.phoneVerified = true;
     else if (a === "--contact-id") flags.contactId = argv[++i] ?? "";
     else if (a === "--label") flags.label = argv[++i] ?? "";
+    else if (a === "--send-email") flags.sendEmail = true;
+    else if (a === "--email-dry-run" || a === "--dry-run-email") flags.emailDryRun = true;
     else if (a === "--totp") flags.totp = argv[++i] ?? "";
     else if (a === "--direct") flags.direct = true;
     else if (a.startsWith("--image-digest=")) {
@@ -439,7 +442,8 @@ Usage:
   clawql payments credits qr --to @alice [--amount 10] [--out pay.svg]
   clawql payments credits activity [--tenant-id ID] [--limit 25] [--filter money|transfers|requests|all]
   clawql payments credits request|invoice --to newbie@acme.com|--to @bob --amount 25 [--note …]
-  clawql payments credits request list|show|accept|decline|cancel|claim-invite …
+  clawql payments credits request list|show|accept|decline|cancel|claim-invite|send-invite …
+  clawql payments credits request --to newbie@acme.com --amount 25 --send-email [--email-dry-run]
   clawql payments credits transfer --to-tenant other-tenant --amount 10
   clawql payments credits transfer --confirm --action-id UUID --code HEX [--totp NNNNNN]
   clawql payments credits step-up enroll|show [--tenant-id ID] [--show-secrets]
@@ -1210,6 +1214,8 @@ async function main(): Promise<void> {
       phoneVerified: Boolean(flags.phoneVerified),
       contactId: typeof flags.contactId === "string" ? flags.contactId : undefined,
       label: typeof flags.label === "string" ? flags.label : undefined,
+      sendEmail: Boolean(flags.sendEmail),
+      emailDryRun: Boolean(flags.emailDryRun),
     };
 
     if (subcmd === "plan") {
@@ -1429,6 +1435,7 @@ async function main(): Promise<void> {
           "decline",
           "cancel",
           "claim-invite",
+          "send-invite",
         ]);
         const action =
           rest[1] && known.has(rest[1]) ? rest[1] : "create";
@@ -1442,6 +1449,10 @@ async function main(): Promise<void> {
         }
         if (action === "claim-invite") {
           process.exitCode = await runPaymentsCreditsRequestClaimInviteCmd(paymentsOpts);
+          return;
+        }
+        if (action === "send-invite") {
+          process.exitCode = await runPaymentsCreditsRequestSendInviteCmd(paymentsOpts);
           return;
         }
         if (action === "accept") {

--- a/src/onboarding/payments-cli.ts
+++ b/src/onboarding/payments-cli.ts
@@ -52,6 +52,7 @@ import {
   runPaymentsCreditsRequestAccept,
   runPaymentsCreditsRequestDecline,
   runPaymentsCreditsRequestCancel,
+  runPaymentsCreditsRequestSendInvite,
   runPaymentsCreditsLink,
   runPaymentsCreditsQr,
   runPaymentsCreditsStepUpEnroll,
@@ -164,6 +165,10 @@ export type PaymentsCliOptions = {
   phoneVerified?: boolean;
   contactId?: string;
   label?: string;
+  /** Send invite email on request create / send-invite. */
+  sendEmail?: boolean;
+  /** Force invite email dry-run preview. */
+  emailDryRun?: boolean;
 };
 
 export async function runPaymentsPlanShowCmd(options: PaymentsCliOptions = {}): Promise<number> {
@@ -651,6 +656,8 @@ export async function runPaymentsCreditsRequestCreateCmd(
     amountUsd: options.amount,
     note: options.note,
     correlationId: options.correlationId,
+    sendEmail: options.sendEmail,
+    emailDryRun: options.emailDryRun,
     json: options.json,
   });
 }
@@ -668,6 +675,8 @@ export async function runPaymentsCreditsInvoiceCmd(
     amountUsd: options.amount,
     note: options.note,
     correlationId: options.correlationId,
+    sendEmail: options.sendEmail,
+    emailDryRun: options.emailDryRun,
     json: options.json,
   });
 }
@@ -732,6 +741,18 @@ export async function runPaymentsCreditsRequestCancelCmd(
   return runPaymentsCreditsRequestCancel({
     requestId: options.requestId,
     tenantId: options.tenantId ?? options.fromTenantId,
+    json: options.json,
+  });
+}
+
+export async function runPaymentsCreditsRequestSendInviteCmd(
+  options: PaymentsCliOptions = {}
+): Promise<number> {
+  return runPaymentsCreditsRequestSendInvite({
+    requestId: options.requestId,
+    inviteToken: options.inviteToken,
+    email: options.directoryEmail ?? options.email,
+    emailDryRun: options.emailDryRun,
     json: options.json,
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Last consumer P2P roadmap bit: **outbound invite email**, dry-run first so print/share URL stays the safe default.

Stacked on `#833` (`cursor/payments-credits-contacts-ui-611b`).

### What shipped
- `sendMoneyRequestInviteEmail` with providers: **dry-run** (default), **webhook**, **Resend**
- CLI: `request --send-email [--email-dry-run]`, `request send-invite`
- MCP: `payments_credits_request_create` (`sendEmail`) + `payments_credits_request_send_invite`
- Docs: [`docs/payments/credits-invite-email.md`](docs/payments/credits-invite-email.md); roadmap checked off

### Safety
- Dry-run until `CLAWQL_CREDITS_INVITE_EMAIL_DRY_RUN=0`
- Invite tokens / emails never written to payment WORM
- Create still always prints invite URL

## Test plan
- [x] `vitest` invite-email + payments-tools-plugin + requests
- [x] `clawql-payments` typecheck
- [ ] Manual: `--send-email --email-dry-run` preview
- [ ] Manual: webhook/resend with `DRY_RUN=0`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

