### PR TITLE
feat(web): clawql-web package — pluggable search & browser providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`clawql-web` package** — pluggable `WebSearchProvider` / `WebBrowserProvider` (Tavily, Brave, SearXNG, OpenSearch, Kitesurf, Chromium/Playwright/Puppeteer, Firecrawl), search→browser fallback with pre-flight audit, MCP tools `web_search` / `web_fetch` / `web_screenshot` / `web_interact`. Docs: [`docs/web/clawql-web.md`](docs/web/clawql-web.md), [`docs/plugins/web.md`](docs/plugins/web.md).
+
 ### Fixed
 
 - **Pulumi edge CI 401 on account-scoped Cloudflare tokens** — `/user/tokens/verify` often returns 401 for Workers account tokens after R2 bucket create succeeds. Accept `CLOUDFLARE_API_TOKEN_ID` (or explicit `CLAWQL_R2_*` S3 keys) when deriving R2 credentials for the Pulumi state backend ([`scripts/pulumi/ensure-r2-state-backend.sh`](scripts/pulumi/ensure-r2-state-backend.sh)).

--- a/charts/clawql-mcp/values.yaml
+++ b/charts/clawql-mcp/values.yaml
@@ -313,6 +313,23 @@ argocd:
 #   Enterprise: https://docs.humansignal.com/guide/install — SAML/RBAC; license required; not redistributed in this chart.
 enableHitlLabelStudio: false
 
+# clawql-web — pluggable web_search / web_fetch (docs/web/clawql-web.md).
+# enableWeb auto-on when a provider/key is set; set false to force off in regulated clusters.
+enableWeb: false
+webSearch:
+  provider: none # tavily|brave|searxng|opensearch|none
+  searxng:
+    enabled: false
+    bundled: false # future: deploy SearXNG subchart
+  opensearch:
+    enabled: false
+    bundled: false # future: deploy OpenSearch subchart (or reuse Onyx OpenSearch)
+webBrowser:
+  provider: kitesurf # kitesurf|chromium|playwright|puppeteer|firecrawl|none
+  chromium:
+    enabled: false
+    bundled: false
+
 # MCP knowledge_search_onyx — Onyx POST /search/send-search-message (#118). Requires onyx in provider merge + ONYX_BASE_URL + Bearer token (extraEnv / secret).
 enableOnyx: false
 # When set, injects ONYX_BASE_URL (non-secret). Prefer extraEnv / envFromSecret for ONYX_API_TOKEN.

--- a/charts/clawql-mcp/values.yaml
+++ b/charts/clawql-mcp/values.yaml
@@ -314,21 +314,23 @@ argocd:
 enableHitlLabelStudio: false
 
 # clawql-web — pluggable web_search / web_fetch (docs/web/clawql-web.md).
-# enableWeb auto-on when a provider/key is set; set false to force off in regulated clusters.
+# enableWeb auto-on when a provider/key is set; set false to force off in regulated clusters
+# (search disabled, no external SaaS; self-host Chromium only if policy allows).
+# *.bundled flags are FUTURE ONLY — they do not install SearXNG/OpenSearch/Chromium subcharts today.
 enableWeb: false
 webSearch:
   provider: none # tavily|brave|searxng|opensearch|none
   searxng:
     enabled: false
-    bundled: false # future: deploy SearXNG subchart
+    bundled: false # future only — not wired to a SearXNG subchart; BYO CLAWQL_SEARXNG_URL
   opensearch:
     enabled: false
-    bundled: false # future: deploy OpenSearch subchart (or reuse Onyx OpenSearch)
+    bundled: false # future only — not wired; or reuse Onyx OpenSearch
 webBrowser:
   provider: kitesurf # kitesurf|chromium|playwright|puppeteer|firecrawl|none
   chromium:
     enabled: false
-    bundled: false
+    bundled: false # future only — not wired to a Chromium subchart
 
 # MCP knowledge_search_onyx — Onyx POST /search/send-search-message (#118). Requires onyx in provider merge + ONYX_BASE_URL + Bearer token (extraEnv / secret).
 enableOnyx: false

--- a/docs/plugins/web.md
+++ b/docs/plugins/web.md
@@ -18,12 +18,12 @@ next: ouroboros
 
 ## MCP tools
 
-| Tool | When |
-| --- | --- |
-| **`web_search`** | Web enabled — falls back to browser-as-search with audit if no search provider |
-| **`web_fetch`** | Browser provider configured |
-| **`web_screenshot`** | Browser provider with screenshot capability |
-| **`web_interact`** | Chromium / Playwright / Puppeteer |
+| Tool                 | When                                                                           |
+| -------------------- | ------------------------------------------------------------------------------ |
+| **`web_search`**     | Web enabled — falls back to browser-as-search with audit if no search provider |
+| **`web_fetch`**      | Browser provider configured                                                    |
+| **`web_screenshot`** | Browser provider with screenshot capability                                    |
+| **`web_interact`**   | Chromium / Playwright / Puppeteer                                              |
 
 ## Enable
 

--- a/docs/plugins/web.md
+++ b/docs/plugins/web.md
@@ -1,0 +1,36 @@
+---
+title: Web
+description: Pluggable web_search / web_fetch / web_screenshot / web_interact via clawql-web (Tavily, Brave, SearXNG, OpenSearch, Kitesurf, Chromium, Firecrawl).
+slug: web
+status: scaffold
+package: clawql-web
+order: 11
+prev: payments
+next: ouroboros
+---
+
+# Web (`clawql-web`)
+
+**Status:** Tier-1 scaffold  
+**Package:** [`packages/clawql-web`](../../packages/clawql-web)  
+**Toggle:** `CLAWQL_ENABLE_WEB` (or auto-on when a provider/API key is configured)  
+**Plugin:** `clawql-web`
+
+## MCP tools
+
+| Tool | When |
+| --- | --- |
+| **`web_search`** | Web enabled — falls back to browser-as-search with audit if no search provider |
+| **`web_fetch`** | Browser provider configured |
+| **`web_screenshot`** | Browser provider with screenshot capability |
+| **`web_interact`** | Chromium / Playwright / Puppeteer |
+
+## Enable
+
+```bash
+export CLAWQL_ENABLE_WEB=1
+export CLAWQL_WEB_BROWSER_PROVIDER=kitesurf
+export CLAWQL_WEB_DRY_RUN=1   # local demos
+```
+
+Full guide: [clawql-web](../web/clawql-web.md).

--- a/docs/plugins/web.md
+++ b/docs/plugins/web.md
@@ -21,9 +21,9 @@ next: ouroboros
 | Tool                 | When                                                                           |
 | -------------------- | ------------------------------------------------------------------------------ |
 | **`web_search`**     | Web enabled — falls back to browser-as-search with audit if no search provider |
-| **`web_fetch`**      | Browser provider configured                                                    |
-| **`web_screenshot`** | Browser provider with screenshot capability                                    |
-| **`web_interact`**   | Chromium / Playwright / Puppeteer                                              |
+| **`web_fetch`**      | Browser markdown, or `raw: true` for bytes + content-type (IDP; no browser)    |
+| **`web_screenshot`** | Capability-gated; structured error if browser is `none` / unsupported          |
+| **`web_interact`**   | Chromium / Playwright / Puppeteer; structured capability errors                |
 
 ## Enable
 

--- a/docs/web/clawql-web.md
+++ b/docs/web/clawql-web.md
@@ -8,21 +8,21 @@ Every managed web search/scrape API is paid or burns free tiers under agent load
 
 ## Taxonomy
 
-| Kind | Providers | Notes |
-| --- | --- | --- |
-| **Search** | Tavily, Brave, SearXNG, OpenSearch | Find content by query |
+| Kind                | Providers                                            | Notes                                 |
+| ------------------- | ---------------------------------------------------- | ------------------------------------- |
+| **Search**          | Tavily, Brave, SearXNG, OpenSearch                   | Find content by query                 |
 | **Browser / fetch** | Kitesurf, Chromium, Playwright, Puppeteer, Firecrawl | URL → content / screenshot / interact |
 
 Local document conversion (pdf-inspector / anydoc) stays in `clawql-documents` — zero-cost, on-box. `clawql-web` owns **external** web access; IDP URL ingestion should import from here over time.
 
 ## Defaults by deployment
 
-| Environment | Search | Browser |
-| --- | --- | --- |
-| Developer / Teams hosted | Tavily (if key) or none | **Kitesurf** (Browser Run beta) |
-| Self-hosted open | SearXNG (optional bundle) | Kitesurf or Chromium |
-| Regulated / air-gapped | OpenSearch (internal) or **disabled** | Chromium self-hosted or **disabled** |
-| Enterprise managed | Brave (DPA) or OpenSearch | Kitesurf or Chromium |
+| Environment              | Search                                | Browser                              |
+| ------------------------ | ------------------------------------- | ------------------------------------ |
+| Developer / Teams hosted | Tavily (if key) or none               | **Kitesurf** (Browser Run beta)      |
+| Self-hosted open         | SearXNG (optional bundle)             | Kitesurf or Chromium                 |
+| Regulated / air-gapped   | OpenSearch (internal) or **disabled** | Chromium self-hosted or **disabled** |
+| Enterprise managed       | Brave (DPA) or OpenSearch             | Kitesurf or Chromium                 |
 
 ## Env
 
@@ -55,31 +55,31 @@ The fallback decision is appended **before** the browser call.
 
 ## MCP tools
 
