### PR TITLE
Make clawql-data Effect-native (sandbox pattern)

### DIFF
--- a/docs/plugins/data.md
+++ b/docs/plugins/data.md
@@ -14,7 +14,9 @@ next: ouroboros
 **Plugin ID:** `clawql-data`  
 **Package:** `packages/clawql-data` — `DataPlugin`
 
-Structured SQL via **pluggable data engine plugins** (`CLAWQL_DATA_ENGINE`, default `duckdb`). Effect-TS services in `packages/clawql-data`.
+Structured SQL via **pluggable data engine plugins** (`CLAWQL_DATA_ENGINE`, default `duckdb`).
+
+**Effect-TS interior:** driver / inventory IO → `DataEnginePlugin` (`Effect.gen`) → `DataEngineService` Layer → `data_*Program` / `runDataEffect`. Promise facades remain only at MCP handlers and `ClawqlDataStore` (lab CLIs).
 
 ## MCP tools
 

--- a/packages/clawql-data/README.md
+++ b/packages/clawql-data/README.md
@@ -4,7 +4,8 @@ Structured data MCP tools (`data_query`, `data_ingest`, `data_status`) behind **
 
 ## Architecture
 
-- **Effect-TS** services (`src/effect/`) — same pattern as `clawql-sandbox`
+- **Effect-TS interior** (`src/effect/`, Effect-native `DataEnginePlugin`) — same pattern as `clawql-sandbox`
+- Promise edges: MCP `runDataEffect` + `ClawqlDataStore` for lab CLIs
 - **Engine plugins** (`src/engines/`) — register via `registerDataEngine(id, factory)`; select with **`CLAWQL_DATA_ENGINE`**
 - **`duckdb`** — first shipped engine plugin (`@duckdb/node-api`)
 

--- a/packages/clawql-data/src/effect/data-effect-runtime.ts
+++ b/packages/clawql-data/src/effect/data-effect-runtime.ts
@@ -5,7 +5,9 @@ import type { DataQueryResult, DataStatus, IngestPayload, IngestResult } from ".
 
 export type DataServices = DataEngineService;
 
