### PR TITLE
feat(openbench): harden B-7.1 — 30 notes, strip IDs, n=3 burn

### DIFF
--- a/.github/workflows/openbench-ab.yml
+++ b/.github/workflows/openbench-ab.yml
@@ -343,7 +343,8 @@ jobs:
               echo "OPENBENCH_TIMEOUT_S=180"
             fi
             if [ "${{ matrix.task }}" = "institutional-knowledge-enumerate" ]; then
-              echo "OPENBENCH_TIMEOUT_S=240"
+              # Hardened 30-note fixture + n≥3; give off-arm room to try exhaustively.
+              echo "OPENBENCH_TIMEOUT_S=400"
               # Three-arm isolate by default (tools+vault vs tools/no-vault vs bare).
               # On dispatch, honor an explicit non-default arms input; on PR/push
               # always use the three-arm set (same burn path as every other cell).

--- a/docs/benchmarks/openbench-b7-calderwood.md
+++ b/docs/benchmarks/openbench-b7-calderwood.md
@@ -76,12 +76,12 @@ Shared OpenBench rules still apply: real `tool:clawql_*` evidence · hard spend 
 
 | Cell  | Task id                             | Fixture                                              | Status                                 |
 | ----- | ----------------------------------- | ---------------------------------------------------- | -------------------------------------- |
-| B-7.1 | `institutional-knowledge-enumerate` | In-repo mini-firm vault seed (12 matters; 5 matches) | Offline pack landed                    |
+| B-7.1 | `institutional-knowledge-enumerate` | In-repo mini-firm vault seed (30 matters; 5 matches) | Hardened n=3 re-burn on `pr_active`    |
 | B-7.2 | `institutional-client-preference`   | Mini-firm client X preferences across 4 matters      | Spec only                              |
 | B-7.3 | `institutional-amortized-session`   | Same vault; 5 related prompts; cost + completeness   | Spec only (needs session harness)      |
 | B-7.4 | Full C&H mount                      | Mount open-sourced filesystem + Harvey task set      | Blocked on stable corpus download path |
 
-B-7.1 live WIN on [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796) (on 5/5 / off 0/5 / no-memory 0/5) — retired from `pr_active`.
+Prior n=1 WIN [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796). Hardening in flight: strip prompt IDs, restore off-arm note access + exhaustive nudge, expand 12→30 matters, `pr_trials=3`.
 
 ### Phase-1 arms (B-7.1)
 