-| Tool | Behavior |
-| --- | --- |
-| `web_search` | Search provider, else browser fallback |
-| `web_fetch` | Browser provider fetch |
-| `web_screenshot` | Capability-gated |
-| `web_interact` | Capability-gated (chromium family) |
+| Tool             | Behavior                               |
+| ---------------- | -------------------------------------- |
+| `web_search`     | Search provider, else browser fallback |
+| `web_fetch`      | Browser provider fetch                 |
+| `web_screenshot` | Capability-gated                       |
+| `web_interact`   | Capability-gated (chromium family)     |
 
 ## Helm sketch (optional subcharts)
 
 ```yaml
 webSearch:
-  provider: none          # tavily|brave|searxng|opensearch|none
+  provider: none # tavily|brave|searxng|opensearch|none
   tavily:
     enabled: false
   brave:
     enabled: false
   searxng:
     enabled: false
-    bundled: false        # deploy SearXNG subchart
+    bundled: false # deploy SearXNG subchart
   opensearch:
     enabled: false
     bundled: false
 
 webBrowser:
-  provider: kitesurf      # recommended zero-cost fetch in Cloudflare stack
+  provider: kitesurf # recommended zero-cost fetch in Cloudflare stack
   chromium:
     enabled: false
     bundled: false
@@ -89,5 +89,5 @@ SearXNG/OpenSearch as bundled subcharts follow the same opt-in pattern as Onyx �
 
 ## Related
 
-- [`docs/plugins/web.md`](../plugins/web.md) — plugin page  
+- [`docs/plugins/web.md`](../plugins/web.md) — plugin page
 - Local docs convert: [`docs/providers/anydoc-onboarding.md`](../providers/anydoc-onboarding.md), [`pdf-inspector-onboarding.md`](../providers/pdf-inspector-onboarding.md)

--- a/docs/web/clawql-web.md
+++ b/docs/web/clawql-web.md
@@ -6,6 +6,19 @@
 
 Every managed web search/scrape API is paid or burns free tiers under agent load. ClawQL therefore treats web access as **pluggable**: mix a search provider and a browser provider, or run fully self-hosted / disabled for regulated environments.
 
+## Regulated / enterprise posture
+
+For regulated and air-gapped tenants, the intended posture is:
+
+| Control | Default / recommendation |
+| ------- | ------------------------ |
+| **Search** | **Disabled** (`CLAWQL_WEB_SEARCH_PROVIDER=none`) — no Tavily/Brave egress |
+| **Browser** | **Self-hosted Chromium** (or `none`) — no Cloudflare Browser Run / Firecrawl SaaS |
+| **External calls** | **None** unless an operator explicitly enables a provider |
+| **Helm** | `enableWeb: false`; `webSearch.provider: none`; leave `*.bundled: false` |
+
+That combination is sales collateral for the enterprise motion: ClawQL can run with **zero outbound web** while still offering optional self-hosted search (OpenSearch / BYO SearXNG) and on-box browser fetch when policy allows.
+
 ## Taxonomy
 
 | Kind                | Providers                                            | Notes                                 |
@@ -13,14 +26,36 @@ Every managed web search/scrape API is paid or burns free tiers under agent load
 | **Search**          | Tavily, Brave, SearXNG, OpenSearch                   | Find content by query                 |
 | **Browser / fetch** | Kitesurf, Chromium, Playwright, Puppeteer, Firecrawl | URL → content / screenshot / interact |
 
-Local document conversion (pdf-inspector / anydoc) stays in `clawql-documents` — zero-cost, on-box. `clawql-web` owns **external** web access; IDP URL ingestion should import from here over time.
+Local document conversion (pdf-inspector / anydoc) stays in `clawql-documents` — zero-cost, on-box. **`clawql-web` is the single package for external web access.** The IDP pipeline **will** import URL ingestion from here (follow-on PR after this scaffold lands) so agent `web_fetch` and IDP URL ingest share one provider surface — including Firecrawl as one browser provider serving both consumers.
+
+## IDP migration (follow-on)
+
+**Do not migrate IDP in the scaffold PR.** Ship `clawql-web` first (tests green, Helm sketch reviewed), then switch IDP in a separate PR for a cleaner bisect.
+
+Today IDP URL ingest lives in `packages/clawql-documents/src/ingest/external-ingest.ts` (`fetchUrlResource`). Behaviors the migration must preserve or deliberately change:
+
+| Behavior | Current IDP (`fetchUrlResource`) | `clawql-web` target |
+| -------- | -------------------------------- | ------------------- |
+| User-Agent | `clawql-mcp-external-ingest/1.0` | `clawql-web/1.0` (intentional rename; document in migration PR) |
+| Accept | `*/*` | same |
+| Redirects | Manual, max **5**, re-check SSRF each hop | same (`fetchRawUrl`) |
+| Timeout | **60s** | same (overridable via `timeoutMs`) |
+| Body / Content-Length cap | **2 MiB** | same |
+| SSRF | https, or http only for localhost; block private/link-local + metadata hosts | same (`assertSafeWebUrl`) |
+| Return shape | UTF-8 **string** body + content-type + finalUrl | `raw: true` → **bytes** + content-type + finalUrl (needed so pdf-inspector can classify before Docling) |
+| Content types | PDF, Office, HTML, raw text | unchanged — classification stays in documents/pdf-inspector |
+
+### `web_fetch` and `raw: true`
+
+- Default `web_fetch`: browser provider → clean markdown/text for agents.
+- `web_fetch` with **`raw: true`**: direct HTTPS fetcher (`fetchRawUrl`) → `{ bytes, contentType, finalUrl }` — **no browser provider required**. This is the IDP / pdf-inspector path.
 
 ## Defaults by deployment
 
 | Environment              | Search                                | Browser                              |
 | ------------------------ | ------------------------------------- | ------------------------------------ |
 | Developer / Teams hosted | Tavily (if key) or none               | **Kitesurf** (Browser Run beta)      |
-| Self-hosted open         | SearXNG (optional bundle)             | Kitesurf or Chromium                 |
+| Self-hosted open         | SearXNG (optional future bundle)      | Kitesurf or Chromium                 |
 | Regulated / air-gapped   | OpenSearch (internal) or **disabled** | Chromium self-hosted or **disabled** |
 | Enterprise managed       | Brave (DPA) or OpenSearch             | Kitesurf or Chromium                 |
 
@@ -49,20 +84,31 @@ CLAWQL_CHROMIUM_CDP_URL=ws://chromium:9222
 ```text
 WEB_SEARCH_FALLBACK { reason: no_search_provider_configured, fallback: browser, provider: kitesurf }
 WEB_SEARCH          { provider: browser:kitesurf, detail: fallback, ok: true }
+# or, if browser throws after the fallback decision:
+WEB_ERROR           { reason: browser_fallback_failed, ok: false }
 ```
 
-The fallback decision is appended **before** the browser call.
+The fallback decision is appended **before** the browser call so a WORM/compliance sink still records `WEB_SEARCH_FALLBACK` even when the browser provider fails.
+
+## Capability degradation
+
+`web_screenshot` and `web_interact` check capabilities **before** execute. When the browser provider is `none` (or search-only / unsupported), tools return a structured `WebCapabilityError`:
+
+```json
+{ "error": { "code": "NO_BROWSER_PROVIDER", "reason": "…" } }
+{ "error": { "code": "CAPABILITY_UNSUPPORTED", "provider": "firecrawl", "capability": "screenshot" } }
+```
 
 ## MCP tools
 
-| Tool             | Behavior                               |
-| ---------------- | -------------------------------------- |
-| `web_search`     | Search provider, else browser fallback |
-| `web_fetch`      | Browser provider fetch                 |
-| `web_screenshot` | Capability-gated                       |
-| `web_interact`   | Capability-gated (chromium family)     |
+| Tool             | Behavior                                                                 |
+| ---------------- | ------------------------------------------------------------------------ |
+| `web_search`     | Search provider, else browser fallback (audited before execute)          |
+| `web_fetch`      | Browser markdown fetch; or `raw: true` for bytes + content-type (IDP)    |
+| `web_screenshot` | Capability-gated (`NO_BROWSER_PROVIDER` / `CAPABILITY_UNSUPPORTED`)      |
+| `web_interact`   | Capability-gated (chromium family)                                       |
 
-## Helm sketch (optional subcharts)
+## Helm sketch (optional subcharts — **not wired yet**)
 
 ```yaml
 webSearch:
@@ -73,21 +119,22 @@ webSearch:
     enabled: false
   searxng:
     enabled: false
-    bundled: false # deploy SearXNG subchart
+    bundled: false # FUTURE ONLY — does not deploy a SearXNG subchart today
   opensearch:
     enabled: false
-    bundled: false
+    bundled: false # FUTURE ONLY — does not deploy OpenSearch for web today
 
 webBrowser:
   provider: kitesurf # recommended zero-cost fetch in Cloudflare stack
   chromium:
     enabled: false
-    bundled: false
+    bundled: false # FUTURE ONLY
 ```
 
-SearXNG/OpenSearch as bundled subcharts follow the same opt-in pattern as Onyx — one flag for regulated operators who accept the quality/ops tradeoffs documented in product discussions (rate limits, scraping gray zone, LLM post-processing).
+**`webSearch.searxng.bundled` is a flag for a future item**, not a live Helm dependency. Setting `bundled: true` does **not** install SearXNG; operators must BYO `CLAWQL_SEARXNG_URL` until a subchart is wired (same opt-in pattern as Onyx). Charts values already comment these as `future:`.
 
 ## Related
 
 - [`docs/plugins/web.md`](../plugins/web.md) — plugin page
 - Local docs convert: [`docs/providers/anydoc-onboarding.md`](../providers/anydoc-onboarding.md), [`pdf-inspector-onboarding.md`](../providers/pdf-inspector-onboarding.md)
+- Current IDP URL ingest (pre-migration): `packages/clawql-documents/src/ingest/external-ingest.ts`

--- a/docs/web/clawql-web.md
+++ b/docs/web/clawql-web.md
@@ -10,12 +10,12 @@ Every managed web search/scrape API is paid or burns free tiers under agent load
 
 For regulated and air-gapped tenants, the intended posture is:
 
-| Control | Default / recommendation |
-| ------- | ------------------------ |
-| **Search** | **Disabled** (`CLAWQL_WEB_SEARCH_PROVIDER=none`) — no Tavily/Brave egress |
-| **Browser** | **Self-hosted Chromium** (or `none`) — no Cloudflare Browser Run / Firecrawl SaaS |
-| **External calls** | **None** unless an operator explicitly enables a provider |
-| **Helm** | `enableWeb: false`; `webSearch.provider: none`; leave `*.bundled: false` |
+| Control            | Default / recommendation                                                          |
+| ------------------ | --------------------------------------------------------------------------------- |
+| **Search**         | **Disabled** (`CLAWQL_WEB_SEARCH_PROVIDER=none`) — no Tavily/Brave egress         |
+| **Browser**        | **Self-hosted Chromium** (or `none`) — no Cloudflare Browser Run / Firecrawl SaaS |
+| **External calls** | **None** unless an operator explicitly enables a provider                         |
+| **Helm**           | `enableWeb: false`; `webSearch.provider: none`; leave `*.bundled: false`          |
 
 That combination is sales collateral for the enterprise motion: ClawQL can run with **zero outbound web** while still offering optional self-hosted search (OpenSearch / BYO SearXNG) and on-box browser fetch when policy allows.
 
@@ -34,16 +34,16 @@ Local document conversion (pdf-inspector / anydoc) stays in `clawql-documents` �
 
 Today IDP URL ingest lives in `packages/clawql-documents/src/ingest/external-ingest.ts` (`fetchUrlResource`). Behaviors the migration must preserve or deliberately change:
 
-| Behavior | Current IDP (`fetchUrlResource`) | `clawql-web` target |
-| -------- | -------------------------------- | ------------------- |
-| User-Agent | `clawql-mcp-external-ingest/1.0` | `clawql-web/1.0` (intentional rename; document in migration PR) |
-| Accept | `*/*` | same |
-| Redirects | Manual, max **5**, re-check SSRF each hop | same (`fetchRawUrl`) |
-| Timeout | **60s** | same (overridable via `timeoutMs`) |
-| Body / Content-Length cap | **2 MiB** | same |
-| SSRF | https, or http only for localhost; block private/link-local + metadata hosts | same (`assertSafeWebUrl`) |
-| Return shape | UTF-8 **string** body + content-type + finalUrl | `raw: true` → **bytes** + content-type + finalUrl (needed so pdf-inspector can classify before Docling) |
-| Content types | PDF, Office, HTML, raw text | unchanged — classification stays in documents/pdf-inspector |
+| Behavior                  | Current IDP (`fetchUrlResource`)                                             | `clawql-web` target                                                                                     |
+| ------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| User-Agent                | `clawql-mcp-external-ingest/1.0`                                             | `clawql-web/1.0` (intentional rename; document in migration PR)                                         |
+| Accept                    | `*/*`                                                                        | same                                                                                                    |
+| Redirects                 | Manual, max **5**, re-check SSRF each hop                                    | same (`fetchRawUrl`)                                                                                    |
+| Timeout                   | **60s**                                                                      | same (overridable via `timeoutMs`)                                                                      |
+| Body / Content-Length cap | **2 MiB**                                                                    | same                                                                                                    |
+| SSRF                      | https, or http only for localhost; block private/link-local + metadata hosts | same (`assertSafeWebUrl`)                                                                               |
+| Return shape              | UTF-8 **string** body + content-type + finalUrl                              | `raw: true` → **bytes** + content-type + finalUrl (needed so pdf-inspector can classify before Docling) |
+| Content types             | PDF, Office, HTML, raw text                                                  | unchanged — classification stays in documents/pdf-inspector                                             |
 
 ### `web_fetch` and `raw: true`
 
@@ -101,12 +101,12 @@ The fallback decision is appended **before** the browser call so a WORM/complian
 
 ## MCP tools
 
-| Tool             | Behavior                                                                 |
-| ---------------- | ------------------------------------------------------------------------ |
-| `web_search`     | Search provider, else browser fallback (audited before execute)          |
-| `web_fetch`      | Browser markdown fetch; or `raw: true` for bytes + content-type (IDP)    |
-| `web_screenshot` | Capability-gated (`NO_BROWSER_PROVIDER` / `CAPABILITY_UNSUPPORTED`)      |
-| `web_interact`   | Capability-gated (chromium family)                                       |
+| Tool             | Behavior                                                              |
+| ---------------- | --------------------------------------------------------------------- |
+| `web_search`     | Search provider, else browser fallback (audited before execute)       |
+| `web_fetch`      | Browser markdown fetch; or `raw: true` for bytes + content-type (IDP) |
+| `web_screenshot` | Capability-gated (`NO_BROWSER_PROVIDER` / `CAPABILITY_UNSUPPORTED`)   |
+| `web_interact`   | Capability-gated (chromium family)                                    |
 
 ## Helm sketch (optional subcharts — **not wired yet**)
 

--- a/docs/web/clawql-web.md
+++ b/docs/web/clawql-web.md
@@ -1,0 +1,93 @@
+# clawql-web — pluggable search & browser
+
+**Status:** Tier-1 scaffold  
+**Package:** [`packages/clawql-web`](../../packages/clawql-web)  
+**Plugin ID:** `clawql-web`
+
+Every managed web search/scrape API is paid or burns free tiers under agent load. ClawQL therefore treats web access as **pluggable**: mix a search provider and a browser provider, or run fully self-hosted / disabled for regulated environments.
+
+## Taxonomy
+
+| Kind | Providers | Notes |
+| --- | --- | --- |
+| **Search** | Tavily, Brave, SearXNG, OpenSearch | Find content by query |
+| **Browser / fetch** | Kitesurf, Chromium, Playwright, Puppeteer, Firecrawl | URL → content / screenshot / interact |
+
+Local document conversion (pdf-inspector / anydoc) stays in `clawql-documents` — zero-cost, on-box. `clawql-web` owns **external** web access; IDP URL ingestion should import from here over time.
+
+## Defaults by deployment
+
+| Environment | Search | Browser |
+| --- | --- | --- |
+| Developer / Teams hosted | Tavily (if key) or none | **Kitesurf** (Browser Run beta) |
+| Self-hosted open | SearXNG (optional bundle) | Kitesurf or Chromium |
+| Regulated / air-gapped | OpenSearch (internal) or **disabled** | Chromium self-hosted or **disabled** |
+| Enterprise managed | Brave (DPA) or OpenSearch | Kitesurf or Chromium |
+
+## Env
+
+```bash
+CLAWQL_ENABLE_WEB=1                    # or auto when a provider/key is set
+CLAWQL_WEB_SEARCH_PROVIDER=tavily|brave|searxng|opensearch|none
+CLAWQL_WEB_BROWSER_PROVIDER=kitesurf|chromium|playwright|puppeteer|firecrawl|none
+CLAWQL_WEB_SEARCH_FALLBACK_DISABLED=1  # opt out of browser-as-search
+CLAWQL_WEB_DRY_RUN=1                   # synthetic results (tests / demos)
+
+CLAWQL_TAVILY_API_KEY=…
+CLAWQL_BRAVE_API_KEY=…
+CLAWQL_SEARXNG_URL=http://searxng:8080
+CLAWQL_OPENSEARCH_URL=https://opensearch:9200
+CLAWQL_OPENSEARCH_INDEX=clawql-web
+CLAWQL_FIRECRAWL_API_KEY=…
+CLAWQL_BROWSER_RUN_API_TOKEN=…         # Cloudflare Browser Run
+CLAWQL_CLOUDFLARE_ACCOUNT_ID=…
+CLAWQL_CHROMIUM_CDP_URL=ws://chromium:9222
+```
+
+## Fallback audit
+
+```text
+WEB_SEARCH_FALLBACK { reason: no_search_provider_configured, fallback: browser, provider: kitesurf }
+WEB_SEARCH          { provider: browser:kitesurf, detail: fallback, ok: true }
+```
+
+The fallback decision is appended **before** the browser call.
+
+## MCP tools
+
+| Tool | Behavior |
+| --- | --- |
+| `web_search` | Search provider, else browser fallback |
+| `web_fetch` | Browser provider fetch |
+| `web_screenshot` | Capability-gated |
+| `web_interact` | Capability-gated (chromium family) |
+
+## Helm sketch (optional subcharts)
+
+```yaml
+webSearch:
+  provider: none          # tavily|brave|searxng|opensearch|none
+  tavily:
+    enabled: false
+  brave:
+    enabled: false
+  searxng:
+    enabled: false
+    bundled: false        # deploy SearXNG subchart
+  opensearch:
+    enabled: false
+    bundled: false
+
+webBrowser:
+  provider: kitesurf      # recommended zero-cost fetch in Cloudflare stack
+  chromium:
+    enabled: false
+    bundled: false
+```
+
+SearXNG/OpenSearch as bundled subcharts follow the same opt-in pattern as Onyx — one flag for regulated operators who accept the quality/ops tradeoffs documented in product discussions (rate limits, scraping gray zone, LLM post-processing).
+
+## Related
+
+- [`docs/plugins/web.md`](../plugins/web.md) — plugin page  
+- Local docs convert: [`docs/providers/anydoc-onboarding.md`](../providers/anydoc-onboarding.md), [`pdf-inspector-onboarding.md`](../providers/pdf-inspector-onboarding.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
                 "clawql-payments": "7.2.0",
                 "clawql-release": "7.2.0",
                 "clawql-sandbox": "7.2.0",
+                "clawql-web": "7.2.0",
                 "dotenv": "^17.4.2",
                 "effect": "3.22.0",
                 "express": "^5.2.1",
@@ -6708,6 +6709,10 @@
         },
         "node_modules/clawql-sandbox": {
             "resolved": "packages/clawql-sandbox",
+            "link": true
+        },
+        "node_modules/clawql-web": {
+            "resolved": "packages/clawql-web",
             "link": true
         },
         "node_modules/cliui": {
@@ -14088,6 +14093,25 @@
             }
         },
         "packages/clawql-sandbox": {
+            "version": "7.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "clawql-api": "7.2.0",
+                "clawql-core": "7.2.0",
+                "effect": "^3.21.4",
+                "zod": "4.3.6"
+            },
+            "devDependencies": {
+                "@types/node": "^26.1.1",
+                "tsup": "^8.3.0",
+                "typescript": "^6.0.3",
+                "vitest": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "packages/clawql-web": {
             "version": "7.2.0",
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
         ".cursor/mcp.json.example"
     ],
     "scripts": {
-        "clean": "rm -rf dist packages/clawql-core/dist packages/clawql-auth/dist packages/clawql-pageindex/dist packages/clawql-codegraph/dist packages/clawql-api/dist packages/clawql-memory/dist packages/clawql-documents/dist packages/clawql-automation/dist packages/clawql-sandbox/dist packages/mcp-grpc-transport/dist packages/mcp-api-adapter/dist packages/clawql-inference/dist packages/clawql-payments/dist packages/clawql-ouroboros/dist packages/panguard-mcp-bridge/dist packages/clawql-operator/dist packages/clawql-release/dist packages/clawql-ontology/dist",
-        "build": "npm run clean && npm run build -w clawql-core && npm run build -w clawql-auth && npm run build -w clawql-pageindex && npm run build -w clawql-codegraph && npm run build -w clawql-api && npm run build -w clawql-memory && npm run build -w clawql-documents && npm run build -w clawql-automation && npm run build -w clawql-sandbox && npm run build -w mcp-grpc-transport && npm run build -w mcp-api-adapter && npm run build -w clawql-payments && npm run build -w clawql-inference && npm run build -w clawql-ouroboros && npm run build -w panguard-mcp-bridge && npm run build -w clawql-operator && npm run build -w clawql-release && npm run build -w clawql-ontology && tsc",
+        "clean": "rm -rf dist packages/clawql-core/dist packages/clawql-auth/dist packages/clawql-pageindex/dist packages/clawql-codegraph/dist packages/clawql-api/dist packages/clawql-memory/dist packages/clawql-documents/dist packages/clawql-automation/dist packages/clawql-sandbox/dist packages/clawql-web/dist packages/mcp-grpc-transport/dist packages/mcp-api-adapter/dist packages/clawql-inference/dist packages/clawql-payments/dist packages/clawql-ouroboros/dist packages/panguard-mcp-bridge/dist packages/clawql-operator/dist packages/clawql-release/dist packages/clawql-ontology/dist",
+        "build": "npm run clean && npm run build -w clawql-core && npm run build -w clawql-auth && npm run build -w clawql-pageindex && npm run build -w clawql-codegraph && npm run build -w clawql-api && npm run build -w clawql-memory && npm run build -w clawql-documents && npm run build -w clawql-automation && npm run build -w clawql-sandbox && npm run build -w clawql-web && npm run build -w mcp-grpc-transport && npm run build -w mcp-api-adapter && npm run build -w clawql-payments && npm run build -w clawql-inference && npm run build -w clawql-ouroboros && npm run build -w panguard-mcp-bridge && npm run build -w clawql-operator && npm run build -w clawql-release && npm run build -w clawql-ontology && tsc",
         "ontology:lint": "npm run build -w clawql-ontology && node packages/clawql-ontology/dist/cli.js lint --dir examples/ontology/entities",
         "ontology:generate": "npm run build -w clawql-ontology && node packages/clawql-ontology/dist/cli.js generate --dir examples/ontology/entities --out generated/ontology",
         "build:turbo": "turbo run build",
@@ -149,6 +149,7 @@
         "clawql-payments": "7.2.0",
         "clawql-release": "7.2.0",
         "clawql-sandbox": "7.2.0",
+        "clawql-web": "7.2.0",
         "dotenv": "^17.4.2",
         "effect": "3.22.0",
         "express": "^5.2.1",

--- a/packages/clawql-api/src/config/optional-flags.ts
+++ b/packages/clawql-api/src/config/optional-flags.ts
@@ -39,6 +39,16 @@ const rawOptionalFlagsSchema = z.object({
   CLAWQL_ENABLE_ONYX: z.string().optional(),
   CLAWQL_ENABLE_OUROBOROS: z.string().optional(),
   CLAWQL_ENABLE_SANDBOX: z.string().optional(),
+  /** Web search/fetch MCP tools (`web_*`). Auto-on when a provider/key is set; `0` forces off. */
+  CLAWQL_ENABLE_WEB: z.string().optional(),
+  CLAWQL_WEB_SEARCH_PROVIDER: z.string().optional(),
+  CLAWQL_WEB_BROWSER_PROVIDER: z.string().optional(),
+  CLAWQL_TAVILY_API_KEY: z.string().optional(),
+  CLAWQL_BRAVE_API_KEY: z.string().optional(),
+  CLAWQL_SEARXNG_URL: z.string().optional(),
+  CLAWQL_OPENSEARCH_URL: z.string().optional(),
+  CLAWQL_FIRECRAWL_API_KEY: z.string().optional(),
+  CLAWQL_BROWSER_RUN_API_TOKEN: z.string().optional(),
   /** Structural code graph MCP tools (`codegraph_*`). Default false — register with `CLAWQL_ENABLE_CODEGRAPH=1`. */
   CLAWQL_ENABLE_CODEGRAPH: z.string().optional(),
   /** Enterprise Ontology fixture MCP tools (`get_contract`, …). Default false — `CLAWQL_ENABLE_ONTOLOGY=1`. */
