### PR TITLE
chore(openbench): Phase 0 n=3 policy-deny-execute

### DIFF
--- a/docs/benchmarks/openbench-advanced-suites.md
+++ b/docs/benchmarks/openbench-advanced-suites.md
@@ -198,7 +198,7 @@ Work **in this order** unless blocked:
 4. **[B3.1-a→e]** Ship `codegraph-impact-edit` to `pr_active`, watch CI, retire. ✅ [30969554941](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/30969554941)
 5. **[B4.2-0] / [B4.3-0]** Spikes; only then optional cells. ← **next**
 6. **[P0-c]** First n=3 on `search-first-discovery`. ✅ [31011980064](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31011980064)
-7. **[P0-d]** Remaining queue: `memory-roundtrip-ingest-recall`, `policy-deny-execute`.
+7. **[P0-d]** Remaining queue complete: memory-roundtrip ✅ [31014040293](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31014040293); policy-deny ✅ [31016004063](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31016004063).
 8. Park B-1/B-2-full/B-5/B-6 until their gates open; keep specs updated here. Collect traces on every live cell in the meantime.
 
 Each shipped cell must also update: `ci-matrix.json`, task explanations, ledger, stack-coverage, and (for product claims) vision/GTM tables when headline-worthy.

--- a/docs/benchmarks/openbench-results-ledger.md
+++ b/docs/benchmarks/openbench-results-ledger.md
@@ -384,7 +384,7 @@ Run: [31014040293](https://github.com/danielsmithdevelopment/ClawQL/actions/runs
 | -------------------------------- | -------- | ------------------------------------------------------------------------------------------------- |
 | `search-first-discovery`         | 3        | **done** [31011980064](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31011980064) |
 | `memory-roundtrip-ingest-recall` | 3        | **done** [31014040293](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31014040293) |
-| `policy-deny-execute`            | 3        | queued                                                                                            |
+| `policy-deny-execute`            | 3        | **in progress** via `pr_active` + `pr_trials: 3`                                                  |
 
 ### 2026-08-05 — Phase 0 n≥3 kickoff (`pr_trials`)
 

--- a/docs/benchmarks/openbench-results-ledger.md
+++ b/docs/benchmarks/openbench-results-ledger.md
@@ -393,10 +393,10 @@ Run: [31016004063](https://github.com/danielsmithdevelopment/ClawQL/actions/runs
 
 ### Replication queue (Phase 0)
 
-| Task                             | Target n | Status                                                                                            |
-| -------------------------------- | -------- | ------------------------------------------------------------------------------------------------- |
-| `search-first-discovery`         | 3        | **done** [31011980064](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31011980064) |
-| `memory-roundtrip-ingest-recall` | 3        | **done** [31014040293](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31014040293) |
+| Task                             | Target n | Status                                                                                                            |
+| -------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
+| `search-first-discovery`         | 3        | **done** [31011980064](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31011980064)                 |
+| `memory-roundtrip-ingest-recall` | 3        | **done** [31014040293](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31014040293)                 |
 | `policy-deny-execute`            | 3        | **done (margin)** [31016004063](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31016004063) on 2/3 |
 
 ### 2026-08-05 — Phase 0 n≥3 kickoff (`pr_trials`)

--- a/docs/benchmarks/openbench-results-ledger.md
+++ b/docs/benchmarks/openbench-results-ledger.md
@@ -382,14 +382,14 @@ Run: [31014040293](https://github.com/danielsmithdevelopment/ClawQL/actions/runs
 
 | Arm        | Success | Mean score | Mean turns | Mean wall (s) |
 | ---------- | ------- | ---------- | ---------- | ------------- |
-| clawql-on  | **3/3** | **1.0**    | 3          | 22.9          |
-| clawql-off | **0/3** | **0.0**    | 3.333      | 23.4          |
+| clawql-on  | **2/3** | **0.667**  | 3          | 22.9          |
+| clawql-off | **0/3** | **0.0**    | 3.3        | 23.4          |
 
-Run: [31016004063](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31016004063). Gate OK. **Durable R2:** 6× schema **1.1** RTP → `r2://clawql-openbench-traces/raw/2026/08/05/run-31016004063/policy-deny-execute/`.
+Run: [31016004063](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31016004063). Gate OK (`on_score=0.667` > off). **Durable R2:** 6× schema **1.1** RTP → `r2://clawql-openbench-traces/raw/2026/08/05/run-31016004063/policy-deny-execute/`.
 
-**Wilson 95%:** on `[0.438, 1.000]` · off `[0.000, 0.562]`.
+**Wilson 95%:** on `[0.208, 0.939]` · off `[0.000, 0.562]` — wider/overlap due to on-arm trial-3 miss (not a clean 3/3). Headline claim remains prior 1.0 run [30872913516](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/30872913516).
 
-**Verdict:** Phase 0 replication queue **complete**. Clear `pr_active`, reset `pr_trials=1`. Next: B-4.2/B-4.3 spikes or optional n≥5.
+**Verdict:** Phase 0 queue **complete** (margin WIN). Clear `pr_active`, reset `pr_trials=1`. Optional: re-run policy-deny n≥5 for cleaner CI; next product spikes B-4.2/B-4.3.
 
 ### Replication queue (Phase 0)
 
@@ -397,7 +397,7 @@ Run: [31016004063](https://github.com/danielsmithdevelopment/ClawQL/actions/runs
 | -------------------------------- | -------- | ------------------------------------------------------------------------------------------------- |
 | `search-first-discovery`         | 3        | **done** [31011980064](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31011980064) |
 | `memory-roundtrip-ingest-recall` | 3        | **done** [31014040293](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31014040293) |
-| `policy-deny-execute`            | 3        | **done** [31016004063](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31016004063) |
+| `policy-deny-execute`            | 3        | **done (margin)** [31016004063](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31016004063) on 2/3 |
 
 ### 2026-08-05 — Phase 0 n≥3 kickoff (`pr_trials`)
 

--- a/docs/benchmarks/openbench-results-ledger.md
+++ b/docs/benchmarks/openbench-results-ledger.md
@@ -313,7 +313,7 @@ Those four were retired after this run; later wave added hybrid/codegraph/schedu
 
 ## Open gaps (not yet headline WIN)
 
-1. **n≥3 (ideally ≥5)** trials per cell for Wilson intervals — `search-first-discovery` + `memory-roundtrip-ingest-recall` **done**; remaining: `policy-deny-execute` — Phase 0 in [`openbench-advanced-suites.md`](./openbench-advanced-suites.md).
+1. **n≥3 (ideally ≥5)** trials per cell for Wilson intervals — Phase 0 headline trio **done** (search / memory-roundtrip / policy-deny n=3); optional n≥5 for non-overlap CIs — Phase 0 in [`openbench-advanced-suites.md`](./openbench-advanced-suites.md).
 2. **Phase 1 advanced:** B-4.1 / B-3.1 / `codegraph-feature-api-surface` / composed RTP recollect **retired WIN**; next B-4.2/B-4.3 spikes (`memory-stale-after-update`, `memory-injection-attempt` task folders exist) or remaining P0 n≥3.
 3. **Trace collection:** GHA call-store JSONL now persists — [`openbench-trace-collection.md`](./openbench-trace-collection.md).
 4. Optional later: agentic external benches / domain HLE-analog (B-6) after fine-tune — not closed-book HLE.
@@ -378,13 +378,26 @@ Run: [31014040293](https://github.com/danielsmithdevelopment/ClawQL/actions/runs
 
 **Verdict:** clear `pr_active`, reset `pr_trials=1`. Next: `policy-deny-execute` n=3.
 
+### 2026-08-05 — Phase 0 n=3 WIN: `policy-deny-execute`
+
+| Arm        | Success | Mean score | Mean turns | Mean wall (s) |
+| ---------- | ------- | ---------- | ---------- | ------------- |
+| clawql-on  | **3/3** | **1.0**    | 3          | 22.9          |
+| clawql-off | **0/3** | **0.0**    | 3.333      | 23.4          |
+
+Run: [31016004063](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31016004063). Gate OK. **Durable R2:** 6× schema **1.1** RTP → `r2://clawql-openbench-traces/raw/2026/08/05/run-31016004063/policy-deny-execute/`.
+
+**Wilson 95%:** on `[0.438, 1.000]` · off `[0.000, 0.562]`.
+
+**Verdict:** Phase 0 replication queue **complete**. Clear `pr_active`, reset `pr_trials=1`. Next: B-4.2/B-4.3 spikes or optional n≥5.
+
 ### Replication queue (Phase 0)
 
 | Task                             | Target n | Status                                                                                            |
 | -------------------------------- | -------- | ------------------------------------------------------------------------------------------------- |
 | `search-first-discovery`         | 3        | **done** [31011980064](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31011980064) |
 | `memory-roundtrip-ingest-recall` | 3        | **done** [31014040293](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31014040293) |
-| `policy-deny-execute`            | 3        | **in progress** via `pr_active` + `pr_trials: 3`                                                  |
+| `policy-deny-execute`            | 3        | **done** [31016004063](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31016004063) |
 
 ### 2026-08-05 — Phase 0 n≥3 kickoff (`pr_trials`)
 

--- a/docs/benchmarks/openbench-stack-coverage.md
+++ b/docs/benchmarks/openbench-stack-coverage.md
@@ -55,7 +55,7 @@ Unit/integration tests prove APIs exist. **OpenBench proves agents use them and 
 
 Still missing after this wave: n≥3 trials; ops-only (Argo / live Onyx / live Slack / R2). Full diary: [`openbench-results-ledger.md`](./openbench-results-ledger.md).
 
-**CI spend control:** only [`openbench/ci-matrix.json`](../../openbench/ci-matrix.json) → `pr_active` burns tokens on PR/push. Graded cells above are **`retired`**; **`pr_active` empty** after Phase 0 memory-roundtrip n=3 WIN ([31014040293](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31014040293)); next `policy-deny-execute` n=3 or B-4.2/B-4.3 spikes. Ouroboros workflow is dispatch-only.
+**CI spend control:** only [`openbench/ci-matrix.json`](../../openbench/ci-matrix.json) → `pr_active` burns tokens on PR/push. Graded cells above are **`retired`**; **`pr_active` empty** after Phase 0 queue complete (policy-deny n=3 [31016004063](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31016004063)); next B-4.2/B-4.3 spikes or optional n≥5. Ouroboros workflow is dispatch-only.
 
 Explanations for every verified cell: [`openbench-task-explanations.md`](./openbench-task-explanations.md).
 
@@ -167,7 +167,7 @@ See [`ouroboros-value-evidence.md`](./ouroboros-value-evidence.md). P0: `doom_lo
 
 16. ~~**Onyx mock cite**~~ — verified on 1.0 / off 0.0 ([30893132189](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/30893132189)).
 17. ~~**Memory wikilink hop**~~ — verified on 1.0 / off 0.0 ([30893132189](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/30893132189)).
-18. **n≥3 trials** on a small headline subset for Wilson intervals (P3) — see Phase 0 in [`openbench-advanced-suites.md`](./openbench-advanced-suites.md).
+18. ~~**n≥3 trials** on headline subset~~ — Phase 0 trio done (search / memory-roundtrip / policy-deny); optional n≥5 — [`openbench-advanced-suites.md`](./openbench-advanced-suites.md).
 
 ### Phase 1 advanced (frugal tool delta — no fine-tune)
 

--- a/openbench/ci-matrix.json
+++ b/openbench/ci-matrix.json
@@ -31,7 +31,7 @@
       "evidence_run": "30872913516"
     },
     "policy-deny-execute": {
-      "reason": "Verified WIN + Phase 0 n=3 Wilson (on 3/3 / off 0/3; RTP v1.1 R2; prior 30872913516)",
+      "reason": "Verified WIN + Phase 0 n=3 margin (on 2/3 / off 0/3; RTP v1.1 R2; prior clean 1.0 @ 30872913516)",
       "evidence_run": "31016004063"
     },
     "ouroboros-oscillation-escape": {

--- a/openbench/ci-matrix.json
+++ b/openbench/ci-matrix.json
@@ -2,9 +2,9 @@
   "$schema_comment": "Controls which OpenBench tasks burn tokens on PR/push. Move a task from pr_active \u2192 retired when thoroughly verified (headline WIN + replication preferred). workflow_dispatch can still select any individual task, or all-including-retired.",
   "live_enabled": true,
   "live_pause_reason": "",
-  "live_resume_note": "Phase 0: policy-deny-execute n=3 after memory-roundtrip WIN 31014040293.",
-  "pr_active": ["policy-deny-execute"],
-  "pr_trials": 3,
+  "live_resume_note": "Phase 0 queue complete (search/memory/policy n=3). Next: B-4.2/B-4.3 spikes or n\u22655.",
+  "pr_active": [],
+  "pr_trials": 1,
   "retired": {
     "codegraph-impact-edit": {
       "reason": "Verified WIN + durable R2 traces (on 1.0 / off 0.0; call_store=17; r2://clawql-openbench-traces)",
@@ -31,8 +31,8 @@
       "evidence_run": "30872913516"
     },
     "policy-deny-execute": {
-      "reason": "Verified WIN \u2014 Panguard fail-closed with tool evidence (on 1.0 / off 0.0)",
-      "evidence_run": "30872913516"
+      "reason": "Verified WIN + Phase 0 n=3 Wilson (on 3/3 / off 0/3; RTP v1.1 R2; prior 30872913516)",
+      "evidence_run": "31016004063"
     },
     "ouroboros-oscillation-escape": {
       "reason": "Verified WIN allow+deny, replicated; dedicated workflow is dispatch-only",

--- a/openbench/ci-matrix.json
+++ b/openbench/ci-matrix.json
@@ -2,9 +2,9 @@
   "$schema_comment": "Controls which OpenBench tasks burn tokens on PR/push. Move a task from pr_active \u2192 retired when thoroughly verified (headline WIN + replication preferred). workflow_dispatch can still select any individual task, or all-including-retired.",
   "live_enabled": true,
   "live_pause_reason": "",
-  "live_resume_note": "Phase 0 memory-roundtrip n=3 WIN (31014040293). Next: policy-deny-execute n=3 or B-4.2/B-4.3 spikes.",
-  "pr_active": [],
-  "pr_trials": 1,
+  "live_resume_note": "Phase 0: policy-deny-execute n=3 after memory-roundtrip WIN 31014040293.",
+  "pr_active": ["policy-deny-execute"],
+  "pr_trials": 3,
   "retired": {
     "codegraph-impact-edit": {
       "reason": "Verified WIN + durable R2 traces (on 1.0 / off 0.0; call_store=17; r2://clawql-openbench-traces)",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Final Phase 0 queue cell: **`policy-deny-execute`** n=3.

## Results — [31016004063](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31016004063)

| Arm | Success | Mean score |
| --- | --- | --- |
| clawql-on | **2/3** | **0.667** |
| clawql-off | **0/3** | **0.0** |

- Gate OK (on > off). Trial 3 on-arm miss — not a clean 3/3.
- Wilson 95%: on `[0.208, 0.939]` · off `[0.000, 0.562]`
- R2: 6× schema 1.1 RTP traces
- Headline 1.0 claim remains prior [30872913516](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/30872913516)

## Phase 0 queue status

| Cell | n=3 |
| --- | --- |
| search-first-discovery | ✅ 3/3 ([31011980064](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31011980064)) |
| memory-roundtrip-ingest-recall | ✅ 3/3 ([31014040293](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31014040293)) |
| policy-deny-execute | ✅ margin 2/3 (this PR) |

`pr_active` cleared; `pr_trials` reset to 1.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

