### PR TITLE
Add clawql.com/streams marketing landing

### DIFF
--- a/landing-page/demo/scripts/generate-agent-assets.mjs
+++ b/landing-page/demo/scripts/generate-agent-assets.mjs
@@ -138,6 +138,8 @@ npm install -g clawql-mcp
     '/about': `# About\n\nSee ${origin}/about/.`,
     '/inference/gtm': `# Inference-first GTM playbook\n\nClawQL provides the Agentic Gateway as the Foundational Platform for Auditable Production AI — Zero-Trust Agentic Fabric (Regional Hubs, Dedicated Virtual Gateways with NATS/Valkey, Edge swarm).\n\nSee ${origin}/inference/gtm/.`,
     '/enterprise/gtm': `# Enterprise GTM playbook\n\nSecondary enterprise / Palantir-facing motion — Auditable Production AI on the Zero-Trust Agentic Fabric; sovereign alternative to Palantir AIP.\n\nSee ${origin}/enterprise/gtm/.`,
+    '/streams': `# ClawQL Streams\n\nEvent-driven autonomous agents with WORM audit, Protocol Fabric, and Durable Object / K8s scale.\n\nSee ${origin}/streams/.\n\nSpecs: ${docs}/streams/clawql-streams · ${docs}/streams/clawql-durable-objects`,
+    '/idp': `# Intelligent Document Processing\n\nSee ${origin}/idp/.`,
     '/signup': `# Sign up\n\n${origin}/signup/`,
     '/privacy-policy': `# Privacy Policy\n\n${origin}/privacy-policy/`,
     '/industries': `# Industries\n\n${origin}/industries/`,