@@ -144,6 +154,11 @@ export type ClawqlOptionalToolFlags = {
    */
   enableSandbox: boolean;
   /**
+   * MCP **`web_search` / `web_fetch` / `web_screenshot` / `web_interact`** (`clawql-web`).
+   * Default false unless `CLAWQL_ENABLE_WEB=1` or a web provider/API key is configured.
+   */
+  enableWeb: boolean;
+  /**
    * Structural code knowledge graph (`codegraph_*`) — Graphify-style AST indexing for TypeScript/JavaScript. Default false.
    */
   enableCodeGraph: boolean;
@@ -201,6 +216,23 @@ export type ClawqlOptionalToolFlags = {
   enableAws: boolean;
 };
 
+function resolveEnableWeb(raw: z.infer<typeof rawOptionalFlagsSchema>): boolean {
+  const flag = raw.CLAWQL_ENABLE_WEB?.trim().toLowerCase();
+  if (flag === "0" || flag === "false" || flag === "no") return false;
+  if (flag === "1" || flag === "true" || flag === "yes") return true;
+  const search = raw.CLAWQL_WEB_SEARCH_PROVIDER?.trim().toLowerCase();
+  const browser = raw.CLAWQL_WEB_BROWSER_PROVIDER?.trim().toLowerCase();
+  if (search && search !== "none" && search !== "off" && search !== "0") return true;
+  if (browser && browser !== "none" && browser !== "off" && browser !== "0") return true;
+  if (raw.CLAWQL_TAVILY_API_KEY?.trim()) return true;
+  if (raw.CLAWQL_BRAVE_API_KEY?.trim()) return true;
+  if (raw.CLAWQL_SEARXNG_URL?.trim()) return true;
+  if (raw.CLAWQL_OPENSEARCH_URL?.trim()) return true;
+  if (raw.CLAWQL_FIRECRAWL_API_KEY?.trim()) return true;
+  if (raw.CLAWQL_BROWSER_RUN_API_TOKEN?.trim()) return true;
+  return false;
+}
+
 function rawToFlags(raw: z.infer<typeof rawOptionalFlagsSchema>): ClawqlOptionalToolFlags {
   return {
     enableGrpc: envTruthy(raw.ENABLE_GRPC),
@@ -216,6 +248,7 @@ function rawToFlags(raw: z.infer<typeof rawOptionalFlagsSchema>): ClawqlOptional
     enableOnyxKnowledge: envTruthy(raw.CLAWQL_ENABLE_ONYX),
     enableOuroboros: envTruthy(raw.CLAWQL_ENABLE_OUROBOROS),
     enableSandbox: envTruthy(raw.CLAWQL_ENABLE_SANDBOX),
+    enableWeb: resolveEnableWeb(raw),
     enableCodeGraph: envTruthy(raw.CLAWQL_ENABLE_CODEGRAPH),
     enableOntology:
       envTruthy(raw.CLAWQL_ENABLE_ONTOLOGY) || envTruthy(raw.CLAWQL_ENABLE_ONTOLOGY_WRITES),

--- a/packages/clawql-operator/src/spec/horizontal-tier-spec.ts
+++ b/packages/clawql-operator/src/spec/horizontal-tier-spec.ts
@@ -20,6 +20,7 @@ export type ClawQLHorizontalTierSpec = {
     readonly hitlLabelStudio?: { readonly enabled?: boolean };
   };
   readonly sandbox?: { readonly enabled?: boolean };
+  readonly web?: { readonly enabled?: boolean };
   readonly ontology?: {
     readonly enabled?: boolean;
     readonly writes?: { readonly enabled?: boolean };
@@ -64,6 +65,7 @@ export function optionalFlagsFromHorizontalTierSpec(
       defaults.enableHitlLabelStudio
     ),
     enableSandbox: tierEnabled(spec.sandbox, defaults.enableSandbox),
+    enableWeb: tierEnabled(spec.web, defaults.enableWeb),
     enableOntology: tierEnabled(spec.ontology, defaults.enableOntology),
     enableOntologyWrites: tierEnabled(spec.ontology?.writes, defaults.enableOntologyWrites),
     enableOuroboros: tierEnabled(spec.ouroboros, defaults.enableOuroboros),

--- a/packages/clawql-web/README.md
+++ b/packages/clawql-web/README.md
@@ -1,0 +1,55 @@
+# clawql-web
+
+Pluggable **web search** and **browser/fetch** for the Agentic Gateway.
+
+ClawQL does not pick one vendor as truth. Operators choose providers by environment (and optional Helm subcharts). Regulated deployments can disable external web entirely or run SearXNG / OpenSearch inside the perimeter.
+
+## Interfaces
+
+| Interface | Purpose |
+| --- | --- |
+| `WebSearchProvider` | `query → SearchResult[]` |
+| `WebBrowserProvider` | `url → PageContent` (+ optional screenshot / interact) |
+
+## Providers
+
+**Search:** `tavily` · `brave` · `searxng` · `opensearch` · `none`  
+**Browser:** `kitesurf` · `chromium` · `playwright` · `puppeteer` · `firecrawl` · `none`
+
+Playwright/Puppeteer are automation API variants over the same Chromium/Browser Run backend.
+
+## Fallback
+
+When no search provider is configured and `CLAWQL_WEB_SEARCH_FALLBACK_DISABLED` is unset, `web_search` falls back to **browser-as-search**. A `WEB_SEARCH_FALLBACK` audit event is written **before** the browser call so compliance reviews see the decision even if the fallback fails.
+
+## MCP tools (`CLAWQL_ENABLE_WEB` / auto)
+
+| Tool | Role |
+| --- | --- |
+| `web_search` | Query → ranked results (+ fallback) |
+| `web_fetch` | URL → markdown/text |
+| `web_screenshot` | URL → image (capability-gated) |
+| `web_interact` | URL + steps → page (capability-gated) |
+
+## Quick start
+
+```bash
+export CLAWQL_ENABLE_WEB=1
+export CLAWQL_WEB_DRY_RUN=1
+export CLAWQL_WEB_BROWSER_PROVIDER=kitesurf
+# optional paid search:
+# export CLAWQL_WEB_SEARCH_PROVIDER=tavily
+# export CLAWQL_TAVILY_API_KEY=…
+
+npm test -w clawql-web
+```
+
+Live Kitesurf (Cloudflare Browser Run):
+
+```bash
+export CLAWQL_WEB_BROWSER_PROVIDER=kitesurf
+export CLAWQL_BROWSER_RUN_API_TOKEN=…
+export CLAWQL_CLOUDFLARE_ACCOUNT_ID=…
+```
+
+Docs: [`docs/web/clawql-web.md`](../../docs/web/clawql-web.md)

--- a/packages/clawql-web/package.json
+++ b/packages/clawql-web/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "clawql-web",
+  "version": "7.2.0",
+  "description": "ClawQL web access: pluggable search + browser providers (Tavily, Brave, SearXNG, OpenSearch, Kitesurf, Chromium, Firecrawl) with search→browser fallback and MCP tools",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./plugin": {
+      "types": "./dist/plugin/index.d.ts",
+      "import": "./dist/plugin/index.js",
+      "require": "./dist/plugin/index.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "npm run clean && tsup",
+    "prepublishOnly": "npm run build",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "clawql-api": "7.2.0",
+    "clawql-core": "7.2.0",
+    "effect": "^3.21.4",
+    "zod": "4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "tsup": "^8.3.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.1"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danielsmithdevelopment/ClawQL.git",
+    "directory": "packages/clawql-web"
+  },
+  "keywords": [
+    "clawql",
+    "web",
+    "search",
+    "browser",
+    "mcp"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/clawql-web/src/audit.ts
+++ b/packages/clawql-web/src/audit.ts
@@ -1,0 +1,54 @@
+/**
+ * In-memory + optional callback audit for web search/fetch provenance.
+ * Regulated operators need fallback decisions recorded before the fallback runs.
+ */
+
+export type WebAuditEventType =
+  | "WEB_SEARCH"
+  | "WEB_SEARCH_FALLBACK"
+  | "WEB_FETCH"
+  | "WEB_SCREENSHOT"
+  | "WEB_INTERACT"
+  | "WEB_ERROR";
+
+export type WebAuditEvent = {
+  type: WebAuditEventType;
+  ts: string;
+  provider?: string;
+  query?: string;
+  url?: string;
+  reason?: string;
+  fallback?: string;
+  correlationId?: string;
+  ok?: boolean;
+  detail?: string;
+};
+
+export type WebAuditSink = (event: WebAuditEvent) => void | Promise<void>;
+
+const buffer: WebAuditEvent[] = [];
+let sink: WebAuditSink | undefined;
+
+export function setWebAuditSink(next: WebAuditSink | undefined): void {
+  sink = next;
+}
+
+export function resetWebAuditForTests(): void {
+  buffer.length = 0;
+  sink = undefined;
+}
+
+export function listWebAuditEvents(): readonly WebAuditEvent[] {
+  return [...buffer];
+}
+
+export async function appendWebAudit(event: Omit<WebAuditEvent, "ts"> & { ts?: string }): Promise<WebAuditEvent> {
+  const full: WebAuditEvent = {
+    ...event,
+    ts: event.ts ?? new Date().toISOString(),
+  };
+  buffer.push(full);
+  if (buffer.length > 500) buffer.shift();
+  if (sink) await sink(full);
+  return full;
+}

--- a/packages/clawql-web/src/config.ts
+++ b/packages/clawql-web/src/config.ts
@@ -1,0 +1,138 @@
+/**
+ * Env resolution for clawql-web providers.
+ *
+ * @see docs/web/clawql-web.md
+ */
+
+import type { WebBrowserProviderId, WebSearchProviderId } from "./interfaces.js";
+
+function envTruthy(v: string | undefined): boolean {
+  if (v === undefined) return false;
+  const t = v.trim().toLowerCase();
+  return t === "1" || t === "true" || t === "yes";
+}
+
+function parseSearchProvider(raw: string | undefined): WebSearchProviderId {
+  const v = raw?.trim().toLowerCase();
+  if (!v || v === "none" || v === "off" || v === "0") return "none";
+  if (v === "tavily" || v === "brave" || v === "searxng" || v === "opensearch") return v;
+  throw new Error(
+    `Unknown CLAWQL_WEB_SEARCH_PROVIDER=${raw} (expected tavily|brave|searxng|opensearch|none)`
+  );
+}
+
+function parseBrowserProvider(raw: string | undefined): WebBrowserProviderId {
+  const v = raw?.trim().toLowerCase();
+  if (!v || v === "none" || v === "off" || v === "0") return "none";
+  if (
+    v === "kitesurf" ||
+    v === "chromium" ||
+    v === "playwright" ||
+    v === "puppeteer" ||
+    v === "firecrawl"
+  ) {
+    return v;
+  }
+  throw new Error(
+    `Unknown CLAWQL_WEB_BROWSER_PROVIDER=${raw} (expected kitesurf|chromium|playwright|puppeteer|firecrawl|none)`
+  );
+}
+
+export type WebConfig = {
+  searchProvider: WebSearchProviderId;
+  browserProvider: WebBrowserProviderId;
+  /** When search provider is none, fall back to browser-as-search (default true). */
+  searchFallbackToBrowser: boolean;
+  dryRun: boolean;
+  tavilyApiKey?: string;
+  braveApiKey?: string;
+  searxngUrl?: string;
+  opensearchUrl?: string;
+  opensearchIndex?: string;
+  firecrawlApiKey?: string;
+  firecrawlBaseUrl?: string;
+  /** Cloudflare Browser Run / Browser Rendering token for Kitesurf & Chromium. */
+  browserRunApiToken?: string;
+  cloudflareAccountId?: string;
+  /** Self-hosted Chromium CDP endpoint (ws://…). */
+  chromiumCdpUrl?: string;
+  defaultSearchLimit: number;
+};
+
+export function loadWebConfig(env: NodeJS.ProcessEnv = process.env): WebConfig {
+  let searchProvider: WebSearchProviderId = "none";
+  let browserProvider: WebBrowserProviderId = "none";
+  try {
+    searchProvider = parseSearchProvider(env.CLAWQL_WEB_SEARCH_PROVIDER);
+  } catch {
+    searchProvider = "none";
+  }
+  try {
+    browserProvider = parseBrowserProvider(env.CLAWQL_WEB_BROWSER_PROVIDER);
+  } catch {
+    browserProvider = "none";
+  }
+
+  // Implicit defaults: Tavily if key set; Kitesurf if Browser Run token set
+  if (searchProvider === "none" && env.CLAWQL_TAVILY_API_KEY?.trim()) {
+    searchProvider = "tavily";
+  }
+  if (browserProvider === "none" && env.CLAWQL_BROWSER_RUN_API_TOKEN?.trim()) {
+    browserProvider = "kitesurf";
+  }
+  if (browserProvider === "none" && env.CLAWQL_FIRECRAWL_API_KEY?.trim()) {
+    browserProvider = "firecrawl";
+  }
+
+  return {
+    searchProvider,
+    browserProvider,
+    searchFallbackToBrowser: !envTruthy(env.CLAWQL_WEB_SEARCH_FALLBACK_DISABLED),
+    dryRun: envTruthy(env.CLAWQL_WEB_DRY_RUN),
+    tavilyApiKey: env.CLAWQL_TAVILY_API_KEY?.trim() || undefined,
+    braveApiKey: env.CLAWQL_BRAVE_API_KEY?.trim() || undefined,
+    searxngUrl: env.CLAWQL_SEARXNG_URL?.trim() || undefined,
+    opensearchUrl: env.CLAWQL_OPENSEARCH_URL?.trim() || undefined,
+    opensearchIndex: env.CLAWQL_OPENSEARCH_INDEX?.trim() || "clawql-web",
+    firecrawlApiKey: env.CLAWQL_FIRECRAWL_API_KEY?.trim() || undefined,
+    firecrawlBaseUrl: env.CLAWQL_FIRECRAWL_BASE_URL?.trim() || "https://api.firecrawl.dev",
+    browserRunApiToken: env.CLAWQL_BROWSER_RUN_API_TOKEN?.trim() || undefined,
+    cloudflareAccountId:
+      env.CLAWQL_CLOUDFLARE_ACCOUNT_ID?.trim() || env.CLOUDFLARE_ACCOUNT_ID?.trim() || undefined,
+    chromiumCdpUrl: env.CLAWQL_CHROMIUM_CDP_URL?.trim() || undefined,
+    defaultSearchLimit: Math.max(
+      1,
+      Number.parseInt(env.CLAWQL_WEB_SEARCH_LIMIT?.trim() || "5", 10) || 5
+    ),
+  };
+}
+
+/**
+ * Whether the web plugin should register MCP tools.
+ * Explicit `CLAWQL_ENABLE_WEB=0` wins; otherwise on when ENABLE_WEB=1 or any provider configured.
+ */
+export function isWebEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.CLAWQL_ENABLE_WEB?.trim().toLowerCase();
+  if (raw === "0" || raw === "false" || raw === "no") return false;
+  if (raw === "1" || raw === "true" || raw === "yes") return true;
+  const cfg = loadWebConfig(env);
+  return cfg.searchProvider !== "none" || cfg.browserProvider !== "none";
+}
+
+/** True when env suggests web should be on (for clawql-api optional flags without importing providers). */
+export function envImpliesWebEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.CLAWQL_ENABLE_WEB?.trim().toLowerCase();
+  if (raw === "0" || raw === "false" || raw === "no") return false;
+  if (raw === "1" || raw === "true" || raw === "yes") return true;
+  const search = env.CLAWQL_WEB_SEARCH_PROVIDER?.trim().toLowerCase();
+  const browser = env.CLAWQL_WEB_BROWSER_PROVIDER?.trim().toLowerCase();
+  if (search && search !== "none" && search !== "off" && search !== "0") return true;
+  if (browser && browser !== "none" && browser !== "off" && browser !== "0") return true;
+  if (env.CLAWQL_TAVILY_API_KEY?.trim()) return true;
+  if (env.CLAWQL_BRAVE_API_KEY?.trim()) return true;
+  if (env.CLAWQL_SEARXNG_URL?.trim()) return true;
+  if (env.CLAWQL_OPENSEARCH_URL?.trim()) return true;
+  if (env.CLAWQL_FIRECRAWL_API_KEY?.trim()) return true;
+  if (env.CLAWQL_BROWSER_RUN_API_TOKEN?.trim()) return true;
+  return false;
+}

--- a/packages/clawql-web/src/errors.ts
+++ b/packages/clawql-web/src/errors.ts
@@ -1,0 +1,46 @@
+/**
+ * Structured capability / config errors for MCP tools and callers.
+ * Prefer these over generic Error so agents get a stable `code` + `reason`.
+ */
+
+export type WebCapabilityErrorCode =
+  | "NO_BROWSER_PROVIDER"
+  | "NO_SEARCH_PROVIDER"
+  | "CAPABILITY_UNSUPPORTED"
+  | "PROVIDER_MISCONFIGURED";
+
+export class WebCapabilityError extends Error {
+  readonly code: WebCapabilityErrorCode;
+  readonly reason: string;
+  readonly provider?: string;
+  readonly capability?: string;
+
+  constructor(input: {
+    code: WebCapabilityErrorCode;
+    reason: string;
+    provider?: string;
+    capability?: string;
+  }) {
+    super(input.reason);
+    this.name = "WebCapabilityError";
+    this.code = input.code;
+    this.reason = input.reason;
+    this.provider = input.provider;
+    this.capability = input.capability;
+  }
+
+  toJSON(): Record<string, unknown> {
+    return {
+      error: {
+        code: this.code,
+        reason: this.reason,
+        provider: this.provider,
+        capability: this.capability,
+      },
+    };
+  }
+}
+
+export function isWebCapabilityError(err: unknown): err is WebCapabilityError {
+  return err instanceof WebCapabilityError;
+}

--- a/packages/clawql-web/src/index.ts
+++ b/packages/clawql-web/src/index.ts
@@ -1,0 +1,33 @@
+export type {
+  BrowserCapabilities,
+  BrowserStep,
+  FetchOptions,
+  PageContent,
+  SearchOptions,
+  SearchResponse,
+  SearchResult,
+  WebBrowserProvider,
+  WebBrowserProviderId,
+  WebSearchProvider,
+  WebSearchProviderId,
+} from "./interfaces.js";
+export {
+  envImpliesWebEnabled,
+  isWebEnabled,
+  loadWebConfig,
+  type WebConfig,
+} from "./config.js";
+export {
+  appendWebAudit,
+  listWebAuditEvents,
+  resetWebAuditForTests,
+  setWebAuditSink,
+  type WebAuditEvent,
+  type WebAuditEventType,
+  type WebAuditSink,
+} from "./audit.js";
+export { createWebService, type WebService } from "./service.js";
+export { browserAsSearch } from "./providers/fallback-search.js";
+export { resolveSearchProvider } from "./providers/search/resolve.js";
+export { resolveBrowserProvider } from "./providers/browser/resolve.js";
+export { createWebPlugin, makeWebLayer, WEB_PLUGIN_ID } from "./plugin/index.js";

--- a/packages/clawql-web/src/index.ts
+++ b/packages/clawql-web/src/index.ts
@@ -26,8 +26,18 @@ export {
   type WebAuditEventType,
   type WebAuditSink,
 } from "./audit.js";
+export {
+  WebCapabilityError,
+  isWebCapabilityError,
+  type WebCapabilityErrorCode,
+} from "./errors.js";
 export { createWebService, type WebService } from "./service.js";
 export { browserAsSearch } from "./providers/fallback-search.js";
 export { resolveSearchProvider } from "./providers/search/resolve.js";
 export { resolveBrowserProvider } from "./providers/browser/resolve.js";
+export {
+  assertSafeWebUrl,
+  fetchRawUrl,
+  type RawFetchResult,
+} from "./providers/browser/raw-fetch.js";
 export { createWebPlugin, makeWebLayer, WEB_PLUGIN_ID } from "./plugin/index.js";

--- a/packages/clawql-web/src/interfaces.ts
+++ b/packages/clawql-web/src/interfaces.ts
@@ -38,6 +38,12 @@ export interface WebSearchProvider {
 export type FetchOptions = {
   /** Prefer markdown / text extraction when provider supports it. */
   format?: "markdown" | "html" | "text";
+  /**
+   * When true, return raw response bytes + content-type (IDP / pdf-inspector path).
+   * Uses the clawql-web direct HTTPS fetcher with IDP-parity SSRF/redirect/timeout caps —
+   * not the markdown-converting browser provider.
+   */
+  raw?: boolean;
   timeoutMs?: number;
   correlationId?: string;
 };
@@ -48,6 +54,10 @@ export type PageContent = {
   markdown?: string;
   html?: string;
   text?: string;
+  /** Present when `FetchOptions.raw` was true. */
+  bytes?: Uint8Array;
+  contentType?: string | null;
+  finalUrl?: string;
   provider: string;
 };
 

--- a/packages/clawql-web/src/interfaces.ts
+++ b/packages/clawql-web/src/interfaces.ts
@@ -1,0 +1,87 @@
+/**
+ * Provider interfaces for external web access.
+ * Search (query → results) and browser/fetch (URL → content) are separate so
+ * operators can mix providers (e.g. Brave search + Kitesurf fetch).
+ */
+
+export type SearchOptions = {
+  /** Max results (provider may clamp). */
+  limit?: number;
+  /** ISO language / region hints when supported. */
+  language?: string;
+  /** Opaque correlation id for audit. */
+  correlationId?: string;
+};
+
+export type SearchResult = {
+  title: string;
+  url: string;
+  snippet?: string;
+  score?: number;
+  source?: string;
+};
+
+export type SearchResponse = {
+  query: string;
+  results: SearchResult[];
+  provider: string;
+  /** True when search fell back to browser-as-search. */
+  fallback?: boolean;
+  fallbackReason?: string;
+};
+
+export interface WebSearchProvider {
+  readonly id: string;
+  search(query: string, options?: SearchOptions): Promise<SearchResponse>;
+}
+
+export type FetchOptions = {
+  /** Prefer markdown / text extraction when provider supports it. */
+  format?: "markdown" | "html" | "text";
+  timeoutMs?: number;
+  correlationId?: string;
+};
+
+export type PageContent = {
+  url: string;
+  title?: string;
+  markdown?: string;
+  html?: string;
+  text?: string;
+  provider: string;
+};
+
+export type BrowserStep =
+  | { action: "click"; selector: string }
+  | { action: "type"; selector: string; text: string }
+  | { action: "wait"; ms: number }
+  | { action: "navigate"; url: string };
+
+export type BrowserCapabilities = {
+  fetch: boolean;
+  screenshot: boolean;
+  interact: boolean;
+};
+
+export interface WebBrowserProvider {
+  readonly id: string;
+  readonly capabilities: BrowserCapabilities;
+  fetch(url: string, options?: FetchOptions): Promise<PageContent>;
+  screenshot?(url: string, options?: FetchOptions): Promise<Uint8Array>;
+  interact?(url: string, steps: BrowserStep[], options?: FetchOptions): Promise<PageContent>;
+}
+
+export type WebSearchProviderId =
+  | "tavily"
+  | "brave"
+  | "searxng"
+  | "opensearch"
+  | "none";
+
+export type WebBrowserProviderId =
+  | "kitesurf"
+  | "chromium"
+  | "playwright"
+  | "puppeteer"
+  | "firecrawl"
+  | "none";

--- a/packages/clawql-web/src/plugin/index.ts
+++ b/packages/clawql-web/src/plugin/index.ts
@@ -1,0 +1,9 @@
+export { makeWebLayer, type WebLayerError } from "./web-layer.js";
+export {
+  createWebPlugin,
+  WEB_PLUGIN_ID,
+  webSearchSchema,
+  webFetchSchema,
+  webScreenshotSchema,
+  webInteractSchema,
+} from "./web-plugin.js";

--- a/packages/clawql-web/src/plugin/web-layer.ts
+++ b/packages/clawql-web/src/plugin/web-layer.ts
@@ -1,0 +1,25 @@
+import type {
+  ClawQLError,
+  McpToolAlreadyRegisteredError,
+  PluginAlreadyRegisteredError,
+} from "clawql-core";
+import { ClawQLApi } from "clawql-api";
+import { Effect, Layer } from "effect";
+import { createWebPlugin } from "./web-plugin.js";
+
+export type WebLayerError =
+  | PluginAlreadyRegisteredError
+  | ClawQLError
+  | McpToolAlreadyRegisteredError;
+
+/** Effect Layer that registers {@link createWebPlugin} via `ClawQLApi.registerPlugin`. */
+export function makeWebLayer(
+  env: NodeJS.ProcessEnv = process.env
+): Layer.Layer<never, WebLayerError, ClawQLApi> {
+  return Layer.effectDiscard(
+    Effect.gen(function* () {
+      const claw = yield* ClawQLApi;
+      yield* claw.registerPlugin(createWebPlugin(env));
+    })
+  );
+}

--- a/packages/clawql-web/src/plugin/web-plugin.ts
+++ b/packages/clawql-web/src/plugin/web-plugin.ts
@@ -3,6 +3,7 @@ import type { Plugin } from "clawql-core";
 import { Effect } from "effect";
 import { z } from "zod";
 import { isWebEnabled } from "../config.js";
+import { isWebCapabilityError } from "../errors.js";
 import { createWebService } from "../service.js";
 
 export const WEB_PLUGIN_ID = "clawql-web";
@@ -16,6 +17,11 @@ export const webSearchSchema = {
 export const webFetchSchema = {
   url: z.string().url().describe("Absolute URL to fetch"),
   format: z.enum(["markdown", "html", "text"]).optional(),
+  /**
+   * When true, return raw bytes + content-type (IDP / pdf-inspector) instead of
+   * markdown via the browser provider. Does not require a browser provider.
+   */
+  raw: z.boolean().optional().describe("Return raw bytes + content-type for IDP ingest"),
   correlationId: z.string().optional(),
 };
 
@@ -44,6 +50,20 @@ function textResult(payload: unknown): { content: { type: "text"; text: string }
   return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
 }
 
+function toolError(err: unknown): { content: { type: "text"; text: string }[]; isError: true } {
+  if (isWebCapabilityError(err)) {
+    return {
+      content: [{ type: "text", text: JSON.stringify(err.toJSON(), null, 2) }],
+      isError: true,
+    };
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return {
+    content: [{ type: "text", text: JSON.stringify({ error: { reason: message } }, null, 2) }],
+    isError: true,
+  };
+}
+
 export function createWebPlugin(env: NodeJS.ProcessEnv = process.env): Plugin {
   const web = createWebService(env);
   return {
@@ -62,54 +82,83 @@ export function createWebPlugin(env: NodeJS.ProcessEnv = process.env): Plugin {
           handler: async (args) => {
             const a = args as { query: string; limit?: number; correlationId?: string };
             logMcpToolShape("web_search", { queryLen: a.query?.length ?? 0, limit: a.limit });
-            const result = await web.search(a.query, {
-              limit: a.limit,
-              correlationId: a.correlationId,
-            });
-            return textResult(result);
+            try {
+              const result = await web.search(a.query, {
+                limit: a.limit,
+                correlationId: a.correlationId,
+              });
+              return textResult(result);
+            } catch (err) {
+              return toolError(err);
+            }
           },
         });
 
         yield* api.registerMcpTool({
           name: "web_fetch",
-          description: "Fetch a URL and return clean content (markdown/text) via the browser provider.",
+          description:
+            "Fetch a URL. Default: clean markdown/text via the browser provider. " +
+            "Pass raw=true for bytes + content-type (IDP / pdf-inspector; no browser required).",
           schema: webFetchSchema,
           handler: async (args) => {
             const a = args as {
               url: string;
               format?: "markdown" | "html" | "text";
+              raw?: boolean;
               correlationId?: string;
             };
-            logMcpToolShape("web_fetch", { url: a.url });
-            const page = await web.fetch(a.url, {
-              format: a.format,
-              correlationId: a.correlationId,
-            });
-            return textResult(page);
+            logMcpToolShape("web_fetch", { url: a.url, raw: a.raw === true });
+            try {
+              const page = await web.fetch(a.url, {
+                format: a.format,
+                raw: a.raw,
+                correlationId: a.correlationId,
+              });
+              if (a.raw === true && page.bytes) {
+                return textResult({
+                  url: page.url,
+                  finalUrl: page.finalUrl,
+                  contentType: page.contentType,
+                  provider: page.provider,
+                  byteLength: page.bytes.byteLength,
+                  base64: Buffer.from(page.bytes).toString("base64"),
+                });
+              }
+              return textResult(page);
+            } catch (err) {
+              return toolError(err);
+            }
           },
         });
 
         yield* api.registerMcpTool({
           name: "web_screenshot",
-          description: "Capture a screenshot of a URL (requires browser provider with screenshot support).",
+          description:
+            "Capture a screenshot of a URL. Requires a browser provider with screenshot support " +
+            "(not SearXNG / search-only; fails with NO_BROWSER_PROVIDER or CAPABILITY_UNSUPPORTED).",
           schema: webScreenshotSchema,
           handler: async (args) => {
             const a = args as { url: string; correlationId?: string };
             logMcpToolShape("web_screenshot", { url: a.url });
-            const buf = await web.screenshot(a.url, { correlationId: a.correlationId });
-            return textResult({
-              url: a.url,
-              provider: web.browserProvider?.id,
-              bytes: buf.byteLength,
-              base64: Buffer.from(buf).toString("base64"),
-            });
+            try {
+              const buf = await web.screenshot(a.url, { correlationId: a.correlationId });
+              return textResult({
+                url: a.url,
+                provider: web.browserProvider?.id,
+                bytes: buf.byteLength,
+                base64: Buffer.from(buf).toString("base64"),
+              });
+            } catch (err) {
+              return toolError(err);
+            }
           },
         });
 
         yield* api.registerMcpTool({
           name: "web_interact",
           description:
-            "Run browser interaction steps on a URL (requires chromium/playwright/puppeteer).",
+            "Run browser interaction steps on a URL (requires chromium/playwright/puppeteer). " +
+            "Returns structured NO_BROWSER_PROVIDER / CAPABILITY_UNSUPPORTED when unavailable.",
           schema: webInteractSchema,
           handler: async (args) => {
             const a = args as {
@@ -124,15 +173,19 @@ export function createWebPlugin(env: NodeJS.ProcessEnv = process.env): Plugin {
               correlationId?: string;
             };
             logMcpToolShape("web_interact", { url: a.url, steps: a.steps?.length ?? 0 });
-            const steps = (a.steps ?? []).map((s) => {
-              if (s.action === "click") return { action: "click" as const, selector: s.selector ?? "" };
-              if (s.action === "type")
-                return { action: "type" as const, selector: s.selector ?? "", text: s.text ?? "" };
-              if (s.action === "wait") return { action: "wait" as const, ms: s.ms ?? 0 };
-              return { action: "navigate" as const, url: s.url ?? a.url };
-            });
-            const page = await web.interact(a.url, steps, { correlationId: a.correlationId });
-            return textResult(page);
+            try {
+              const steps = (a.steps ?? []).map((s) => {
+                if (s.action === "click") return { action: "click" as const, selector: s.selector ?? "" };
+                if (s.action === "type")
+                  return { action: "type" as const, selector: s.selector ?? "", text: s.text ?? "" };
+                if (s.action === "wait") return { action: "wait" as const, ms: s.ms ?? 0 };
+                return { action: "navigate" as const, url: s.url ?? a.url };
+              });
+              const page = await web.interact(a.url, steps, { correlationId: a.correlationId });
+              return textResult(page);
+            } catch (err) {
+              return toolError(err);
+            }
           },
         });
       }),

--- a/packages/clawql-web/src/plugin/web-plugin.ts
+++ b/packages/clawql-web/src/plugin/web-plugin.ts
@@ -1,0 +1,140 @@
+import { logMcpToolShape } from "clawql-api/mcp/tool-shape-log";
+import type { Plugin } from "clawql-core";
+import { Effect } from "effect";
+import { z } from "zod";
+import { isWebEnabled } from "../config.js";
+import { createWebService } from "../service.js";
+
+export const WEB_PLUGIN_ID = "clawql-web";
+
+export const webSearchSchema = {
+  query: z.string().describe("Search query"),
+  limit: z.number().int().min(1).max(20).optional().describe("Max results"),
+  correlationId: z.string().optional(),
+};
+
+export const webFetchSchema = {
+  url: z.string().url().describe("Absolute URL to fetch"),
+  format: z.enum(["markdown", "html", "text"]).optional(),
+  correlationId: z.string().optional(),
+};
+
+export const webScreenshotSchema = {
+  url: z.string().url().describe("Absolute URL to screenshot"),
+  correlationId: z.string().optional(),
+};
+
+export const webInteractSchema = {
+  url: z.string().url(),
+  steps: z
+    .array(
+      z.object({
+        action: z.enum(["click", "type", "wait", "navigate"]),
+        selector: z.string().optional(),
+        text: z.string().optional(),
+        ms: z.number().optional(),
+        url: z.string().optional(),
+      })
+    )
+    .describe("Browser automation steps"),
+  correlationId: z.string().optional(),
+};
+
+function textResult(payload: unknown): { content: { type: "text"; text: string }[] } {
+  return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
+}
+
+export function createWebPlugin(env: NodeJS.ProcessEnv = process.env): Plugin {
+  const web = createWebService(env);
+  return {
+    id: WEB_PLUGIN_ID,
+    version: "0.1.0",
+    kind: "default",
+    onRegister: (api) =>
+      Effect.gen(function* () {
+        if (!isWebEnabled(env)) return;
+
+        yield* api.registerMcpTool({
+          name: "web_search",
+          description:
+            "Search the web. Uses configured search provider, or falls back to browser-as-search with an audit note.",
+          schema: webSearchSchema,
+          handler: async (args) => {
+            const a = args as { query: string; limit?: number; correlationId?: string };
+            logMcpToolShape("web_search", { queryLen: a.query?.length ?? 0, limit: a.limit });
+            const result = await web.search(a.query, {
+              limit: a.limit,
+              correlationId: a.correlationId,
+            });
+            return textResult(result);
+          },
+        });
+
+        yield* api.registerMcpTool({
+          name: "web_fetch",
+          description: "Fetch a URL and return clean content (markdown/text) via the browser provider.",
+          schema: webFetchSchema,
+          handler: async (args) => {
+            const a = args as {
+              url: string;
+              format?: "markdown" | "html" | "text";
+              correlationId?: string;
+            };
+            logMcpToolShape("web_fetch", { url: a.url });
+            const page = await web.fetch(a.url, {
+              format: a.format,
+              correlationId: a.correlationId,
+            });
+            return textResult(page);
+          },
+        });
+
+        yield* api.registerMcpTool({
+          name: "web_screenshot",
+          description: "Capture a screenshot of a URL (requires browser provider with screenshot support).",
+          schema: webScreenshotSchema,
+          handler: async (args) => {
+            const a = args as { url: string; correlationId?: string };
+            logMcpToolShape("web_screenshot", { url: a.url });
+            const buf = await web.screenshot(a.url, { correlationId: a.correlationId });
+            return textResult({
+              url: a.url,
+              provider: web.browserProvider?.id,
+              bytes: buf.byteLength,
+              base64: Buffer.from(buf).toString("base64"),
+            });
+          },
+        });
+
+        yield* api.registerMcpTool({
+          name: "web_interact",
+          description:
+            "Run browser interaction steps on a URL (requires chromium/playwright/puppeteer).",
+          schema: webInteractSchema,
+          handler: async (args) => {
+            const a = args as {
+              url: string;
+              steps: Array<{
+                action: "click" | "type" | "wait" | "navigate";
+                selector?: string;
+                text?: string;
+                ms?: number;
+                url?: string;
+              }>;
+              correlationId?: string;
+            };
+            logMcpToolShape("web_interact", { url: a.url, steps: a.steps?.length ?? 0 });
+            const steps = (a.steps ?? []).map((s) => {
+              if (s.action === "click") return { action: "click" as const, selector: s.selector ?? "" };
+              if (s.action === "type")
+                return { action: "type" as const, selector: s.selector ?? "", text: s.text ?? "" };
+              if (s.action === "wait") return { action: "wait" as const, ms: s.ms ?? 0 };
+              return { action: "navigate" as const, url: s.url ?? a.url };
+            });
+            const page = await web.interact(a.url, steps, { correlationId: a.correlationId });
+            return textResult(page);
+          },
+        });
+      }),
+  };
+}

--- a/packages/clawql-web/src/providers/browser/chromium.ts
+++ b/packages/clawql-web/src/providers/browser/chromium.ts
@@ -1,0 +1,83 @@
+import type {
+  BrowserCapabilities,
+  BrowserStep,
+  FetchOptions,
+  PageContent,
+  WebBrowserProvider,
+} from "../../interfaces.js";
+import type { WebConfig } from "../../config.js";
+
+const CAPS: BrowserCapabilities = { fetch: true, screenshot: true, interact: true };
+
+/**
+ * Chromium via CDP URL or Cloudflare Browser Run.
+ * Playwright/Puppeteer wrappers share this backend; full CDP automation is Tier-2.
+ */
+export function createChromiumBrowserProvider(
+  config: WebConfig,
+  fetchImpl: typeof fetch = fetch,
+  variant: "chromium" | "playwright" | "puppeteer" = "chromium"
+): WebBrowserProvider {
+  return {
+    id: variant,
+    capabilities: CAPS,
+    async fetch(url: string, options?: FetchOptions): Promise<PageContent> {
+      // Prefer Browser Run markdown endpoint when available (same as Kitesurf path)
+      if (config.browserRunApiToken && config.cloudflareAccountId && !config.dryRun) {
+        const endpoint = `https://api.cloudflare.com/client/v4/accounts/${config.cloudflareAccountId}/browser-rendering/markdown`;
+        const res = await fetchImpl(endpoint, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${config.browserRunApiToken}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ url }),
+          signal: options?.timeoutMs ? AbortSignal.timeout(options.timeoutMs) : undefined,
+        });
+        if (!res.ok) {
+          throw new Error(`${variant} (Browser Run) fetch failed: HTTP ${res.status}`);
+        }
+        const body = (await res.json()) as { result?: string };
+        const markdown = typeof body.result === "string" ? body.result : "";
+        return { url, markdown, text: markdown, provider: variant };
+      }
+
+      if (config.dryRun || config.chromiumCdpUrl) {
+        if (!config.dryRun && !config.chromiumCdpUrl) {
+          throw new Error(
+            `${variant} requires CLAWQL_CHROMIUM_CDP_URL or Browser Run credentials (or CLAWQL_WEB_DRY_RUN=1)`
+          );
+        }
+        return {
+          url,
+          title: `[dry-run] ${variant}`,
+          markdown: `# Dry-run ${variant}\n\n${url}\n\nConnect CDP or Browser Run for live browsing.`,
+          text: `Dry-run ${url}`,
+          provider: variant,
+        };
+      }
+
+      throw new Error(
+        `${variant}: set CLAWQL_CHROMIUM_CDP_URL or CLAWQL_BROWSER_RUN_API_TOKEN + account id`
+      );
+    },
+    async screenshot(url: string): Promise<Uint8Array> {
+      if (config.dryRun) {
+        return new TextEncoder().encode(`dry-run-${variant}-screenshot:${url}`);
+      }
+      throw new Error(`${variant} screenshot requires live Browser Run or CDP (Tier-2)`);
+    },
+    async interact(url: string, steps: BrowserStep[]): Promise<PageContent> {
+      if (config.dryRun) {
+        return {
+          url,
+          title: `[dry-run] ${variant} interact`,
+          markdown: `Steps: ${JSON.stringify(steps)}`,
+          text: `interact dry-run ${url}`,
+          provider: variant,
+        };
+      }
+      throw new Error(`${variant} interact requires live CDP session (Tier-2)`);
+    },
+  };
+}

--- a/packages/clawql-web/src/providers/browser/firecrawl.ts
+++ b/packages/clawql-web/src/providers/browser/firecrawl.ts
@@ -1,0 +1,73 @@
+import type {
+  BrowserCapabilities,
+  BrowserStep,
+  FetchOptions,
+  PageContent,
+  WebBrowserProvider,
+} from "../../interfaces.js";
+import type { WebConfig } from "../../config.js";
+
+const CAPS: BrowserCapabilities = { fetch: true, screenshot: false, interact: false };
+
+/**
+ * Firecrawl managed scrape API — clean markdown for LLM consumption.
+ */
+export function createFirecrawlBrowserProvider(
+  config: WebConfig,
+  fetchImpl: typeof fetch = fetch
+): WebBrowserProvider {
+  return {
+    id: "firecrawl",
+    capabilities: CAPS,
+    async fetch(url: string, options?: FetchOptions): Promise<PageContent> {
+      if (config.dryRun || !config.firecrawlApiKey) {
+        if (!config.dryRun && !config.firecrawlApiKey) {
+          throw new Error("Firecrawl requires CLAWQL_FIRECRAWL_API_KEY (or CLAWQL_WEB_DRY_RUN=1)");
+        }
+        return {
+          url,
+          title: "[dry-run] firecrawl",
+          markdown: `# Dry-run Firecrawl\n\n${url}`,
+          text: `Dry-run ${url}`,
+          provider: "firecrawl",
+        };
+      }
+      const base = (config.firecrawlBaseUrl ?? "https://api.firecrawl.dev").replace(/\/$/, "");
+      const res = await fetchImpl(`${base}/v1/scrape`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${config.firecrawlApiKey}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          url,
+          formats: [options?.format === "html" ? "html" : "markdown"],
+        }),
+        signal: options?.timeoutMs ? AbortSignal.timeout(options.timeoutMs) : undefined,
+      });
+      if (!res.ok) {
+        throw new Error(`Firecrawl scrape failed: HTTP ${res.status}`);
+      }
+      const body = (await res.json()) as {
+        data?: { markdown?: string; html?: string; metadata?: { title?: string } };
+      };
+      return {
+        url,
+        title: body.data?.metadata?.title,
+        markdown: body.data?.markdown,
+        html: body.data?.html,
+        text: body.data?.markdown ?? body.data?.html,
+        provider: "firecrawl",
+      };
+    },
+    async screenshot(_url: string): Promise<Uint8Array> {
+      throw new Error("Firecrawl screenshot not implemented in clawql-web v1 — use Kitesurf/Chromium");
+    },
+    async interact(
+      _url: string,
+      _steps: BrowserStep[]
+    ): Promise<PageContent> {
+      throw new Error("Firecrawl interact not implemented — use chromium/playwright");
+    },
+  };
+}