-export function dataServicesLiveLayer(env: NodeJS.ProcessEnv = process.env): Layer.Layer<DataServices> {
+export function dataServicesLiveLayer(
+  env: NodeJS.ProcessEnv = process.env
+): Layer.Layer<DataServices> {
   return dataEngineLiveLayer(env);
 }
 
@@ -20,19 +22,25 @@ export async function runDataEffect<A>(
   program: Effect.Effect<A, DataError | unknown, DataServices>,
   env?: NodeJS.ProcessEnv
 ): Promise<A> {
-  const exit = await Effect.runPromiseExit(program.pipe(Effect.provide(dataServicesLiveLayer(env))));
+  const exit = await Effect.runPromiseExit(
+    program.pipe(Effect.provide(dataServicesLiveLayer(env)))
+  );
   if (Exit.isSuccess(exit)) return exit.value;
   throwDataFailure(exit.cause);
 }
 
-export function dataQueryProgram(sql: string): Effect.Effect<DataQueryResult, DataError, DataServices> {
+export function dataQueryProgram(
+  sql: string
+): Effect.Effect<DataQueryResult, DataError, DataServices> {
   return Effect.gen(function* () {
     const svc = yield* DataEngineService;
     return yield* svc.query(sql);
   });
 }
 
-export function dataIngestProgram(payload: IngestPayload): Effect.Effect<IngestResult, DataError, DataServices> {
+export function dataIngestProgram(
+  payload: IngestPayload
+): Effect.Effect<IngestResult, DataError, DataServices> {
   return Effect.gen(function* () {
     const svc = yield* DataEngineService;
     return yield* svc.ingest(payload);

--- a/packages/clawql-data/src/effect/data-effect-runtime.ts
+++ b/packages/clawql-data/src/effect/data-effect-runtime.ts
@@ -1,5 +1,6 @@
 import { Cause, Effect, Exit, Layer } from "effect";
 import { DataEngineService, dataEngineLiveLayer } from "./data-engine-service.js";
+import type { DataError } from "./data-errors.js";
 import type { DataQueryResult, DataStatus, IngestPayload, IngestResult } from "../engines/types.js";
 
 export type DataServices = DataEngineService;
@@ -9,30 +10,36 @@ export function dataServicesLiveLayer(env: NodeJS.ProcessEnv = process.env): Lay
 }
 
 function throwDataFailure(cause: Cause.Cause<unknown>): never {
-  throw Cause.squash(cause);
+  const squashed = Cause.squash(cause);
+  if (squashed instanceof Error) throw squashed;
+  throw new Error(typeof squashed === "string" ? squashed : Cause.pretty(cause));
 }
 
-export async function runDataEffect<A>(program: Effect.Effect<A, unknown, DataServices>, env?: NodeJS.ProcessEnv): Promise<A> {
+/** Promise edge for MCP handlers / CLIs — runs Effect programs against the live data layer. */
+export async function runDataEffect<A>(
+  program: Effect.Effect<A, DataError | unknown, DataServices>,
+  env?: NodeJS.ProcessEnv
+): Promise<A> {
   const exit = await Effect.runPromiseExit(program.pipe(Effect.provide(dataServicesLiveLayer(env))));
   if (Exit.isSuccess(exit)) return exit.value;
   throwDataFailure(exit.cause);
 }
 
-export function dataQueryProgram(sql: string): Effect.Effect<DataQueryResult, unknown, DataServices> {
+export function dataQueryProgram(sql: string): Effect.Effect<DataQueryResult, DataError, DataServices> {
   return Effect.gen(function* () {
     const svc = yield* DataEngineService;
     return yield* svc.query(sql);
   });
 }
 
-export function dataIngestProgram(payload: IngestPayload): Effect.Effect<IngestResult, unknown, DataServices> {
+export function dataIngestProgram(payload: IngestPayload): Effect.Effect<IngestResult, DataError, DataServices> {
   return Effect.gen(function* () {
     const svc = yield* DataEngineService;
     return yield* svc.ingest(payload);
   });
 }
 
-export function dataStatusProgram(): Effect.Effect<DataStatus, unknown, DataServices> {
+export function dataStatusProgram(): Effect.Effect<DataStatus, never, DataServices> {
   return Effect.gen(function* () {
     const svc = yield* DataEngineService;
     return svc.status();

--- a/packages/clawql-data/src/effect/data-effect-utils.ts
+++ b/packages/clawql-data/src/effect/data-effect-utils.ts
@@ -1,9 +1,26 @@
 import { Effect } from "effect";
+import { DataError } from "./data-errors.js";
 
-/** Lift Promise IO into Effect (errors become defects at MCP boundary). */
-export function dataFromPromise<A>(fn: () => Promise<A>): Effect.Effect<A, never> {
+/** Lift a Promise into Effect with {@link DataError} on failure. */
+export function dataFromPromise<A>(tryFn: () => Promise<A>): Effect.Effect<A, DataError> {
   return Effect.tryPromise({
-    try: fn,
-    catch: (cause) => cause,
-  }).pipe(Effect.catchAll((cause) => Effect.die(cause)));
+    try: tryFn,
+    catch: (cause) =>
+      new DataError({
+        reason: "data async operation failed",
+        cause,
+      }),
+  });
+}
+
+/** Lift sync work that may throw into Effect with {@link DataError}. */
+export function dataFromSync<A>(tryFn: () => A): Effect.Effect<A, DataError> {
+  return Effect.try({
+    try: tryFn,
+    catch: (cause) =>
+      new DataError({
+        reason: "data sync operation failed",
+        cause,
+      }),
+  });
 }

--- a/packages/clawql-data/src/effect/data-effect.test.ts
+++ b/packages/clawql-data/src/effect/data-effect.test.ts
@@ -1,0 +1,62 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect } from "effect";
+import { afterEach, describe, expect, it } from "vitest";
+import "../engines/duckdb/index.js";
+import {
+  dataIngestProgram,
+  dataQueryProgram,
+  dataServicesLiveLayer,
+  DataError,
+  runDataEffect,
+} from "./index.js";
+import { resetClawqlDataStoreForTests } from "../store.js";
+
+describe("clawql-data Effect pipeline", () => {
+  afterEach(async () => {
+    await resetClawqlDataStoreForTests();
+  });
+
+  it("ingest + query via Effect.gen programs", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "clawql-data-effect-"));
+    const env = {
+      CLAWQL_DATA_PATH: join(dir, "matters.duckdb"),
+      CLAWQL_DATA_ENGINE: "duckdb",
+    };
+
+    const ingest = await runDataEffect(
+      dataIngestProgram({
+        replace: true,
+        matters: [
+          {
+            matter_id: "1005-00001",
+            practice_area: "Banking & Finance",
+            matter_type: "Credit Facility",
+            is_credit_facility: true,
+          },
+        ],
+      }),
+      env
+    );
+    expect(ingest.ok).toBe(true);
+    expect(ingest.matterCount).toBe(1);
+
+    const out = await runDataEffect(
+      dataQueryProgram("SELECT matter_id FROM matters WHERE is_credit_facility ORDER BY matter_id"),
+      env
+    );
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.rows).toEqual([{ matter_id: "1005-00001" }]);
+  });
+
+  it("maps Promise failures to DataError (not die)", async () => {
+    const program = Effect.gen(function* () {
+      return yield* Effect.fail(new DataError({ reason: "boom", cause: new Error("x") }));
+    }).pipe(Effect.provide(dataServicesLiveLayer({ CLAWQL_DATA_ENGINE: "duckdb" })));
+
+    const exit = await Effect.runPromiseExit(program);
+    expect(exit._tag).toBe("Failure");
+  });
+});

--- a/packages/clawql-data/src/effect/data-engine-service.ts
+++ b/packages/clawql-data/src/effect/data-engine-service.ts
@@ -17,7 +17,9 @@ export class DataEngineService extends Context.Tag("clawql/DataEngineService")<
   }
 >() {}
 
-export function dataEngineLiveLayer(env: NodeJS.ProcessEnv = process.env): Layer.Layer<DataEngineService> {
+export function dataEngineLiveLayer(
+  env: NodeJS.ProcessEnv = process.env
+): Layer.Layer<DataEngineService> {
   const plugin = resolveDataEnginePlugin(env);
   return Layer.succeed(
     DataEngineService,

--- a/packages/clawql-data/src/effect/data-engine-service.ts
+++ b/packages/clawql-data/src/effect/data-engine-service.ts
@@ -3,17 +3,17 @@ import type { DataEnginePlugin } from "../engines/types.js";
 import { resolveDataEnginePlugin } from "../engines/registry.js";
 import "../engines/duckdb/index.js";
 import type { DataQueryResult, DataStatus, IngestPayload, IngestResult } from "../engines/types.js";
-import { dataFromPromise } from "./data-effect-utils.js";
+import type { DataError } from "./data-errors.js";
 
-/** Effect service: active {@link DataEnginePlugin} from registry. */
+/** Effect service: active {@link DataEnginePlugin} from registry (Effect-native). */
 export class DataEngineService extends Context.Tag("clawql/DataEngineService")<
   DataEngineService,
   {
     readonly engine: () => DataEnginePlugin;
-    readonly query: (sql: string) => Effect.Effect<DataQueryResult, never>;
-    readonly ingest: (payload: IngestPayload) => Effect.Effect<IngestResult, never>;
+    readonly query: (sql: string) => Effect.Effect<DataQueryResult, DataError>;
+    readonly ingest: (payload: IngestPayload) => Effect.Effect<IngestResult, DataError>;
     readonly status: () => DataStatus;
-    readonly close: () => Effect.Effect<void, never>;
+    readonly close: () => Effect.Effect<void, DataError>;
   }
 >() {}
 
@@ -23,10 +23,10 @@ export function dataEngineLiveLayer(env: NodeJS.ProcessEnv = process.env): Layer
     DataEngineService,
     DataEngineService.of({
       engine: () => plugin,
-      query: (sql) => dataFromPromise(() => plugin.query(sql)),
-      ingest: (payload) => dataFromPromise(() => plugin.ingest(payload)),
+      query: (sql) => plugin.query(sql),
+      ingest: (payload) => plugin.ingest(payload),
       status: () => plugin.status(),
-      close: () => dataFromPromise(() => plugin.close()),
+      close: () => plugin.close(),
     })
   );
 }

--- a/packages/clawql-data/src/effect/data-errors.ts
+++ b/packages/clawql-data/src/effect/data-errors.ts
@@ -1,6 +1,7 @@
 import { Data } from "effect";
 
+/** Unexpected failure in a clawql-data Effect pipeline. */
 export class DataError extends Data.TaggedError("DataError")<{
-  readonly message: string;
+  readonly reason: string;
   readonly cause?: unknown;
 }> {}

--- a/packages/clawql-data/src/effect/index.ts
+++ b/packages/clawql-data/src/effect/index.ts
@@ -1,4 +1,5 @@
 export { DataError } from "./data-errors.js";
+export { dataFromPromise, dataFromSync } from "./data-effect-utils.js";
 export { DataEngineService, dataEngineLiveLayer } from "./data-engine-service.js";
 export {
   dataQueryProgram,

--- a/packages/clawql-data/src/engines/duckdb/duckdb-driver.ts
+++ b/packages/clawql-data/src/engines/duckdb/duckdb-driver.ts
@@ -1,7 +1,10 @@
-/** DuckDB driver (`@duckdb/node-api`) — implementation detail of the `duckdb` engine plugin. */
+/** DuckDB driver (`@duckdb/node-api`) — Promise IO + Effect wrappers. */
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { DuckDBConnection, DuckDBInstance, type DuckDBValue } from "@duckdb/node-api";
+import type { Effect } from "effect";
+import { dataFromPromise, dataFromSync } from "../../effect/data-effect-utils.js";
+import type { DataError } from "../../effect/data-errors.js";
 import type { DataQueryOk } from "../types.js";
 
 export const DUCKDB_QUERY_HINT =
@@ -43,6 +46,10 @@ export async function openDuckDb(path: string): Promise<DuckDbHandle> {
   return { path, instance, connection };
 }
 
+export function openDuckDbEffect(path: string): Effect.Effect<DuckDbHandle, DataError> {
+  return dataFromPromise(() => openDuckDb(path));
+}
+
 export async function runSql(
   handle: DuckDbHandle,
   sql: string,
@@ -53,6 +60,14 @@ export async function runSql(
     return;
   }
   await handle.connection.run(sql);
+}
+
+export function runSqlEffect(
+  handle: DuckDbHandle,
+  sql: string,
+  params?: readonly unknown[]
+): Effect.Effect<void, DataError> {
+  return dataFromPromise(() => runSql(handle, sql, params));
 }
 
 function serializeCell(value: unknown, maxChars: number): unknown {
@@ -107,6 +122,14 @@ export async function queryDuckDb(
   };
 }
 
+export function queryDuckDbEffect(
+  handle: DuckDbHandle,
+  sql: string,
+  options: { maxRows?: number; maxChars?: number } = {}
+): Effect.Effect<DataQueryOk, DataError> {
+  return dataFromPromise(() => queryDuckDb(handle, sql, options));
+}
+
 export async function closeDuckDb(handle: DuckDbHandle): Promise<void> {
   try {
     handle.connection.closeSync();
@@ -118,4 +141,19 @@ export async function closeDuckDb(handle: DuckDbHandle): Promise<void> {
   } catch {
     /* already closed */
   }
+}
+
+export function closeDuckDbEffect(handle: DuckDbHandle): Effect.Effect<void, DataError> {
+  return dataFromSync(() => {
+    try {
+      handle.connection.closeSync();
+    } catch {
+      /* already closed */
+    }
+    try {
+      handle.instance.closeSync();
+    } catch {
+      /* already closed */
+    }
+  });
 }

--- a/packages/clawql-data/src/engines/duckdb/duckdb-engine-plugin.ts
+++ b/packages/clawql-data/src/engines/duckdb/duckdb-engine-plugin.ts
@@ -11,7 +11,12 @@ import {
   extractKeyTermsFromText,
   inferDocType,
 } from "../../inventory.js";
-import { CREATE_LAB_SCHEMA_SQL, CREATE_LAB_VIEW_SQL, DROP_LAB_SCHEMA_SQL, MATTER_COLUMNS } from "../../schema.js";
+import {
+  CREATE_LAB_SCHEMA_SQL,
+  CREATE_LAB_VIEW_SQL,
+  DROP_LAB_SCHEMA_SQL,
+  MATTER_COLUMNS,
+} from "../../schema.js";
 import { validateReadonlySelect } from "../../sql-guard.js";
 import type {
   DataEnginePlugin,
@@ -133,7 +138,10 @@ function matterValues(row: Record<string, unknown>): unknown[] {
   });
 }
 
-function collectOpenFacts(matters: readonly Record<string, unknown>[], extra?: readonly OpenFactRow[]): OpenFactRow[] {
+function collectOpenFacts(
+  matters: readonly Record<string, unknown>[],
+  extra?: readonly OpenFactRow[]
+): OpenFactRow[] {
   const out: OpenFactRow[] = [...(extra ?? [])];
   for (const row of matters) {
     const mid = str(row.matter_id);
@@ -159,7 +167,10 @@ function collectDocuments(
     if (!Array.isArray(docs)) continue;
     for (const d of docs) {
       if (!d || typeof d !== "object") continue;
-      out.push({ ...(d as Record<string, unknown>), matter_id: (d as { matter_id?: string }).matter_id || mid });
+      out.push({
+        ...(d as Record<string, unknown>),
+        matter_id: (d as { matter_id?: string }).matter_id || mid,
+      });
     }
   }
   return out;
@@ -168,14 +179,26 @@ function collectDocuments(
 function documentInsert(d: Record<string, unknown>): unknown[] {
   const rel = str(d.rel_path);
   const filename = str(d.filename, rel.split("/").pop() ?? "");
-  const ext = str(d.ext, filename.includes(".") ? filename.split(".").pop() ?? "" : "").toLowerCase();
+  const ext = str(
+    d.ext,
+    filename.includes(".") ? (filename.split(".").pop() ?? "") : ""
+  ).toLowerCase();
   let docType = d.doc_type ? str(d.doc_type) : inferDocType(rel, filename);
   let keyTerms = d.key_terms;
   const text = str(d.text ?? d.text_snippet);
-  if (text && (!keyTerms || (typeof keyTerms === "object" && !Array.isArray(keyTerms) && Object.keys(keyTerms as object).length === 0))) {
+  if (
+    text &&
+    (!keyTerms ||
+      (typeof keyTerms === "object" &&
+        !Array.isArray(keyTerms) &&
+        Object.keys(keyTerms as object).length === 0))
+  ) {
     const extracted = extractKeyTermsFromText(text, { docType, filename });
     keyTerms = Object.keys(extracted).length ? extracted : null;
-    if ((extracted as { lock_up_period_days?: number }).lock_up_period_days && docType !== "lock-up-agreement") {
+    if (
+      (extracted as { lock_up_period_days?: number }).lock_up_period_days &&
+      docType !== "lock-up-agreement"
+    ) {
       docType = "lock-up-agreement";
     }
   }
@@ -183,7 +206,12 @@ function documentInsert(d: Record<string, unknown>): unknown[] {
   if (keyTerms && typeof keyTerms === "object") {
     const keys = Object.keys(keyTerms as object);
     ktJson = keys.length ? JSON.stringify(keyTerms) : null;
-  } else if (typeof keyTerms === "string" && keyTerms.trim() && keyTerms.trim() !== "{}" && keyTerms.trim() !== "[]") {
+  } else if (
+    typeof keyTerms === "string" &&
+    keyTerms.trim() &&
+    keyTerms.trim() !== "{}" &&
+    keyTerms.trim() !== "[]"
+  ) {
     ktJson = keyTerms;
   }
   return [
@@ -212,40 +240,39 @@ export class DuckDbEnginePlugin implements DataEnginePlugin {
   ) {}
 
   private ensureOpen(): Effect.Effect<DuckDbHandle, DataError> {
-    const self = this;
-    return Effect.gen(function* () {
-      if (self.handle) return self.handle;
-      self.handle = yield* openDuckDbEffect(self.path);
-      return self.handle;
+    return Effect.gen(this, function* () {
+      if (this.handle) return this.handle;
+      this.handle = yield* openDuckDbEffect(this.path);
+      return this.handle;
     });
   }
 
   private applySchema(replace: boolean): Effect.Effect<void, DataError> {
-    const self = this;
-    return Effect.gen(function* () {
-      const handle = yield* self.ensureOpen();
-      if (replace || !self.schemaReady) {
+    return Effect.gen(this, function* () {
+      const handle = yield* this.ensureOpen();
+      if (replace || !this.schemaReady) {
         for (const sql of DROP_LAB_SCHEMA_SQL) yield* runSqlEffect(handle, sql);
         for (const sql of CREATE_LAB_SCHEMA_SQL) yield* runSqlEffect(handle, sql);
         for (const sql of CREATE_LAB_VIEW_SQL) yield* runSqlEffect(handle, sql);
-        self.schemaReady = true;
+        this.schemaReady = true;
       }
     });
   }
 
   ingest(payload: IngestPayload): Effect.Effect<IngestResult, DataError> {
-    const self = this;
-    return Effect.gen(function* () {
+    return Effect.gen(this, function* () {
       const replace = payload.replace !== false;
-      yield* self.applySchema(replace);
-      const handle = yield* self.ensureOpen();
+      yield* this.applySchema(replace);
+      const handle = yield* this.ensureOpen();
       const matters = [...(payload.matters ?? [])];
       const openFacts = collectOpenFacts(matters, payload.openFacts);
       const documents = collectDocuments(matters, payload.documents);
 
       if (payload.mattersRoot) {
-        const root = yield* assertAllowedIngestRootEffect(payload.mattersRoot, self.env);
-        const skipRaw = self.env.CLAWQL_DATA_INVENTORY_SKIP_EXT ?? ".png,.jpg,.jpeg,.gif,.webp,.xlsx,.xls,.zip,.gz";
+        const root = yield* assertAllowedIngestRootEffect(payload.mattersRoot, this.env);
+        const skipRaw =
+          this.env.CLAWQL_DATA_INVENTORY_SKIP_EXT ??
+          ".png,.jpg,.jpeg,.gif,.webp,.xlsx,.xls,.zip,.gz";
         const skipExt = new Set(
           skipRaw
             .split(",")
@@ -253,8 +280,8 @@ export class DuckDbEnginePlugin implements DataEnginePlugin {
             .filter(Boolean)
             .map((s) => (s.startsWith(".") ? s : `.${s}`))
         );
-        const parseLimit = Number.parseInt(self.env.CLAWQL_DATA_INVENTORY_PARSE_LIMIT ?? "20", 10);
-        const textCap = Number.parseInt(self.env.CLAWQL_DATA_INVENTORY_TEXT_CAP ?? "500", 10);
+        const parseLimit = Number.parseInt(this.env.CLAWQL_DATA_INVENTORY_PARSE_LIMIT ?? "20", 10);
+        const textCap = Number.parseInt(this.env.CLAWQL_DATA_INVENTORY_TEXT_CAP ?? "500", 10);
         const dirs = yield* dataFromPromise(async () =>
           (await readdir(root, { withFileTypes: true })).filter((d) => d.isDirectory())
         );
@@ -263,13 +290,20 @@ export class DuckDbEnginePlugin implements DataEnginePlugin {
           const matterId = dirent.name;
           const matterDir = join(root, matterId);
           let rows = yield* catalogMatterFilesEffect(matterDir, { skipExt });
-          rows = yield* enrichInventoryRowsEffect(matterDir, rows, { parseLimit, textCap, skipExt });
+          rows = yield* enrichInventoryRowsEffect(matterDir, rows, {
+            parseLimit,
+            textCap,
+            skipExt,
+          });
           const rels = rows.map((r) => r.rel_path);
           const cm = detectCapitalMarkets(rels);
           const re = detectRestructuring(rels);
           const existing = byId.get(matterId);
           if (existing) {
-            if (cm.practice_area && (!existing.practice_area || existing.practice_area === "Other")) {
+            if (
+              cm.practice_area &&
+              (!existing.practice_area || existing.practice_area === "Other")
+            ) {
               existing.practice_area = cm.practice_area;
               existing.matter_type = cm.matter_type ?? existing.matter_type;
             }
@@ -348,7 +382,7 @@ export class DuckDbEnginePlugin implements DataEnginePlugin {
       return {
         ok: true as const,
         engine: ENGINE_ID,
-        path: self.path,
+        path: this.path,
         matterCount: matters.filter((m) => m.matter_id).length,
         documentCount,
         openFactCount: openFacts.length,
@@ -357,8 +391,7 @@ export class DuckDbEnginePlugin implements DataEnginePlugin {
   }
 
   query(sql: string): Effect.Effect<DataQueryResult, DataError> {
-    const self = this;
-    return Effect.gen(function* () {
+    return Effect.gen(this, function* () {
       const validated = yield* dataFromSync(() => validateReadonlySelect(sql)).pipe(
         Effect.map((safeSql) => ({ ok: true as const, safeSql })),
         Effect.catchAll((err) =>
@@ -367,7 +400,8 @@ export class DuckDbEnginePlugin implements DataEnginePlugin {
             result: {
               ok: false as const,
               engine: ENGINE_ID,
-              error: err.cause instanceof Error ? err.cause.message : String(err.cause ?? err.reason),
+              error:
+                err.cause instanceof Error ? err.cause.message : String(err.cause ?? err.reason),
             } satisfies DataQueryResult,
           })
         )
@@ -375,11 +409,11 @@ export class DuckDbEnginePlugin implements DataEnginePlugin {
       if (!validated.ok) return validated.result;
 
       const safeSql = validated.safeSql;
-      return yield* self.ensureOpen().pipe(
+      return yield* this.ensureOpen().pipe(
         Effect.flatMap((handle) =>
           queryDuckDbEffect(handle, safeSql, {
-            maxRows: maxQueryRows(self.env),
-            maxChars: maxCellChars(self.env),
+            maxRows: maxQueryRows(this.env),
+            maxChars: maxCellChars(this.env),
           })
         ),
         Effect.catchAll((err) =>
@@ -404,12 +438,11 @@ export class DuckDbEnginePlugin implements DataEnginePlugin {
   }
 
   close(): Effect.Effect<void, DataError> {
-    const self = this;
-    return Effect.gen(function* () {
-      if (!self.handle) return;
-      yield* closeDuckDbEffect(self.handle);
-      self.handle = null;
-      self.schemaReady = false;
+    return Effect.gen(this, function* () {
+      if (!this.handle) return;
+      yield* closeDuckDbEffect(this.handle);
+      this.handle = null;
+      this.schemaReady = false;
     });
   }
 }

--- a/packages/clawql-data/src/engines/duckdb/duckdb-engine-plugin.ts
+++ b/packages/clawql-data/src/engines/duckdb/duckdb-engine-plugin.ts
@@ -1,10 +1,13 @@
-import { realpath } from "node:fs/promises";
+import { readdir, realpath } from "node:fs/promises";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { Effect } from "effect";
+import { dataFromPromise, dataFromSync } from "../../effect/data-effect-utils.js";
+import type { DataError } from "../../effect/data-errors.js";
 import {
-  catalogMatterFiles,
+  catalogMatterFilesEffect,
   detectCapitalMarkets,
   detectRestructuring,
-  enrichInventoryRows,
+  enrichInventoryRowsEffect,
   extractKeyTermsFromText,
   inferDocType,
 } from "../../inventory.js";
@@ -19,13 +22,13 @@ import type {
   OpenFactRow,
 } from "../types.js";
 import {
-  closeDuckDb,
+  closeDuckDbEffect,
   maxCellChars,
   maxQueryRows,
-  openDuckDb,
-  queryDuckDb,
+  openDuckDbEffect,
+  queryDuckDbEffect,
   resolveDuckDbPath,
-  runSql,
+  runSqlEffect,
   type DuckDbHandle,
 } from "./duckdb-driver.js";
 
@@ -79,34 +82,39 @@ function isPathInside(root: string, candidate: string): boolean {
   return rel === "" || (!rel.startsWith(`..${sep}`) && rel !== ".." && !rel.startsWith(".."));
 }
 
-async function assertAllowedIngestRoot(mattersRoot: string, env: NodeJS.ProcessEnv): Promise<string> {
-  if (!mattersRoot || !isAbsolute(mattersRoot)) {
-    throw new Error("mattersRoot must be an absolute directory path");
-  }
-  const resolved = resolve(mattersRoot);
-  const real = await realpath(resolved);
-  const extra = (env.CLAWQL_DATA_INGEST_ROOTS ?? "")
-    .split(":")
-    .map((s) => s.trim())
-    .filter(Boolean);
-  const vault = env.CLAWQL_OBSIDIAN_VAULT_PATH?.trim();
-  const defaults = ["/workspace", "/tmp", join(env.HOME ?? "/home", ".ClawQL")];
-  const roots = [...defaults, ...extra, vault ? resolve(vault) : ""].filter(Boolean);
-  const allowed = await Promise.all(
-    roots.map(async (r) => {
-      try {
-        return await realpath(resolve(r));
-      } catch {
-        return resolve(r);
-      }
-    })
-  );
-  if (!allowed.some((root) => isPathInside(root, real))) {
-    throw new Error(
-      `mattersRoot ${real} is outside CLAWQL_DATA_INGEST_ROOTS (and /workspace, /tmp, vault)`
+function assertAllowedIngestRootEffect(
+  mattersRoot: string,
+  env: NodeJS.ProcessEnv
+): Effect.Effect<string, DataError> {
+  return dataFromPromise(async () => {
+    if (!mattersRoot || !isAbsolute(mattersRoot)) {
+      throw new Error("mattersRoot must be an absolute directory path");
+    }
+    const resolved = resolve(mattersRoot);
+    const real = await realpath(resolved);
+    const extra = (env.CLAWQL_DATA_INGEST_ROOTS ?? "")
+      .split(":")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const vault = env.CLAWQL_OBSIDIAN_VAULT_PATH?.trim();
+    const defaults = ["/workspace", "/tmp", join(env.HOME ?? "/home", ".ClawQL")];
+    const roots = [...defaults, ...extra, vault ? resolve(vault) : ""].filter(Boolean);
+    const allowed = await Promise.all(
+      roots.map(async (r) => {
+        try {
+          return await realpath(resolve(r));
+        } catch {
+          return resolve(r);
+        }
+      })
     );
-  }
-  return real;
+    if (!allowed.some((root) => isPathInside(root, real))) {
+      throw new Error(
+        `mattersRoot ${real} is outside CLAWQL_DATA_INGEST_ROOTS (and /workspace, /tmp, vault)`
+      );
+    }
+    return real;
+  });
 }
 
 function matterValues(row: Record<string, unknown>): unknown[] {
@@ -192,7 +200,7 @@ function documentInsert(d: Record<string, unknown>): unknown[] {
   ];
 }
 
-/** DuckDB engine plugin — registers under id `duckdb`. */
+/** DuckDB engine plugin — Effect-native domain; registers under id `duckdb`. */
 export class DuckDbEnginePlugin implements DataEnginePlugin {
   readonly id = ENGINE_ID;
   private handle: DuckDbHandle | null = null;
@@ -203,167 +211,206 @@ export class DuckDbEnginePlugin implements DataEnginePlugin {
     private readonly env: NodeJS.ProcessEnv
   ) {}
 
-  private async ensureOpen(): Promise<DuckDbHandle> {
-    if (this.handle) return this.handle;
-    this.handle = await openDuckDb(this.path);
-    return this.handle;
+  private ensureOpen(): Effect.Effect<DuckDbHandle, DataError> {
+    const self = this;
+    return Effect.gen(function* () {
+      if (self.handle) return self.handle;
+      self.handle = yield* openDuckDbEffect(self.path);
+      return self.handle;
+    });
   }
 
-  private async applySchema(replace: boolean): Promise<void> {
-    const handle = await this.ensureOpen();
-    if (replace || !this.schemaReady) {
-      for (const sql of DROP_LAB_SCHEMA_SQL) await runSql(handle, sql);
-      for (const sql of CREATE_LAB_SCHEMA_SQL) await runSql(handle, sql);
-      for (const sql of CREATE_LAB_VIEW_SQL) await runSql(handle, sql);
-      this.schemaReady = true;
-    }
+  private applySchema(replace: boolean): Effect.Effect<void, DataError> {
+    const self = this;
+    return Effect.gen(function* () {
+      const handle = yield* self.ensureOpen();
+      if (replace || !self.schemaReady) {
+        for (const sql of DROP_LAB_SCHEMA_SQL) yield* runSqlEffect(handle, sql);
+        for (const sql of CREATE_LAB_SCHEMA_SQL) yield* runSqlEffect(handle, sql);
+        for (const sql of CREATE_LAB_VIEW_SQL) yield* runSqlEffect(handle, sql);
+        self.schemaReady = true;
+      }
+    });
   }
 
-  async ingest(payload: IngestPayload): Promise<IngestResult> {
-    const replace = payload.replace !== false;
-    await this.applySchema(replace);
-    const handle = await this.ensureOpen();
-    const matters = [...(payload.matters ?? [])];
-    const openFacts = collectOpenFacts(matters, payload.openFacts);
-    const documents = collectDocuments(matters, payload.documents);
+  ingest(payload: IngestPayload): Effect.Effect<IngestResult, DataError> {
+    const self = this;
+    return Effect.gen(function* () {
+      const replace = payload.replace !== false;
+      yield* self.applySchema(replace);
+      const handle = yield* self.ensureOpen();
+      const matters = [...(payload.matters ?? [])];
+      const openFacts = collectOpenFacts(matters, payload.openFacts);
+      const documents = collectDocuments(matters, payload.documents);
 
-    if (payload.mattersRoot) {
-      const root = await assertAllowedIngestRoot(payload.mattersRoot, this.env);
-      const skipRaw = this.env.CLAWQL_DATA_INVENTORY_SKIP_EXT ?? ".png,.jpg,.jpeg,.gif,.webp,.xlsx,.xls,.zip,.gz";
-      const skipExt = new Set(
-        skipRaw
-          .split(",")
-          .map((s) => s.trim().toLowerCase())
-          .filter(Boolean)
-          .map((s) => (s.startsWith(".") ? s : `.${s}`))
-      );
-      const parseLimit = Number.parseInt(this.env.CLAWQL_DATA_INVENTORY_PARSE_LIMIT ?? "20", 10);
-      const textCap = Number.parseInt(this.env.CLAWQL_DATA_INVENTORY_TEXT_CAP ?? "500", 10);
-      const { readdir } = await import("node:fs/promises");
-      const dirs = (await readdir(root, { withFileTypes: true })).filter((d) => d.isDirectory());
-      const byId = new Map(matters.map((m) => [str(m.matter_id), m]));
-      for (const dirent of dirs) {
-        const matterId = dirent.name;
-        const matterDir = join(root, matterId);
-        let rows = await catalogMatterFiles(matterDir, { skipExt });
-        rows = await enrichInventoryRows(matterDir, rows, { parseLimit, textCap, skipExt });
-        const rels = rows.map((r) => r.rel_path);
-        const cm = detectCapitalMarkets(rels);
-        const re = detectRestructuring(rels);
-        const existing = byId.get(matterId);
-        if (existing) {
-          if (cm.practice_area && (!existing.practice_area || existing.practice_area === "Other")) {
-            existing.practice_area = cm.practice_area;
-            existing.matter_type = cm.matter_type ?? existing.matter_type;
+      if (payload.mattersRoot) {
+        const root = yield* assertAllowedIngestRootEffect(payload.mattersRoot, self.env);
+        const skipRaw = self.env.CLAWQL_DATA_INVENTORY_SKIP_EXT ?? ".png,.jpg,.jpeg,.gif,.webp,.xlsx,.xls,.zip,.gz";
+        const skipExt = new Set(
+          skipRaw
+            .split(",")
+            .map((s) => s.trim().toLowerCase())
+            .filter(Boolean)
+            .map((s) => (s.startsWith(".") ? s : `.${s}`))
+        );
+        const parseLimit = Number.parseInt(self.env.CLAWQL_DATA_INVENTORY_PARSE_LIMIT ?? "20", 10);
+        const textCap = Number.parseInt(self.env.CLAWQL_DATA_INVENTORY_TEXT_CAP ?? "500", 10);
+        const dirs = yield* dataFromPromise(async () =>
+          (await readdir(root, { withFileTypes: true })).filter((d) => d.isDirectory())
+        );
+        const byId = new Map(matters.map((m) => [str(m.matter_id), m]));
+        for (const dirent of dirs) {
+          const matterId = dirent.name;
+          const matterDir = join(root, matterId);
+          let rows = yield* catalogMatterFilesEffect(matterDir, { skipExt });
+          rows = yield* enrichInventoryRowsEffect(matterDir, rows, { parseLimit, textCap, skipExt });
+          const rels = rows.map((r) => r.rel_path);
+          const cm = detectCapitalMarkets(rels);
+          const re = detectRestructuring(rels);
+          const existing = byId.get(matterId);
+          if (existing) {
+            if (cm.practice_area && (!existing.practice_area || existing.practice_area === "Other")) {
+              existing.practice_area = cm.practice_area;
+              existing.matter_type = cm.matter_type ?? existing.matter_type;
+            }
+            if (re.practice_area && existing.practice_area !== "Capital Markets") {
+              existing.practice_area = re.practice_area;
+              existing.matter_type = re.matter_type ?? existing.matter_type;
+            }
+            existing.document_count = rows.length;
+            existing.indexed_doc_count = rows.filter((r) => r.parse_status === "ok").length;
+          } else {
+            const practice = cm.practice_area ?? re.practice_area ?? "Other";
+            const added: Record<string, unknown> = {
+              matter_id: matterId,
+              client_short_name: "",
+              practice_area: practice,
+              matter_type: cm.matter_type ?? re.matter_type ?? "Other",
+              title: matterId,
+              sandbox_root: matterDir,
+              document_count: rows.length,
+              indexed_doc_count: rows.filter((r) => r.parse_status === "ok").length,
+            };
+            matters.push(added);
+            byId.set(matterId, added);
           }
-          if (re.practice_area && existing.practice_area !== "Capital Markets") {
-            existing.practice_area = re.practice_area;
-            existing.matter_type = re.matter_type ?? existing.matter_type;
+          for (const row of rows) {
+            documents.push({ ...row, matter_id: matterId });
           }
-          existing.document_count = rows.length;
-          existing.indexed_doc_count = rows.filter((r) => r.parse_status === "ok").length;
-        } else {
-          const practice = cm.practice_area ?? re.practice_area ?? "Other";
-          const added: Record<string, unknown> = {
-            matter_id: matterId,
-            client_short_name: "",
-            practice_area: practice,
-            matter_type: cm.matter_type ?? re.matter_type ?? "Other",
-            title: matterId,
-            sandbox_root: matterDir,
-            document_count: rows.length,
-            indexed_doc_count: rows.filter((r) => r.parse_status === "ok").length,
-          };
-          matters.push(added);
-          byId.set(matterId, added);
-        }
-        for (const row of rows) {
-          documents.push({ ...row, matter_id: matterId });
         }
       }
-    }
 
-    const placeholders = MATTER_COLUMNS.map(() => "?").join(", ");
-    for (const row of matters) {
-      if (!row.matter_id) continue;
-      await runSql(
-        handle,
-        `INSERT INTO matters (${MATTER_COLUMNS.join(", ")}) VALUES (${placeholders})`,
-        matterValues(row)
-      );
-    }
-    for (const fact of openFacts) {
-      await runSql(handle, "INSERT INTO open_facts VALUES (?, ?, ?, ?, ?, ?)", [
-        str(fact.matter_id),
-        str(fact.rel_doc),
-        str(fact.fact_key),
-        str(fact.fact_value),
-        str(fact.evidence_snippet),
-        str(fact.extractor, "open-kv-v0"),
-      ]);
-    }
-    const seen = new Set<string>();
-    let documentCount = 0;
-    for (const d of documents) {
-      const mid = str(d.matter_id);
-      const rel = str(d.rel_path);
-      if (!mid || !rel) continue;
-      const key = `${mid}\0${rel}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      await runSql(
-        handle,
-        "INSERT INTO matter_documents VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        documentInsert(d)
-      );
-      documentCount += 1;
-    }
-    if (documentCount > 0) {
-      await runSql(handle, "CREATE INDEX IF NOT EXISTS idx_matter_documents_filename ON matter_documents(filename)");
-      await runSql(handle, "CREATE INDEX IF NOT EXISTS idx_matter_documents_doc_type ON matter_documents(doc_type)");
-    }
-    return {
-      ok: true,
-      engine: ENGINE_ID,
-      path: this.path,
-      matterCount: matters.filter((m) => m.matter_id).length,
-      documentCount,
-      openFactCount: openFacts.length,
-    };
+      const placeholders = MATTER_COLUMNS.map(() => "?").join(", ");
+      for (const row of matters) {
+        if (!row.matter_id) continue;
+        yield* runSqlEffect(
+          handle,
+          `INSERT INTO matters (${MATTER_COLUMNS.join(", ")}) VALUES (${placeholders})`,
+          matterValues(row)
+        );
+      }
+      for (const fact of openFacts) {
+        yield* runSqlEffect(handle, "INSERT INTO open_facts VALUES (?, ?, ?, ?, ?, ?)", [
+          str(fact.matter_id),
+          str(fact.rel_doc),
+          str(fact.fact_key),
+          str(fact.fact_value),
+          str(fact.evidence_snippet),
+          str(fact.extractor, "open-kv-v0"),
+        ]);
+      }
+      const seen = new Set<string>();
+      let documentCount = 0;
+      for (const d of documents) {
+        const mid = str(d.matter_id);
+        const rel = str(d.rel_path);
+        if (!mid || !rel) continue;
+        const key = `${mid}\0${rel}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        yield* runSqlEffect(
+          handle,
+          "INSERT INTO matter_documents VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          documentInsert(d)
+        );
+        documentCount += 1;
+      }
+      if (documentCount > 0) {
+        yield* runSqlEffect(
+          handle,
+          "CREATE INDEX IF NOT EXISTS idx_matter_documents_filename ON matter_documents(filename)"
+        );
+        yield* runSqlEffect(
+          handle,
+          "CREATE INDEX IF NOT EXISTS idx_matter_documents_doc_type ON matter_documents(doc_type)"
+        );
+      }
+      return {
+        ok: true as const,
+        engine: ENGINE_ID,
+        path: self.path,
+        matterCount: matters.filter((m) => m.matter_id).length,
+        documentCount,
+        openFactCount: openFacts.length,
+      };
+    });
   }
 
-  async query(sql: string): Promise<DataQueryResult> {
-    let safe: string;
-    try {
-      safe = validateReadonlySelect(sql);
-    } catch (err) {
-      return { ok: false, engine: ENGINE_ID, error: err instanceof Error ? err.message : String(err) };
-    }
-    try {
-      const handle = await this.ensureOpen();
-      return await queryDuckDb(handle, safe, {
-        maxRows: maxQueryRows(this.env),
-        maxChars: maxCellChars(this.env),
-      });
-    } catch (err) {
-      return {
-        ok: false,
-        engine: ENGINE_ID,
-        sql: safe,
-        error: err instanceof Error ? err.message : String(err),
-      };
-    }
+  query(sql: string): Effect.Effect<DataQueryResult, DataError> {
+    const self = this;
+    return Effect.gen(function* () {
+      const validated = yield* dataFromSync(() => validateReadonlySelect(sql)).pipe(
+        Effect.map((safeSql) => ({ ok: true as const, safeSql })),
+        Effect.catchAll((err) =>
+          Effect.succeed({
+            ok: false as const,
+            result: {
+              ok: false as const,
+              engine: ENGINE_ID,
+              error: err.cause instanceof Error ? err.cause.message : String(err.cause ?? err.reason),
+            } satisfies DataQueryResult,
+          })
+        )
+      );
+      if (!validated.ok) return validated.result;
+
+      const safeSql = validated.safeSql;
+      return yield* self.ensureOpen().pipe(
+        Effect.flatMap((handle) =>
+          queryDuckDbEffect(handle, safeSql, {
+            maxRows: maxQueryRows(self.env),
+            maxChars: maxCellChars(self.env),
+          })
+        ),
+        Effect.catchAll((err) =>
+          Effect.succeed({
+            ok: false as const,
+            engine: ENGINE_ID,
+            sql: safeSql,
+            error:
+              err.cause instanceof Error
+                ? err.cause.message
+                : typeof err.cause === "string"
+                  ? err.cause
+                  : err.reason,
+          } satisfies DataQueryResult)
+        )
+      );
+    });
   }
 
   status(): DataStatus {
     return { ok: true, engine: ENGINE_ID, path: this.path, enabled: true };
   }
 
-  async close(): Promise<void> {
-    if (!this.handle) return;
-    await closeDuckDb(this.handle);
-    this.handle = null;
-    this.schemaReady = false;
+  close(): Effect.Effect<void, DataError> {
+    const self = this;
+    return Effect.gen(function* () {
+      if (!self.handle) return;
+      yield* closeDuckDbEffect(self.handle);
+      self.handle = null;
+      self.schemaReady = false;
+    });
   }
 }
 

--- a/packages/clawql-data/src/engines/types.ts
+++ b/packages/clawql-data/src/engines/types.ts
@@ -1,3 +1,6 @@
+import type { Effect } from "effect";
+import type { DataError } from "../effect/data-errors.js";
+
 export type DataEngineId = string;
 
 export type DataQueryOk = {
@@ -53,14 +56,17 @@ export type DataStatus = {
   enabled: true;
 };
 
-/** Pluggable structured-data backend (DuckDB today; more engines register here). */
+/**
+ * Pluggable structured-data backend (DuckDB today; more engines register here).
+ * Domain methods are Effect-native; Promise facades live on {@link ClawqlDataStore} / MCP.
+ */
 export interface DataEnginePlugin {
   readonly id: DataEngineId;
   readonly path: string;
-  query(sql: string): Promise<DataQueryResult>;
-  ingest(payload: IngestPayload): Promise<IngestResult>;
+  query(sql: string): Effect.Effect<DataQueryResult, DataError>;
+  ingest(payload: IngestPayload): Effect.Effect<IngestResult, DataError>;
   status(): DataStatus;
-  close(): Promise<void>;
+  close(): Effect.Effect<void, DataError>;
 }
 
 export type DataEngineFactory = (env: NodeJS.ProcessEnv) => DataEnginePlugin;

--- a/packages/clawql-data/src/index.ts
+++ b/packages/clawql-data/src/index.ts
@@ -17,18 +17,25 @@ export {
   inferDocType,
   extractKeyTermsFromText,
   catalogMatterFiles,
+  catalogMatterFilesEffect,
   detectCapitalMarkets,
   detectRestructuring,
   enrichInventoryRows,
+  enrichInventoryRowsEffect,
 } from "./inventory.js";
 export { ClawqlDataStore, getClawqlDataStore, resetClawqlDataStoreForTests } from "./store.js";
 export { MATTER_COLUMNS } from "./schema.js";
 export {
+  DataError,
+  dataFromPromise,
+  dataFromSync,
   runDataEffect,
   dataQueryProgram,
   dataIngestProgram,
   dataStatusProgram,
   resetDataEngineForTests,
+  DataEngineService,
+  dataEngineLiveLayer,
 } from "./effect/index.js";
 
 /** @deprecated Use {@link DUCKDB_QUERY_HINT} or engine plugin hint. */

--- a/packages/clawql-data/src/inventory.ts
+++ b/packages/clawql-data/src/inventory.ts
@@ -1,6 +1,9 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import { basename, extname, join, relative } from "node:path";
+import type { Effect } from "effect";
 import { unzipSync } from "fflate";
+import { dataFromPromise } from "./effect/data-effect-utils.js";
+import type { DataError } from "./effect/data-errors.js";
 
 const DOC_TYPE_RULES: readonly { signals: readonly string[]; docType: string }[] = [
   { signals: ["lock-up", "lockup", "lock_up"], docType: "lock-up-agreement" },
@@ -383,4 +386,21 @@ export async function enrichInventoryRows(
     }
   }
   return rows;
+}
+
+/** Effect wrapper — FS IO at the Promise edge. */
+export function catalogMatterFilesEffect(
+  matterDir: string,
+  opts: { skipExt?: Set<string> } = {}
+): Effect.Effect<MatterDocumentRow[], DataError> {
+  return dataFromPromise(() => catalogMatterFiles(matterDir, opts));
+}
+
+/** Effect wrapper — FS/parse IO at the Promise edge. */
+export function enrichInventoryRowsEffect(
+  matterDir: string,
+  rows: MatterDocumentRow[],
+  opts: { parseLimit?: number; textCap?: number; skipExt?: Set<string> } = {}
+): Effect.Effect<MatterDocumentRow[], DataError> {
+  return dataFromPromise(() => enrichInventoryRows(matterDir, rows, opts));
 }

--- a/packages/clawql-data/src/inventory.ts
+++ b/packages/clawql-data/src/inventory.ts
@@ -17,7 +17,10 @@ const DOC_TYPE_RULES: readonly { signals: readonly string[]; docType: string }[]
     docType: "offering-document",
   },
   { signals: ["dip", "debtor-in-possession", "debtor_in_possession"], docType: "dip-financing" },
-  { signals: ["credit-agreement", "loan-agreement", "bridge", "term-loan"], docType: "credit-agreement" },
+  {
+    signals: ["credit-agreement", "loan-agreement", "bridge", "term-loan"],
+    docType: "credit-agreement",
+  },
   { signals: ["hsr", "second-request", "second_request"], docType: "hsr-filing" },
   { signals: ["form-of-", "form_of_"], docType: "form-document" },
 ];
@@ -156,7 +159,9 @@ export function extractKeyTermsFromText(
 
   if (wantLock) {
     const m =
-      LOCK_UP_DAYS_PREFIX_RE.exec(text) || LOCK_UP_DAYS_ALT_RE.exec(text) || LOCK_UP_DAYS_RE.exec(text);
+      LOCK_UP_DAYS_PREFIX_RE.exec(text) ||
+      LOCK_UP_DAYS_ALT_RE.exec(text) ||
+      LOCK_UP_DAYS_RE.exec(text);
     if (m) {
       const days = Number.parseInt(m[1] ?? "", 10);
       if (days >= 1 && days <= 730) {
@@ -197,7 +202,10 @@ export function extractKeyTermsFromText(
   let pm: RegExpExecArray | null;
   while ((pm = PARTY_RE.exec(head)) && parties.length < 4) {
     for (const g of pm.slice(1)) {
-      const party = g.replace(/\s+/g, " ").replace(/^[ ,.]|[ ,.]$/g, "").trim();
+      const party = g
+        .replace(/\s+/g, " ")
+        .replace(/^[ ,.]|[ ,.]$/g, "")
+        .trim();
       if (party.length >= 3 && !parties.includes(party)) parties.push(party);
       if (parties.length >= 4) break;
     }
@@ -223,9 +231,7 @@ export function extractDocxText(bytes: Uint8Array): string {
 
 /** OOXML word/document.xml → plain text via `<w:t>` runs (not HTML sanitization). */
 function ooxmlDocumentXmlToPlainText(xml: string): string {
-  const withBreaks = xml
-    .replace(/<w:tab\b[^/]*\/>/g, "\t")
-    .replace(/<\/w:p>/g, "\n");
+  const withBreaks = xml.replace(/<w:tab\b[^/]*\/>/g, "\t").replace(/<\/w:p>/g, "\n");
   const parts: string[] = [];
   const re = /<w:t\b[^>]*>([^<]*)<\/w:t>/g;
   let m: RegExpExecArray | null;
@@ -341,7 +347,9 @@ export async function enrichInventoryRows(
 ): Promise<MatterDocumentRow[]> {
   const parseLimit = opts.parseLimit ?? 20;
   const textCap = opts.textCap ?? 500;
-  const skip = opts.skipExt ?? new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".xlsx", ".xls", ".zip", ".gz"]);
+  const skip =
+    opts.skipExt ??
+    new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".xlsx", ".xls", ".zip", ".gz"]);
   const ranked = [...rows].sort((a, b) => {
     const pd = docTypeParsePriority(b.doc_type) - docTypeParsePriority(a.doc_type);
     if (pd !== 0) return pd;

--- a/packages/clawql-data/src/store.ts
+++ b/packages/clawql-data/src/store.ts
@@ -1,3 +1,4 @@
+import { Effect } from "effect";
 import "./engines/duckdb/index.js";
 import { resolveDataEnginePlugin } from "./engines/registry.js";
 import type {
@@ -12,7 +13,10 @@ import type { MatterDocumentRow } from "./inventory.js";
 
 export type { MatterDocumentRow };
 
-/** Facade over the active {@link DataEnginePlugin} (registry-selected). */
+/**
+ * Promise facade over the Effect-native {@link DataEnginePlugin}.
+ * Lab scripts and tests use this; MCP goes through {@link runDataEffect}.
+ */
 export class ClawqlDataStore {
   private readonly plugin: DataEnginePlugin;
 
@@ -29,11 +33,11 @@ export class ClawqlDataStore {
   }
 
   ingest(payload: IngestPayload): Promise<IngestResult> {
-    return this.plugin.ingest(payload);
+    return Effect.runPromise(this.plugin.ingest(payload));
   }
 
   query(sql: string): Promise<DataQueryResult> {
-    return this.plugin.query(sql);
+    return Effect.runPromise(this.plugin.query(sql));
   }
 
   status(): DataStatus {
@@ -41,7 +45,7 @@ export class ClawqlDataStore {
   }
 
   close(): Promise<void> {
-    return this.plugin.close();
+    return Effect.runPromise(this.plugin.close());
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Make `packages/clawql-data` **Effect-native** end-to-end (same pattern as `clawql-sandbox`).

### Interior (Effect)
- `DataEnginePlugin.query` / `ingest` / `close` → `Effect.Effect<…, DataError>`
- `DuckDbEnginePlugin` implemented with `Effect.gen`
- Inventory FS helpers have `*Effect` wrappers
- DuckDB driver IO lifted via `dataFromPromise` / `dataFromSync` → typed `DataError` (no more `die`)
- `DataEngineService` Layer calls plugin Effects directly (no whole-plugin Promise wrap)

### Edges (Promise — unchanged for callers)
- `ClawqlDataStore` / lab `.mjs` scripts
- MCP handlers via `runDataEffect`

### Verify
```bash
npx vitest run packages/clawql-data   # 19 passed
npm run build -w clawql-data
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f882a-d0b4-7cf2-96f0-ab1d0a594ff0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

