### PR TITLE
fix: Pattern G NameError (import re) — do not merge until 26–50 finishes

### DIFF
--- a/.github/workflows/harvey-lab-firm-knowledge.yml
+++ b/.github/workflows/harvey-lab-firm-knowledge.yml
@@ -140,7 +140,7 @@ jobs:
           TASK_LIMIT=1
           SWEEP_INCLUDE_JSON=""
           if [ -f integrations/harvey-labs/.skip-lab-matrix ]; then
-            echo "::notice::.skip-lab-matrix present — dummy outputs only; gate sets can_run=false"
+            echo "::notice::.skip-lab-matrix present — dummy outputs only; gate sets can_run=false (force cancel)"
             ARMS_CSV="nemotron"
             TASK="firm-knowledge/tasks/001"
             TASK_LIMIT=1

--- a/integrations/harvey-labs/.run-nemotron-sweep
+++ b/integrations/harvey-labs/.run-nemotron-sweep
@@ -1,7 +1,7 @@
-# Pattern G / document-inventory theory test — clawql-only 026–050.
-# Baseline already scored this range; do not re-run nemotron arm.
-# Agent: nvidia/nemotron-3.5-lightning (OpenRouter)
-# Judge: claude-sonnet-4-6 (GHA default for nemotron-sweep marker)
-# 25 cells
-# After this matrix completes, re-arm nemotron-clawql 1-25 for regression.
-nemotron-clawql 26-50
+# Fix-only branch — do NOT arm a sweep here.
+# Live 026–050 theory test is on cursor/harvey-lab-inventory-sweep-4ff0
+# (run 32329764178). Pushing a 26-50 marker on this branch would start a
+# second matrix and burn OpenRouter quota.
+#
+# After 32329764178 finishes, overlay this import-re fix onto the sweep
+# branch and resume failed cells only.

--- a/integrations/harvey-labs/.skip-lab-matrix
+++ b/integrations/harvey-labs/.skip-lab-matrix
@@ -1,0 +1,1 @@
+Stop token burn — do not run live LAB cells.

--- a/integrations/harvey-labs/harness/clawql_agent_loop.py
+++ b/integrations/harvey-labs/harness/clawql_agent_loop.py
@@ -255,6 +255,9 @@ _CLAWQL_REQUIRE_PATTERN_G = (
 
 def _clawql_prompt_needs_pattern_g(messages: list) -> bool:
     # Detect CM / Restructuring / lock-up / DIP / withdrawn offering asks.
+    # Local import: injected into harvey-labs agent_loop.py which may not import re.
+    import re
+
     blob = " ".join(
         str(getattr(m, "content", m) if not isinstance(m, dict) else m.get("content", ""))
         for m in (messages or [])

--- a/integrations/harvey-labs/tests/test_deliverable_guard.py
+++ b/integrations/harvey-labs/tests/test_deliverable_guard.py
@@ -178,6 +178,23 @@ class DeliverableGuardPatchTests(unittest.TestCase):
             os.environ["CLAWQL_LAB_MAX_TOOL_RESULT_CHARS"] = "100"
             self.assertEqual(ns["_clawql_max_tool_result_chars"](), 4000)
 
+    def test_pattern_g_detector_imports_re_in_host_agent_loop(self) -> None:
+        """Host harvey-labs agent_loop.py does not import re; Pattern G must.
+
+        GHA 026/028 (run 32329764178) crashed:
+        NameError: name 're' is not defined in _clawql_prompt_needs_pattern_g.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "agent_loop.py"
+            path.write_text(STOCK_LOOP, encoding="utf-8")
+            patch_agent_loop_deliverable_guard(path)
+            ns = _exec_helpers(path.read_text(encoding="utf-8"))
+            self.assertNotIn("re", ns)
+            dip = [{"role": "user", "content": "Which DIP financing matters have we closed?"}]
+            self.assertTrue(ns["_clawql_prompt_needs_pattern_g"](dip))
+            generic = [{"role": "user", "content": "List HSR second request matters."}]
+            self.assertFalse(ns["_clawql_prompt_needs_pattern_g"](generic))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Do not merge while run 32329764178 is in progress

`cancel-in-progress` on this base would kill the live 026–050 matrix.

## Cause

LAB cells **026** and **028** failed after a successful DuckDB ingest:

```
NameError: name 're' is not defined
  File ".../harness/agent_loop.py", in _clawql_prompt_needs_pattern_g
    re.search(...)
```

Turn-1 require-recall injects `_clawql_prompt_needs_pattern_g` into harvey-labs `agent_loop.py`, which does not import `re`. `_clawql_infer_task_kind` already did a local `import re`; Pattern G did not. Every task whose prompt matches lock-up / CM / DIP / withdrawn / offering will crash before the first model turn.

## Fix

Local `import re` inside the injected Pattern G detector, plus a unit test that execs the helper namespace **without** `re` on the module.

Sweep marker on this branch is **disarmed** so opening the PR does not start a second 26–50 matrix.

## After 32329764178 finishes

Merge this (or cherry-pick `a2c748cc`) onto `cursor/harvey-lab-inventory-sweep-4ff0` and resume **failed cells only**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