--- a/packages/clawql-web/src/providers/browser/kitesurf.ts
+++ b/packages/clawql-web/src/providers/browser/kitesurf.ts
@@ -1,0 +1,86 @@
+import type {
+  BrowserCapabilities,
+  BrowserStep,
+  FetchOptions,
+  PageContent,
+  WebBrowserProvider,
+} from "../../interfaces.js";
+import type { WebConfig } from "../../config.js";
+
+const CAPS: BrowserCapabilities = { fetch: true, screenshot: true, interact: false };
+
+/**
+ * Kitesurf via Cloudflare Browser Run / Browser Rendering (free beta).
+ * Uses the Cloudflare account Browser Rendering REST API when token+account are set.
+ */
+export function createKitesurfBrowserProvider(
+  config: WebConfig,
+  fetchImpl: typeof fetch = fetch
+): WebBrowserProvider {
+  return {
+    id: "kitesurf",
+    capabilities: CAPS,
+    async fetch(url: string, options?: FetchOptions): Promise<PageContent> {
+      if (config.dryRun || !config.browserRunApiToken || !config.cloudflareAccountId) {
+        if (!config.dryRun && (!config.browserRunApiToken || !config.cloudflareAccountId)) {
+          throw new Error(
+            "Kitesurf requires CLAWQL_BROWSER_RUN_API_TOKEN + CLAWQL_CLOUDFLARE_ACCOUNT_ID (or CLAWQL_WEB_DRY_RUN=1)"
+          );
+        }
+        return {
+          url,
+          title: "[dry-run] kitesurf",
+          markdown: `# Dry-run fetch\n\nURL: ${url}\n\nSet Browser Run credentials for live Kitesurf.`,
+          text: `Dry-run content for ${url}`,
+          provider: "kitesurf",
+        };
+      }
+
+      const endpoint = `https://api.cloudflare.com/client/v4/accounts/${config.cloudflareAccountId}/browser-rendering/markdown`;
+      const res = await fetchImpl(endpoint, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${config.browserRunApiToken}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ url }),
+        signal: options?.timeoutMs ? AbortSignal.timeout(options.timeoutMs) : undefined,
+      });
+      if (!res.ok) {
+        throw new Error(`Kitesurf fetch failed: HTTP ${res.status}`);
+      }
+      const body = (await res.json()) as { result?: string; success?: boolean };
+      const markdown = typeof body.result === "string" ? body.result : JSON.stringify(body);
+      return { url, markdown, text: markdown, provider: "kitesurf" };
+    },
+    async screenshot(url: string, options?: FetchOptions): Promise<Uint8Array> {
+      if (config.dryRun || !config.browserRunApiToken || !config.cloudflareAccountId) {
+        if (!config.dryRun && (!config.browserRunApiToken || !config.cloudflareAccountId)) {
+          throw new Error("Kitesurf screenshot requires Browser Run credentials");
+        }
+        return new TextEncoder().encode(`dry-run-screenshot:${url}`);
+      }
+      const endpoint = `https://api.cloudflare.com/client/v4/accounts/${config.cloudflareAccountId}/browser-rendering/screenshot`;
+      const res = await fetchImpl(endpoint, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${config.browserRunApiToken}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ url }),
+        signal: options?.timeoutMs ? AbortSignal.timeout(options.timeoutMs) : undefined,
+      });
+      if (!res.ok) {
+        throw new Error(`Kitesurf screenshot failed: HTTP ${res.status}`);
+      }
+      return new Uint8Array(await res.arrayBuffer());
+    },
+    async interact(
+      _url: string,
+      _steps: BrowserStep[],
+      _options?: FetchOptions
+    ): Promise<PageContent> {
+      throw new Error("Kitesurf provider does not support web_interact yet — use chromium/playwright");
+    },
+  };
+}

