### PR TITLE
test(web): optional live CDP smoke behind CLAWQL_CHROMIUM_CDP_URL

### DIFF
--- a/docs/web/clawql-web.md
+++ b/docs/web/clawql-web.md
@@ -117,6 +117,12 @@ When `CLAWQL_CHROMIUM_CDP_URL` is set (and dry-run is off), the chromium-family 
 
 HTTP base URLs are resolved via `/json/version` → `webSocketDebuggerUrl`.
 
+Optional live smoke (skipped in CI unless the env is set):
+
+```bash
+CLAWQL_CHROMIUM_CDP_URL=http://127.0.0.1:9222 npm test -w clawql-web -- src/cdp.live.test.ts
+```
+
 ## MCP tools
 
 | Tool             | Behavior                                                              |

--- a/packages/clawql-web/src/cdp.live.test.ts
+++ b/packages/clawql-web/src/cdp.live.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Optional live CDP smoke — skipped unless CLAWQL_CHROMIUM_CDP_URL is set.
+ * Run: CLAWQL_CHROMIUM_CDP_URL=http://127.0.0.1:9222 npm test -w clawql-web -- src/cdp.live.test.ts
+ */
+
+import { describe, expect, it } from "vitest";
+import { createWebService, resolveCdpWebSocketUrl } from "./index.js";
+
+const cdpUrl = process.env.CLAWQL_CHROMIUM_CDP_URL?.trim();
+
+describe.runIf(Boolean(cdpUrl))("clawql-web live CDP", () => {
+  it("resolves http CDP endpoint to a websocket debugger URL", async () => {
+    const ws = await resolveCdpWebSocketUrl(cdpUrl!);
+    expect(ws.startsWith("ws://") || ws.startsWith("wss://")).toBe(true);
+  });
+
+  it("fetches and screenshots via chromium provider", async () => {
+    const web = createWebService({
+      ...process.env,
+      CLAWQL_WEB_BROWSER_PROVIDER: "chromium",
+      CLAWQL_CHROMIUM_CDP_URL: cdpUrl,
+      CLAWQL_WEB_DRY_RUN: "0",
+      CLAWQL_WEB_SEARCH_PROVIDER: "none",
+    });
+    const page = await web.fetch("https://example.com", { timeoutMs: 30_000 });
+    expect(page.provider).toBe("chromium");
+    expect((page.text ?? page.markdown ?? "").length).toBeGreaterThan(0);
+
+    const shot = await web.screenshot("https://example.com", { timeoutMs: 30_000 });
+    expect(shot.byteLength).toBeGreaterThan(100);
+  }, 60_000);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Optional live CDP smoke tests for `clawql-web`, skipped unless `CLAWQL_CHROMIUM_CDP_URL` is set. Documents the local run command in `docs/web/clawql-web.md`.

Default CI remains dry-run only (2 tests skipped).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5a07-15ee-7a2a-828a-9ad0a5c8763c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5a07-15ee-7a2a-828a-9ad0a5c8763c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