@@ -89,9 +89,9 @@ B-7.1 live WIN on [31228280796](https://github.com/danielsmithdevelopment/ClawQL
 | ------------------ | --------------------------------------------------------------- |
 | `clawql-on`        | ClawQL MCP + **seeded vault** (memory representation available) |
 | `clawql-no-memory` | ClawQL MCP tools present but **memory disabled / no seed**      |
-| `clawql-off`       | Bare OpenCode — no ClawQL MCP                                   |
+| `clawql-off`       | Bare OpenCode — no ClawQL MCP; may read `.openbench/memory-seed/` |
 
-Dispatch defaults to all three for this task (override via the workflow `arms` input).
+PR/push defaults to all three arms (override via workflow `arms` on dispatch).
 
 ### Grader diagnostics (B-7.1)
 

--- a/docs/benchmarks/openbench-b7-calderwood.md
+++ b/docs/benchmarks/openbench-b7-calderwood.md
@@ -85,10 +85,10 @@ Prior n=1 WIN [31228280796](https://github.com/danielsmithdevelopment/ClawQL/act
 
 ### Phase-1 arms (B-7.1)
 
-| Arm                | What it isolates                                                |
-| ------------------ | --------------------------------------------------------------- |
-| `clawql-on`        | ClawQL MCP + **seeded vault** (memory representation available) |
-| `clawql-no-memory` | ClawQL MCP tools present but **memory disabled / no seed**      |
+| Arm                | What it isolates                                                  |
+| ------------------ | ----------------------------------------------------------------- |
+| `clawql-on`        | ClawQL MCP + **seeded vault** (memory representation available)   |
+| `clawql-no-memory` | ClawQL MCP tools present but **memory disabled / no seed**        |
 | `clawql-off`       | Bare OpenCode — no ClawQL MCP; may read `.openbench/memory-seed/` |
 
 PR/push defaults to all three arms (override via workflow `arms` on dispatch).

--- a/docs/benchmarks/openbench-b7-calderwood.md
+++ b/docs/benchmarks/openbench-b7-calderwood.md
@@ -81,7 +81,7 @@ Shared OpenBench rules still apply: real `tool:clawql_*` evidence · hard spend 
 | B-7.3 | `institutional-amortized-session`   | Same vault; 5 related prompts; cost + completeness   | Spec only (needs session harness)      |
 | B-7.4 | Full C&H mount                      | Mount open-sourced filesystem + Harvey task set      | Blocked on stable corpus download path |
 
-Prior n=1 WIN [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796). Hardening in flight: strip prompt IDs, restore off-arm note access + exhaustive nudge, expand 12→30 matters, `pr_trials=3`.
+Hardened n=3 [31230837116](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31230837116): on mean **2.67/5** < off mean **4/5** (gate FAIL). Prior n=1 [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796) was confounded (off had no seed files + early stop). Do not outreach a vault WIN until a fixture where exhaustive bare read fails.
 
 ### Phase-1 arms (B-7.1)
 

--- a/docs/benchmarks/openbench-results-ledger.md
+++ b/docs/benchmarks/openbench-results-ledger.md
@@ -1,12 +1,24 @@
-### 2026-08-07 — `institutional-knowledge-enumerate` (B-7.1) WIN
+### 2026-08-08 — `institutional-knowledge-enumerate` (B-7.1) hardened n=3 — gate FAIL
+
+Hardening: 30-note fixture (still 5 matches), stripped prompt IDs, off-arm seed restore + exhaustive nudge, caps 50/400s, `pr_trials=3`.
+
+| Arm              | Matters / trial   | Mean matters | Mean score | Notes |
+| ---------------- | ----------------- | ------------ | ---------- | ----- |
+| clawql-on        | 5/5, **0/5**, 3/5 | **2.67/5**   | 0.533      | high variance; t2 wrote `/tmp/matters.json` (wrong path) |
+| clawql-off       | 5/5, 3/5, 4/5     | **4.0/5**    | **0.8**    | ~30×`read` of seed dir — exhaustive file search works |
+| clawql-no-memory | 0/5, 0/5, 0/5     | **0/5**      | 0.0        | tools without vault still useless |
+
+Run: [31230837116](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31230837116) (PR [#872](https://github.com/danielsmithdevelopment/ClawQL/pull/872)). **Gate FAIL** (`on_score < off_score`). **Verdict:** clear `pr_active`; do **not** claim vault WIN. At 30 short machine-readable notes, a persistent bare agent nearly enumerates by reading files; `memory_recall` is not uniquely necessary and is less reliable (n=3). `no-memory` still 0/5. Next: harder distribution / larger corpus / features not trivially file-grepable before re-activate.
+
+### 2026-08-07 — `institutional-knowledge-enumerate` (B-7.1) n=1 (historical; confounded)
 
 | Arm              | Matters found | Score             | Notes                                   |
 | ---------------- | ------------- | ----------------- | --------------------------------------- |
 | clawql-on        | **5/5**       | **1.0** (3t, 30s) | seeded vault + `memory_recall`          |
-| clawql-off       | **0/5**       | **0.0** (2t, 11s) | no ClawQL MCP; `matters.json` missing   |
+| clawql-off       | **0/5**       | **0.0** (2t, 11s) | early give-up; seed stripped from workdir |
 | clawql-no-memory | **0/5**       | **0.0** (2t, 41s) | tools without seeded vault; no artifact |
 
-Run: [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796) (PR [#871](https://github.com/danielsmithdevelopment/ClawQL/pull/871)). Gate OK. Three-arm isolate. **Verdict:** retire from `pr_active`. Headline: exhaustive matter enumeration needs persisted vault memory, not tools alone.
+Run: [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796) (PR [#871](https://github.com/danielsmithdevelopment/ClawQL/pull/871)). Gate OK at the time, but **not outreach-ready** after hardening exposed the confound.
 
 ### 2026-08-07 — `idp-pipeline-resilience` (B-2.2) WIN
 

--- a/docs/benchmarks/openbench-results-ledger.md
+++ b/docs/benchmarks/openbench-results-ledger.md
@@ -2,21 +2,21 @@
 
 Hardening: 30-note fixture (still 5 matches), stripped prompt IDs, off-arm seed restore + exhaustive nudge, caps 50/400s, `pr_trials=3`.
 
-| Arm              | Matters / trial   | Mean matters | Mean score | Notes |
-| ---------------- | ----------------- | ------------ | ---------- | ----- |
+| Arm              | Matters / trial   | Mean matters | Mean score | Notes                                                    |
+| ---------------- | ----------------- | ------------ | ---------- | -------------------------------------------------------- |
 | clawql-on        | 5/5, **0/5**, 3/5 | **2.67/5**   | 0.533      | high variance; t2 wrote `/tmp/matters.json` (wrong path) |
-| clawql-off       | 5/5, 3/5, 4/5     | **4.0/5**    | **0.8**    | ~30×`read` of seed dir — exhaustive file search works |
-| clawql-no-memory | 0/5, 0/5, 0/5     | **0/5**      | 0.0        | tools without vault still useless |
+| clawql-off       | 5/5, 3/5, 4/5     | **4.0/5**    | **0.8**    | ~30×`read` of seed dir — exhaustive file search works    |
+| clawql-no-memory | 0/5, 0/5, 0/5     | **0/5**      | 0.0        | tools without vault still useless                        |
 
 Run: [31230837116](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31230837116) (PR [#872](https://github.com/danielsmithdevelopment/ClawQL/pull/872)). **Gate FAIL** (`on_score < off_score`). **Verdict:** clear `pr_active`; do **not** claim vault WIN. At 30 short machine-readable notes, a persistent bare agent nearly enumerates by reading files; `memory_recall` is not uniquely necessary and is less reliable (n=3). `no-memory` still 0/5. Next: harder distribution / larger corpus / features not trivially file-grepable before re-activate.
 
 ### 2026-08-07 — `institutional-knowledge-enumerate` (B-7.1) n=1 (historical; confounded)
 
-| Arm              | Matters found | Score             | Notes                                   |
-| ---------------- | ------------- | ----------------- | --------------------------------------- |
-| clawql-on        | **5/5**       | **1.0** (3t, 30s) | seeded vault + `memory_recall`          |
+| Arm              | Matters found | Score             | Notes                                     |
+| ---------------- | ------------- | ----------------- | ----------------------------------------- |
+| clawql-on        | **5/5**       | **1.0** (3t, 30s) | seeded vault + `memory_recall`            |
 | clawql-off       | **0/5**       | **0.0** (2t, 11s) | early give-up; seed stripped from workdir |
-| clawql-no-memory | **0/5**       | **0.0** (2t, 41s) | tools without seeded vault; no artifact |
+| clawql-no-memory | **0/5**       | **0.0** (2t, 41s) | tools without seeded vault; no artifact   |
 
 Run: [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796) (PR [#871](https://github.com/danielsmithdevelopment/ClawQL/pull/871)). Gate OK at the time, but **not outreach-ready** after hardening exposed the confound.
 

--- a/docs/benchmarks/openbench-stack-coverage.md
+++ b/docs/benchmarks/openbench-stack-coverage.md
@@ -182,7 +182,7 @@ Full breakdown (B-1 flywheel → B-7 institutional / C&H): [`openbench-advanced-
 
 ### Phase 1d — Institutional knowledge (Harvey C&H)
 
-23. **`institutional-knowledge-enumerate` (B-7.1)** — **WIN** three-arm [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796): on **5/5** / off **0/5** / no-memory **0/5**. Retired.
+23. **`institutional-knowledge-enumerate` (B-7.1)** — prior n=1 WIN [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796). Hardened re-burn on `pr_active`: 30-note fixture, stripped prompt IDs, exhaustive off nudge, `pr_trials=3`.
 
 ### P3 — keep out of PR OpenBench (ops / cluster / paid SaaS)
 

--- a/docs/benchmarks/openbench-stack-coverage.md
+++ b/docs/benchmarks/openbench-stack-coverage.md
@@ -182,7 +182,7 @@ Full breakdown (B-1 flywheel → B-7 institutional / C&H): [`openbench-advanced-
 
 ### Phase 1d — Institutional knowledge (Harvey C&H)
 
-23. **`institutional-knowledge-enumerate` (B-7.1)** — prior n=1 WIN [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796). Hardened re-burn on `pr_active`: 30-note fixture, stripped prompt IDs, exhaustive off nudge, `pr_trials=3`.
+23. **`institutional-knowledge-enumerate` (B-7.1)** — hardened n=3 [31230837116](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31230837116): on **2.67/5** < off **4/5** (gate FAIL). Pack kept; not a claim WIN.
 
 ### P3 — keep out of PR OpenBench (ops / cluster / paid SaaS)
 

--- a/openbench/README.md
+++ b/openbench/README.md
@@ -117,7 +117,7 @@ Prefer the Python adapter: it writes the instruction file, parses
 | `memory-dependent-continuation` | Prior argon2id + 900s TTL decisions live only in vault memory after seed removal; raw harnesses that follow the misleading bcrypt comment fail. |
 | `token-budget-constrained`      | Correct YAML `parse_config` under a 5k-token budget; exploration-heavy agents overspend.                                                        |
 | `multi-provider-api-workflow`   | Offline Cloudflare Worker + GitHub releases scaffold; rewards structured API discovery over dumping specs.                                      |
-| `institutional-knowledge-enumerate` | B-7.1 mini Calderwood & Harkness fixture — exhaustive matter enumeration (escrow≥10 ∧ NC>18) via vault `memory_recall`.                    |
+| `institutional-knowledge-enumerate` | B-7.1 mini Calderwood & Harkness fixture (30 notes / 5 matches) — exhaustive escrow≥10 ∧ NC>18 via vault `memory_recall`.                  |
 
 Validate checkers offline (no model, no network):
 

--- a/openbench/ci-matrix.json
+++ b/openbench/ci-matrix.json
@@ -2,14 +2,12 @@
   "$schema_comment": "Controls which OpenBench tasks burn tokens on PR/push. Move a task from pr_active → retired when thoroughly verified (headline WIN + replication preferred). workflow_dispatch can still select any individual task, or all-including-retired.",
   "live_enabled": true,
   "live_pause_reason": "",
-  "live_resume_note": "pr_active empty after B-7.1 WIN. Next: B-7.2 preference / B-7.3 amortized session when harness ready. See docs/benchmarks/openbench-b7-calderwood.md.",
-  "pr_active": [],
-  "pr_trials": 1,
+  "live_resume_note": "Re-burning institutional-knowledge-enumerate (hardened 30-note fixture, strip prompt IDs, exhaustive off nudge, n=3). See docs/benchmarks/openbench-b7-calderwood.md.",
+  "pr_active": [
+    "institutional-knowledge-enumerate"
+  ],
+  "pr_trials": 3,
   "retired": {
-    "institutional-knowledge-enumerate": {
-      "reason": "Verified WIN — mini-firm exhaustive escrow≥10 ∧ NC>18 (on 5/5 / off 0/5 / no-memory 0/5)",
-      "evidence_run": "31228280796"
-    },
     "idp-safe-pipeline-lite": {
       "reason": "Verified WIN — stubbed 7-stage IDP orchestration (on 1.0 / off 0.0; RTP v1.1)",
       "evidence_run": "31039035892"

--- a/openbench/ci-matrix.json
+++ b/openbench/ci-matrix.json
@@ -2,12 +2,14 @@
   "$schema_comment": "Controls which OpenBench tasks burn tokens on PR/push. Move a task from pr_active → retired when thoroughly verified (headline WIN + replication preferred). workflow_dispatch can still select any individual task, or all-including-retired.",
   "live_enabled": true,
   "live_pause_reason": "",
-  "live_resume_note": "Re-burning institutional-knowledge-enumerate (hardened 30-note fixture, strip prompt IDs, exhaustive off nudge, n=3). See docs/benchmarks/openbench-b7-calderwood.md.",
-  "pr_active": [
-    "institutional-knowledge-enumerate"
-  ],
-  "pr_trials": 3,
+  "live_resume_note": "B-7.1 hardened n=3 [31230837116]: on mean 2.67/5 < off mean 4/5 — gate FAIL. Keep off pr_active; fixture hardening kept. See ledger + openbench-b7-calderwood.md.",
+  "pr_active": [],
+  "pr_trials": 1,
   "retired": {
+    "institutional-knowledge-enumerate": {
+      "reason": "Prior n=1 WIN 31228280796; hardened n=3 31230837116 showed on 2.67/5 < off 4/5 (off can exhaustively read 30 short notes) — not a headline WIN. Keep pack; redesign before re-activate.",
+      "evidence_run": "31230837116"
+    },
     "idp-safe-pipeline-lite": {
       "reason": "Verified WIN — stubbed 7-stage IDP orchestration (on 1.0 / off 0.0; RTP v1.1)",
       "evidence_run": "31039035892"

--- a/openbench/scripts/run-ab-compare.py
+++ b/openbench/scripts/run-ab-compare.py
@@ -326,10 +326,11 @@ TASK_HARD_CAPS: dict[str, dict] = {
         "require_conflict": True,
     },
     "institutional-knowledge-enumerate": {
-        "max_turns": 30,
-        "max_tokens": 8000,
-        "max_wall_s": 240,
-        "default_timeout_s": 240,
+        # Hardened B-7.1: 30-note fixture + exhaustive off-arm try; n≥3 via pr_trials.
+        "max_turns": 50,
+        "max_tokens": 12000,
+        "max_wall_s": 400,
+        "default_timeout_s": 400,
         "disable_memory": False,
         "require_institutional": True,
     },
@@ -712,12 +713,28 @@ Do NOT invent 48 or pick only one price. Call memory_recall now.
 
 INSTITUTIONAL_NUDGE = """Continue the institutional knowledge enumeration task (B-7.1).
 
-1. clawql_memory_recall across the vault (matter notes with CLAWQL_MATTER_ID / ESCROW_PCT / NONCOMPETE_MONTHS)
+1. clawql_memory_recall across the vault (raise limit/maxDepth — there are many matter notes).
+   Fields: CLAWQL_MATTER_ID / ESCROW_PCT / NONCOMPETE_MONTHS
 2. Keep ONLY matters with escrow_pct >= 10 AND noncompete_months > 18
 3. write relative filePath matters.json with the COMPLETE set (order free):
-   {"matters":["MAT-2388","MAT-2401","MAT-2415","MAT-2450","MAT-2462"],"criteria":{"escrow_pct_min":10,"noncompete_months_gt":18},"source":"memory_recall","search_sufficiency":"…"}
+   {"matters":["MAT-XXXX","MAT-YYYY"],"criteria":{"escrow_pct_min":10,"noncompete_months_gt":18},"source":"memory_recall","search_sufficiency":"how many notes you checked"}
 
-Partial lists fail. Near-misses (9% escrow, exactly 18 months NC) must not appear. Call memory_recall now.
+Do NOT copy placeholder IDs. Discover real IDs from recall. Partial lists fail.
+Near-misses (9% escrow, exactly 18 months NC, missing escrow) must not appear.
+Search exhaustively — do not stop after the first hits. Call memory_recall now.
+"""
+
+INSTITUTIONAL_OFF_NUDGE = """Continue. Memory tools are unavailable — that is expected on this arm.
+
+You MUST still finish the task by exhaustively searching the workspace:
+
+1. List and read EVERY markdown note under `.openbench/memory-seed/` (ignore `decoy/`).
+2. For each note, record CLAWQL_MATTER_ID, CLAWQL_ESCROW_PCT, CLAWQL_NONCOMPETE_MONTHS when present.
+3. Keep ONLY matters with escrow_pct >= 10 AND noncompete_months > 18.
+4. write relative filePath matters.json:
+   {"matters":["MAT-XXXX"],"criteria":{"escrow_pct_min":10,"noncompete_months_gt":18},"source":"workspace_notes","search_sufficiency":"checked all notes under .openbench/memory-seed"}
+
+Do not stop after 1–2 files. Do not invent IDs. Exhaust the directory, then write.
 """
 
 POLICY_WRITE_NUDGE = """Continue. execute was blocked by policy.
@@ -3212,14 +3229,15 @@ def render_markdown(report: dict) -> str:
         )
     elif task == "institutional-knowledge-enumerate":
         interp.append(
-            "- Arms graded for exhaustive matter enumeration via memory_recall "
+            "- Arms graded for exhaustive matter enumeration on the 30-note mini-firm "
             "(escrow≥10 and noncompete>18); score = hits/5 (partial credit); "
-            "false positives → 0.0; require real memory_recall tool_use."
+            "false positives → 0.0. On / no-memory require real memory_recall tool_use; "
+            "off may score via exhaustive workspace note reads."
         )
         interp.append(
             "- **clawql-on** = seeded vault + memory tools; **clawql-no-memory** = "
             "ClawQL tools but empty/disabled memory (isolates persistence); "
-            "**clawql-off** = no ClawQL MCP."
+            "**clawql-off** = no ClawQL MCP (nudged to read `.openbench/memory-seed/`)."
         )
     interp.append("")
     lines.extend(interp)
@@ -3278,8 +3296,16 @@ def run_trial(
     task_name = task_dir.name
     caps = TASK_HARD_CAPS.get(task_name) or {}
     corr = openbench_correlation_id(arm, trial)
+    seed_snapshot: Path | None = None
     try:
         materialize_workspace(task_dir, tmp)
+        # Snapshot multi-file seeds before seed_and_remove_memory deletes them from
+        # the workdir. Off-arm needs those notes to attempt exhaustive filesystem
+        # search; on-arm keeps them vault-only so wins require memory_recall.
+        seed_dir_src = tmp / ".openbench" / "memory-seed"
+        if caps.get("require_institutional") and seed_dir_src.is_dir():
+            seed_snapshot = Path(tempfile.mkdtemp(prefix="ik_seed_snap_"))
+            shutil.copytree(seed_dir_src, seed_snapshot / "memory-seed")
         vault = seed_and_remove_memory(tmp)
         if vault is None and caps.get("empty_vault") and arm != "clawql-off":
             vault = empty_vault_home()
@@ -3288,9 +3314,47 @@ def run_trial(
             if appendix:
                 instruction = instruction.rstrip() + "\n" + appendix
         if arm == "clawql-off":
+            if seed_snapshot and (seed_snapshot / "memory-seed").is_dir():
+                dest = tmp / ".openbench" / "memory-seed"
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                if dest.exists():
+                    shutil.rmtree(dest)
+                shutil.copytree(seed_snapshot / "memory-seed", dest)
             agent = run_arm_off(
                 instruction, tmp, model, timeout_s, inference_url, correlation_id=corr
             )
+            # B-7.1: force a genuine exhaustive try (Risk: early give-up).
+            if (
+                caps.get("require_institutional")
+                and not agent.get("timed_out")
+                and not (tmp / "matters.json").is_file()
+            ):
+                used = float(agent.get("wall_s") or 0.0)
+                remaining = int(timeout_s) - int(used)
+                if remaining >= 40:
+                    cont_timeout = max(40, min(200, remaining))
+                    agent2 = run_arm_off(
+                        INSTITUTIONAL_OFF_NUDGE,
+                        tmp,
+                        model,
+                        cont_timeout,
+                        inference_url,
+                        correlation_id=corr,
+                    )
+                    log1 = agent.pop("_combined_log", "") or ""
+                    log2 = agent2.pop("_combined_log", "") or ""
+                    merged = (log1 + "\n" + log2).strip()
+                    turns1 = agent.get("turns")
+                    agent = dict(agent2)
+                    agent["arm"] = "clawql-off"
+                    agent["_combined_log"] = merged
+                    agent["wall_s"] = round(used + float(agent2.get("wall_s") or 0.0), 3)
+                    try:
+                        if turns1 is not None and agent2.get("turns") is not None:
+                            agent["turns"] = int(turns1) + int(agent2.get("turns") or 0)
+                    except (TypeError, ValueError):
+                        pass
+                    agent["output_tail"] = merged[-2000:]
             if vault:
                 shutil.rmtree(vault, ignore_errors=True)
                 vault = None
@@ -3421,7 +3485,12 @@ def run_trial(
             checker_env_extra["OPENBENCH_REQUIRE_WIKILINK"] = "1"
         if caps.get("require_conflict"):
             checker_env_extra["OPENBENCH_REQUIRE_CONFLICT"] = "1"
-        if caps.get("require_institutional"):
+        # Memory-tool evidence is required for MCP arms only. Off may score via
+        # exhaustive reads of `.openbench/memory-seed/` (hardened B-7.1).
+        if caps.get("require_institutional") and arm in (
+            "clawql-on",
+            "clawql-no-memory",
+        ):
             checker_env_extra["OPENBENCH_REQUIRE_INSTITUTIONAL"] = "1"
         checker = run_checker(task_dir, tmp, env_extra=checker_env_extra)
         checker = apply_hard_caps(task_name, agent, checker)
@@ -3433,6 +3502,8 @@ def run_trial(
             "workdir": str(tmp),
         }
     finally:
+        if seed_snapshot:
+            shutil.rmtree(seed_snapshot, ignore_errors=True)
         if vault:
             shutil.rmtree(vault, ignore_errors=True)
         if os.environ.get("CLAWQL_AB_KEEP_WORKDIR") != "1":

--- a/openbench/tasks/institutional-knowledge-enumerate/checker.sh
+++ b/openbench/tasks/institutional-knowledge-enumerate/checker.sh
@@ -34,6 +34,7 @@ import sys
 from pathlib import Path
 
 expected = {"MAT-2388", "MAT-2401", "MAT-2415", "MAT-2450", "MAT-2462"}
+# All other seeded matter IDs (12→30 fixture). Including any → 0/5.
 near_miss = {
     "MAT-2390",
     "MAT-2405",
@@ -42,6 +43,24 @@ near_miss = {
     "MAT-2433",
     "MAT-2444",
     "MAT-2470",
+    "MAT-2501",
+    "MAT-2502",
+    "MAT-2503",
+    "MAT-2504",
+    "MAT-2505",
+    "MAT-2506",
+    "MAT-2507",
+    "MAT-2508",
+    "MAT-2509",
+    "MAT-2510",
+    "MAT-2511",
+    "MAT-2512",
+    "MAT-2513",
+    "MAT-2514",
+    "MAT-2515",
+    "MAT-2516",
+    "MAT-2517",
+    "MAT-2518",
 }
 n_exp = len(expected)
 
@@ -90,9 +109,20 @@ if false_pos:
 hits = sorted(ids & expected)
 partial = len(hits) / float(n_exp)
 src = str(d.get("source") or "").strip().lower()
-ok_src = "memory" in src or "recall" in src
+# On-arm uses memory_recall; off-arm may cite workspace note reads after exhaustive search.
+ok_src = (
+    "memory" in src
+    or "recall" in src
+    or "workspace" in src
+    or "note" in src
+    or "seed" in src
+)
 if not ok_src:
-    emit(0, 0.0, err=f"FAIL: source must reference memory_recall; got {src!r}")
+    emit(
+        0,
+        0.0,
+        err=f"FAIL: source must reference memory_recall or workspace notes; got {src!r}",
+    )
     raise SystemExit(0)
 
 emit(len(hits), partial, ids=hits)

--- a/openbench/tasks/institutional-knowledge-enumerate/instruction.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/instruction.md
@@ -1,8 +1,8 @@
 # Institutional knowledge — exhaustive matter enumeration (B-7.1)
 
 You are an associate at a synthetic firm (mini **Calderwood & Harkness** fixture).
-The vault holds prior matter notes. Feature fields are **distributed across notes**
-and are **not** in the note titles.
+Prior matter notes live in the vault / workspace. Feature fields are **distributed
+across notes** and are **not** in the note titles.
 
 ## Goal
 
@@ -13,38 +13,45 @@ List **every** matter that has **both**:
 
 ## Steps
 
-1. Call **`clawql_memory_recall`** (multiple queries / higher `limit` / `maxDepth` as needed).
-   Look for machine-readable fields in vault notes:
+1. **Search exhaustively.** Do **not** stop after the first few hits.
+   - Prefer **`clawql_memory_recall`** when available (multiple queries; raise
+     `limit` / `maxDepth` until you have covered the firm notes).
+   - If memory tools are unavailable, **read every** matter note under
+     `.openbench/memory-seed/` (ignore `decoy/`). Check each note’s fields before
+     finishing.
+2. Machine-readable fields to collect:
    - `CLAWQL_MATTER_ID=…`
    - `CLAWQL_ESCROW_PCT=…`
    - `CLAWQL_NONCOMPETE_MONTHS=…`
-2. Apply the filters above. Near-misses (9% escrow, exactly 18 months NC, etc.) must
-   **not** appear in the answer.
-3. Write relative path `matters.json` with the **complete** matching set (order free).
+3. Apply the filters above. Near-misses (e.g. 9% escrow, exactly 18 months NC,
+   missing escrow) must **not** appear in the answer.
+4. Write relative path `matters.json` with the **complete** matching set (order free).
 
 ## Artifact
 
 ```json
 {
-  "matters": ["MAT-2401", "MAT-2415", "MAT-2388", "MAT-2450", "MAT-2462"],
+  "matters": ["MAT-XXXX", "MAT-YYYY"],
   "criteria": {
     "escrow_pct_min": 10,
     "noncompete_months_gt": 18
   },
   "source": "memory_recall",
-  "search_sufficiency": "short note on why the set is complete"
+  "search_sufficiency": "short note on why the set is complete — how many notes you checked"
 }
 ```
 
+Use placeholder IDs in the schema only. Discover real IDs from the notes.
+
 ## Scoring
 
-- **Partial credit:** `SCORE = hits / 5` (how many of the five matching matters you found).
-- Checker also emits **`MATTERS_FOUND: k/5`** — the headline diagnostic (not just the float).
-- Extra / near-miss IDs → `0/5` and `SCORE: 0.0`.
-- Live A/B requires a real `clawql_memory_recall` tool_use (guessing IDs without tools scores 0).
+- **Partial credit:** `SCORE = hits / N` (how many of the matching matters you found).
+- Checker also emits **`MATTERS_FOUND: k/N`** — the headline diagnostic.
+- Extra / near-miss IDs → `0/N` and `SCORE: 0.0`.
+- Live on-arm grading requires a real `clawql_memory_recall` tool_use when memory tools are available.
 
 ## Rules
 
 - Ignore `decoy/`. Prefer the complete set; partial sets score proportionally.
-- Inventing `matters.json` without a real `clawql_memory_recall` tool_use fails under live grading.
-- Stop after writing `matters.json`.
+- Do not invent matter IDs. Exhaust the corpus before writing `matters.json`.
+- Stop only after writing `matters.json` with the complete set.

--- a/openbench/tasks/institutional-knowledge-enumerate/solution/matters.json
+++ b/openbench/tasks/institutional-knowledge-enumerate/solution/matters.json
@@ -5,5 +5,5 @@
     "noncompete_months_gt": 18
   },
   "source": "memory_recall",
-  "search_sufficiency": "Recalled all seeded matter notes and retained only those with escrow_pct>=10 and noncompete_months>18."
+  "search_sufficiency": "Recalled all 30 seeded matter notes and retained only the five with escrow_pct>=10 and noncompete_months>18."
 }

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Amber secondary.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Amber secondary.md
@@ -1,0 +1,11 @@
+# Amber secondary
+
+Closing / diligence excerpt — Amber Secondary (secondary).
+
+CLAWQL_MATTER_ID=MAT-2513
+CLAWQL_CLIENT=Amber Secondary
+CLAWQL_ESCROW_PCT=7
+CLAWQL_NONCOMPETE_MONTHS=24
+CLAWQL_DEAL_TYPE=secondary
+
+NC twenty-four months; escrow seven percent — near miss on escrow.

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Boreal growth.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Boreal growth.md
@@ -1,0 +1,11 @@
+# Boreal growth
+
+Closing / diligence excerpt — Boreal Partners (growth-equity).
+
+CLAWQL_MATTER_ID=MAT-2514
+CLAWQL_CLIENT=Boreal Partners
+CLAWQL_ESCROW_PCT=16
+CLAWQL_NONCOMPETE_MONTHS=17
+CLAWQL_DEAL_TYPE=growth-equity
+
+Escrow sixteen percent; NC seventeen months — one month short of >18.

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Canyon software.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Canyon software.md
@@ -1,0 +1,11 @@
+# Canyon software
+
+Closing / diligence excerpt — Canyon Soft (pe-software).
+
+CLAWQL_MATTER_ID=MAT-2515
+CLAWQL_CLIENT=Canyon Soft
+CLAWQL_ESCROW_PCT=12
+CLAWQL_NONCOMPETE_MONTHS=18
+CLAWQL_DEAL_TYPE=pe-software
+
+Boundary case: escrow ok, NC exactly eighteen months.

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Delta escrow-only.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Delta escrow-only.md
@@ -1,0 +1,10 @@
+# Delta escrow-only
+
+Closing / diligence excerpt — Delta Holdco (holdco).
+
+CLAWQL_MATTER_ID=MAT-2516
+CLAWQL_CLIENT=Delta Holdco
+CLAWQL_ESCROW_PCT=30
+CLAWQL_DEAL_TYPE=holdco
+
+Large escrow holdback; non-compete months field absent from memo.

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Echo low both.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Echo low both.md
@@ -1,0 +1,11 @@
+# Echo low both
+
+Closing / diligence excerpt — Echo Retail (retail).
+
+CLAWQL_MATTER_ID=MAT-2517
+CLAWQL_CLIENT=Echo Retail
+CLAWQL_ESCROW_PCT=4
+CLAWQL_NONCOMPETE_MONTHS=12
+CLAWQL_DEAL_TYPE=retail
+
+Neither field meets the dual criteria.

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Frost line.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Frost line.md
@@ -1,0 +1,11 @@
+# Frost line
+
+Closing / diligence excerpt — Frost Line PE (pe-software).
+
+CLAWQL_MATTER_ID=MAT-2518
+CLAWQL_CLIENT=Frost Line PE
+CLAWQL_ESCROW_PCT=9
+CLAWQL_NONCOMPETE_MONTHS=19
+CLAWQL_DEAL_TYPE=pe-software
+
+NC clears nineteen months but escrow stuck at nine percent.

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Marble rollup.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Marble rollup.md
@@ -1,0 +1,11 @@
+# Marble rollup
+
+Closing / diligence excerpt — Marble Industries (add-on).
+
+CLAWQL_MATTER_ID=MAT-2503
+CLAWQL_CLIENT=Marble Industries
+CLAWQL_ESCROW_PCT=14
+CLAWQL_NONCOMPETE_MONTHS=12
+CLAWQL_DEAL_TYPE=add-on
+
+Healthy escrow; non-compete only twelve months post-close.

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Orchard seed A.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Orchard seed A.md
@@ -1,0 +1,10 @@
+# Orchard seed A
+
+Closing / diligence excerpt — Orchard Ventures (seed).
+
+CLAWQL_MATTER_ID=MAT-2504
+CLAWQL_CLIENT=Orchard Ventures
+CLAWQL_NONCOMPETE_MONTHS=24
+CLAWQL_DEAL_TYPE=seed
+
+Non-compete on file; escrow percentage never recorded in the closing set.

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Pinnacle carve.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Pinnacle carve.md
@@ -1,0 +1,11 @@
+# Pinnacle carve
+
+Closing / diligence excerpt — Pinnacle Soft (carve-out).
+
+CLAWQL_MATTER_ID=MAT-2505
+CLAWQL_CLIENT=Pinnacle Soft
+CLAWQL_ESCROW_PCT=8
+CLAWQL_NONCOMPETE_MONTHS=30
+CLAWQL_DEAL_TYPE=carve-out
+
+Long NC; escrow held at eight percent of consideration.

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Quarry bolt.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Quarry bolt.md
@@ -1,0 +1,11 @@
+# Quarry bolt
+
+Closing / diligence excerpt — Quarry Systems (saas).
+
+CLAWQL_MATTER_ID=MAT-2506
+CLAWQL_CLIENT=Quarry Systems
+CLAWQL_ESCROW_PCT=22
+CLAWQL_NONCOMPETE_MONTHS=18
+CLAWQL_DEAL_TYPE=saas
+
+Escrow twenty-two percent; NC exactly eighteen months (not longer).

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Redwood minority.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Redwood minority.md
@@ -1,0 +1,11 @@
+# Redwood minority
+
+Closing / diligence excerpt — Redwood Capital (growth-equity).
+
+CLAWQL_MATTER_ID=MAT-2501
+CLAWQL_CLIENT=Redwood Capital
+CLAWQL_ESCROW_PCT=10
+CLAWQL_NONCOMPETE_MONTHS=18
+CLAWQL_DEAL_TYPE=growth-equity
+
+Escrow at the ten percent floor; non-compete capped at exactly eighteen months — fails the >18 filter.

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Silverline tuck.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Silverline tuck.md
@@ -1,0 +1,11 @@
+# Silverline tuck
+
+Closing / diligence excerpt — Silverline Partners (pe-software).
+
+CLAWQL_MATTER_ID=MAT-2502
+CLAWQL_CLIENT=Silverline Partners
+CLAWQL_ESCROW_PCT=9
+CLAWQL_NONCOMPETE_MONTHS=36
+CLAWQL_DEAL_TYPE=pe-software
+
+Strong NC term but escrow one point under the ten percent floor.

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Tidepool add-on.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Tidepool add-on.md
@@ -1,0 +1,11 @@
+# Tidepool add-on
+
+Closing / diligence excerpt — Tidepool Holdings (add-on).
+
+CLAWQL_MATTER_ID=MAT-2507
+CLAWQL_CLIENT=Tidepool Holdings
+CLAWQL_ESCROW_PCT=5
+CLAWQL_NONCOMPETE_MONTHS=6
+CLAWQL_DEAL_TYPE=add-on
+
+Both escrow and NC below thresholds — clear miss.

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Umbra platform.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Umbra platform.md
@@ -1,0 +1,11 @@
+# Umbra platform
+
+Closing / diligence excerpt — Umbra Labs (platform).
+
+CLAWQL_MATTER_ID=MAT-2508
+CLAWQL_CLIENT=Umbra Labs
+CLAWQL_ESCROW_PCT=11
+CLAWQL_NONCOMPETE_MONTHS=15
+CLAWQL_DEAL_TYPE=platform
+
+Escrow clears the floor; NC only fifteen months.

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Vesper minority.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Vesper minority.md
@@ -1,0 +1,11 @@
+# Vesper minority
+
+Closing / diligence excerpt — Vesper Growth (growth-equity).
+
+CLAWQL_MATTER_ID=MAT-2509
+CLAWQL_CLIENT=Vesper Growth
+CLAWQL_ESCROW_PCT=0
+CLAWQL_NONCOMPETE_MONTHS=48
+CLAWQL_DEAL_TYPE=growth-equity
+
+No purchase-price escrow; long NC alone is insufficient.

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Willow term sheet.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Willow term sheet.md
@@ -1,0 +1,11 @@
+# Willow term sheet
+
+Closing / diligence excerpt — Willow Bridge (term-sheet).
+
+CLAWQL_MATTER_ID=MAT-2510
+CLAWQL_CLIENT=Willow Bridge
+CLAWQL_ESCROW_PCT=13
+CLAWQL_NONCOMPETE_MONTHS=18
+CLAWQL_DEAL_TYPE=term-sheet
+
+Escrow thirteen percent; NC term locked at eighteen months flat.

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Yarrow consulting.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Yarrow consulting.md
@@ -1,0 +1,10 @@
+# Yarrow consulting
+
+Closing / diligence excerpt — Yarrow Advisors (services).
+
+CLAWQL_MATTER_ID=MAT-2511
+CLAWQL_CLIENT=Yarrow Advisors
+CLAWQL_NONCOMPETE_MONTHS=36
+CLAWQL_DEAL_TYPE=services
+
+Services engagement with a long NC; no escrow field present.

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Zephyr tuck-in.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/.openbench/memory-seed/Zephyr tuck-in.md
@@ -1,0 +1,11 @@
+# Zephyr tuck-in
+
+Closing / diligence excerpt — Zephyr Media (tuck-in).
+
+CLAWQL_MATTER_ID=MAT-2512
+CLAWQL_CLIENT=Zephyr Media
+CLAWQL_ESCROW_PCT=10
+CLAWQL_NONCOMPETE_MONTHS=9
+CLAWQL_DEAL_TYPE=tuck-in
+
+Escrow at floor; NC only nine months for key employees.

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/README.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/README.md
@@ -1,4 +1,7 @@
 # Mini Calderwood & Harkness fixture (B-7.1)
 
-Vault seed under `.openbench/memory-seed/` holds 12 synthetic PE/software matter
+Vault seed under `.openbench/memory-seed/` holds **30** synthetic PE/software matter
 notes. Enumerate every matter with escrow ≥ 10% **and** non-compete > 18 months.
+
+Ground-truth match count is fixed at **5** (many near-misses and decoys). Search
+exhaustively — do not stop after the first hits.

--- a/openbench/tasks/institutional-knowledge-enumerate/workspace/decoy/partial_list.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/workspace/decoy/partial_list.md
@@ -2,6 +2,7 @@
 
 A rushed associate once listed only:
 
-MAT-2401, MAT-2415
+MAT-2401, MAT-2415, MAT-2501
 
-That list is **incomplete**. Graders reject partial enumeration.
+That list is **incomplete** (and includes a near-miss). Graders reject partial
+or incorrect enumeration. Search the full matter set.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Hardened B-7.1 and burned n=3 three-arm A/B on PR CI. **Result: gate FAIL — do not outreach a vault WIN.**

## Live run

[31230837116](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31230837116)

| Arm | Matters / trial | Mean |
|-----|-----------------|------|
| clawql-on | 5/5, 0/5, 3/5 | **2.67/5** (score 0.533) |
| clawql-off | 5/5, 3/5, 4/5 | **4.0/5** (score 0.8) |
| clawql-no-memory | 0/5 ×3 | **0/5** |

Off beat on by exhaustively reading all 30 seed notes (~30 `read` calls). On had high variance (including a wrong-path write to `/tmp/matters.json`). `no-memory` still 0.

## What this PR ships

- 12→30 note fixture (same 5 ground-truth matches)
- Stripped answer IDs from instruction/nudge
- Off-arm seed restore + exhaustive nudge + higher caps
- Honest ledger of the n=3 gate FAIL; `pr_active` cleared

Prior n=1 [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796) was confounded (off had no seed files). Keep pack; redesign before claiming.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

