### PR TITLE
feat(openbench): re-burn B-7.1 on qwen3.6-plus — ClawQL ruled out

### DIFF
--- a/.github/workflows/openbench-ab.yml
+++ b/.github/workflows/openbench-ab.yml
@@ -344,7 +344,10 @@ jobs:
             fi
             if [ "${{ matrix.task }}" = "institutional-knowledge-enumerate" ]; then
               # Hardened 30-note fixture + n≥3; give off-arm room to try exhaustively.
+              # Use Qwen3.6 Plus (standard) — DeepSeek frugal flaked on post-recall
+              # write/filter; this re-burn rules out ClawQL memory as the failure.
               echo "OPENBENCH_TIMEOUT_S=400"
+              echo "OPENBENCH_MODEL=openrouter/qwen/qwen3.6-plus"
               # Three-arm isolate by default (tools+vault vs tools/no-vault vs bare).
               # On dispatch, honor an explicit non-default arms input; on PR/push
               # always use the three-arm set (same burn path as every other cell).

--- a/docs/benchmarks/openbench-advanced-specs.md
+++ b/docs/benchmarks/openbench-advanced-specs.md
@@ -10,14 +10,14 @@ Related: [`openbench.md`](openbench.md) · [`openbench/README.md`](../../openben
 
 ## Suite index
 
-| Suite | Claim category                             | Priority | Status                                                                                                                 |
-| ----- | ------------------------------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------- |
-| B-1   | Fine-tuning flywheel delta                 | Highest  | Spec only                                                                                                              |
-| B-2   | Multi-turn IDP pipeline                    | Highest  | Spec only                                                                                                              |
-| B-3   | Long-horizon codegraph (SWE-bench style)   | High     | Spec only — Phase 1 task packs landed                                                                                  |
-| B-4   | Adversarial memory / conflict resolution   | High     | Spec only — Phase 1 task packs landed                                                                                  |
-| B-5   | NSV/SGDOP ensemble diversity               | High     | Spec only                                                                                                              |
-| B-6   | Domain-specific compliance QA (HLE analog) | Medium   | Spec only                                                                                                              |
+| Suite | Claim category                             | Priority | Status                                                                                                                                                                    |
+| ----- | ------------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| B-1   | Fine-tuning flywheel delta                 | Highest  | Spec only                                                                                                                                                                 |
+| B-2   | Multi-turn IDP pipeline                    | Highest  | Spec only                                                                                                                                                                 |
+| B-3   | Long-horizon codegraph (SWE-bench style)   | High     | Spec only — Phase 1 task packs landed                                                                                                                                     |
+| B-4   | Adversarial memory / conflict resolution   | High     | Spec only — Phase 1 task packs landed                                                                                                                                     |
+| B-5   | NSV/SGDOP ensemble diversity               | High     | Spec only                                                                                                                                                                 |
+| B-6   | Domain-specific compliance QA (HLE analog) | Medium   | Spec only                                                                                                                                                                 |
 | B-7   | Institutional knowledge (C&H / amortized)  | Highest  | B-7.1 **FAIL** (Qwen+DeepSeek; ClawQL OK) [31236859868](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31236859868); redesign before claim; B-7.2–7.4 next |
 
 ---
@@ -199,14 +199,14 @@ Harvey + EngramLab open-sourced **Calderwood & Harkness (C&H)** — a ~100M+ tok
 
 ### B-7.1 — Exhaustive feature enumeration
 
-| Field         | Value                                                                                                                                                  |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Product claim | ClawQL memory recall recovers more of the matching matter set than bare / no-memory; vault persistence is the Harvey-baseline delta                    |
-| Arms          | Phase-1: `clawql-on` + `clawql-off` + `clawql-no-memory` (tools without seeded vault)                                                                  |
-| Task IDs      | `institutional-knowledge-enumerate` (**offline pack landed**)                                                                                          |
-| Grader        | Partial credit `hits/5`; emit `MATTERS_FOUND: k/5`; reject false positives; require real `memory_recall` when `REQUIRE_INSTITUTIONAL=1`                |
-| Spend cap     | 30 turns / 240s / 8,000 tokens (single cell); B-7.3 adds first-task vs reuse asymmetry                                                                 |
-| Expected      | on mean matters_found ≫ off / no-memory; headline copy uses `k/5` not only mean score                                                                  |
+| Field         | Value                                                                                                                                                                                                                                                                                               |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Product claim | ClawQL memory recall recovers more of the matching matter set than bare / no-memory; vault persistence is the Harvey-baseline delta                                                                                                                                                                 |
+| Arms          | Phase-1: `clawql-on` + `clawql-off` + `clawql-no-memory` (tools without seeded vault)                                                                                                                                                                                                               |
+| Task IDs      | `institutional-knowledge-enumerate` (**offline pack landed**)                                                                                                                                                                                                                                       |
+| Grader        | Partial credit `hits/5`; emit `MATTERS_FOUND: k/5`; reject false positives; require real `memory_recall` when `REQUIRE_INSTITUTIONAL=1`                                                                                                                                                             |
+| Spend cap     | 30 turns / 240s / 8,000 tokens (single cell); B-7.3 adds first-task vs reuse asymmetry                                                                                                                                                                                                              |
+| Expected      | on mean matters_found ≫ off / no-memory; headline copy uses `k/5` not only mean score                                                                                                                                                                                                               |
 | Status        | **FAIL** — Qwen n=3 [31236859868](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31236859868) on 1.67 < off 3.33; DeepSeek n=3 [31230837116](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31230837116) same; n=1 WIN confounded. ClawQL recall OK; redesign fixture |
 
 **In-repo offline pack:** [`openbench/tasks/institutional-knowledge-enumerate/`](../../openbench/tasks/institutional-knowledge-enumerate/)
@@ -227,15 +227,15 @@ Mount Harvey/EngramLab open-sourced filesystem + short-form matter specs as grou
 
 ## Recommended sequencing
 
-| Phase       | What runs                                                                | Dependency                                                                                            |
-| ----------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
-| **1 (now)** | B-3.1, B-4.1, B-4.2, B-4.3 offline packs + live A/B when secrets present | Already on `main` infra                                                                               |
+| Phase       | What runs                                                                | Dependency                                                                                                                                |
+| ----------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **1 (now)** | B-3.1, B-4.1, B-4.2, B-4.3 offline packs + live A/B when secrets present | Already on `main` infra                                                                                                                   |
 | **1d**      | B-7.1 mini-firm enumerate live A/B                                       | **Done** FAIL (ClawQL ruled out) [31236859868](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31236859868) — redesign next |
-| **2**       | B-1.1, B-1.2                                                             | Fine-tune v1 in `tier-map.json`                                                                       |
-| **3**       | B-2.1–B-2.3                                                              | Post B-1; vendor-live IDP + provenance graders                                                        |
-| **4**       | B-6.1                                                                    | Fine-tune + vertical adapter + Onyx corpus                                                            |
-| **5**       | B-5.1–B-5.2                                                              | NSV/SGDOP instrumentation                                                                             |
-| **6**       | B-1.3, B-3.2, B-6.3, B-7.3–B-7.4                                         | Long-horizon / full C&H mount                                                                         |
+| **2**       | B-1.1, B-1.2                                                             | Fine-tune v1 in `tier-map.json`                                                                                                           |
+| **3**       | B-2.1–B-2.3                                                              | Post B-1; vendor-live IDP + provenance graders                                                                                            |
+| **4**       | B-6.1                                                                    | Fine-tune + vertical adapter + Onyx corpus                                                                                                |
+| **5**       | B-5.1–B-5.2                                                              | NSV/SGDOP instrumentation                                                                                                                 |
+| **6**       | B-1.3, B-3.2, B-6.3, B-7.3–B-7.4                                         | Long-horizon / full C&H mount                                                                                                             |
 
 ### What a full B-1.2 win would mean
 

--- a/docs/benchmarks/openbench-advanced-specs.md
+++ b/docs/benchmarks/openbench-advanced-specs.md
@@ -18,7 +18,7 @@ Related: [`openbench.md`](openbench.md) · [`openbench/README.md`](../../openben
 | B-4   | Adversarial memory / conflict resolution   | High     | Spec only — Phase 1 task packs landed                                                                                  |
 | B-5   | NSV/SGDOP ensemble diversity               | High     | Spec only                                                                                                              |
 | B-6   | Domain-specific compliance QA (HLE analog) | Medium   | Spec only                                                                                                              |
-| B-7   | Institutional knowledge (C&H / amortized)  | Highest  | B-7.1 **WIN** [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796); B-7.2–7.4 next |
+| B-7   | Institutional knowledge (C&H / amortized)  | Highest  | B-7.1 **FAIL** (Qwen+DeepSeek; ClawQL OK) [31236859868](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31236859868); redesign before claim; B-7.2–7.4 next |
 
 ---
 
@@ -207,7 +207,7 @@ Harvey + EngramLab open-sourced **Calderwood & Harkness (C&H)** — a ~100M+ tok
 | Grader        | Partial credit `hits/5`; emit `MATTERS_FOUND: k/5`; reject false positives; require real `memory_recall` when `REQUIRE_INSTITUTIONAL=1`                |
 | Spend cap     | 30 turns / 240s / 8,000 tokens (single cell); B-7.3 adds first-task vs reuse asymmetry                                                                 |
 | Expected      | on mean matters_found ≫ off / no-memory; headline copy uses `k/5` not only mean score                                                                  |
-| Status        | **WIN** three-arm [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796): on 5/5 / off 0/5 / no-memory 0/5 — retired |
+| Status        | **FAIL** — Qwen n=3 [31236859868](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31236859868) on 1.67 < off 3.33; DeepSeek n=3 [31230837116](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31230837116) same; n=1 WIN confounded. ClawQL recall OK; redesign fixture |
 
 **In-repo offline pack:** [`openbench/tasks/institutional-knowledge-enumerate/`](../../openbench/tasks/institutional-knowledge-enumerate/)
 
@@ -230,7 +230,7 @@ Mount Harvey/EngramLab open-sourced filesystem + short-form matter specs as grou
 | Phase       | What runs                                                                | Dependency                                                                                            |
 | ----------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
 | **1 (now)** | B-3.1, B-4.1, B-4.2, B-4.3 offline packs + live A/B when secrets present | Already on `main` infra                                                                               |
-| **1d**      | B-7.1 mini-firm enumerate live A/B                                       | **Done** WIN [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796) |
+| **1d**      | B-7.1 mini-firm enumerate live A/B                                       | **Done** FAIL (ClawQL ruled out) [31236859868](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31236859868) — redesign next |
 | **2**       | B-1.1, B-1.2                                                             | Fine-tune v1 in `tier-map.json`                                                                       |
 | **3**       | B-2.1–B-2.3                                                              | Post B-1; vendor-live IDP + provenance graders                                                        |
 | **4**       | B-6.1                                                                    | Fine-tune + vertical adapter + Onyx corpus                                                            |

--- a/docs/benchmarks/openbench-b7-calderwood.md
+++ b/docs/benchmarks/openbench-b7-calderwood.md
@@ -81,7 +81,7 @@ Shared OpenBench rules still apply: real `tool:clawql_*` evidence · hard spend 
 | B-7.3 | `institutional-amortized-session`   | Same vault; 5 related prompts; cost + completeness   | Spec only (needs session harness)      |
 | B-7.4 | Full C&H mount                      | Mount open-sourced filesystem + Harvey task set      | Blocked on stable corpus download path |
 
-Hardened n=3 [31230837116](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31230837116): on mean **2.67/5** < off mean **4/5** (gate FAIL). Prior n=1 [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796) was confounded (off had no seed files + early stop). Do not outreach a vault WIN until a fixture where exhaustive bare read fails.
+Hardened n=3 on DeepSeek [31230837116](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31230837116): on **2.67/5** < off **4/5** (gate FAIL) — recall returned 30/30; post-recall agent flakes. Re-burn on `pr_active` with **`openrouter/qwen/qwen3.6-plus`** (n=3) to rule out ClawQL memory. Prior n=1 [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796) was confounded.
 
 ### Phase-1 arms (B-7.1)
 

--- a/docs/benchmarks/openbench-b7-calderwood.md
+++ b/docs/benchmarks/openbench-b7-calderwood.md
@@ -81,7 +81,7 @@ Shared OpenBench rules still apply: real `tool:clawql_*` evidence · hard spend 
 | B-7.3 | `institutional-amortized-session`   | Same vault; 5 related prompts; cost + completeness   | Spec only (needs session harness)      |
 | B-7.4 | Full C&H mount                      | Mount open-sourced filesystem + Harvey task set      | Blocked on stable corpus download path |
 
-Hardened n=3 on DeepSeek [31230837116](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31230837116): on **2.67/5** < off **4/5** (gate FAIL) — recall returned 30/30; post-recall agent flakes. Re-burn on `pr_active` with **`openrouter/qwen/qwen3.6-plus`** (n=3) to rule out ClawQL memory. Prior n=1 [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796) was confounded.
+Qwen3.6-plus n=3 [31236859868](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31236859868): on **1.67/5** < off **3.33/5** — **ClawQL recall OK** (30/30); failures are agent follow-through + off file-read fixture. DeepSeek n=3 [31230837116](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31230837116) same pattern. Prior n=1 [31228280796](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31228280796) confounded.
 
 ### Phase-1 arms (B-7.1)
 

--- a/docs/benchmarks/openbench-results-ledger.md
+++ b/docs/benchmarks/openbench-results-ledger.md
@@ -1,4 +1,16 @@
-### 2026-08-08 — `institutional-knowledge-enumerate` (B-7.1) hardened n=3 — gate FAIL
+### 2026-08-08 — `institutional-knowledge-enumerate` (B-7.1) qwen3.6-plus n=3 — gate FAIL (ClawQL OK)
+
+Same hardened 30-note fixture; model **`openrouter/qwen/qwen3.6-plus`**.
+
+| Arm              | Matters / trial   | Mean matters | Mean score | Notes |
+| ---------------- | ----------------- | ------------ | ---------- | ----- |
+| clawql-on        | 0/5, 0/5*, 5/5    | **1.67/5**   | 0.333      | Recall returned 30/30 repeatedly; t1 thrashed writing seed files (no `matters.json`); t2 wrote artifact but empty `source` → grader 0; t3 clean 5/5 |
+| clawql-off       | 5/5, 0/5†, 5/5    | **3.33/5**   | 0.667      | Exhaustive file read still wins when it finishes; †`source=filesystem` rejected by grader |
+| clawql-no-memory | 0/5 ×3            | **0/5**      | 0.0        | Still no vault → no win |
+
+Run: [31236859868](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31236859868) (PR [#873](https://github.com/danielsmithdevelopment/ClawQL/pull/873)). **Gate FAIL.** **Verdict:** ClawQL memory is **not** the bottleneck (full recall confirmed on Qwen). Stronger model still flaky on post-recall agent steps; fixture still lets bare `read` compete. Clear `pr_active`; redesign cell before claims.
+
+### 2026-08-08 — `institutional-knowledge-enumerate` (B-7.1) DeepSeek hardened n=3 — gate FAIL
 
 Hardening: 30-note fixture (still 5 matches), stripped prompt IDs, off-arm seed restore + exhaustive nudge, caps 50/400s, `pr_trials=3`.
 

--- a/docs/benchmarks/openbench-results-ledger.md
+++ b/docs/benchmarks/openbench-results-ledger.md
@@ -2,11 +2,11 @@
 
 Same hardened 30-note fixture; model **`openrouter/qwen/qwen3.6-plus`**.
 
-| Arm              | Matters / trial   | Mean matters | Mean score | Notes |
-| ---------------- | ----------------- | ------------ | ---------- | ----- |
-| clawql-on        | 0/5, 0/5*, 5/5    | **1.67/5**   | 0.333      | Recall returned 30/30 repeatedly; t1 thrashed writing seed files (no `matters.json`); t2 wrote artifact but empty `source` → grader 0; t3 clean 5/5 |
-| clawql-off       | 5/5, 0/5†, 5/5    | **3.33/5**   | 0.667      | Exhaustive file read still wins when it finishes; †`source=filesystem` rejected by grader |
-| clawql-no-memory | 0/5 ×3            | **0/5**      | 0.0        | Still no vault → no win |
+| Arm              | Matters / trial | Mean matters | Mean score | Notes                                                                                                                                               |
+| ---------------- | --------------- | ------------ | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| clawql-on        | 0/5, 0/5*, 5/5  | **1.67/5**   | 0.333      | Recall returned 30/30 repeatedly; t1 thrashed writing seed files (no `matters.json`); t2 wrote artifact but empty `source` → grader 0; t3 clean 5/5 |
+| clawql-off       | 5/5, 0/5†, 5/5  | **3.33/5**   | 0.667      | Exhaustive file read still wins when it finishes; †`source=filesystem` rejected by grader                                                           |
+| clawql-no-memory | 0/5 ×3          | **0/5**      | 0.0        | Still no vault → no win                                                                                                                             |
 
 Run: [31236859868](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31236859868) (PR [#873](https://github.com/danielsmithdevelopment/ClawQL/pull/873)). **Gate FAIL.** **Verdict:** ClawQL memory is **not** the bottleneck (full recall confirmed on Qwen). Stronger model still flaky on post-recall agent steps; fixture still lets bare `read` compete. Clear `pr_active`; redesign cell before claims.
 

--- a/docs/benchmarks/openbench-stack-coverage.md
+++ b/docs/benchmarks/openbench-stack-coverage.md
@@ -182,7 +182,7 @@ Full breakdown (B-1 flywheel → B-7 institutional / C&H): [`openbench-advanced-
 
 ### Phase 1d — Institutional knowledge (Harvey C&H)
 
-23. **`institutional-knowledge-enumerate` (B-7.1)** — hardened n=3 [31230837116](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31230837116): on **2.67/5** < off **4/5** (gate FAIL). Pack kept; not a claim WIN.
+23. **`institutional-knowledge-enumerate` (B-7.1)** — qwen3.6-plus n=3 [31236859868](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31236859868): on **1.67/5** < off **3.33/5**; recall 30/30 — not a ClawQL memory bug. Pack kept; redesign needed.
 
 ### P3 — keep out of PR OpenBench (ops / cluster / paid SaaS)
 

--- a/openbench/ci-matrix.json
+++ b/openbench/ci-matrix.json
@@ -2,12 +2,14 @@
   "$schema_comment": "Controls which OpenBench tasks burn tokens on PR/push. Move a task from pr_active → retired when thoroughly verified (headline WIN + replication preferred). workflow_dispatch can still select any individual task, or all-including-retired.",
   "live_enabled": true,
   "live_pause_reason": "",
-  "live_resume_note": "Re-burning B-7.1 hardened fixture with openrouter/qwen/qwen3.6-plus (n=3) to rule out ClawQL memory after DeepSeek post-recall flakes. See docs/benchmarks/openbench-b7-calderwood.md.",
-  "pr_active": [
-    "institutional-knowledge-enumerate"
-  ],
-  "pr_trials": 3,
+  "live_resume_note": "B-7.1 qwen3.6-plus n=3 [31236859868]: on 1.67/5 < off 3.33/5 — ClawQL recall OK (30/30); agent/fixture still fail gate. Keep off pr_active.",
+  "pr_active": [],
+  "pr_trials": 1,
   "retired": {
+    "institutional-knowledge-enumerate": {
+      "reason": "Qwen3.6-plus n=3 31236859868: recall returns full vault; on mean 1.67/5 < off 3.33/5. Not ClawQL memory failure — agent follow-through + off file-read fixture. Redesign before re-activate.",
+      "evidence_run": "31236859868"
+    },
     "idp-safe-pipeline-lite": {
       "reason": "Verified WIN — stubbed 7-stage IDP orchestration (on 1.0 / off 0.0; RTP v1.1)",
       "evidence_run": "31039035892"

--- a/openbench/ci-matrix.json
+++ b/openbench/ci-matrix.json
@@ -2,14 +2,12 @@
   "$schema_comment": "Controls which OpenBench tasks burn tokens on PR/push. Move a task from pr_active → retired when thoroughly verified (headline WIN + replication preferred). workflow_dispatch can still select any individual task, or all-including-retired.",
   "live_enabled": true,
   "live_pause_reason": "",
-  "live_resume_note": "B-7.1 hardened n=3 [31230837116]: on mean 2.67/5 < off mean 4/5 — gate FAIL. Keep off pr_active; fixture hardening kept. See ledger + openbench-b7-calderwood.md.",
-  "pr_active": [],
-  "pr_trials": 1,
+  "live_resume_note": "Re-burning B-7.1 hardened fixture with openrouter/qwen/qwen3.6-plus (n=3) to rule out ClawQL memory after DeepSeek post-recall flakes. See docs/benchmarks/openbench-b7-calderwood.md.",
+  "pr_active": [
+    "institutional-knowledge-enumerate"
+  ],
+  "pr_trials": 3,
   "retired": {
-    "institutional-knowledge-enumerate": {
-      "reason": "Prior n=1 WIN 31228280796; hardened n=3 31230837116 showed on 2.67/5 < off 4/5 (off can exhaustively read 30 short notes) — not a headline WIN. Keep pack; redesign before re-activate.",
-      "evidence_run": "31230837116"
-    },
     "idp-safe-pipeline-lite": {
       "reason": "Verified WIN — stubbed 7-stage IDP orchestration (on 1.0 / off 0.0; RTP v1.1)",
       "evidence_run": "31039035892"

--- a/openbench/scripts/run-ab-compare.py
+++ b/openbench/scripts/run-ab-compare.py
@@ -716,11 +716,12 @@ INSTITUTIONAL_NUDGE = """Continue the institutional knowledge enumeration task (
 1. clawql_memory_recall across the vault (raise limit/maxDepth — there are many matter notes).
    Fields: CLAWQL_MATTER_ID / ESCROW_PCT / NONCOMPETE_MONTHS
 2. Keep ONLY matters with escrow_pct >= 10 AND noncompete_months > 18
-3. write relative filePath matters.json with the COMPLETE set (order free):
+3. write relative filePath **matters.json** only (never /tmp/matters.json) with the COMPLETE set:
    {"matters":["MAT-XXXX","MAT-YYYY"],"criteria":{"escrow_pct_min":10,"noncompete_months_gt":18},"source":"memory_recall","search_sufficiency":"how many notes you checked"}
 
 Do NOT copy placeholder IDs. Discover real IDs from recall. Partial lists fail.
 Near-misses (9% escrow, exactly 18 months NC, missing escrow) must not appear.
+After recall returns the vault notes, filter carefully — all matches must appear.
 Search exhaustively — do not stop after the first hits. Call memory_recall now.
 """
 

--- a/openbench/tasks/institutional-knowledge-enumerate/instruction.md
+++ b/openbench/tasks/institutional-knowledge-enumerate/instruction.md
@@ -25,7 +25,8 @@ List **every** matter that has **both**:
    - `CLAWQL_NONCOMPETE_MONTHS=…`
 3. Apply the filters above. Near-misses (e.g. 9% escrow, exactly 18 months NC,
    missing escrow) must **not** appear in the answer.
-4. Write relative path `matters.json` with the **complete** matching set (order free).
+4. Write **relative** path `matters.json` (exactly that name — not `/tmp/…` or an
+   absolute path) with the **complete** matching set (order free).
 
 ## Artifact
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Re-ran hardened B-7.1 (`institutional-knowledge-enumerate`) on **`openrouter/qwen/qwen3.6-plus`** (n=3, three arms) to rule out ClawQL as the failure mode after DeepSeek n=3 FAIL.

## Results — [31236859868](https://github.com/danielsmithdevelopment/ClawQL/actions/runs/31236859868)

| Arm | Matters / trial | Mean |
|-----|-----------------|------|
| clawql-on | 0/5, 0/5*, 5/5 | **1.67/5** |
| clawql-off | 5/5, 0/5†, 5/5 | **3.33/5** |
| clawql-no-memory | 0×3 | **0/5** |

\* empty `source` → grader 0 · † `source=filesystem` rejected

**Gate FAIL** (on ≤ off). **Verdict: ClawQL is not the problem** — full 30-note `memory_recall` on Qwen and DeepSeek. Failures are post-recall agent path + off linear file-read of the mini-firm.

## This PR

- Workflow override: B-7.1 → Qwen3.6-Plus + 400s + three arms
- Retire `institutional-knowledge-enumerate` from `pr_active` with evidence
- Ledger / stack / B-7 / advanced-specs updated (clear stale confounded WIN claims)

## Not in this PR

Fixture redesign (non-linear-readable corpus, source grading, on-arm scaffolding) — next cell before Harvey outreach.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

