### PR TITLE
fix: OpenRouter key limit ≠ account credits; re-arm B-7.1 fair burn

### DIFF
--- a/.github/workflows/openbench-ab.yml
+++ b/.github/workflows/openbench-ab.yml
@@ -344,9 +344,9 @@ jobs:
               echo "OPENBENCH_TIMEOUT_S=180"
             fi
             if [ "${{ matrix.task }}" = "institutional-knowledge-enumerate" ]; then
-              # Fair same-files cell. Off first so a provider credit failure on-arm
-              # cannot skip the filesystem baseline. DeepSeek until OpenRouter
-              # Sonnet key limit is raised (403 on prior Sonnet burns).
+              # Fair same-files cell. Off first so a provider budget failure on-arm
+              # cannot skip the filesystem baseline. DeepSeek until the CI key's
+              # per-key spend cap is raised (403 Key limit exceeded ≠ account $).
               echo "OPENBENCH_TIMEOUT_S=480"
               echo "OPENBENCH_MODEL=openrouter/deepseek/deepseek-chat"
               if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -395,6 +395,28 @@ jobs:
             reason="Add OPENROUTER_API_KEY or a vendor BYOK secret."
           fi
 
+          # OpenRouter: account balance ≠ per-key spend cap. Probe GET /api/v1/key
+          # and fail fast when limit_remaining is exhausted (no secret leak).
+          or_key_note=""
+          if [ "$run_benchmark" = true ] && [[ "$MODEL" == openrouter/* ]] && [ -n "${OPENROUTER_API_KEY:-}" ]; then
+            key_json="$(curl -fsS --max-time 20 \
+              -H "Authorization: Bearer ${OPENROUTER_API_KEY}" \
+              https://openrouter.ai/api/v1/key)" || {
+              run_benchmark=false
+              reason="OPENROUTER_API_KEY present but GET https://openrouter.ai/api/v1/key failed (network/auth)."
+              key_json=""
+            }
+            if [ -n "${key_json}" ]; then
+              eval "$(printf '%s' "$key_json" | python3 openbench/scripts/openrouter-key-preflight.py)"
+              or_key_note="OpenRouter key label='${OR_LABEL}' limit=\$${OR_LIMIT} remaining=\$${OR_REMAINING} usage=\$${OR_USAGE} reset=${OR_RESET}"
+              echo "::notice::${or_key_note}"
+              if [ "${OR_EXHAUSTED}" = "1" ]; then
+                run_benchmark=false
+                reason="OpenRouter per-key spend limit exhausted (limit_remaining=\$${OR_REMAINING}, key limit=\$${OR_LIMIT}). Account credits are separate — raise/remove this key's limit at https://openrouter.ai/settings/keys or rotate OPENROUTER_API_KEY to an uncapped key."
+              fi
+            fi
+          fi
+
           echo "run_benchmark=${run_benchmark}" >> "$GITHUB_OUTPUT"
           {
             echo "## OpenBench credential preflight"
@@ -406,10 +428,15 @@ jobs:
             echo "- Trials/arm: \`${OPENBENCH_TRIALS}\`"
             echo "- Run live benchmark: \`${run_benchmark}\`"
             echo "- Note: ${reason}"
+            if [ -n "${or_key_note}" ]; then
+              echo "- OpenRouter key: ${or_key_note}"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [ "$run_benchmark" != "true" ]; then
-            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Key-limit / auth failures must fail CI (not silent skip) so we do not
+            # misread empty matrices as green A/B results.
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [[ "${reason}" == *"per-key spend limit"* ]] || [[ "${reason}" == *"GET https://openrouter.ai/api/v1/key failed"* ]]; then
               echo "::error::${reason}"
               exit 1
             fi

--- a/openbench/ci-matrix.json
+++ b/openbench/ci-matrix.json
@@ -2,9 +2,11 @@
   "$schema_comment": "Controls which OpenBench tasks burn tokens on PR/push. Move a task from pr_active \u2192 retired when thoroughly verified (headline WIN + replication preferred). workflow_dispatch can still select any individual task, or all-including-retired.",
   "live_enabled": true,
   "live_pause_reason": "",
-  "live_resume_note": "B-7.1 fair same-files harness landed (PR #875). Burns blocked: OpenRouter key limit/credits (Sonnet 403 @ 31241200178; DeepSeek 402 @ 31242620062). Top up OPENROUTER_API_KEY then re-activate pr_active.",
-  "pr_active": [],
-  "pr_trials": 1,
+  "live_resume_note": "B-7.1 fair same-files on main (#875). Prior abort was OpenRouter per-key spend cap (403 Key limit exceeded on CI key …c145e2f7), not account balance. Raise that key's limit, then this pr_active burn runs (DeepSeek, off→on→no-memory, n=3).",
+  "pr_active": [
+    "institutional-knowledge-enumerate"
+  ],
+  "pr_trials": 3,
   "retired": {
     "idp-safe-pipeline-lite": {
       "reason": "Verified WIN \u2014 stubbed 7-stage IDP orchestration (on 1.0 / off 0.0; RTP v1.1)",
@@ -113,10 +115,6 @@
     "memory-recall-pageindex-pin": {
       "reason": "Verified WIN \u2014 memory_recall(sources=[pageindex]) after build_tree (on 1.0 / off 0.0)",
       "evidence_run": "31189112838"
-    },
-    "institutional-knowledge-enumerate": {
-      "reason": "Fair same-files harness on main via #875; live A/B blocked on OpenRouter credits. Re-activate after top-up.",
-      "evidence_run": "31242620062"
     }
   },
   "ouroboros_pr_enabled": false,

--- a/openbench/scripts/openrouter-key-preflight.py
+++ b/openbench/scripts/openrouter-key-preflight.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Parse OpenRouter GET /api/v1/key JSON from stdin; emit shell-safe KEY=value lines.
+
+Never prints the API key. Distinguishes per-key spend caps (limit / limit_remaining)
+from account balance — see https://openrouter.ai/docs/api/reference/limits
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def esc(s: str) -> str:
+    return (
+        s.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("$", "\\$")
+        .replace("`", "\\`")
+    )
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        print(f"OR_PARSE_ERROR=\"{esc(str(exc))}\"", file=sys.stderr)
+        return 2
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, dict):
+        print('OR_PARSE_ERROR="missing data object"', file=sys.stderr)
+        return 2
+
+    label = str(data.get("label") or "")
+    limit = data.get("limit")
+    remaining = data.get("limit_remaining")
+    usage = data.get("usage")
+    reset = data.get("limit_reset")
+
+    print(f'OR_LABEL="{esc(label)}"')
+    print(f'OR_LIMIT="{limit if limit is not None else "unlimited"}"')
+    print(f'OR_REMAINING="{remaining if remaining is not None else "unlimited"}"')
+    print(f'OR_USAGE="{usage if usage is not None else "n/a"}"')
+    print(f'OR_RESET="{reset if reset is not None else "n/a"}"')
+    # Exhausted only when a numeric remaining is present and <= 0.
+    # null remaining means unlimited (no per-key cap).
+    exhausted = isinstance(remaining, (int, float)) and float(remaining) <= 0
+    print(f"OR_EXHAUSTED={'1' if exhausted else '0'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/openbench/scripts/run-ab-compare.py
+++ b/openbench/scripts/run-ab-compare.py
@@ -1245,6 +1245,23 @@ def credit_exhausted(agent: dict) -> bool:
     )
 
 
+def provider_budget_abort_reason(agent: dict, arm: str) -> str:
+    """Human message for credit_exhausted aborts — distinguish key cap vs account balance."""
+    blob = (agent.get("output_tail") or "") + (agent.get("error") or "")
+    if "Key limit exceeded" in blob or "key limit exceeded" in blob:
+        return (
+            f"OpenRouter per-key spend limit hit on {arm} "
+            f"(HTTP 403 Key limit exceeded — not the same as account balance). "
+            f"Raise or remove the limit on the GitHub secret OPENROUTER_API_KEY "
+            f"at https://openrouter.ai/settings/keys (or rotate the secret to a key "
+            f"with a higher/unlimited cap), then re-run. Account credits alone do not clear this."
+        )
+    return (
+        f"provider credits exhausted on {arm} (HTTP 402 / openrouter_credits / affordability). "
+        f"Top up the OpenRouter account balance for OPENROUTER_API_KEY (or use BYOK) before re-running."
+    )
+
+
 def _dec_timeout_output(exc) -> str:
     def _dec(x):
         if x is None:
@@ -3682,10 +3699,7 @@ def main(argv=None) -> int:
             if credit_exhausted(ag):
                 abort_all = True
                 skip_remaining = True
-                abort_reason = (
-                    f"provider credits exhausted on {arm} (HTTP 402 / openrouter_credits). "
-                    "Top up OPENROUTER_API_KEY (or use BYOK) before re-running."
-                )
+                abort_reason = provider_budget_abort_reason(ag, arm)
                 skip_reason = abort_reason
                 print(f"    !! {abort_reason} — aborting remaining arms/trials", flush=True)
                 continue


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
You're right that ~$14 account credits does not mean CI can call OpenRouter.

## What actually failed

Fair B-7.1 burns aborted with:

```text
Key limit exceeded (total limit)
```

on the GitHub secret `OPENROUTER_API_KEY` (hash ending `…c145e2f7`). That is OpenRouter's **per-key spend cap**, not the workspace/account balance. Raising account credits alone does not clear it.

## Fix in this PR

1. **Abort copy** in `run-ab-compare.py` — distinguish key-cap (403 Key limit exceeded) from account/affordability (402).
2. **Credential preflight** — `GET https://openrouter.ai/api/v1/key`, print `limit` / `limit_remaining` / `usage` (no secret leak), fail fast when `limit_remaining <= 0`.
3. **Re-activate** `institutional-knowledge-enumerate` on `pr_active` with `pr_trials: 3` (DeepSeek, fair same-files, off → on → no-memory).

## Operator action required

At [OpenRouter Keys](https://openrouter.ai/settings/keys), raise or remove the spend limit on the CI key (or rotate `OPENROUTER_API_KEY` to an uncapped key). Then merge/reburn — preflight will show remaining headroom.

Until the key cap is raised, this PR's live A/B should fail at preflight with an explicit key-limit error (preferred over burning a partial trial and saying "no credits").

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

