### PR TITLE
chore(openbench): activate B-7.1 on pr_active for live A/B

### DIFF
--- a/.github/workflows/openbench-ab.yml
+++ b/.github/workflows/openbench-ab.yml
@@ -344,21 +344,24 @@ jobs:
             fi
             if [ "${{ matrix.task }}" = "institutional-knowledge-enumerate" ]; then
               echo "OPENBENCH_TIMEOUT_S=240"
-              # Three-arm isolate (tools+vault vs tools/no-vault vs bare) unless
-              # dispatch explicitly chose a different arms set.
+              # Three-arm isolate by default (tools+vault vs tools/no-vault vs bare).
+              # On dispatch, honor an explicit non-default arms input; on PR/push
+              # always use the three-arm set (same burn path as every other cell).
               if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
                 case "${{ inputs.arms }}" in
                   clawql-on,clawql-off|"")
                     echo "OPENBENCH_ARMS=clawql-on,clawql-off,clawql-no-memory"
                     ;;
                 esac
+              else
+                echo "OPENBENCH_ARMS=clawql-on,clawql-off,clawql-no-memory"
               fi
             fi
           } >> "$GITHUB_ENV"
           if [ "${{ matrix.task }}" = "sandbox-trusted-compute" ]; then
             docker pull python:3.12-alpine
           fi
-          echo "::notice::${{ matrix.task }} → arms=clawql-on,off timeout=${OPENBENCH_TIMEOUT_S:-180}s"
+          echo "::notice::${{ matrix.task }} → arms=${OPENBENCH_ARMS:-clawql-on,clawql-off} timeout=${OPENBENCH_TIMEOUT_S:-180}s"
 
       - name: Credential preflight
         id: preflight

