### PR TITLE
feat(web): OpenSearch auth and dedicated clawql-web index docs

### DIFF
--- a/charts/clawql-mcp/templates/deployment.yaml
+++ b/charts/clawql-mcp/templates/deployment.yaml
@@ -272,6 +272,14 @@ spec:
             - name: CLAWQL_SEARXNG_URL
               value: {{ printf "http://%s-searxng:%v" (include "clawql-mcp.fullname" .) (.Values.webSearch.searxng.port | default 8080) | quote }}
             {{- end }}
+            {{- if and .Values.webSearch.opensearch.enabled .Values.webSearch.opensearch.url }}
+            - name: CLAWQL_OPENSEARCH_URL
+              value: {{ .Values.webSearch.opensearch.url | quote }}
+            {{- end }}
+            {{- if and .Values.webSearch.opensearch.enabled .Values.webSearch.opensearch.index }}
+            - name: CLAWQL_OPENSEARCH_INDEX
+              value: {{ .Values.webSearch.opensearch.index | quote }}
+            {{- end }}
             {{- if and .Values.webBrowser.chromium.enabled .Values.webBrowser.chromium.bundled }}
             - name: CLAWQL_CHROMIUM_CDP_URL
               value: {{ printf "http://%s-chromium:%v" (include "clawql-mcp.fullname" .) (.Values.webBrowser.chromium.port | default 9222) | quote }}

--- a/charts/clawql-mcp/values.yaml
+++ b/charts/clawql-mcp/values.yaml
@@ -333,7 +333,14 @@ webSearch:
     resources: {}
   opensearch:
     enabled: false
-    bundled: false # not wired — reuse onyx OpenSearch or BYO CLAWQL_OPENSEARCH_URL
+    bundled: false # not wired as a chart Deployment — BYO URL or advanced reuse of Onyx OS
+    # Non-secret URL/index injected when enabled + url set. Auth via envFromSecret / extraEnv.
+    url: "" # e.g. https://opensearch:9200 or http://{{ release }}-onyx-opensearch:9200
+    index: clawql-web # dedicated index; do not share Onyx document indexes
+    # Prefer Vault/ESO secrets for:
+    #   CLAWQL_OPENSEARCH_USERNAME / CLAWQL_OPENSEARCH_PASSWORD
+    #   CLAWQL_OPENSEARCH_API_KEY
+    #   CLAWQL_OPENSEARCH_AUTHORIZATION (full header override)
 webBrowser:
   provider: kitesurf # kitesurf|chromium|playwright|puppeteer|firecrawl|none
   chromium:

--- a/docs/web/clawql-web.md
+++ b/docs/web/clawql-web.md
@@ -81,6 +81,11 @@ CLAWQL_BRAVE_API_KEY=…
 CLAWQL_SEARXNG_URL=http://searxng:8080
 CLAWQL_OPENSEARCH_URL=https://opensearch:9200
 CLAWQL_OPENSEARCH_INDEX=clawql-web
+# Auth (pick one): basic, API key / Bearer, or full Authorization override
+CLAWQL_OPENSEARCH_USERNAME=admin
+CLAWQL_OPENSEARCH_PASSWORD=…
+# CLAWQL_OPENSEARCH_API_KEY=…
+# CLAWQL_OPENSEARCH_AUTHORIZATION='ApiKey …'
 CLAWQL_FIRECRAWL_API_KEY=…
 CLAWQL_BROWSER_RUN_API_TOKEN=…
 CLAWQL_CLOUDFLARE_ACCOUNT_ID=…
@@ -132,6 +137,20 @@ CLAWQL_CHROMIUM_CDP_URL=http://127.0.0.1:9222 npm test -w clawql-web -- src/cdp.
 | `web_screenshot` | Capability-gated; live CDP when configured                            |
 | `web_interact`   | Capability-gated; live CDP when configured                            |
 