--- a/packages/clawql-web/src/providers/browser/raw-fetch.ts
+++ b/packages/clawql-web/src/providers/browser/raw-fetch.ts
@@ -1,0 +1,116 @@
+/**
+ * Direct HTTPS/HTTP raw fetch for IDP URL ingestion parity.
+ * Mirrors clawql-documents `fetchUrlResource` behaviors so the IDP migration
+ * can switch to clawql-web without silently changing timeouts, redirects, or SSRF gates.
+ *
+ * @see packages/clawql-documents/src/ingest/external-ingest.ts
+ */
+
+import { isPrivateOrLoopbackIp } from "clawql-api";
+
+const MAX_URL_RESPONSE_BYTES = 2 * 1024 * 1024;
+const MAX_URL_REDIRECTS = 5;
+const DEFAULT_TIMEOUT_MS = 60_000;
+const BLOCKED_HOSTNAMES = new Set(["metadata.google.internal", "metadata.google"]);
+
+const DEFAULT_UA =
+  "Mozilla/5.0 (compatible; clawql-web/1.0; +https://github.com/danielsmithdevelopment/ClawQL)";
+
+export type RawFetchResult = {
+  url: string;
+  finalUrl: string;
+  bytes: Uint8Array;
+  contentType: string | null;
+  provider: "raw-http";
+};
+
+/** SSRF gate — same posture as IDP external ingest. */
+export function assertSafeWebUrl(urlStr: string): URL {
+  let u: URL;
+  try {
+    u = new URL(urlStr);
+  } catch {
+    throw new Error("invalid url");
+  }
+  if (u.protocol !== "https:" && u.protocol !== "http:") {
+    throw new Error("only http and https URLs are allowed");
+  }
+  const host = u.hostname.trim().toLowerCase();
+  const isLoopbackHost = host === "localhost" || host === "127.0.0.1" || host === "::1";
+  if (u.protocol === "http:" && !isLoopbackHost) {
+    throw new Error("http is only allowed for localhost; use https");
+  }
+  if (BLOCKED_HOSTNAMES.has(host) || host.endsWith(".localhost")) {
+    throw new Error("URL host is not allowed");
+  }
+  if (!isLoopbackHost && isPrivateOrLoopbackIp(host)) {
+    throw new Error("URL must not target private or link-local addresses");
+  }
+  return u;
+}
+
+export async function fetchRawUrl(
+  urlStr: string,
+  options: {
+    timeoutMs?: number;
+    maxBytes?: number;
+    dryRun?: boolean;
+    fetchImpl?: typeof fetch;
+  } = {}
+): Promise<RawFetchResult> {
+  if (options.dryRun) {
+    const text = `dry-run raw bytes for ${urlStr}`;
+    return {
+      url: urlStr,
+      finalUrl: urlStr,
+      bytes: new TextEncoder().encode(text),
+      contentType: "text/plain; charset=utf-8",
+      provider: "raw-http",
+    };
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const maxBytes = options.maxBytes ?? MAX_URL_RESPONSE_BYTES;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  let current = assertSafeWebUrl(urlStr).href;
+
+  for (let hop = 0; hop <= MAX_URL_REDIRECTS; hop += 1) {
+    const res = await fetchImpl(current, {
+      redirect: "manual",
+      signal: AbortSignal.timeout(timeoutMs),
+      headers: {
+        "User-Agent": DEFAULT_UA,
+        Accept: "*/*",
+      },
+    });
+    if (res.status >= 300 && res.status < 400) {
+      const loc = res.headers.get("location");
+      if (!loc?.trim()) {
+        throw new Error(`HTTP ${res.status} redirect without Location`);
+      }
+      current = assertSafeWebUrl(new URL(loc, current).href).href;
+      continue;
+    }
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    const len = res.headers.get("content-length");
+    if (len && Number.parseInt(len, 10) > maxBytes) {
+      throw new Error("Content-Length exceeds cap");
+    }
+    const buf = new Uint8Array(await res.arrayBuffer());
+    if (buf.byteLength > maxBytes) {
+      throw new Error("response body exceeds cap");
+    }
+    const rawCt = res.headers.get("content-type");
+    const contentType = rawCt?.split(";")[0]?.trim() ?? null;
+    return {
+      url: urlStr,
+      finalUrl: current,
+      bytes: buf,
+      contentType,
+      provider: "raw-http",
+    };
+  }
+  throw new Error("too many redirects");
+}

--- a/packages/clawql-web/src/providers/browser/resolve.ts
+++ b/packages/clawql-web/src/providers/browser/resolve.ts
@@ -1,0 +1,26 @@
+import type { WebConfig } from "../../config.js";
+import type { WebBrowserProvider } from "../../interfaces.js";
+import { createKitesurfBrowserProvider } from "./kitesurf.js";
+import { createFirecrawlBrowserProvider } from "./firecrawl.js";
+import { createChromiumBrowserProvider } from "./chromium.js";
+
+export function resolveBrowserProvider(
+  config: WebConfig,
+  fetchImpl: typeof fetch = fetch
+): WebBrowserProvider | undefined {
+  switch (config.browserProvider) {
+    case "kitesurf":
+      return createKitesurfBrowserProvider(config, fetchImpl);
+    case "firecrawl":
+      return createFirecrawlBrowserProvider(config, fetchImpl);
+    case "chromium":
+      return createChromiumBrowserProvider(config, fetchImpl, "chromium");
+    case "playwright":
+      return createChromiumBrowserProvider(config, fetchImpl, "playwright");
+    case "puppeteer":
+      return createChromiumBrowserProvider(config, fetchImpl, "puppeteer");
+    case "none":
+    default:
+      return undefined;
+  }
+}

--- a/packages/clawql-web/src/providers/fallback-search.ts
+++ b/packages/clawql-web/src/providers/fallback-search.ts
@@ -1,0 +1,54 @@
+/**
+ * Last-resort search: navigate a public search engine via the browser provider
+ * and extract title/url/snippet heuristics from markdown/text.
+ */
+
+import type { WebBrowserProvider, SearchOptions, SearchResponse } from "../interfaces.js";
+
+function extractResultsFromText(query: string, text: string, limit: number): SearchResponse["results"] {
+  const results: SearchResponse["results"] = [];
+  const linkRe = /\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = linkRe.exec(text)) !== null && results.length < limit) {
+    const title = m[1]?.trim() ?? "";
+    const url = m[2]?.trim() ?? "";
+    if (!url || url.includes("google.com/search") || url.includes("duckduckgo.com/?q=")) continue;
+    results.push({
+      title: title || url,
+      url,
+      snippet: `Extracted via browser-as-search for “${query}”`,
+      source: "browser-fallback",
+    });
+  }
+  if (results.length === 0) {
+    results.push({
+      title: `Browser fallback search: ${query}`,
+      url: `https://duckduckgo.com/?q=${encodeURIComponent(query)}`,
+      snippet:
+        "No structured links extracted from browser page — open the search URL or configure a search provider.",
+      source: "browser-fallback",
+    });
+  }
+  return results.slice(0, limit);
+}
+
+export async function browserAsSearch(
+  query: string,
+  browser: WebBrowserProvider,
+  options?: SearchOptions
+): Promise<SearchResponse> {
+  const limit = options?.limit ?? 5;
+  const searchUrl = `https://duckduckgo.com/html/?q=${encodeURIComponent(query)}`;
+  const page = await browser.fetch(searchUrl, {
+    format: "markdown",
+    correlationId: options?.correlationId,
+  });
+  const text = page.markdown ?? page.text ?? page.html ?? "";
+  return {
+    query,
+    provider: `browser:${browser.id}`,
+    fallback: true,
+    fallbackReason: "no_search_provider_configured",
+    results: extractResultsFromText(query, text, limit),
+  };
+}