--- a/docs/benchmarks/openbench-advanced-specs.md
+++ b/docs/benchmarks/openbench-advanced-specs.md
@@ -10,14 +10,14 @@ Related: [`openbench.md`](openbench.md) · [`openbench/README.md`](../../openben
 
 ## Suite index
 
-| Suite | Claim category                             | Priority | Status                                                            |
-| ----- | ------------------------------------------ | -------- | ----------------------------------------------------------------- |
-| B-1   | Fine-tuning flywheel delta                 | Highest  | Spec only                                                         |
-| B-2   | Multi-turn IDP pipeline                    | Highest  | Spec only                                                         |
-| B-3   | Long-horizon codegraph (SWE-bench style)   | High     | Spec only — Phase 1 task packs landed                             |
-| B-4   | Adversarial memory / conflict resolution   | High     | Spec only — Phase 1 task packs landed                             |
-| B-5   | NSV/SGDOP ensemble diversity               | High     | Spec only                                                         |
-| B-6   | Domain-specific compliance QA (HLE analog) | Medium   | Spec only                                                         |
+| Suite | Claim category                             | Priority | Status                                                                                                                 |
+| ----- | ------------------------------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| B-1   | Fine-tuning flywheel delta                 | Highest  | Spec only                                                                                                              |
+| B-2   | Multi-turn IDP pipeline                    | Highest  | Spec only                                                                                                              |
+| B-3   | Long-horizon codegraph (SWE-bench style)   | High     | Spec only — Phase 1 task packs landed                                                                                  |
+| B-4   | Adversarial memory / conflict resolution   | High     | Spec only — Phase 1 task packs landed                                                                                  |
+| B-5   | NSV/SGDOP ensemble diversity               | High     | Spec only                                                                                                              |
+| B-6   | Domain-specific compliance QA (HLE analog) | Medium   | Spec only                                                                                                              |
 | B-7   | Institutional knowledge (C&H / amortized)  | Highest  | B-7.1 **WIN** [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796); B-7.2–7.4 next |
 
 ---
@@ -199,14 +199,14 @@ Harvey + EngramLab open-sourced **Calderwood & Harkness (C&H)** — a ~100M+ tok
 
 ### B-7.1 — Exhaustive feature enumeration
 
-| Field         | Value                                                                                                                                   |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| Product claim | ClawQL memory recall recovers more of the matching matter set than bare / no-memory; vault persistence is the Harvey-baseline delta     |
-| Arms          | Phase-1: `clawql-on` + `clawql-off` + `clawql-no-memory` (tools without seeded vault)                                                   |
-| Task IDs      | `institutional-knowledge-enumerate` (**offline pack landed**)                                                                           |
-| Grader        | Partial credit `hits/5`; emit `MATTERS_FOUND: k/5`; reject false positives; require real `memory_recall` when `REQUIRE_INSTITUTIONAL=1` |
-| Spend cap     | 30 turns / 240s / 8,000 tokens (single cell); B-7.3 adds first-task vs reuse asymmetry                                                  |
-| Expected      | on mean matters_found ≫ off / no-memory; headline copy uses `k/5` not only mean score                                                   |
+| Field         | Value                                                                                                                                                  |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Product claim | ClawQL memory recall recovers more of the matching matter set than bare / no-memory; vault persistence is the Harvey-baseline delta                    |
+| Arms          | Phase-1: `clawql-on` + `clawql-off` + `clawql-no-memory` (tools without seeded vault)                                                                  |
+| Task IDs      | `institutional-knowledge-enumerate` (**offline pack landed**)                                                                                          |
+| Grader        | Partial credit `hits/5`; emit `MATTERS_FOUND: k/5`; reject false positives; require real `memory_recall` when `REQUIRE_INSTITUTIONAL=1`                |
+| Spend cap     | 30 turns / 240s / 8,000 tokens (single cell); B-7.3 adds first-task vs reuse asymmetry                                                                 |
+| Expected      | on mean matters_found ≫ off / no-memory; headline copy uses `k/5` not only mean score                                                                  |
 | Status        | **WIN** three-arm [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796): on 5/5 / off 0/5 / no-memory 0/5 — retired |
 
 **In-repo offline pack:** [`openbench/tasks/institutional-knowledge-enumerate/`](../../openbench/tasks/institutional-knowledge-enumerate/)
@@ -227,15 +227,15 @@ Mount Harvey/EngramLab open-sourced filesystem + short-form matter specs as grou
 
 ## Recommended sequencing
 
-| Phase       | What runs                                                                | Dependency                                     |
-| ----------- | ------------------------------------------------------------------------ | ---------------------------------------------- |
-| **1 (now)** | B-3.1, B-4.1, B-4.2, B-4.3 offline packs + live A/B when secrets present | Already on `main` infra                        |
+| Phase       | What runs                                                                | Dependency                                                                                            |
+| ----------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| **1 (now)** | B-3.1, B-4.1, B-4.2, B-4.3 offline packs + live A/B when secrets present | Already on `main` infra                                                                               |
 | **1d**      | B-7.1 mini-firm enumerate live A/B                                       | **Done** WIN [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796) |
-| **2**       | B-1.1, B-1.2                                                             | Fine-tune v1 in `tier-map.json`                |
-| **3**       | B-2.1–B-2.3                                                              | Post B-1; vendor-live IDP + provenance graders |
-| **4**       | B-6.1                                                                    | Fine-tune + vertical adapter + Onyx corpus     |
-| **5**       | B-5.1–B-5.2                                                              | NSV/SGDOP instrumentation                      |
-| **6**       | B-1.3, B-3.2, B-6.3, B-7.3–B-7.4                                         | Long-horizon / full C&H mount                  |
+| **2**       | B-1.1, B-1.2                                                             | Fine-tune v1 in `tier-map.json`                                                                       |
+| **3**       | B-2.1–B-2.3                                                              | Post B-1; vendor-live IDP + provenance graders                                                        |
+| **4**       | B-6.1                                                                    | Fine-tune + vertical adapter + Onyx corpus                                                            |
+| **5**       | B-5.1–B-5.2                                                              | NSV/SGDOP instrumentation                                                                             |
+| **6**       | B-1.3, B-3.2, B-6.3, B-7.3–B-7.4                                         | Long-horizon / full C&H mount                                                                         |
 
 ### What a full B-1.2 win would mean
 

--- a/docs/benchmarks/openbench-advanced-specs.md
+++ b/docs/benchmarks/openbench-advanced-specs.md
@@ -2,7 +2,7 @@
 
 **Status:** Spec only (August 2026). Extends the OpenBench ledger from [#759](https://github.com/danielsmithdevelopment/ClawQL/pull/759) and the in-repo pack under [`openbench/`](../../openbench/).
 
-**These are specifications, not results.** No run IDs exist yet for B-7 live cells. Update suite status when cells land. Every live cell must link a GitHub Actions run ID; use **n≥3** before statistical claim confidence.
+**These are specifications, not results** except where a suite row links a live run ID (e.g. B-7.1). Update suite status when cells land. Every live cell must link a GitHub Actions run ID; use **n≥3** before statistical claim confidence.
 
 Related: [`openbench.md`](openbench.md) · [`openbench/README.md`](../../openbench/README.md) · [`openbench-github-actions.md`](openbench-github-actions.md) · [`openbench-b7-calderwood.md`](openbench-b7-calderwood.md)
 
@@ -18,7 +18,7 @@ Related: [`openbench.md`](openbench.md) · [`openbench/README.md`](../../openben
 | B-4   | Adversarial memory / conflict resolution   | High     | Spec only — Phase 1 task packs landed                             |
 | B-5   | NSV/SGDOP ensemble diversity               | High     | Spec only                                                         |
 | B-6   | Domain-specific compliance QA (HLE analog) | Medium   | Spec only                                                         |
-| B-7   | Institutional knowledge (C&H / amortized)  | Highest  | Spec + Phase-1 offline pack (`institutional-knowledge-enumerate`) |
+| B-7   | Institutional knowledge (C&H / amortized)  | Highest  | B-7.1 **WIN** [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796); B-7.2–7.4 next |
 
 ---
 
@@ -230,7 +230,7 @@ Mount Harvey/EngramLab open-sourced filesystem + short-form matter specs as grou
 | Phase       | What runs                                                                | Dependency                                     |
 | ----------- | ------------------------------------------------------------------------ | ---------------------------------------------- |
 | **1 (now)** | B-3.1, B-4.1, B-4.2, B-4.3 offline packs + live A/B when secrets present | Already on `main` infra                        |
-| **1d**      | B-7.1 mini-firm enumerate live A/B                                       | Offline pack on branch; dispatch when ready    |
+| **1d**      | B-7.1 mini-firm enumerate live A/B                                       | **Done** WIN [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796) |
 | **2**       | B-1.1, B-1.2                                                             | Fine-tune v1 in `tier-map.json`                |
 | **3**       | B-2.1–B-2.3                                                              | Post B-1; vendor-live IDP + provenance graders |
 | **4**       | B-6.1                                                                    | Fine-tune + vertical adapter + Onyx corpus     |

--- a/docs/benchmarks/openbench-advanced-specs.md
+++ b/docs/benchmarks/openbench-advanced-specs.md
@@ -207,7 +207,7 @@ Harvey + EngramLab open-sourced **Calderwood & Harkness (C&H)** — a ~100M+ tok
 | Grader        | Partial credit `hits/5`; emit `MATTERS_FOUND: k/5`; reject false positives; require real `memory_recall` when `REQUIRE_INSTITUTIONAL=1` |
 | Spend cap     | 30 turns / 240s / 8,000 tokens (single cell); B-7.3 adds first-task vs reuse asymmetry                                                  |
 | Expected      | on mean matters_found ≫ off / no-memory; headline copy uses `k/5` not only mean score                                                   |
-| Status        | Offline pack ready; live A/B via `workflow_dispatch` — **not** on `pr_active` until WIN                                                 |
+| Status        | **WIN** three-arm [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796): on 5/5 / off 0/5 / no-memory 0/5 — retired |
 
 **In-repo offline pack:** [`openbench/tasks/institutional-knowledge-enumerate/`](../../openbench/tasks/institutional-knowledge-enumerate/)
 

--- a/docs/benchmarks/openbench-b7-calderwood.md
+++ b/docs/benchmarks/openbench-b7-calderwood.md
@@ -81,7 +81,7 @@ Shared OpenBench rules still apply: real `tool:clawql_*` evidence · hard spend 
 | B-7.3 | `institutional-amortized-session`   | Same vault; 5 related prompts; cost + completeness   | Spec only (needs session harness)      |
 | B-7.4 | Full C&H mount                      | Mount open-sourced filesystem + Harvey task set      | Blocked on stable corpus download path |
 
-B-7.1 is on `pr_active` for the same PR-burn path as prior OpenBench cells (three-arm A/B). Retire after a clean live WIN.
+B-7.1 live WIN on [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796) (on 5/5 / off 0/5 / no-memory 0/5) — retired from `pr_active`.
 
 ### Phase-1 arms (B-7.1)
 

--- a/docs/benchmarks/openbench-b7-calderwood.md
+++ b/docs/benchmarks/openbench-b7-calderwood.md
@@ -81,7 +81,7 @@ Shared OpenBench rules still apply: real `tool:clawql_*` evidence · hard spend 
 | B-7.3 | `institutional-amortized-session`   | Same vault; 5 related prompts; cost + completeness   | Spec only (needs session harness)      |
 | B-7.4 | Full C&H mount                      | Mount open-sourced filesystem + Harvey task set      | Blocked on stable corpus download path |
 
-Do **not** put B-7.1 on `pr_active` until a clean live WIN; prefer `workflow_dispatch`.
+B-7.1 is on `pr_active` for the same PR-burn path as prior OpenBench cells (three-arm A/B). Retire after a clean live WIN.
 
 ### Phase-1 arms (B-7.1)
 

--- a/docs/benchmarks/openbench-results-ledger.md
+++ b/docs/benchmarks/openbench-results-ledger.md
@@ -1,10 +1,10 @@
 ### 2026-08-07 — `institutional-knowledge-enumerate` (B-7.1) WIN
 
-| Arm                 | Matters found | Score              | Notes                                      |
-| ------------------- | ------------- | ------------------ | ------------------------------------------ |
-| clawql-on           | **5/5**       | **1.0** (3t, 30s)  | seeded vault + `memory_recall`             |
-| clawql-off          | **0/5**       | **0.0** (2t, 11s)  | no ClawQL MCP; `matters.json` missing      |
-| clawql-no-memory    | **0/5**       | **0.0** (2t, 41s)  | tools without seeded vault; no artifact    |
+| Arm              | Matters found | Score             | Notes                                   |
+| ---------------- | ------------- | ----------------- | --------------------------------------- |
+| clawql-on        | **5/5**       | **1.0** (3t, 30s) | seeded vault + `memory_recall`          |
+| clawql-off       | **0/5**       | **0.0** (2t, 11s) | no ClawQL MCP; `matters.json` missing   |
+| clawql-no-memory | **0/5**       | **0.0** (2t, 41s) | tools without seeded vault; no artifact |
 
 Run: [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796) (PR [#871](https://github.com/danielsmithdevelopment/ClawQL/pull/871)). Gate OK. Three-arm isolate. **Verdict:** retire from `pr_active`. Headline: exhaustive matter enumeration needs persisted vault memory, not tools alone.
 

--- a/docs/benchmarks/openbench-results-ledger.md
+++ b/docs/benchmarks/openbench-results-ledger.md
@@ -1,3 +1,13 @@
+### 2026-08-07 — `institutional-knowledge-enumerate` (B-7.1) WIN
+
+| Arm                 | Matters found | Score              | Notes                                      |
+| ------------------- | ------------- | ------------------ | ------------------------------------------ |
+| clawql-on           | **5/5**       | **1.0** (3t, 30s)  | seeded vault + `memory_recall`             |
+| clawql-off          | **0/5**       | **0.0** (2t, 11s)  | no ClawQL MCP; `matters.json` missing      |
+| clawql-no-memory    | **0/5**       | **0.0** (2t, 41s)  | tools without seeded vault; no artifact    |
+
+Run: [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796) (PR [#871](https://github.com/danielsmithdevelopment/ClawQL/pull/871)). Gate OK. Three-arm isolate. **Verdict:** retire from `pr_active`. Headline: exhaustive matter enumeration needs persisted vault memory, not tools alone.
+
 ### 2026-08-07 — `idp-pipeline-resilience` (B-2.2) WIN
 
 | Arm           | Score                                     | Notes                                         |

--- a/docs/benchmarks/openbench-stack-coverage.md
+++ b/docs/benchmarks/openbench-stack-coverage.md
@@ -182,7 +182,7 @@ Full breakdown (B-1 flywheel → B-7 institutional / C&H): [`openbench-advanced-
 
 ### Phase 1d — Institutional knowledge (Harvey C&H)
 
-23. **`institutional-knowledge-enumerate` (B-7.1)** — offline pack landed (mini-firm vault; exhaustive escrow≥10 ∧ NC>18). Live A/B via `workflow_dispatch` next; keep off `pr_active` until WIN.
+23. **`institutional-knowledge-enumerate` (B-7.1)** — offline pack landed (mini-firm vault; exhaustive escrow≥10 ∧ NC>18). On `pr_active` for live three-arm A/B (same burn path as prior cells); retire after clean WIN.
 
 ### P3 — keep out of PR OpenBench (ops / cluster / paid SaaS)
 

--- a/docs/benchmarks/openbench-stack-coverage.md
+++ b/docs/benchmarks/openbench-stack-coverage.md
@@ -182,7 +182,7 @@ Full breakdown (B-1 flywheel → B-7 institutional / C&H): [`openbench-advanced-
 
 ### Phase 1d — Institutional knowledge (Harvey C&H)
 
-23. **`institutional-knowledge-enumerate` (B-7.1)** — offline pack landed (mini-firm vault; exhaustive escrow≥10 ∧ NC>18). On `pr_active` for live three-arm A/B (same burn path as prior cells); retire after clean WIN.
+23. **`institutional-knowledge-enumerate` (B-7.1)** — **WIN** three-arm [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796): on **5/5** / off **0/5** / no-memory **0/5**. Retired.
 
 ### P3 — keep out of PR OpenBench (ops / cluster / paid SaaS)
 

--- a/openbench/ci-matrix.json
+++ b/openbench/ci-matrix.json
@@ -2,8 +2,10 @@
   "$schema_comment": "Controls which OpenBench tasks burn tokens on PR/push. Move a task from pr_active → retired when thoroughly verified (headline WIN + replication preferred). workflow_dispatch can still select any individual task, or all-including-retired.",
   "live_enabled": true,
   "live_pause_reason": "",
-  "live_resume_note": "pr_active empty. Next candidate: institutional-knowledge-enumerate (B-7.1) via workflow_dispatch after offline pack — keep off PR burn until WIN. See docs/benchmarks/openbench-b7-calderwood.md.",
-  "pr_active": [],
+  "live_resume_note": "Burning institutional-knowledge-enumerate (B-7.1) on pr_active — same path as prior cells. Retire after clean WIN. See docs/benchmarks/openbench-b7-calderwood.md.",
+  "pr_active": [
+    "institutional-knowledge-enumerate"
+  ],
   "pr_trials": 1,
   "retired": {
     "idp-safe-pipeline-lite": {

--- a/openbench/ci-matrix.json
+++ b/openbench/ci-matrix.json
@@ -2,12 +2,14 @@
   "$schema_comment": "Controls which OpenBench tasks burn tokens on PR/push. Move a task from pr_active → retired when thoroughly verified (headline WIN + replication preferred). workflow_dispatch can still select any individual task, or all-including-retired.",
   "live_enabled": true,
   "live_pause_reason": "",
-  "live_resume_note": "Burning institutional-knowledge-enumerate (B-7.1) on pr_active — same path as prior cells. Retire after clean WIN. See docs/benchmarks/openbench-b7-calderwood.md.",
-  "pr_active": [
-    "institutional-knowledge-enumerate"
-  ],
+  "live_resume_note": "pr_active empty after B-7.1 WIN. Next: B-7.2 preference / B-7.3 amortized session when harness ready. See docs/benchmarks/openbench-b7-calderwood.md.",
+  "pr_active": [],
   "pr_trials": 1,
   "retired": {
+    "institutional-knowledge-enumerate": {
+      "reason": "Verified WIN — mini-firm exhaustive escrow≥10 ∧ NC>18 (on 5/5 / off 0/5 / no-memory 0/5)",
+      "evidence_run": "31228280796"
+    },
     "idp-safe-pipeline-lite": {
       "reason": "Verified WIN — stubbed 7-stage IDP orchestration (on 1.0 / off 0.0; RTP v1.1)",
       "evidence_run": "31039035892"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Activate then retire `institutional-knowledge-enumerate` on the standard OpenBench path (`pr_active` → PR CI → WIN → `retired`).

## Live result

[OpenBench A/B run 31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796)

| Arm | Matters found | Score |
|-----|---------------|-------|
| clawql-on | **5/5** | **1.0** |
| clawql-off | 0/5 | 0.0 |
| clawql-no-memory | 0/5 | 0.0 |

Also defaults three arms on PR/push for this task (not dispatch-only). Ledger + matrix retire included.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