+## OpenSearch (internal corpus)
+
+OpenSearch is for **indexed / internal** search — not open-web SERP. Use a **dedicated index** (`CLAWQL_OPENSEARCH_INDEX`, default `clawql-web`) with documents shaped as `{ title, url, content|text|snippet }`.
+
+**Do not** point this at Onyx’s document indexes by default. Onyx OpenSearch uses the security plugin + different mappings; sharing risks auth mismatches and colliding with Onyx data. Advanced operators may set `webSearch.opensearch.url` to the Onyx OpenSearch service **only** with a separate `clawql-web` index and credentials wired via `envFromSecret`.
+
+Auth (first match wins):
+
+1. `CLAWQL_OPENSEARCH_AUTHORIZATION` — full `Authorization` header
+2. `CLAWQL_OPENSEARCH_API_KEY` — sent as `Bearer …` (or keep an `ApiKey ` / `Bearer ` prefix if already present)
+3. `CLAWQL_OPENSEARCH_USERNAME` + `CLAWQL_OPENSEARCH_PASSWORD` — HTTP Basic
+
+Helm injects non-secret `url` / `index` when `webSearch.opensearch.enabled` is true; put passwords in Vault/ESO.
+
 ## Helm — bundled SearXNG / Chromium
 
 `charts/clawql-mcp/templates/web-stack.yaml` deploys optional in-cluster workloads when:
@@ -143,6 +162,11 @@ webSearch:
   searxng:
     enabled: true
     bundled: true # deploys Deployment+Service; injects CLAWQL_SEARXNG_URL
+  # Or indexed internal search (BYO / optional Onyx OS host — dedicated index only):
+  # opensearch:
+  #   enabled: true
+  #   url: https://opensearch:9200
+  #   index: clawql-web
 webBrowser:
   provider: chromium
   chromium:
@@ -151,7 +175,7 @@ webBrowser:
 webAuditStore: jsonl # optional
 ```
 
-These are **in-chart Deployments**, not Chart.yaml Helm dependencies. OpenSearch for web is **not** bundled here — BYO `CLAWQL_OPENSEARCH_URL` or reuse the Onyx OpenSearch stack.
+These are **in-chart Deployments**, not Chart.yaml Helm dependencies. OpenSearch for web is **not** bundled as a Deployment — BYO `CLAWQL_OPENSEARCH_URL` (or point at Onyx OS with a dedicated index + auth).
 
 ## Related
 

--- a/packages/clawql-web/src/config.ts
+++ b/packages/clawql-web/src/config.ts
@@ -49,6 +49,20 @@ export type WebConfig = {
   searxngUrl?: string;
   opensearchUrl?: string;
   opensearchIndex?: string;
+  /** Basic auth username (OpenSearch security plugin). */
+  opensearchUsername?: string;
+  /** Basic auth password. Prefer secrets / envFromSecret in Helm. */
+  opensearchPassword?: string;
+  /**
+   * Bearer / API key value for `Authorization: Bearer …` or raw header when
+   * `opensearchAuthHeader` is set (e.g. `ApiKey <base64>`).
+   */
+  opensearchApiKey?: string;
+  /**
+   * Full Authorization header value override (takes precedence over username/password
+   * and apiKey helpers). Example: `Basic …` or `ApiKey …`.
+   */
+  opensearchAuthorization?: string;
   firecrawlApiKey?: string;
   firecrawlBaseUrl?: string;
   /** Cloudflare Browser Run / Browser Rendering token for Kitesurf & Chromium. */
@@ -94,6 +108,10 @@ export function loadWebConfig(env: NodeJS.ProcessEnv = process.env): WebConfig {
     searxngUrl: env.CLAWQL_SEARXNG_URL?.trim() || undefined,
     opensearchUrl: env.CLAWQL_OPENSEARCH_URL?.trim() || undefined,
     opensearchIndex: env.CLAWQL_OPENSEARCH_INDEX?.trim() || "clawql-web",
+    opensearchUsername: env.CLAWQL_OPENSEARCH_USERNAME?.trim() || undefined,
+    opensearchPassword: env.CLAWQL_OPENSEARCH_PASSWORD?.trim() || undefined,
+    opensearchApiKey: env.CLAWQL_OPENSEARCH_API_KEY?.trim() || undefined,
+    opensearchAuthorization: env.CLAWQL_OPENSEARCH_AUTHORIZATION?.trim() || undefined,
     firecrawlApiKey: env.CLAWQL_FIRECRAWL_API_KEY?.trim() || undefined,
     firecrawlBaseUrl: env.CLAWQL_FIRECRAWL_BASE_URL?.trim() || "https://api.firecrawl.dev",
     browserRunApiToken: env.CLAWQL_BROWSER_RUN_API_TOKEN?.trim() || undefined,

--- a/packages/clawql-web/src/index.ts
+++ b/packages/clawql-web/src/index.ts
@@ -37,6 +37,7 @@ export { WebCapabilityError, isWebCapabilityError, type WebCapabilityErrorCode }
 export { createWebService, type WebService } from "./service.js";
 export { browserAsSearch } from "./providers/fallback-search.js";
 export { resolveSearchProvider } from "./providers/search/resolve.js";
+export { buildOpensearchAuthHeaders } from "./providers/search/opensearch.js";
 export { resolveBrowserProvider } from "./providers/browser/resolve.js";
 export {
   assertSafeWebUrl,

--- a/packages/clawql-web/src/providers/search/opensearch.ts
+++ b/packages/clawql-web/src/providers/search/opensearch.ts
@@ -1,6 +1,27 @@
 import type { SearchOptions, SearchResponse, WebSearchProvider } from "../../interfaces.js";
 import type { WebConfig } from "../../config.js";
 
+/** Build OpenSearch / Elasticsearch Authorization header from config. */
+export function buildOpensearchAuthHeaders(config: WebConfig): Record<string, string> {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (config.opensearchAuthorization?.trim()) {
+    headers.Authorization = config.opensearchAuthorization.trim();
+    return headers;
+  }
+  if (config.opensearchApiKey?.trim()) {
+    const key = config.opensearchApiKey.trim();
+    // Accept raw token or already-prefixed ApiKey/Bearer values
+    headers.Authorization = /^(ApiKey|Bearer)\s+/i.test(key) ? key : `Bearer ${key}`;
+    return headers;
+  }
+  if (config.opensearchUsername?.trim()) {
+    const user = config.opensearchUsername.trim();
+    const pass = config.opensearchPassword ?? "";
+    headers.Authorization = `Basic ${Buffer.from(`${user}:${pass}`, "utf8").toString("base64")}`;
+  }
+  return headers;
+}
+
 /** Self-hosted OpenSearch / Elasticsearch index search (maximum sovereignty). */
 export function createOpensearchSearchProvider(
   config: WebConfig,
@@ -31,16 +52,17 @@ export function createOpensearchSearchProvider(
       const index = config.opensearchIndex ?? "clawql-web";
       const res = await fetchImpl(`${base}/${encodeURIComponent(index)}/_search`, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: buildOpensearchAuthHeaders(config),
         body: JSON.stringify({
           size: limit,
           query: {
             multi_match: {
               query,
-              fields: ["title^2", "content", "text", "snippet"],
+              fields: ["title^2", "content", "text", "snippet", "url"],
             },
           },
         }),
+        signal: AbortSignal.timeout(30_000),
       });
       if (!res.ok) {
         throw new Error(`OpenSearch search failed: HTTP ${res.status}`);
@@ -49,7 +71,7 @@ export function createOpensearchSearchProvider(
         hits?: {
           hits?: Array<{
             _score?: number;
-            _source?: { title?: string; url?: string; content?: string; snippet?: string };
+            _source?: { title?: string; url?: string; content?: string; snippet?: string; text?: string };
           }>;
         };
       };
@@ -59,7 +81,7 @@ export function createOpensearchSearchProvider(
         results: (body.hits?.hits ?? []).map((h) => ({
           title: h._source?.title ?? "",
           url: h._source?.url ?? "",
-          snippet: h._source?.snippet ?? h._source?.content,
+          snippet: h._source?.snippet ?? h._source?.content ?? h._source?.text,
           score: h._score,
           source: "opensearch",
         })),

--- a/packages/clawql-web/src/web.test.ts
+++ b/packages/clawql-web/src/web.test.ts
@@ -237,4 +237,59 @@ describe("clawql-web", () => {
     expect(page.provider).toBe("chromium");
     expect(page.markdown).toMatch(/Steps:/);
   });
+
+  it("OpenSearch sends Basic auth and searches the configured index", async () => {
+    delete process.env.CLAWQL_WEB_DRY_RUN;
+    const calls: Array<{ url: string; auth?: string | null }> = [];
+    const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const headers = new Headers(init?.headers);
+      calls.push({ url, auth: headers.get("Authorization") });
+      return new Response(
+        JSON.stringify({
+          hits: {
+            hits: [
+              {
+                _score: 1.2,
+                _source: {
+                  title: "Internal runbook",
+                  url: "https://intranet.example/runbook",
+                  snippet: "How to rotate keys",
+                },
+              },
+            ],
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }) as typeof fetch;
+
+    const web = createWebService(
+      {
+        CLAWQL_WEB_SEARCH_PROVIDER: "opensearch",
+        CLAWQL_OPENSEARCH_URL: "https://os.internal:9200",
+        CLAWQL_OPENSEARCH_INDEX: "clawql-web",
+        CLAWQL_OPENSEARCH_USERNAME: "admin",
+        CLAWQL_OPENSEARCH_PASSWORD: "s3cret",
+        CLAWQL_WEB_BROWSER_PROVIDER: "none",
+        CLAWQL_WEB_SEARCH_FALLBACK_DISABLED: "1",
+      },
+      fetchImpl
+    );
+    const result = await web.search("rotate keys", { limit: 3 });
+    expect(result.provider).toBe("opensearch");
+    expect(result.results[0]?.title).toBe("Internal runbook");
+    expect(calls[0]?.url).toBe("https://os.internal:9200/clawql-web/_search");
+    expect(calls[0]?.auth).toBe(`Basic ${Buffer.from("admin:s3cret", "utf8").toString("base64")}`);
+  });
+
+  it("OpenSearch prefers CLAWQL_OPENSEARCH_AUTHORIZATION over username/password", async () => {
+    const { buildOpensearchAuthHeaders, loadWebConfig } = await import("./index.js");
+    const cfg = loadWebConfig({
+      CLAWQL_OPENSEARCH_AUTHORIZATION: "ApiKey abc.def",
+      CLAWQL_OPENSEARCH_USERNAME: "ignored",
+      CLAWQL_OPENSEARCH_PASSWORD: "ignored",
+    });
+    expect(buildOpensearchAuthHeaders(cfg).Authorization).toBe("ApiKey abc.def");
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds authentication for the `clawql-web` OpenSearch search provider and documents the dedicated-index posture (no default reuse of Onyx indexes).

### Auth (first match wins)

1. `CLAWQL_OPENSEARCH_AUTHORIZATION` — full `Authorization` header
2. `CLAWQL_OPENSEARCH_API_KEY` — `Bearer …` (keeps `ApiKey `/`Bearer ` prefix if present)
3. `CLAWQL_OPENSEARCH_USERNAME` + `CLAWQL_OPENSEARCH_PASSWORD` — HTTP Basic

### Helm

- `webSearch.opensearch.url` / `index` injected when `enabled`
- Secrets stay in Vault/ESO / `extraEnv` (not plaintext values)

### Docs

- Dedicated `clawql-web` index shape `{ title, url, content|text|snippet }`
- Explicit warning against sharing Onyx document indexes

### Tests

- `npm test -w clawql-web` — 16 passing (incl. Basic auth header + Authorization override)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5a07-15ee-7a2a-828a-9ad0a5c8763c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5a07-15ee-7a2a-828a-9ad0a5c8763c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

