### PR TITLE
fix(pulumi): handle Cloudflare account-token 401 for R2 state auth

### DIFF
--- a/.github/workflows/pulumi-cloudflare-edge.yml
+++ b/.github/workflows/pulumi-cloudflare-edge.yml
@@ -7,8 +7,10 @@
 #   CLOUDFLARE_API_TOKEN   — required for deploy
 #   CLOUDFLARE_ACCOUNT_ID  — required for deploy
 # Optional:
+#   CLOUDFLARE_API_TOKEN_ID — token UUID (needed when token is account-scoped and
+#     /user/tokens/verify returns 401; Access Key ID for R2 S3 mapping)
 #   CLAWQL_R2_ACCESS_KEY_ID / CLAWQL_R2_SECRET_ACCESS_KEY — explicit R2 S3 keys
-#     (otherwise derived from API token id + SHA-256 of token value)
+#     (preferred over token derivation)
 #   PULUMI_CONFIG_PASSPHRASE — preferred stable passphrase for stack secrets
 #
 name: Pulumi Cloudflare edge
@@ -111,6 +113,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN_ID: ${{ secrets.CLOUDFLARE_API_TOKEN_ID }}
           CLAWQL_R2_ACCESS_KEY_ID: ${{ secrets.CLAWQL_R2_ACCESS_KEY_ID }}
           CLAWQL_R2_SECRET_ACCESS_KEY: ${{ secrets.CLAWQL_R2_SECRET_ACCESS_KEY }}
           CLAWQL_SYNC_ACCESS_KEY_ID: ${{ secrets.CLAWQL_SYNC_ACCESS_KEY_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Pulumi edge CI 401 on account-scoped Cloudflare tokens** — `/user/tokens/verify` often returns 401 for Workers account tokens after R2 bucket create succeeds. Accept `CLOUDFLARE_API_TOKEN_ID` (or explicit `CLAWQL_R2_*` S3 keys) when deriving R2 credentials for the Pulumi state backend ([`scripts/pulumi/ensure-r2-state-backend.sh`](scripts/pulumi/ensure-r2-state-backend.sh)).
+
 ### Added
 
 - **Pulumi Cloudflare edge CI/CD** — [`.github/workflows/pulumi-cloudflare-edge.yml`](.github/workflows/pulumi-cloudflare-edge.yml) runs unit tests on PR and `workflow_dispatch` `preview`/`up` against R2-backed Pulumi state (`clawql-pulumi-state`). Scripts: [`scripts/pulumi/ensure-r2-state-backend.sh`](scripts/pulumi/ensure-r2-state-backend.sh), [`scripts/pulumi/deploy-edge.sh`](scripts/pulumi/deploy-edge.sh). Reuses `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`.

--- a/docs/deployment/hosted-live-bootstrap.md
+++ b/docs/deployment/hosted-live-bootstrap.md
@@ -13,14 +13,18 @@ Workflow: [`.github/workflows/pulumi-cloudflare-edge.yml`](../../.github/workflo
 | `workflow_dispatch`               | Ensure R2 bucket `clawql-pulumi-state`, `pulumi login` to R2, then `preview` or `up` for stack `edge-prod` |
 
 **Secrets (reuse docs/landing):** `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`.  
-Optional: `CLAWQL_R2_ACCESS_KEY_ID` / `CLAWQL_R2_SECRET_ACCESS_KEY` (else derived from API token per [Cloudflare R2 token docs](https://developers.cloudflare.com/r2/api/tokens/)); `PULUMI_CONFIG_PASSPHRASE` (stable passphrase — recommended).
+Optional:
+
+- `CLOUDFLARE_API_TOKEN_ID` — required when the token is **account-scoped** (Workers template). Those tokens 401 on `/user/tokens/verify`; the Token ID from the dashboard is the R2 Access Key ID.
+- `CLAWQL_R2_ACCESS_KEY_ID` / `CLAWQL_R2_SECRET_ACCESS_KEY` — dedicated R2 S3 keys (clearest for CI).
+- `PULUMI_CONFIG_PASSPHRASE` — stable passphrase (recommended).
 
 ```bash
 gh workflow run pulumi-cloudflare-edge.yml -f action=preview -f stack=edge-prod
 gh workflow run pulumi-cloudflare-edge.yml -f action=up -f stack=edge-prod -f deploy_worker_stub=true
 ```
 
-Token needs **Workers R2 Storage Write** (and Workers Scripts Edit if deploying the stub). Account-scoped tokens that cannot call `/user/tokens/verify` must use explicit R2 access key secrets.
+Token needs **Workers R2 Storage Write** (and Workers Scripts Edit if deploying the stub). If preview fails with HTTP 401 on credential derivation, add `CLOUDFLARE_API_TOKEN_ID` or R2 S3 key secrets and re-run.
 
 ## Separation of concerns
 

--- a/scripts/pulumi/ensure-r2-state-backend.sh
+++ b/scripts/pulumi/ensure-r2-state-backend.sh
@@ -2,14 +2,21 @@
 # Ensure Pulumi R2 state bucket exists and export AWS_* + PULUMI_BACKEND_URL for pulumi login.
 #
 # Uses CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID (same secrets as docs/landing deploy).
-# Derives R2 S3 Access Key ID / Secret from the API token per Cloudflare docs:
-#   Access Key ID = token id (from /user/tokens/verify)
-#   Secret Access Key = SHA-256 hex of the token value
-# https://developers.cloudflare.com/r2/api/tokens/
 #
-# Optional overrides (long-lived R2 keys):
-#   CLAWQL_R2_ACCESS_KEY_ID / CLAWQL_R2_SECRET_ACCESS_KEY
-#   or CLAWQL_SYNC_ACCESS_KEY_ID / CLAWQL_SYNC_SECRET_ACCESS_KEY
+# R2 S3 credentials for `pulumi login` (S3-compatible API), in order:
+#   1) CLAWQL_R2_ACCESS_KEY_ID + CLAWQL_R2_SECRET_ACCESS_KEY
+#      (or CLAWQL_SYNC_ACCESS_KEY_ID / CLAWQL_SYNC_SECRET_ACCESS_KEY)
+#   2) Derive from Cloudflare API token per
+#      https://developers.cloudflare.com/r2/api/tokens/
+#        Access Key ID = token id
+#        Secret Access Key = SHA-256 hex of the token value
+#      Token id sources:
+#        a) CLOUDFLARE_API_TOKEN_ID secret (required for account-scoped Workers tokens)
+#        b) GET /user/tokens/verify (works for user-scoped tokens only)
+#
+# Account-scoped "Edit Cloudflare Workers" tokens often 401 on /user/tokens/verify —
+# that is expected. Add CLOUDFLARE_API_TOKEN_ID (Dashboard → API Tokens → token id)
+# or create R2 S3 keys under R2 → Manage API Tokens.
 #
 # Usage (CI):
 #   source scripts/pulumi/ensure-r2-state-backend.sh
@@ -46,6 +53,21 @@ cf_api() {
   fi
 }
 
+# Like cf_api but do not fail the script on HTTP errors (caller inspects status/body).
+cf_api_soft() {
+  local method="$1"
+  local path="$2"
+  local out_file="$3"
+  local http_code
+  http_code="$(
+    curl -sS -o "${out_file}" -w "%{http_code}" -X "${method}" \
+      "https://api.cloudflare.com/client/v4${path}" \
+      -H "Authorization: Bearer ${API_TOKEN}" \
+      -H "Content-Type: application/json" || true
+  )"
+  echo "${http_code}"
+}
+
 echo "::group::Ensure R2 state bucket ${STATE_BUCKET}"
 # List / create via Cloudflare R2 REST (Workers R2 Storage Write)
 list_json="$(cf_api GET "/accounts/${ACCOUNT_ID}/r2/buckets" || echo '{}')"
@@ -74,24 +96,55 @@ fi
 echo "::endgroup::"
 
 echo "::group::Resolve R2 S3 credentials for Pulumi backend"
+TOKEN_ID=""
 if [[ -n "${CLAWQL_R2_ACCESS_KEY_ID:-${CLAWQL_SYNC_ACCESS_KEY_ID:-}}" && -n "${CLAWQL_R2_SECRET_ACCESS_KEY:-${CLAWQL_SYNC_SECRET_ACCESS_KEY:-}}" ]]; then
   export AWS_ACCESS_KEY_ID="${CLAWQL_R2_ACCESS_KEY_ID:-${CLAWQL_SYNC_ACCESS_KEY_ID}}"
   export AWS_SECRET_ACCESS_KEY="${CLAWQL_R2_SECRET_ACCESS_KEY:-${CLAWQL_SYNC_SECRET_ACCESS_KEY}}"
   echo "Using explicit R2/S3 access keys from environment"
 else
-  # Derive from Cloudflare API token (documented R2 mapping)
-  verify_json="$(cf_api GET "/user/tokens/verify")"
-  TOKEN_ID="$(echo "${verify_json}" | jq -r '.result.id // empty')"
+  # Prefer explicit token id (account-scoped Workers tokens cannot call /user/tokens/verify)
+  if [[ -n "${CLOUDFLARE_API_TOKEN_ID:-}" ]]; then
+    TOKEN_ID="${CLOUDFLARE_API_TOKEN_ID}"
+    echo "Using CLOUDFLARE_API_TOKEN_ID for R2 Access Key ID"
+  else
+    verify_code=""
+    verify_code="$(cf_api_soft GET "/user/tokens/verify" /tmp/clawql-token-verify.json)"
+    if [[ "${verify_code}" == "200" ]]; then
+      TOKEN_ID="$(jq -r '.result.id // empty' /tmp/clawql-token-verify.json)"
+      echo "Resolved token id via /user/tokens/verify"
+    else
+      echo "::warning::/user/tokens/verify returned HTTP ${verify_code} (common for account-scoped API tokens)."
+      jq . /tmp/clawql-token-verify.json 2>/dev/null || cat /tmp/clawql-token-verify.json || true
+    fi
+  fi
+
   if [[ -z "${TOKEN_ID}" || "${TOKEN_ID}" == "null" ]]; then
-    echo "::error::Could not resolve API token id from /user/tokens/verify. Token may be account-scoped without user verify — set CLAWQL_R2_ACCESS_KEY_ID / CLAWQL_R2_SECRET_ACCESS_KEY secrets instead." >&2
-    echo "${verify_json}" | jq . >&2 || true
+    cat >&2 <<'EOF'
+::error::Cannot derive R2 S3 credentials for Pulumi state backend.
+
+Your CLOUDFLARE_API_TOKEN can manage R2 via the Cloudflare REST API (bucket create
+succeeded) but cannot be mapped to S3 Access Keys without the token id.
+
+Pick one fix (then re-run the workflow):
+
+  A) Add repo secret CLOUDFLARE_API_TOKEN_ID
+     Dashboard → My Profile → API Tokens → open the token → copy Token ID
+     (Access Key ID = token id; Secret = SHA-256 of the token value — we compute that)
+
+  B) Add dedicated R2 S3 keys (recommended for CI)
+     R2 → Overview → API Tokens → Create API token (Object Read & Write on clawql-pulumi-state)
+     Secrets: CLAWQL_R2_ACCESS_KEY_ID + CLAWQL_R2_SECRET_ACCESS_KEY
+
+Docs: https://developers.cloudflare.com/r2/api/tokens/
+EOF
     exit 1
   fi
+
   export AWS_ACCESS_KEY_ID="${TOKEN_ID}"
   derived_secret=""
   derived_secret="$(printf '%s' "${API_TOKEN}" | sha256sum | awk '{print $1}')"
   export AWS_SECRET_ACCESS_KEY="${derived_secret}"
-  echo "Derived R2 S3 credentials from CLOUDFLARE_API_TOKEN (Access Key ID = token id)"
+  echo "Derived R2 S3 Secret Access Key = SHA-256(CLOUDFLARE_API_TOKEN)"
 fi
 export AWS_REGION="${AWS_REGION:-auto}"
 export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-auto}"
@@ -105,8 +158,9 @@ echo "PULUMI_BACKEND_URL=${PULUMI_BACKEND_URL}"
 
 # Stable passphrase: prefer dedicated secret; else deterministic from account id (document rotation risk)
 if [[ -z "${PULUMI_CONFIG_PASSPHRASE:-}" && -z "${PULUMI_CONFIG_PASSPHRASE_FILE:-}" ]]; then
-  export PULUMI_CONFIG_PASSPHRASE
-  PULUMI_CONFIG_PASSPHRASE="$(printf 'clawql-pulumi-v1:%s' "${ACCOUNT_ID}" | sha256sum | awk '{print $1}')"
+  derived_pass=""
+  derived_pass="$(printf 'clawql-pulumi-v1:%s' "${ACCOUNT_ID}" | sha256sum | awk '{print $1}')"
+  export PULUMI_CONFIG_PASSPHRASE="${derived_pass}"
   echo "::warning::PULUMI_CONFIG_PASSPHRASE unset — using account-derived passphrase. Prefer a dedicated repo secret PULUMI_CONFIG_PASSPHRASE for production."
 fi
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Cloudflare edge deploy **401** from [run 30981428232](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/30981428232).

### Cause
`CLOUDFLARE_API_TOKEN` successfully created the R2 bucket via REST, then the script called `GET /user/tokens/verify` to derive S3 Access Key ID. Account-scoped Workers tokens return **401** on that user endpoint — that is expected, not a bad token.

### Fix
- Soft-fail `/user/tokens/verify` instead of hard-failing on 401
- Accept `CLOUDFLARE_API_TOKEN_ID` (Access Key ID = token id; Secret = SHA-256 of token value)
- Prefer explicit `CLAWQL_R2_ACCESS_KEY_ID` / `CLAWQL_R2_SECRET_ACCESS_KEY` when set
- Clearer error text with both options

### After merge (operator)
Add one of:
1. **`CLAWQL_R2_ACCESS_KEY_ID` + `CLAWQL_R2_SECRET_ACCESS_KEY`** (recommended) — R2 → Manage API Tokens, Object R/W on `clawql-pulumi-state`
2. **`CLOUDFLARE_API_TOKEN_ID`** — Token ID from the same token as `CLOUDFLARE_API_TOKEN`

Then re-run:
```bash
gh workflow run pulumi-cloudflare-edge.yml --ref main -f action=preview -f stack=edge-prod
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5a07-15ee-7a2a-828a-9ad0a5c8763c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5a07-15ee-7a2a-828a-9ad0a5c8763c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