--- a/packages/clawql-web/src/providers/search/brave.ts
+++ b/packages/clawql-web/src/providers/search/brave.ts
@@ -1,0 +1,56 @@
+import type { SearchOptions, SearchResponse, WebSearchProvider } from "../../interfaces.js";
+import type { WebConfig } from "../../config.js";
+
+export function createBraveSearchProvider(
+  config: WebConfig,
+  fetchImpl: typeof fetch = fetch
+): WebSearchProvider {
+  return {
+    id: "brave",
+    async search(query: string, options?: SearchOptions): Promise<SearchResponse> {
+      const limit = options?.limit ?? config.defaultSearchLimit;
+      if (config.dryRun || !config.braveApiKey) {
+        if (!config.dryRun && !config.braveApiKey) {
+          throw new Error("Brave Search requires CLAWQL_BRAVE_API_KEY (or CLAWQL_WEB_DRY_RUN=1)");
+        }
+        return {
+          query,
+          provider: "brave",
+          results: [
+            {
+              title: `[dry-run] ${query}`,
+              url: `https://search.brave.com/search?q=${encodeURIComponent(query)}`,
+              snippet: "Dry-run Brave result — set CLAWQL_BRAVE_API_KEY for live search.",
+            },
+          ].slice(0, limit),
+        };
+      }
+
+      const url = new URL("https://api.search.brave.com/res/v1/web/search");
+      url.searchParams.set("q", query);
+      url.searchParams.set("count", String(limit));
+      const res = await fetchImpl(url, {
+        headers: {
+          Accept: "application/json",
+          "X-Subscription-Token": config.braveApiKey,
+        },
+      });
+      if (!res.ok) {
+        throw new Error(`Brave search failed: HTTP ${res.status}`);
+      }
+      const body = (await res.json()) as {
+        web?: { results?: Array<{ title?: string; url?: string; description?: string }>; };
+      };
+      return {
+        query,
+        provider: "brave",
+        results: (body.web?.results ?? []).map((r) => ({
+          title: r.title ?? "",
+          url: r.url ?? "",
+          snippet: r.description,
+          source: "brave",
+        })),
+      };
+    },
+  };
+}

--- a/packages/clawql-web/src/providers/search/opensearch.ts
+++ b/packages/clawql-web/src/providers/search/opensearch.ts
@@ -1,0 +1,69 @@
+import type { SearchOptions, SearchResponse, WebSearchProvider } from "../../interfaces.js";
+import type { WebConfig } from "../../config.js";
+
+/** Self-hosted OpenSearch / Elasticsearch index search (maximum sovereignty). */
+export function createOpensearchSearchProvider(
+  config: WebConfig,
+  fetchImpl: typeof fetch = fetch
+): WebSearchProvider {
+  return {
+    id: "opensearch",
+    async search(query: string, options?: SearchOptions): Promise<SearchResponse> {
+      const limit = options?.limit ?? config.defaultSearchLimit;
+      if (config.dryRun || !config.opensearchUrl) {
+        if (!config.dryRun && !config.opensearchUrl) {
+          throw new Error("OpenSearch requires CLAWQL_OPENSEARCH_URL (or CLAWQL_WEB_DRY_RUN=1)");
+        }
+        return {
+          query,
+          provider: "opensearch",
+          results: [
+            {
+              title: `[dry-run] ${query}`,
+              url: `https://internal.example/docs?q=${encodeURIComponent(query)}`,
+              snippet: "Dry-run OpenSearch result — point CLAWQL_OPENSEARCH_URL at your index.",
+            },
+          ].slice(0, limit),
+        };
+      }
+
+      const base = config.opensearchUrl.replace(/\/$/, "");
+      const index = config.opensearchIndex ?? "clawql-web";
+      const res = await fetchImpl(`${base}/${encodeURIComponent(index)}/_search`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          size: limit,
+          query: {
+            multi_match: {
+              query,
+              fields: ["title^2", "content", "text", "snippet"],
+            },
+          },
+        }),
+      });
+      if (!res.ok) {
+        throw new Error(`OpenSearch search failed: HTTP ${res.status}`);
+      }
+      const body = (await res.json()) as {
+        hits?: {
+          hits?: Array<{
+            _score?: number;
+            _source?: { title?: string; url?: string; content?: string; snippet?: string };
+          }>;
+        };
+      };
+      return {
+        query,
+        provider: "opensearch",
+        results: (body.hits?.hits ?? []).map((h) => ({
+          title: h._source?.title ?? "",
+          url: h._source?.url ?? "",
+          snippet: h._source?.snippet ?? h._source?.content,
+          score: h._score,
+          source: "opensearch",
+        })),
+      };
+    },
+  };
+}

--- a/packages/clawql-web/src/providers/search/resolve.ts
+++ b/packages/clawql-web/src/providers/search/resolve.ts
@@ -1,0 +1,25 @@
+import type { WebConfig } from "../../config.js";
+import type { WebSearchProvider } from "../../interfaces.js";
+import { createTavilySearchProvider } from "./tavily.js";
+import { createBraveSearchProvider } from "./brave.js";
+import { createSearxngSearchProvider } from "./searxng.js";
+import { createOpensearchSearchProvider } from "./opensearch.js";
+
+export function resolveSearchProvider(
+  config: WebConfig,
+  fetchImpl: typeof fetch = fetch
+): WebSearchProvider | undefined {
+  switch (config.searchProvider) {
+    case "tavily":
+      return createTavilySearchProvider(config, fetchImpl);
+    case "brave":
+      return createBraveSearchProvider(config, fetchImpl);
+    case "searxng":
+      return createSearxngSearchProvider(config, fetchImpl);
+    case "opensearch":
+      return createOpensearchSearchProvider(config, fetchImpl);
+    case "none":
+    default:
+      return undefined;
+  }
+}

--- a/packages/clawql-web/src/providers/search/searxng.ts
+++ b/packages/clawql-web/src/providers/search/searxng.ts
@@ -1,0 +1,52 @@
+import type { SearchOptions, SearchResponse, WebSearchProvider } from "../../interfaces.js";
+import type { WebConfig } from "../../config.js";
+
+export function createSearxngSearchProvider(
+  config: WebConfig,
+  fetchImpl: typeof fetch = fetch
+): WebSearchProvider {
+  return {
+    id: "searxng",
+    async search(query: string, options?: SearchOptions): Promise<SearchResponse> {
+      const limit = options?.limit ?? config.defaultSearchLimit;
+      if (config.dryRun || !config.searxngUrl) {
+        if (!config.dryRun && !config.searxngUrl) {
+          throw new Error("SearXNG requires CLAWQL_SEARXNG_URL (or CLAWQL_WEB_DRY_RUN=1)");
+        }
+        return {
+          query,
+          provider: "searxng",
+          results: [
+            {
+              title: `[dry-run] ${query}`,
+              url: `https://example.com/?q=${encodeURIComponent(query)}`,
+              snippet: "Dry-run SearXNG result — set CLAWQL_SEARXNG_URL for self-hosted search.",
+            },
+          ].slice(0, limit),
+        };
+      }
+
+      const base = config.searxngUrl.replace(/\/$/, "");
+      const url = new URL(`${base}/search`);
+      url.searchParams.set("q", query);
+      url.searchParams.set("format", "json");
+      const res = await fetchImpl(url);
+      if (!res.ok) {
+        throw new Error(`SearXNG search failed: HTTP ${res.status}`);
+      }
+      const body = (await res.json()) as {
+        results?: Array<{ title?: string; url?: string; content?: string; engine?: string }>;
+      };
+      return {
+        query,
+        provider: "searxng",
+        results: (body.results ?? []).slice(0, limit).map((r) => ({
+          title: r.title ?? "",
+          url: r.url ?? "",
+          snippet: r.content,
+          source: r.engine ?? "searxng",
+        })),
+      };
+    },
+  };
+}