@@ -407,6 +409,7 @@ writeText(
 
 - [Docs](${docs})
 - [Getting started](${docs}/getting-started)
+- [ClawQL Streams](${origin}/streams/)
 - [Inference-first GTM playbook](${origin}/inference/gtm/)
 - [Enterprise GTM playbook](${origin}/enterprise/gtm/)
 - [MCP Server Card](/.well-known/mcp/server-card.json)

--- a/landing-page/demo/src/app/layout.tsx
+++ b/landing-page/demo/src/app/layout.tsx
@@ -123,6 +123,9 @@ export default function RootLayout({
                   Workflows
                 </NavbarLink>
                 <NavbarLink href={site.urls.idp}>IDP</NavbarLink>
+                <NavbarLink href={site.urls.streams} className="max-lg:hidden">
+                  Streams
+                </NavbarLink>
                 <NavbarIndustriesMenu />
                 <NavbarLink href="/#security">Security</NavbarLink>
                 <NavbarLink href={site.urls.pricing}>Pricing</NavbarLink>
@@ -168,6 +171,7 @@ export default function RootLayout({
                   <FooterLink href="/#tools">Tools</FooterLink>
                   <FooterLink href="/#workflows">Workflows</FooterLink>
                   <FooterLink href={site.urls.idp}>IDP</FooterLink>
+                  <FooterLink href={site.urls.streams}>Streams</FooterLink>
                   <FooterLink href="/#security">Security</FooterLink>
                   <FooterLink href={site.urls.pricing}>Pricing</FooterLink>
                   <FooterLink href={site.urls.signup}>Sign up</FooterLink>

--- a/landing-page/demo/src/app/sitemap.ts
+++ b/landing-page/demo/src/app/sitemap.ts
@@ -16,6 +16,7 @@ const ROUTES: Array<{
   { path: '/inference/gtm', changeFrequency: 'monthly', priority: 0.9 },
   { path: '/idp', changeFrequency: 'monthly', priority: 0.9 },
   { path: '/idp/gtm', changeFrequency: 'monthly', priority: 0.88 },
+  { path: '/streams', changeFrequency: 'monthly', priority: 0.9 },
   { path: '/enterprise/gtm', changeFrequency: 'monthly', priority: 0.75 },
   { path: '/privacy-policy', changeFrequency: 'yearly', priority: 0.3 },
   { path: '/industries', changeFrequency: 'monthly', priority: 0.75 },

--- a/landing-page/demo/src/app/streams/page.tsx
+++ b/landing-page/demo/src/app/streams/page.tsx
@@ -1,0 +1,13 @@
+import { StreamsLanding } from '@/components/sections/streams-landing'
+import { pageMetadata } from '@/lib/seo'
+
+export const metadata = pageMetadata({
+  title: 'Streams',
+  description:
+    'ClawQL Streams — event-driven autonomous agents with WORM audit, Protocol Fabric, and Durable Object scale. The self-sovereign alternative to managed agent runtimes.',
+  path: '/streams',
+})
+
+export default function Page() {
+  return <StreamsLanding />
+}

--- a/landing-page/demo/src/components/sections/streams-landing.css
+++ b/landing-page/demo/src/components/sections/streams-landing.css
@@ -1,0 +1,300 @@
+/* ClawQL Streams marketing landing — page-scoped atmosphere + motion */
+
+.streams-page {
+  --streams-ink: oklch(16% 0.02 210);
+  --streams-foam: oklch(97% 0.01 195);
+  --streams-signal: oklch(68% 0.09 195);
+  --streams-signal-deep: oklch(48% 0.07 205);
+  --streams-mid: oklch(32% 0.035 210);
+}
+
+.streams-hero {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  min-height: min(100svh, 52rem);
+  display: flex;
+  align-items: flex-end;
+  padding-block: 5rem 4.5rem;
+  color: var(--streams-foam);
+  background:
+    radial-gradient(120% 80% at 50% -10%, oklch(28% 0.04 200 / 0.55), transparent 55%),
+    radial-gradient(90% 70% at 100% 100%, oklch(30% 0.05 185 / 0.35), transparent 50%),
+    linear-gradient(165deg, oklch(14% 0.02 220) 0%, var(--streams-ink) 42%, oklch(18% 0.03 195) 100%);
+}
+
+.streams-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background-image:
+    linear-gradient(oklch(100% 0 0 / 0.03) 1px, transparent 1px),
+    linear-gradient(90deg, oklch(100% 0 0 / 0.03) 1px, transparent 1px);
+  background-size: 48px 48px;
+  mask-image: linear-gradient(180deg, oklch(0% 0 0 / 0.55), transparent 85%);
+  pointer-events: none;
+}
+
+.streams-hero__visual {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.streams-hero__visual svg {
+  width: 100%;
+  height: 100%;
+}
+
+.streams-path {
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.streams-path--a {
+  stroke: oklch(72% 0.08 195 / 0.55);
+  stroke-width: 1.5;
+  stroke-dasharray: 8 14;
+  animation: streams-flow 18s linear infinite;
+}
+
+.streams-path--b {
+  stroke: oklch(62% 0.1 185 / 0.4);
+  stroke-width: 2.25;
+  stroke-dasharray: 2 18;
+  animation: streams-flow 24s linear infinite reverse;
+}
+
+.streams-path--c {
+  stroke: oklch(78% 0.06 210 / 0.28);
+  stroke-width: 1;
+  animation: streams-drift 12s ease-in-out infinite alternate;
+}
+
+.streams-node {
+  fill: var(--streams-signal);
+  animation: streams-pulse 3.2s ease-in-out infinite;
+  transform-origin: center;
+  transform-box: fill-box;
+}
+
+.streams-node--late {
+  animation-delay: 1.1s;
+}
+
+.streams-hero__content {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  animation: streams-rise 0.9s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.streams-brand {
+  font-family: var(--font-display);
+  font-variation-settings: 'wdth' 112.5;
+  font-weight: 650;
+  letter-spacing: -0.03em;
+  font-size: clamp(2.75rem, 7vw, 5.25rem);
+  line-height: 0.95;
+  color: var(--streams-foam);
+  text-wrap: balance;
+}
+
+.streams-brand span {
+  display: block;
+  font-weight: 450;
+  font-size: 0.42em;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--streams-signal);
+  margin-bottom: 0.55rem;
+}
+
+.streams-section-band {
+  background:
+    linear-gradient(180deg, oklch(96% 0.008 200) 0%, oklch(93% 0.012 205) 100%);
+}
+
+:is(html.dark) .streams-section-band,
+.dark .streams-section-band {
+  background: linear-gradient(180deg, oklch(18% 0.015 215) 0%, oklch(15% 0.012 220) 100%);
+}
+
+.streams-mode {
+  position: relative;
+  padding-block: 1.25rem;
+  padding-inline-start: 1.25rem;
+  border-inline-start: 2px solid var(--streams-signal-deep);
+  animation: streams-rise 0.8s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.streams-mode:nth-child(2) {
+  animation-delay: 0.08s;
+}
+
+.streams-mode:nth-child(3) {
+  animation-delay: 0.16s;
+}
+
+.streams-mode__label {
+  font-family: var(--font-display);
+  font-variation-settings: 'wdth' 112.5;
+  font-size: 1.35rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--color-mist-950);
+}
+
+.dark .streams-mode__label {
+  color: white;
+}
+
+.streams-compare {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.streams-compare th,
+.streams-compare td {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  vertical-align: top;
+  border-bottom: 1px solid oklch(70% 0.01 210 / 0.35);
+}
+
+.streams-compare th {
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--color-mist-950);
+  white-space: nowrap;
+}
+
+.dark .streams-compare th {
+  color: white;
+  border-bottom-color: oklch(40% 0.02 210 / 0.4);
+}
+
+.dark .streams-compare td {
+  border-bottom-color: oklch(40% 0.02 210 / 0.4);
+}
+
+.streams-compare th:last-child,
+.streams-compare td:last-child {
+  background: oklch(68% 0.09 195 / 0.08);
+}
+
+.dark .streams-compare th:last-child,
+.dark .streams-compare td:last-child {
+  background: oklch(68% 0.09 195 / 0.12);
+}
+
+.streams-fabric {
+  display: grid;
+  gap: 0.75rem;
+  font-family: var(--font-display);
+  font-variation-settings: 'wdth' 112.5;
+  letter-spacing: -0.02em;
+}
+
+.streams-fabric__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.65rem 1rem;
+  animation: streams-rise 0.75s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.streams-fabric__row:nth-child(2) {
+  animation-delay: 0.1s;
+}
+
+.streams-fabric__row:nth-child(3) {
+  animation-delay: 0.2s;
+}
+
+.streams-fabric__chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.45rem 0.85rem;
+  border: 1px solid oklch(55% 0.04 205 / 0.35);
+  color: var(--color-mist-800);
+  background: oklch(100% 0 0 / 0.35);
+}
+
+.dark .streams-fabric__chip {
+  color: var(--color-mist-200);
+  background: oklch(20% 0.02 210 / 0.5);
+  border-color: oklch(55% 0.04 205 / 0.25);
+}
+
+.streams-fabric__arrow {
+  color: var(--streams-signal-deep);
+  font-size: 1.1rem;
+}
+
+.streams-fabric__core {
+  font-weight: 650;
+  color: var(--streams-signal-deep);
+  letter-spacing: -0.03em;
+}
+
+.dark .streams-fabric__core {
+  color: var(--streams-signal);
+}
+
+@keyframes streams-flow {
+  to {
+    stroke-dashoffset: -220;
+  }
+}
+
+@keyframes streams-drift {
+  from {
+    opacity: 0.35;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0.7;
+    transform: translateY(-6px);
+  }
+}
+
+@keyframes streams-pulse {
+  0%,
+  100% {
+    opacity: 0.45;
+    transform: scale(0.85);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.15);
+  }
+}
+
+@keyframes streams-rise {
+  from {
+    opacity: 0;
+    transform: translateY(1.1rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .streams-path--a,
+  .streams-path--b,
+  .streams-path--c,
+  .streams-node,
+  .streams-hero__content,
+  .streams-mode,
+  .streams-fabric__row {
+    animation: none !important;
+  }
+}

--- a/landing-page/demo/src/components/sections/streams-landing.tsx
+++ b/landing-page/demo/src/components/sections/streams-landing.tsx
@@ -1,0 +1,329 @@
+import { ButtonLink, PlainButtonLink } from '@/components/elements/button'
+import { Link } from '@/components/elements/link'
+import { Section } from '@/components/elements/section'
+import { Text } from '@/components/elements/text'
+import { ArrowNarrowRightIcon } from '@/components/icons/arrow-narrow-right-icon'
+import { CallToActionSimpleCentered } from '@/components/sections/call-to-action-simple-centered'
+import { site } from '@/lib/site'
+
+import './streams-landing.css'
+
+const STREAMS_SPEC = `${site.urls.docs}/streams/clawql-streams`
+const DO_SPEC = `${site.urls.docs}/streams/clawql-durable-objects`
+const ADAPTER_DOCS = `${site.urls.docs}/mcp/mcp-api-adapter`
+
+const modes = [
+  {
+    name: 'Reactive',
+    detail: 'Every event writes to WORM immediately — compliance-grade recording whether an agent wakes or not.',
+  },
+  {
+    name: 'Ambient',
+    detail: 'Events buffer in NATS and surface on the next MCP tool call — awareness without spawning a subprocess.',
+  },
+  {
+    name: 'Autonomous',
+    detail: 'A significance filter escalates only what matters into a full agent session with ClawQL tools and budget.',
+  },
+] as const
+
+const compareRows = [
+  {
+    axis: 'Sovereignty',
+    stripe: 'Internal only',
+    anthropic: 'Anthropic-hosted',
+    openai: 'Managed runtime',
+    clawql: 'Self-host or Cloudflare',
+  },
+  {
+    axis: 'Triggers',
+    stripe: 'Slack reactions',
+    anthropic: 'Cron / API',
+    openai: 'Pipeline / API',
+    clawql: 'WebSocket · NATS · webhook · cron',
+  },
+  {
+    axis: 'Tools',
+    stripe: 'Custom Toolshed',
+    anthropic: 'Built-in + custom',
+    openai: 'Built-in + custom',
+    clawql: 'Any MCP surface via Protocol Fabric',
+  },
+  {
+    axis: 'Audit',
+    stripe: 'Internal',
+    anthropic: 'Provider logs',
+    openai: 'Provider logs',
+    clawql: 'Operator-owned WORM Merkle trail',
+  },
+  {
+    axis: 'Scale',
+    stripe: 'Custom',
+    anthropic: 'Session hours',
+    openai: 'Managed',
+    clawql: 'Durable Objects or K8s HPA',
+  },
+] as const
+
+function StreamField() {
+  return (
+    <div className="streams-hero__visual" aria-hidden>
+      <svg viewBox="0 0 1440 900" preserveAspectRatio="xMidYMid slice" role="presentation">
+        <path
+          className="streams-path streams-path--c"
+          d="M-40 180 C 220 120, 380 260, 620 210 S 980 80, 1220 160 S 1480 280, 1520 240"
+        />
+        <path
+          className="streams-path streams-path--a"
+          d="M-60 320 C 180 280, 340 400, 560 360 S 900 240, 1120 320 S 1400 460, 1520 400"
+        />
+        <path
+          className="streams-path streams-path--b"
+          d="M-40 520 C 200 470, 360 610, 600 560 S 940 430, 1160 510 S 1420 650, 1520 590"
+        />
+        <path
+          className="streams-path streams-path--a"
+          d="M-80 680 C 160 620, 320 760, 540 710 S 880 580, 1100 660 S 1380 780, 1520 720"
+        />
+        <circle className="streams-node" cx="560" cy="360" r="5" />
+        <circle className="streams-node streams-node--late" cx="1160" cy="510" r="6" />
+        <circle className="streams-node" cx="900" cy="240" r="4" />
+      </svg>
+    </div>
+  )
+}
+
+export function StreamsLanding() {
+  return (
+    <div className="streams-page">
+      <section id="hero" className="streams-hero" aria-labelledby="streams-brand">
+        <StreamField />
+        <div className="streams-hero__content mx-auto w-full max-w-7xl px-6 sm:px-8">
+          <div className="max-w-3xl">
+            <h1 id="streams-brand" className="streams-brand">
+              <span>ClawQL</span>
+              Streams
+            </h1>
+            <p className="mt-6 max-w-xl font-display text-xl/8 font-medium tracking-tight text-balance text-white/90 sm:text-2xl/9">
+              Event-driven autonomous agents you own — not a metered lab runtime.
+            </p>
+            <p className="mt-4 max-w-lg text-base/7 text-white/70 sm:text-lg/8">
+              World events enter. WORM records everything. Significance filters decide when agents wake — with full MCP
+              tools, virtual-key budgets, and Durable Object scale.
+            </p>
+            <div className="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center">
+              <ButtonLink href={STREAMS_SPEC} size="lg" color="light">
+                Read the Streams spec
+              </ButtonLink>
+              <PlainButtonLink href={site.urls.signup} size="lg" color="light">
+                Start free trial <ArrowNarrowRightIcon />
+              </PlainButtonLink>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <Section
+        id="modes"
+        className="streams-section-band"
+        eyebrow="Three delivery modes"
+        headline="One event loop. Three ways to respond."
+        subheadline={
+          <p>
+            The same subscription can audit continuously, keep agents ambiently aware, and escalate only when the world
+            crosses a threshold — without a human opening a chat.
+          </p>
+        }
+      >
+        <div className="grid gap-10 md:grid-cols-3 md:gap-8">
+          {modes.map((mode) => (
+            <div key={mode.name} className="streams-mode">
+              <h3 className="streams-mode__label">{mode.name}</h3>
+              <Text className="mt-3">{mode.detail}</Text>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section
+        id="fabric"
+        eyebrow="Protocol Fabric"
+        headline="Anything in. Anything out. MCP as the IR."
+        subheadline={
+          <p>
+            ClawQL Core turns any API into MCP. <Link href={ADAPTER_DOCS}>mcp-api-adapter</Link> turns MCP back into
+            OpenAPI, GraphQL, gRPC, CLI, or WebSocket. Streams wraps that fabric in an event loop so the bus can act
+            without a human at the console.
+          </p>
+        }
+      >
+        <div className="streams-fabric max-w-3xl">
+          <div className="streams-fabric__row">
+            <span className="streams-fabric__chip">OpenAPI</span>
+            <span className="streams-fabric__chip">GraphQL</span>
+            <span className="streams-fabric__chip">gRPC</span>
+            <span className="streams-fabric__chip">WebSocket</span>
+            <span className="streams-fabric__chip">CLI</span>
+            <span className="streams-fabric__arrow" aria-hidden>
+              →
+            </span>
+            <span className="streams-fabric__core">ClawQL Core</span>
+          </div>
+          <div className="streams-fabric__row">
+            <span className="streams-fabric__arrow" aria-hidden>
+              ↓
+            </span>
+            <span className="streams-fabric__core">MCP · common IR</span>
+            <span className="streams-fabric__arrow" aria-hidden>
+              ↓
+            </span>
+          </div>
+          <div className="streams-fabric__row">
+            <span className="streams-fabric__core">mcp-api-adapter</span>
+            <span className="streams-fabric__arrow" aria-hidden>
+              →
+            </span>
+            <span className="streams-fabric__chip">OpenAPI</span>
+            <span className="streams-fabric__chip">GraphQL</span>
+            <span className="streams-fabric__chip">gRPC</span>
+            <span className="streams-fabric__chip">WebSocket</span>
+            <span className="streams-fabric__chip">CLI</span>
+          </div>
+        </div>
+        <Text className="mt-10 max-w-2xl">
+          ESB lesson, agent era: N×M protocol integrations collapse to N+M. Streams is how the fabric reacts to
+          webhooks, NATS topics, cron, and live sockets — not only interactive MCP clients.
+        </Text>
+      </Section>
+
+      <Section
+        id="scale"
+        className="streams-section-band"
+        eyebrow="Durable Objects · Kubernetes"
+        headline="Infinite session scale without losing the audit trail"
+        subheadline={
+          <p>
+            <Link href={DO_SPEC}>SubscriptionDO</Link> holds the event buffer and significance state.{' '}
+            <Link href={DO_SPEC}>AgentSessionDO</Link> runs the wake — with Audit, Inference, and TrainingData sidecars.
+            Same mental model on Cloudflare Workers or Kubernetes HPA.
+          </p>
+        }
+      >
+        <ul className="grid max-w-4xl gap-8 sm:grid-cols-3">
+          <li>
+            <h3 className="font-display text-lg font-semibold tracking-tight text-mist-950 dark:text-white">
+              Virtual-key budgets
+            </h3>
+            <Text className="mt-2">
+              Keys bind on session create and expire on destroy — every autonomous wake has a hard spend ceiling through{' '}
+              <code className="font-mono text-[0.9em]">clawql-inference</code>.
+            </Text>
+          </li>
+          <li>
+            <h3 className="font-display text-lg font-semibold tracking-tight text-mist-950 dark:text-white">
+              WORM on every action
+            </h3>
+            <Text className="mt-2">
+              Reactive ingest never waits on the model. Forensic reconstruction is a hash chain you own, not a vendor
+              console export.
+            </Text>
+          </li>
+          <li>
+            <h3 className="font-display text-lg font-semibold tracking-tight text-mist-950 dark:text-white">
+              Training emission
+            </h3>
+            <Text className="mt-2">
+              Optional RTP + OpenBenchTrace export with consent scopes — the Intelligence Flywheel without surrendering
+              sovereignty.
+            </Text>
+          </li>
+        </ul>
+      </Section>
+
+      <Section
+        id="compare"
+        eyebrow="Positioning"
+        headline="The pattern labs built for themselves — as a platform"
+        subheadline={
+          <p>
+            Stripe Minions, Anthropic Managed Agents, and OpenAI Agents SDK all implement event → context → reason →
+            tools → audit. ClawQL Streams is that pattern with operator-owned infrastructure.
+          </p>
+        }
+      >
+        <div className="-mx-6 overflow-x-auto px-6 sm:mx-0 sm:px-0">
+          <table className="streams-compare min-w-[44rem]">
+            <thead>
+              <tr>
+                <th scope="col"> </th>
+                <th scope="col">Stripe Minions</th>
+                <th scope="col">Managed Agents</th>
+                <th scope="col">Agents SDK</th>
+                <th scope="col">ClawQL Streams</th>
+              </tr>
+            </thead>
+            <tbody>
+              {compareRows.map((row) => (
+                <tr key={row.axis}>
+                  <th scope="row">{row.axis}</th>
+                  <td className="text-mist-700 dark:text-mist-400">{row.stripe}</td>
+                  <td className="text-mist-700 dark:text-mist-400">{row.anthropic}</td>
+                  <td className="text-mist-700 dark:text-mist-400">{row.openai}</td>
+                  <td className="text-mist-900 dark:text-mist-100">{row.clawql}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Section>
+
+      <Section
+        id="specs"
+        className="streams-section-band"
+        eyebrow="Specifications"
+        headline="Draft specs live on docs.clawql.com"
+        subheadline={
+          <p>
+            Streams is shipping as an opt-in coordination layer over packages you already deploy — inference, payments,
+            Ouroboros, NATS, and WORM memory.
+          </p>
+        }
+      >
+        <ul className="flex max-w-2xl flex-col gap-4 text-base/7 text-mist-800 dark:text-mist-300">
+          <li>
+            <Link href={STREAMS_SPEC}>ClawQL Streams specification</Link> — event loop, delivery modes, significance
+            filters, training emission
+          </li>
+          <li>
+            <Link href={DO_SPEC}>ClawQL Durable Objects</Link> — SubscriptionDO, AgentSessionDO, sidecars, K8s parity
+          </li>
+          <li>
+            <Link href={ADAPTER_DOCS}>mcp-api-adapter</Link> — five (plus WebSocket) surfaces that complete the Protocol
+            Fabric
+          </li>
+        </ul>
+      </Section>
+
+      <CallToActionSimpleCentered
+        id="cta"
+        headline="Put an event loop under your agents"
+        subheadline={
+          <p>
+            Start a trial on the Agentic Gateway today. When Streams lands, the same MCP endpoint, vault, and WORM trail
+            become the autonomous runtime — not a second product.
+          </p>
+        }
+        cta={
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-center">
+            <ButtonLink href={site.urls.signup} size="lg">
+              Start free trial
+            </ButtonLink>
+            <PlainButtonLink href={STREAMS_SPEC} size="lg">
+              Read the Streams spec <ArrowNarrowRightIcon />
+            </PlainButtonLink>
+          </div>
+        }
+      />
+    </div>
+  )
+}

--- a/landing-page/demo/src/lib/agent-discovery.ts
+++ b/landing-page/demo/src/lib/agent-discovery.ts
@@ -377,6 +377,8 @@ ClawQL exposes tiered MCP tools (search, execute, memory, optional IDP and enter
 
 /** Paths exported in agent-markdown.json for Accept: text/markdown negotiation. */
 export function getAgentMarkdownMap(origin = getSiteOriginString()): Record<string, string> {
+  const docs = site.urls.docs.replace(/\/$/, '')
+
   return {
     '/': buildHomeMarkdown(origin),
     '/pricing': `# Pricing\n\nClawQL pricing — self-host free on Apache 2.0 or start a 14-day Developer trial.\n\nSee ${origin}/pricing/ for tier details.`,
@@ -387,6 +389,7 @@ export function getAgentMarkdownMap(origin = getSiteOriginString()): Record<stri
     '/inference/gtm': `# Inference-first GTM playbook\n\nClawQL provides the Agentic Gateway as the Foundational Platform for Auditable Production AI — Zero-Trust Agentic Fabric.\n\nSee ${origin}/inference/gtm/.`,
     '/idp': `# Intelligent Document Processing\n\nClawQL IDP — full document lifecycle (ingest → VDR), flat Starter pricing vs ABBYY / Hyperscience / Intralinks, Helm deploy or 14-day trial.\n\nSee ${origin}/idp/.`,
     '/idp/gtm': `# IDP-first GTM playbook\n\nStandalone ClawQL Intelligent Document Processing go-to-market — market reality, honest positioning, sales motion, and landing-page brief vs ABBYY, Hyperscience, and Intralinks.\n\nSee ${origin}/idp/gtm/.`,
+    '/streams': `# ClawQL Streams\n\nEvent-driven autonomous agents with WORM audit, Protocol Fabric (Core + mcp-api-adapter), and Durable Object / K8s scale — the self-sovereign alternative to managed agent runtimes.\n\nSee ${origin}/streams/.\n\nSpecs: ${docs}/streams/clawql-streams · ${docs}/streams/clawql-durable-objects`,
     '/enterprise/gtm': `# Enterprise GTM playbook\n\nSecondary enterprise motion — Auditable Production AI on the Zero-Trust Agentic Fabric.\n\nSee ${origin}/enterprise/gtm/.`,
   }
 }

--- a/landing-page/demo/src/lib/site.ts
+++ b/landing-page/demo/src/lib/site.ts
@@ -27,6 +27,8 @@ export const site = {
     idp: '/idp',
     /** IDP-first GTM playbook — strategy source of truth for the IDP motion. */
     idpGtm: '/idp/gtm',
+    /** ClawQL Streams — event-driven autonomous agents / Protocol Fabric. */
+    streams: '/streams',
     /** Secondary enterprise / Palantir-facing GTM motion. */
     enterpriseGtm: '/enterprise/gtm',
     privacy: '/privacy-policy',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a dedicated marketing page at **`/streams`** for ClawQL Streams — the event-driven autonomous agent layer and Protocol Fabric story from the Streams / Durable Objects specs.

### Page (`clawql.com/streams`)
- Brand-first full-bleed hero with animated stream field visual
- Three delivery modes: Reactive · Ambient · Autonomous
- Protocol Fabric (Core → MCP → mcp-api-adapter)
- Durable Objects / K8s scale, virtual keys, WORM, training emission
- Competitive table vs Stripe Minions / Managed Agents / Agents SDK
- CTAs to docs specs + trial signup

### Wiring
- Nav + footer Product links
- `site.urls.streams`
- Sitemap + agent-markdown / `llms.txt` discovery

### Spec links (live once Streams docs PR merges)
- `docs.clawql.com/streams/clawql-streams`
- `docs.clawql.com/streams/clawql-durable-objects`
- `docs.clawql.com/mcp/mcp-api-adapter`

### Visual QA

[Streams hero desktop](https://cursor.com/agents/bc-019f9b5e-4d74-72e6-90bb-d0c2100f09d7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstreams-hero-desktop.png)
[Streams modes section](https://cursor.com/agents/bc-019f9b5e-4d74-72e6-90bb-d0c2100f09d7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstreams-modes.png)
[Streams hero mobile](https://cursor.com/agents/bc-019f9b5e-4d74-72e6-90bb-d0c2100f09d7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstreams-hero-mobile.png)

## Test plan
- [x] `cd landing-page/demo && npm run build` — `/streams` in route list
- [x] Visual QA desktop + mobile hero; nav/footer Streams links
- [ ] Spec CTAs resolve after Streams docs PR merges to main
- [ ] Confirm Cloudflare Pages preview after merge

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9b5e-4d74-72e6-90bb-d0c2100f09d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9b5e-4d74-72e6-90bb-d0c2100f09d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