--- a/packages/clawql-web/src/providers/search/tavily.ts
+++ b/packages/clawql-web/src/providers/search/tavily.ts
@@ -1,0 +1,57 @@
+import type { SearchOptions, SearchResponse, WebSearchProvider } from "../../interfaces.js";
+import type { WebConfig } from "../../config.js";
+
+export function createTavilySearchProvider(
+  config: WebConfig,
+  fetchImpl: typeof fetch = fetch
+): WebSearchProvider {
+  return {
+    id: "tavily",
+    async search(query: string, options?: SearchOptions): Promise<SearchResponse> {
+      const limit = options?.limit ?? config.defaultSearchLimit;
+      if (config.dryRun || !config.tavilyApiKey) {
+        if (!config.dryRun && !config.tavilyApiKey) {
+          throw new Error("Tavily requires CLAWQL_TAVILY_API_KEY (or CLAWQL_WEB_DRY_RUN=1)");
+        }
+        return {
+          query,
+          provider: "tavily",
+          results: [
+            {
+              title: `[dry-run] ${query}`,
+              url: `https://example.com/search?q=${encodeURIComponent(query)}`,
+              snippet: "Dry-run Tavily result — set CLAWQL_TAVILY_API_KEY for live search.",
+            },
+          ].slice(0, limit),
+        };
+      }
+
+      const res = await fetchImpl("https://api.tavily.com/search", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          api_key: config.tavilyApiKey,
+          query,
+          max_results: limit,
+        }),
+      });
+      if (!res.ok) {
+        throw new Error(`Tavily search failed: HTTP ${res.status}`);
+      }
+      const body = (await res.json()) as {
+        results?: Array<{ title?: string; url?: string; content?: string; score?: number }>;
+      };
+      return {
+        query,
+        provider: "tavily",
+        results: (body.results ?? []).map((r) => ({
+          title: r.title ?? "",
+          url: r.url ?? "",
+          snippet: r.content,
+          score: r.score,
+          source: "tavily",
+        })),
+      };
+    },
+  };
+}

--- a/packages/clawql-web/src/service.ts
+++ b/packages/clawql-web/src/service.ts
@@ -1,0 +1,182 @@
+/**
+ * Orchestration: search with optional browser fallback, fetch/screenshot/interact.
+ */
+
+import { appendWebAudit } from "./audit.js";
+import { loadWebConfig, type WebConfig } from "./config.js";
+import type {
+  BrowserStep,
+  FetchOptions,
+  PageContent,
+  SearchOptions,
+  SearchResponse,
+  WebBrowserProvider,
+  WebSearchProvider,
+} from "./interfaces.js";
+import { browserAsSearch } from "./providers/fallback-search.js";
+import { resolveBrowserProvider } from "./providers/browser/resolve.js";
+import { resolveSearchProvider } from "./providers/search/resolve.js";
+
+export type WebService = {
+  config: WebConfig;
+  searchProvider?: WebSearchProvider;
+  browserProvider?: WebBrowserProvider;
+  search(query: string, options?: SearchOptions): Promise<SearchResponse>;
+  fetch(url: string, options?: FetchOptions): Promise<PageContent>;
+  screenshot(url: string, options?: FetchOptions): Promise<Uint8Array>;
+  interact(url: string, steps: BrowserStep[], options?: FetchOptions): Promise<PageContent>;
+};
+
+export function createWebService(
+  env: NodeJS.ProcessEnv = process.env,
+  fetchImpl: typeof fetch = fetch
+): WebService {
+  const config = loadWebConfig(env);
+  const searchProvider = resolveSearchProvider(config, fetchImpl);
+  const browserProvider = resolveBrowserProvider(config, fetchImpl);
+
+  return {
+    config,
+    searchProvider,
+    browserProvider,
+
+    async search(query: string, options?: SearchOptions): Promise<SearchResponse> {
+      const q = query.trim();
+      if (!q) throw new Error("query is required");
+
+      if (searchProvider) {
+        const result = await searchProvider.search(q, options);
+        await appendWebAudit({
+          type: "WEB_SEARCH",
+          provider: searchProvider.id,
+          query: q,
+          correlationId: options?.correlationId,
+          ok: true,
+        });
+        return result;
+      }
+
+      if (!config.searchFallbackToBrowser || !browserProvider) {
+        await appendWebAudit({
+          type: "WEB_ERROR",
+          query: q,
+          reason: "no_search_provider_and_no_browser_fallback",
+          ok: false,
+          correlationId: options?.correlationId,
+        });
+        throw new Error(
+          "No web search provider configured. Set CLAWQL_WEB_SEARCH_PROVIDER or enable browser fallback."
+        );
+      }
+
+      // Audit BEFORE fallback executes (compliance requirement)
+      await appendWebAudit({
+        type: "WEB_SEARCH_FALLBACK",
+        reason: "no_search_provider_configured",
+        fallback: "browser",
+        provider: browserProvider.id,
+        query: q,
+        correlationId: options?.correlationId,
+      });
+
+      try {
+        const result = await browserAsSearch(q, browserProvider, options);
+        await appendWebAudit({
+          type: "WEB_SEARCH",
+          provider: result.provider,
+          query: q,
+          ok: true,
+          detail: "fallback",
+          correlationId: options?.correlationId,
+        });
+        return result;
+      } catch (err) {
+        await appendWebAudit({
+          type: "WEB_ERROR",
+          provider: browserProvider.id,
+          query: q,
+          reason: "browser_fallback_failed",
+          ok: false,
+          detail: err instanceof Error ? err.message : String(err),
+          correlationId: options?.correlationId,
+        });
+        throw err;
+      }
+    },
+
+    async fetch(url: string, options?: FetchOptions): Promise<PageContent> {
+      if (!browserProvider) {
+        throw new Error("No web browser provider configured (CLAWQL_WEB_BROWSER_PROVIDER)");
+      }
+      if (!browserProvider.capabilities.fetch) {
+        throw new Error(`Browser provider ${browserProvider.id} does not support fetch`);
+      }
+      try {
+        const page = await browserProvider.fetch(url, options);
+        await appendWebAudit({
+          type: "WEB_FETCH",
+          provider: browserProvider.id,
+          url,
+          ok: true,
+          correlationId: options?.correlationId,
+        });
+        return page;
+      } catch (err) {
+        await appendWebAudit({
+          type: "WEB_ERROR",
+          provider: browserProvider.id,
+          url,
+          reason: "fetch_failed",
+          ok: false,
+          detail: err instanceof Error ? err.message : String(err),
+          correlationId: options?.correlationId,
+        });
+        throw err;
+      }
+    },
+
+    async screenshot(url: string, options?: FetchOptions): Promise<Uint8Array> {
+      if (!browserProvider) {
+        throw new Error("No web browser provider configured");
+      }
+      if (!browserProvider.capabilities.screenshot || !browserProvider.screenshot) {
+        throw new Error(
+          `Browser provider ${browserProvider.id} does not support screenshot`
+        );
+      }
+      const buf = await browserProvider.screenshot(url, options);
+      await appendWebAudit({
+        type: "WEB_SCREENSHOT",
+        provider: browserProvider.id,
+        url,
+        ok: true,
+        correlationId: options?.correlationId,
+      });
+      return buf;
+    },
+
+    async interact(
+      url: string,
+      steps: BrowserStep[],
+      options?: FetchOptions
+    ): Promise<PageContent> {
+      if (!browserProvider) {
+        throw new Error("No web browser provider configured");
+      }
+      if (!browserProvider.capabilities.interact || !browserProvider.interact) {
+        throw new Error(
+          `Browser provider ${browserProvider.id} does not support interact`
+        );
+      }
+      const page = await browserProvider.interact(url, steps, options);
+      await appendWebAudit({
+        type: "WEB_INTERACT",
+        provider: browserProvider.id,
+        url,
+        ok: true,
+        correlationId: options?.correlationId,
+      });
+      return page;
+    },
+  };
+}

--- a/packages/clawql-web/src/service.ts
+++ b/packages/clawql-web/src/service.ts
@@ -4,6 +4,7 @@
 
 import { appendWebAudit } from "./audit.js";
 import { loadWebConfig, type WebConfig } from "./config.js";
+import { WebCapabilityError } from "./errors.js";
 import type {
   BrowserStep,
   FetchOptions,
@@ -14,6 +15,7 @@ import type {
   WebSearchProvider,
 } from "./interfaces.js";
 import { browserAsSearch } from "./providers/fallback-search.js";
+import { fetchRawUrl } from "./providers/browser/raw-fetch.js";
 import { resolveBrowserProvider } from "./providers/browser/resolve.js";
 import { resolveSearchProvider } from "./providers/search/resolve.js";
 
@@ -26,6 +28,44 @@ export type WebService = {
   screenshot(url: string, options?: FetchOptions): Promise<Uint8Array>;
   interact(url: string, steps: BrowserStep[], options?: FetchOptions): Promise<PageContent>;
 };
+
+function requireBrowser(
+  browserProvider: WebBrowserProvider | undefined,
+  tool: string
+): WebBrowserProvider {
+  if (!browserProvider) {
+    throw new WebCapabilityError({
+      code: "NO_BROWSER_PROVIDER",
+      reason:
+        "No browser provider configured (CLAWQL_WEB_BROWSER_PROVIDER=none or unset). " +
+        "Search-only providers (e.g. SearXNG) cannot run browser tools.",
+      capability: tool,
+    });
+  }
+  return browserProvider;
+}
+
+function requireCapability(
+  browser: WebBrowserProvider,
+  capability: "fetch" | "screenshot" | "interact",
+  tool: string
+): void {
+  const caps = browser.capabilities;
+  const supported =
+    capability === "fetch"
+      ? caps.fetch
+      : capability === "screenshot"
+        ? caps.screenshot && typeof browser.screenshot === "function"
+        : caps.interact && typeof browser.interact === "function";
+  if (!supported) {
+    throw new WebCapabilityError({
+      code: "CAPABILITY_UNSUPPORTED",
+      reason: `Browser provider "${browser.id}" does not support ${capability}.`,
+      provider: browser.id,
+      capability,
+    });
+  }
+}
 
 export function createWebService(
   env: NodeJS.ProcessEnv = process.env,
@@ -64,12 +104,14 @@ export function createWebService(
           ok: false,
           correlationId: options?.correlationId,
         });
-        throw new Error(
-          "No web search provider configured. Set CLAWQL_WEB_SEARCH_PROVIDER or enable browser fallback."
-        );
+        throw new WebCapabilityError({
+          code: "NO_SEARCH_PROVIDER",
+          reason:
+            "No web search provider configured. Set CLAWQL_WEB_SEARCH_PROVIDER or enable browser fallback.",
+        });
       }
 
-      // Audit BEFORE fallback executes (compliance requirement)
+      // Audit BEFORE fallback executes (compliance: record even if browser throws)
       await appendWebAudit({
         type: "WEB_SEARCH_FALLBACK",
         reason: "no_search_provider_configured",
@@ -105,17 +147,49 @@ export function createWebService(
     },
 
     async fetch(url: string, options?: FetchOptions): Promise<PageContent> {
-      if (!browserProvider) {
-        throw new Error("No web browser provider configured (CLAWQL_WEB_BROWSER_PROVIDER)");
+      // Raw path: IDP / pdf-inspector — bytes + content-type, no browser required
+      if (options?.raw === true) {
+        try {
+          const raw = await fetchRawUrl(url, {
+            timeoutMs: options.timeoutMs,
+            dryRun: config.dryRun,
+            fetchImpl,
+          });
+          await appendWebAudit({
+            type: "WEB_FETCH",
+            provider: raw.provider,
+            url,
+            ok: true,
+            detail: "raw",
+            correlationId: options?.correlationId,
+          });
+          return {
+            url: raw.url,
+            finalUrl: raw.finalUrl,
+            bytes: raw.bytes,
+            contentType: raw.contentType,
+            provider: raw.provider,
+          };
+        } catch (err) {
+          await appendWebAudit({
+            type: "WEB_ERROR",
+            url,
+            reason: "raw_fetch_failed",
+            ok: false,
+            detail: err instanceof Error ? err.message : String(err),
+            correlationId: options?.correlationId,
+          });
+          throw err;
+        }
       }
-      if (!browserProvider.capabilities.fetch) {
-        throw new Error(`Browser provider ${browserProvider.id} does not support fetch`);
-      }
+
+      const browser = requireBrowser(browserProvider, "web_fetch");
+      requireCapability(browser, "fetch", "web_fetch");
       try {
-        const page = await browserProvider.fetch(url, options);
+        const page = await browser.fetch(url, options);
         await appendWebAudit({
           type: "WEB_FETCH",
-          provider: browserProvider.id,
+          provider: browser.id,
           url,
           ok: true,
           correlationId: options?.correlationId,
@@ -124,7 +198,7 @@ export function createWebService(
       } catch (err) {
         await appendWebAudit({
           type: "WEB_ERROR",
-          provider: browserProvider.id,
+          provider: browser.id,
           url,
           reason: "fetch_failed",
           ok: false,
@@ -136,18 +210,12 @@ export function createWebService(
     },
 
     async screenshot(url: string, options?: FetchOptions): Promise<Uint8Array> {
-      if (!browserProvider) {
-        throw new Error("No web browser provider configured");
-      }
-      if (!browserProvider.capabilities.screenshot || !browserProvider.screenshot) {
-        throw new Error(
-          `Browser provider ${browserProvider.id} does not support screenshot`
-        );
-      }
-      const buf = await browserProvider.screenshot(url, options);
+      const browser = requireBrowser(browserProvider, "web_screenshot");
+      requireCapability(browser, "screenshot", "web_screenshot");
+      const buf = await browser.screenshot!(url, options);
       await appendWebAudit({
         type: "WEB_SCREENSHOT",
-        provider: browserProvider.id,
+        provider: browser.id,
         url,
         ok: true,
         correlationId: options?.correlationId,
@@ -160,18 +228,12 @@ export function createWebService(
       steps: BrowserStep[],
       options?: FetchOptions
     ): Promise<PageContent> {
-      if (!browserProvider) {
-        throw new Error("No web browser provider configured");
-      }
-      if (!browserProvider.capabilities.interact || !browserProvider.interact) {
-        throw new Error(
-          `Browser provider ${browserProvider.id} does not support interact`
-        );
-      }
-      const page = await browserProvider.interact(url, steps, options);
+      const browser = requireBrowser(browserProvider, "web_interact");
+      requireCapability(browser, "interact", "web_interact");
+      const page = await browser.interact!(url, steps, options);
       await appendWebAudit({
         type: "WEB_INTERACT",
-        provider: browserProvider.id,
+        provider: browser.id,
         url,
         ok: true,
         correlationId: options?.correlationId,

--- a/packages/clawql-web/src/web.test.ts
+++ b/packages/clawql-web/src/web.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createWebService,
+  envImpliesWebEnabled,
+  isWebEnabled,
+  listWebAuditEvents,
+  loadWebConfig,
+  resetWebAuditForTests,
+} from "./index.js";
+
+describe("clawql-web", () => {
+  beforeEach(() => {
+    resetWebAuditForTests();
+    delete process.env.CLAWQL_ENABLE_WEB;
+    delete process.env.CLAWQL_WEB_SEARCH_PROVIDER;
+    delete process.env.CLAWQL_WEB_BROWSER_PROVIDER;
+    delete process.env.CLAWQL_TAVILY_API_KEY;
+    delete process.env.CLAWQL_BROWSER_RUN_API_TOKEN;
+    delete process.env.CLAWQL_CLOUDFLARE_ACCOUNT_ID;
+    delete process.env.CLAWQL_WEB_DRY_RUN;
+    delete process.env.CLAWQL_WEB_SEARCH_FALLBACK_DISABLED;
+  });
+
+  afterEach(() => {
+    resetWebAuditForTests();
+  });
+
+  it("loadWebConfig defaults to none/none", () => {
+    const cfg = loadWebConfig({});
+    expect(cfg.searchProvider).toBe("none");
+    expect(cfg.browserProvider).toBe("none");
+  });
+
+  it("implicitly selects tavily/kitesurf from credentials", () => {
+    const cfg = loadWebConfig({
+      CLAWQL_TAVILY_API_KEY: "tvly-test",
+      CLAWQL_BROWSER_RUN_API_TOKEN: "cf-token",
+    });
+    expect(cfg.searchProvider).toBe("tavily");
+    expect(cfg.browserProvider).toBe("kitesurf");
+  });
+
+  it("envImpliesWebEnabled follows keys and explicit off", () => {
+    expect(envImpliesWebEnabled({})).toBe(false);
+    expect(envImpliesWebEnabled({ CLAWQL_TAVILY_API_KEY: "x" })).toBe(true);
+    expect(
+      envImpliesWebEnabled({ CLAWQL_ENABLE_WEB: "0", CLAWQL_TAVILY_API_KEY: "x" })
+    ).toBe(false);
+  });
+
+  it("search falls back to browser with audit before execute", async () => {
+    process.env.CLAWQL_WEB_BROWSER_PROVIDER = "kitesurf";
+    process.env.CLAWQL_WEB_DRY_RUN = "1";
+    process.env.CLAWQL_WEB_SEARCH_PROVIDER = "none";
+
+    const web = createWebService(process.env);
+    expect(isWebEnabled(process.env)).toBe(true);
+
+    const result = await web.search("clawql agentic gateway");
+    expect(result.fallback).toBe(true);
+    expect(result.provider).toMatch(/^browser:/);
+    expect(result.results.length).toBeGreaterThan(0);
+
+    const events = listWebAuditEvents();
+    const fallbackIdx = events.findIndex((e) => e.type === "WEB_SEARCH_FALLBACK");
+    const searchIdx = events.findIndex((e) => e.type === "WEB_SEARCH" && e.detail === "fallback");
+    expect(fallbackIdx).toBeGreaterThanOrEqual(0);
+    expect(searchIdx).toBeGreaterThan(fallbackIdx);
+    expect(events[fallbackIdx]?.reason).toBe("no_search_provider_configured");
+    expect(events[fallbackIdx]?.fallback).toBe("browser");
+  });
+
+  it("tavily dry-run search records WEB_SEARCH without fallback", async () => {
+    process.env.CLAWQL_WEB_SEARCH_PROVIDER = "tavily";
+    process.env.CLAWQL_WEB_DRY_RUN = "1";
+    const web = createWebService(process.env);
+    const result = await web.search("test query", { limit: 1 });
+    expect(result.provider).toBe("tavily");
+    expect(result.fallback).toBeUndefined();
+    expect(listWebAuditEvents().some((e) => e.type === "WEB_SEARCH_FALLBACK")).toBe(false);
+  });
+
+  it("web_fetch uses kitesurf dry-run", async () => {
+    process.env.CLAWQL_WEB_BROWSER_PROVIDER = "kitesurf";
+    process.env.CLAWQL_WEB_DRY_RUN = "1";
+    const web = createWebService(process.env);
+    const page = await web.fetch("https://example.com");
+    expect(page.provider).toBe("kitesurf");
+    expect(page.markdown).toMatch(/example.com/);
+    expect(listWebAuditEvents().some((e) => e.type === "WEB_FETCH" && e.ok)).toBe(true);
+  });
+
+  it("screenshot capability error is clear for unsupported paths", async () => {
+    process.env.CLAWQL_WEB_BROWSER_PROVIDER = "firecrawl";
+    process.env.CLAWQL_WEB_DRY_RUN = "1";
+    const web = createWebService(process.env);
+    await expect(web.screenshot("https://example.com")).rejects.toThrow(/does not support screenshot/i);
+  });
+
+  it("disabling fallback fails closed when no search provider", async () => {
+    process.env.CLAWQL_WEB_BROWSER_PROVIDER = "kitesurf";
+    process.env.CLAWQL_WEB_DRY_RUN = "1";
+    process.env.CLAWQL_WEB_SEARCH_FALLBACK_DISABLED = "1";
+    const web = createWebService(process.env);
+    await expect(web.search("x")).rejects.toThrow(/No web search provider/i);
+  });
+});

--- a/packages/clawql-web/src/web.test.ts
+++ b/packages/clawql-web/src/web.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  WebCapabilityError,
   createWebService,
   envImpliesWebEnabled,
   isWebEnabled,
@@ -48,13 +49,15 @@ describe("clawql-web", () => {
     ).toBe(false);
   });
 
-  it("search falls back to browser with audit before execute", async () => {
+  it("fallback chain: no search provider → audit then browser-as-search", async () => {
     process.env.CLAWQL_WEB_BROWSER_PROVIDER = "kitesurf";
     process.env.CLAWQL_WEB_DRY_RUN = "1";
     process.env.CLAWQL_WEB_SEARCH_PROVIDER = "none";
 
     const web = createWebService(process.env);
     expect(isWebEnabled(process.env)).toBe(true);
+    expect(web.searchProvider).toBeUndefined();
+    expect(web.browserProvider?.id).toBe("kitesurf");
 
     const result = await web.search("clawql agentic gateway");
     expect(result.fallback).toBe(true);
@@ -68,6 +71,29 @@ describe("clawql-web", () => {
     expect(searchIdx).toBeGreaterThan(fallbackIdx);
     expect(events[fallbackIdx]?.reason).toBe("no_search_provider_configured");
     expect(events[fallbackIdx]?.fallback).toBe("browser");
+    expect(events[fallbackIdx]?.provider).toBe("kitesurf");
+  });
+
+  it("WEB_SEARCH_FALLBACK audit is written even when browser fallback fails", async () => {
+    // No dry-run and no Browser Run credentials → kitesurf fetch throws
+    process.env.CLAWQL_WEB_BROWSER_PROVIDER = "kitesurf";
+    process.env.CLAWQL_WEB_SEARCH_PROVIDER = "none";
+
+    const web = createWebService(process.env);
+    await expect(web.search("regulated query")).rejects.toThrow(/Kitesurf requires/i);
+
+    const events = listWebAuditEvents();
+    const fallback = events.find((e) => e.type === "WEB_SEARCH_FALLBACK");
+    expect(fallback).toBeDefined();
+    expect(fallback?.reason).toBe("no_search_provider_configured");
+    expect(fallback?.provider).toBe("kitesurf");
+    expect(events.some((e) => e.type === "WEB_ERROR" && e.reason === "browser_fallback_failed")).toBe(
+      true
+    );
+    // Fallback must precede the error (WORM order)
+    const fallbackIdx = events.findIndex((e) => e.type === "WEB_SEARCH_FALLBACK");
+    const errorIdx = events.findIndex((e) => e.type === "WEB_ERROR");
+    expect(fallbackIdx).toBeLessThan(errorIdx);
   });
 
   it("tavily dry-run search records WEB_SEARCH without fallback", async () => {
@@ -90,11 +116,50 @@ describe("clawql-web", () => {
     expect(listWebAuditEvents().some((e) => e.type === "WEB_FETCH" && e.ok)).toBe(true);
   });
 
-  it("screenshot capability error is clear for unsupported paths", async () => {
+  it("web_fetch raw=true returns bytes + content-type without a browser provider", async () => {
+    process.env.CLAWQL_WEB_BROWSER_PROVIDER = "none";
+    process.env.CLAWQL_WEB_DRY_RUN = "1";
+    const web = createWebService(process.env);
+    expect(web.browserProvider).toBeUndefined();
+
+    const page = await web.fetch("https://example.com/report.pdf", { raw: true });
+    expect(page.provider).toBe("raw-http");
+    expect(page.bytes).toBeInstanceOf(Uint8Array);
+    expect(page.bytes!.byteLength).toBeGreaterThan(0);
+    expect(page.contentType).toMatch(/text\/plain/);
+    expect(page.finalUrl).toBe("https://example.com/report.pdf");
+    expect(listWebAuditEvents().some((e) => e.type === "WEB_FETCH" && e.detail === "raw")).toBe(
+      true
+    );
+  });
+
+  it("web_screenshot with no browser provider returns structured WebCapabilityError", async () => {
+    process.env.CLAWQL_WEB_BROWSER_PROVIDER = "none";
+    const web = createWebService(process.env);
+    expect(web.browserProvider).toBeUndefined();
+
+    try {
+      await web.screenshot("https://example.com");
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(WebCapabilityError);
+      const e = err as WebCapabilityError;
+      expect(e.code).toBe("NO_BROWSER_PROVIDER");
+      expect(e.reason).toMatch(/No browser provider/i);
+      expect(e.toJSON().error).toMatchObject({ code: "NO_BROWSER_PROVIDER" });
+    }
+  });
+
+  it("screenshot capability error is structured for unsupported providers", async () => {
     process.env.CLAWQL_WEB_BROWSER_PROVIDER = "firecrawl";
     process.env.CLAWQL_WEB_DRY_RUN = "1";
     const web = createWebService(process.env);
-    await expect(web.screenshot("https://example.com")).rejects.toThrow(/does not support screenshot/i);
+    await expect(web.screenshot("https://example.com")).rejects.toMatchObject({
+      name: "WebCapabilityError",
+      code: "CAPABILITY_UNSUPPORTED",
+      capability: "screenshot",
+      provider: "firecrawl",
+    });
   });
 
   it("disabling fallback fails closed when no search provider", async () => {
@@ -102,6 +167,9 @@ describe("clawql-web", () => {
     process.env.CLAWQL_WEB_DRY_RUN = "1";
     process.env.CLAWQL_WEB_SEARCH_FALLBACK_DISABLED = "1";
     const web = createWebService(process.env);
-    await expect(web.search("x")).rejects.toThrow(/No web search provider/i);
+    await expect(web.search("x")).rejects.toMatchObject({
+      name: "WebCapabilityError",
+      code: "NO_SEARCH_PROVIDER",
+    });
   });
 });

--- a/packages/clawql-web/tsconfig.json
+++ b/packages/clawql-web/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "noEmit": true,
+    "ignoreDeprecations": "6.0",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/clawql-web/tsup.config.ts
+++ b/packages/clawql-web/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+    "plugin/index": "src/plugin/index.ts",
+  },
+  format: ["esm", "cjs"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+});

--- a/packages/clawql-web/vitest.config.ts
+++ b/packages/clawql-web/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/src/clawql-optional-flags.test.ts
+++ b/src/clawql-optional-flags.test.ts
@@ -17,6 +17,7 @@ describe("getClawqlOptionalToolFlags", () => {
       CLAWQL_ENABLE_ONYX: undefined,
       CLAWQL_ENABLE_OUROBOROS: undefined,
       CLAWQL_ENABLE_SANDBOX: undefined,
+      CLAWQL_ENABLE_WEB: undefined,
       CLAWQL_ENABLE_HITL_LABEL_STUDIO: undefined,
       CLAWQL_ENABLE_CONESHARE: undefined,
       CLAWQL_ENABLE_IDP_PIPELINE: undefined,
@@ -38,6 +39,7 @@ describe("getClawqlOptionalToolFlags", () => {
     expect(f.enableOnyxKnowledge).toBe(false);
     expect(f.enableOuroboros).toBe(false);
     expect(f.enableSandbox).toBe(false);
+    expect(f.enableWeb).toBe(false);
     expect(f.enableHitlLabelStudio).toBe(false);
     expect(f.enableConeshare).toBe(false);
     expect(f.enableIdpPipeline).toBe(false);
@@ -91,6 +93,7 @@ describe("getClawqlOptionalToolFlags", () => {
       CLAWQL_ENABLE_ONYX: "1",
       CLAWQL_ENABLE_OUROBOROS: "yes",
       CLAWQL_ENABLE_SANDBOX: "1",
+      CLAWQL_ENABLE_WEB: "1",
       CLAWQL_ENABLE_DOCUMENTS: "1",
       CLAWQL_ENABLE_IDP_PIPELINE: "1",
       CLAWQL_ENABLE_IDP_CLASSIFIER: "1",
@@ -108,6 +111,7 @@ describe("getClawqlOptionalToolFlags", () => {
     expect(f.enableOnyxKnowledge).toBe(true);
     expect(f.enableOuroboros).toBe(true);
     expect(f.enableSandbox).toBe(true);
+    expect(f.enableWeb).toBe(true);
     expect(f.enableIdpPipeline).toBe(true);
     expect(f.enableIdpClassifier).toBe(true);
     expect(f.enableLangextract).toBe(true);

--- a/src/compose-horizontal-plugin-layers.test.ts
+++ b/src/compose-horizontal-plugin-layers.test.ts
@@ -14,6 +14,7 @@ describe("composeHorizontalPluginLayers", () => {
       enableMemory: true,
       enableDocuments: false,
       enableSandbox: true,
+      enableWeb: false,
       enableOuroboros: false,
       enableSchedule: false,
       enableNotify: false,
@@ -32,6 +33,12 @@ describe("composeHorizontalPluginLayers", () => {
       externalIngestPreview: false,
       enableVision: false,
       enableConeshare: false,
+      enableCodeGraph: false,
+      enableOntology: false,
+      enableOntologyWrites: false,
+      enableGoogle: false,
+      enableCloudflare: true,
+      enableAws: false,
     });
     const api = createClawQLApi({ plugins: [], pluginLayers: layers });
     const ids = api.registry.list().map((p) => p.id);

--- a/src/compose-horizontal-plugin-layers.ts
+++ b/src/compose-horizontal-plugin-layers.ts
@@ -14,6 +14,7 @@ import { makeMemoryLayer } from "clawql-memory/plugin";
 import { makeOntologyLayer } from "clawql-ontology/plugin";
 import { makeOuroborosLayer } from "clawql-ouroboros/plugin";
 import { makeSandboxLayer } from "clawql-sandbox/plugin";
+import { makeWebLayer } from "clawql-web/plugin";
 import {
   optionalFlagsFromHorizontalTierSpec,
   type ClawQLHorizontalTierSpec,
@@ -73,6 +74,9 @@ export function composeHorizontalPluginLayers(
   }
   if (flags.enableSandbox) {
     layers.push(makeSandboxLayer());
+  }
+  if (flags.enableWeb) {
+    layers.push(makeWebLayer());
   }
   if (flags.enableOntology) {
     layers.push(makeOntologyLayer({ enableWrites: flags.enableOntologyWrites }));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **`packages/clawql-web`**: one package for all external web access, with separate search vs browser interfaces so operators can mix providers (and disable web entirely for regulated / air-gapped).

**Decision:** IDP URL ingestion **will** migrate to this package (follow-on PR). This scaffold does not switch IDP yet.

### Interfaces & providers

| Kind | Plugins |
| --- | --- |
| **Search** | Tavily, Brave, SearXNG, OpenSearch, `none` |
| **Browser** | Kitesurf (Cloudflare Browser Run), Chromium, Playwright, Puppeteer, Firecrawl, `none` |

### Behavior

- **Search → browser fallback** when no search provider is set (opt out with `CLAWQL_WEB_SEARCH_FALLBACK_DISABLED=1`)
- **`WEB_SEARCH_FALLBACK` is written before** the browser call — still present in the audit buffer if the browser fallback throws
- MCP tools: `web_search`, `web_fetch`, `web_screenshot`, `web_interact`
- **`web_fetch` `raw: true`** → bytes + content-type via `fetchRawUrl` (IDP / pdf-inspector; no browser required)
- **Capability degradation:** `web_screenshot` / `web_interact` return structured `WebCapabilityError` (`NO_BROWSER_PROVIDER` / `CAPABILITY_UNSUPPORTED`) instead of generic failures
- Enable via `CLAWQL_ENABLE_WEB=1` **or** auto when a provider/API key is configured
- `CLAWQL_WEB_DRY_RUN=1` for synthetic results in tests/demos

### Wiring

- `enableWeb` in `clawql-api` optional flags + horizontal tier spec
- `makeWebLayer()` in horizontal plugin composition
- Helm values sketch: `webSearch` / `webBrowser` — **`*.bundled` is future-only** (does **not** deploy SearXNG/OpenSearch/Chromium subcharts today; BYO URLs)

### Docs

- [`docs/web/clawql-web.md`](docs/web/clawql-web.md) — regulated posture, IDP fetch-parity table, `raw: true`, Helm future flags
- [`docs/plugins/web.md`](docs/plugins/web.md)

### Tests

`npm test -w clawql-web` — **11 passing**, including:

- Fallback chain: no search provider → audit then browser
- `WEB_SEARCH_FALLBACK` retained when browser fallback fails
- `web_screenshot` with no browser → `NO_BROWSER_PROVIDER`
- `web_fetch` `raw: true` without a browser provider

### Follow-ups (separate PRs)

1. Migrate IDP `fetchUrlResource` → `clawql-web` `web_fetch` / `raw: true` (preserve SSRF/redirect/timeout/2MiB behaviors; bytes for pdf-inspector)
2. Wire SearXNG / OpenSearch / Chromium as real Helm subcharts (`bundled: true`)
3. Live CDP interact for Playwright/Puppeteer
4. Push web audit events into payment/WORM audit when desired

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5a07-15ee-7a2a-828a-9ad0a5c8763c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5a07-15ee-7a2a-828a-9ad0a5c8763c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

