### PR TITLE
docs(clawql-auth): clarify XAA roles and SAML bridge scope

### DIFF
--- a/docs/security/clawql-auth-package-spec.md
+++ b/docs/security/clawql-auth-package-spec.md
@@ -204,19 +204,19 @@ Enterprise-Managed Authorization is the stable MCP extension for org-wide connec
 
 **XAA roles (terminology):** XAA defines three parties. `clawql-auth` participates in **one or two** of them depending on deployment — never as the Requesting App.
 
-| Role | Responsibility | `clawql-auth` |
-| ---- | -------------- | ------------- |
-| **Requesting App** | App the user is logged into (Claude, Cursor, ClawQL-embedded agent product). Obtains an ID-JAG from the enterprise IdP via RFC 8693 token exchange, then presents it to the Resource App AS. | **Not clawql-auth** — upstream MCP client / agent host. |
-| **Enterprise IdP** | Mints ID-JAG assertions after enterprise policy checks (Okta XAA, Auth0 tenant, or self-hosted issuer). | **Optional (Layer A)** — `id-jag-issuer.ts` when `CLAWQL_ID_JAG_ISSUER_ENABLED=1`. Typical deployments use Okta/Auth0 instead. |
-| **Resource App AS** | Verifies the ID-JAG (IdP JWKS), maps groups → scopes, issues its own access token for its API/MCP gateway. Grant: `urn:ietf:params:oauth:grant-type:jwt-bearer` (RFC 7523). | **Shipped (primary)** — `mcp-oauth.ts` `exchangeIdJag` on `POST /oauth/token`. Mirrors Auth0’s “Resource App Authorization Server” documentation. |
+| Role                | Responsibility                                                                                                                                                                               | `clawql-auth`                                                                                                                                     |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Requesting App**  | App the user is logged into (Claude, Cursor, ClawQL-embedded agent product). Obtains an ID-JAG from the enterprise IdP via RFC 8693 token exchange, then presents it to the Resource App AS. | **Not clawql-auth** — upstream MCP client / agent host.                                                                                           |
+| **Enterprise IdP**  | Mints ID-JAG assertions after enterprise policy checks (Okta XAA, Auth0 tenant, or self-hosted issuer).                                                                                      | **Optional (Layer A)** — `id-jag-issuer.ts` when `CLAWQL_ID_JAG_ISSUER_ENABLED=1`. Typical deployments use Okta/Auth0 instead.                    |
+| **Resource App AS** | Verifies the ID-JAG (IdP JWKS), maps groups → scopes, issues its own access token for its API/MCP gateway. Grant: `urn:ietf:params:oauth:grant-type:jwt-bearer` (RFC 7523).                  | **Shipped (primary)** — `mcp-oauth.ts` `exchangeIdJag` on `POST /oauth/token`. Mirrors Auth0’s “Resource App Authorization Server” documentation. |
 
 **Deployment modes:**
 
-| Mode | IdP | Resource App AS | Typical customer |
-| ---- | --- | --------------- | ---------------- |
-| Resource-App-only | Okta / Auth0 / Azure AD | ClawQL MCP OAuth AS | Enterprise MCP gateway behind existing IdP (**default, shipped today**) |
-| IdP-only | ClawQL ID-JAG issuer | Third-party MCP server | Self-hosted EMA without Okta custody |
-| Both | ClawQL ID-JAG issuer | ClawQL MCP OAuth AS | Air-gapped or self-contained AI/MCP slice with no third-party IdP for EMA |
+| Mode              | IdP                     | Resource App AS        | Typical customer                                                          |
+| ----------------- | ----------------------- | ---------------------- | ------------------------------------------------------------------------- |
+| Resource-App-only | Okta / Auth0 / Azure AD | ClawQL MCP OAuth AS    | Enterprise MCP gateway behind existing IdP (**default, shipped today**)   |
+| IdP-only          | ClawQL ID-JAG issuer    | Third-party MCP server | Self-hosted EMA without Okta custody                                      |
+| Both              | ClawQL ID-JAG issuer    | ClawQL MCP OAuth AS    | Air-gapped or self-contained AI/MCP slice with no third-party IdP for EMA |
 
 **SAML interoperability (IdP / Requesting App — not Resource App AS):** When enterprise SSO is SAML rather than OIDC, XAA profiles a **pre-step before ID-JAG**: the Requesting App exchanges a SAML assertion for an OAuth refresh token at the IdP (`grant_type=token-exchange`, `subject_token_type=saml2`), then exchanges that refresh token for an ID-JAG. `clawql-auth` does **not** implement this bridge — it only receives a finished ID-JAG JWT at `/oauth/token`. SAML-only enterprises rely on their IdP (Okta SAML XAA guide, Auth0 [Okta as SAML IdP](https://auth0.com/docs/ai-agents-mcp/cross-app-access/idp/okta-as-saml-idp)) and Requesting App to perform SAML→refresh→ID-JAG. The Okta preset (`okta-id-jag.ts` → `buildOktaEmaOrgConfig`) configures **OIDC JWKS verification only** (`/oauth2/{authServerId}/v1/keys`).
 

--- a/docs/security/clawql-auth-package-spec.md
+++ b/docs/security/clawql-auth-package-spec.md
@@ -200,7 +200,25 @@ Every successful `issueToken` emits **`MCP_TOKEN_ISSUED`** to the auth WORM (no 
 
 **Shipped** in `inbound/id-jag.ts` + `inbound/mcp-oauth.ts` (`exchangeIdJag`).
 
-Enterprise-Managed Authorization is the stable MCP extension for org-wide connector authorization via the identity provider (Okta Cross App Access at launch). Admins map IdP groups → ATR scopes once; users inherit MCP access on first login with no per-connector consent.
+Enterprise-Managed Authorization is the stable MCP extension for org-wide connector authorization via the identity provider. The wire protocol is **Cross App Access (XAA)** — formally the **identity assertion authorization grant (ID-JAG)** — as implemented by Okta, Auth0 ([Cross App Access docs](https://auth0.com/docs/ai-agents-mcp/cross-app-access)), and other enterprise IdPs. Admins map IdP groups → ATR scopes once; users inherit MCP access on first login with no per-connector consent.
+
+**XAA roles (terminology):** XAA defines three parties. `clawql-auth` participates in **one or two** of them depending on deployment — never as the Requesting App.
+
+| Role | Responsibility | `clawql-auth` |
+| ---- | -------------- | ------------- |
+| **Requesting App** | App the user is logged into (Claude, Cursor, ClawQL-embedded agent product). Obtains an ID-JAG from the enterprise IdP via RFC 8693 token exchange, then presents it to the Resource App AS. | **Not clawql-auth** — upstream MCP client / agent host. |
+| **Enterprise IdP** | Mints ID-JAG assertions after enterprise policy checks (Okta XAA, Auth0 tenant, or self-hosted issuer). | **Optional (Layer A)** — `id-jag-issuer.ts` when `CLAWQL_ID_JAG_ISSUER_ENABLED=1`. Typical deployments use Okta/Auth0 instead. |
+| **Resource App AS** | Verifies the ID-JAG (IdP JWKS), maps groups → scopes, issues its own access token for its API/MCP gateway. Grant: `urn:ietf:params:oauth:grant-type:jwt-bearer` (RFC 7523). | **Shipped (primary)** — `mcp-oauth.ts` `exchangeIdJag` on `POST /oauth/token`. Mirrors Auth0’s “Resource App Authorization Server” documentation. |
+
+**Deployment modes:**
+
+| Mode | IdP | Resource App AS | Typical customer |
+| ---- | --- | --------------- | ---------------- |
+| Resource-App-only | Okta / Auth0 / Azure AD | ClawQL MCP OAuth AS | Enterprise MCP gateway behind existing IdP (**default, shipped today**) |
+| IdP-only | ClawQL ID-JAG issuer | Third-party MCP server | Self-hosted EMA without Okta custody |
+| Both | ClawQL ID-JAG issuer | ClawQL MCP OAuth AS | Air-gapped or self-contained AI/MCP slice with no third-party IdP for EMA |
+
+**SAML interoperability (IdP / Requesting App — not Resource App AS):** When enterprise SSO is SAML rather than OIDC, XAA profiles a **pre-step before ID-JAG**: the Requesting App exchanges a SAML assertion for an OAuth refresh token at the IdP (`grant_type=token-exchange`, `subject_token_type=saml2`), then exchanges that refresh token for an ID-JAG. `clawql-auth` does **not** implement this bridge — it only receives a finished ID-JAG JWT at `/oauth/token`. SAML-only enterprises rely on their IdP (Okta SAML XAA guide, Auth0 [Okta as SAML IdP](https://auth0.com/docs/ai-agents-mcp/cross-app-access/idp/okta-as-saml-idp)) and Requesting App to perform SAML→refresh→ID-JAG. The Okta preset (`okta-id-jag.ts` → `buildOktaEmaOrgConfig`) configures **OIDC JWKS verification only** (`/oauth2/{authServerId}/v1/keys`).
 
 Grant types:
 
@@ -241,7 +259,9 @@ Discovery metadata already advertises ID-JAG in `website/src/lib/oauth-discovery
 
 **Shipped (Layers A + B)** in [#961](https://github.com/danielsmithdevelopment/ClawQL/pull/961): `inbound/id-jag-issuer.ts`, `inbound/ema-connector-registry.ts`, HTTP routes under `/oauth/id-jag/*` and `/.well-known/id-jag-jwks.json`.
 
-Positioning: ClawQL can act as a **self-hosted, attestation-backed identity provider for organizations that need EMA without third-party session-token custody** — the same Enterprise-Managed Authorization path Okta Cross App Access provides, without Okta's centralized custody surface. ClawQL remains an auth _consumer_ everywhere else (not a full human IdP).
+This section covers the **Enterprise IdP** XAA role only. The **Resource App AS** role (verify external ID-JAG → mint ClawQL MCP access JWT) is §4.1.1 and is independent: a deployment can enable either, or both.
+
+Positioning: ClawQL can act as a **self-hosted, attestation-backed identity provider for organizations that need EMA without third-party session-token custody** — the same Enterprise-Managed Authorization path Okta Cross App Access provides, without Okta's centralized custody surface. This is **not** a replacement for Okta/Auth0 human SSO (password, SAML SP, OIDC login UI). ClawQL remains an auth _consumer_ for human inbound paths (`oidc` JWT mode) and outbound provider OAuth everywhere else.
 
 | Layer               | Scope                                                                             | Status                                                                                                                              |
 | ------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
@@ -255,7 +275,7 @@ Positioning: ClawQL can act as a **self-hosted, attestation-backed identity prov
 
 **Signing keys (blast radius):** Dedicated issuer material via `CLAWQL_ID_JAG_ISSUER_PRIVATE_KEY_PEM(_PATH)` is the production recommendation. Falling back to the MCP OAuth AS signing key is allowed for v0 / single-node convenience, but **production deployments concerned about blast radius must use separate keys** — a compromise of the AS signing key must not also mint forged ID-JAG assertions (and vice versa). Shared keys quietly becoming the default would recreate the single-point-of-failure the self-hosted positioning argument is against.
 
-**Never:** Okta competitor, password/SSO IdP, SAML/LDAP server, per-user connector consent UI.
+**Never:** Okta competitor, password/SSO IdP, SAML/LDAP server, SAML→refresh-token interoperability layer, per-user connector consent UI. SAML bridge and Requesting-App token exchange stay with the enterprise IdP and agent host; Resource App AS accepts only finished ID-JAG JWTs.
 
 **Env:** `CLAWQL_ID_JAG_ISSUER_ENABLED=1`, `CLAWQL_ID_JAG_ISSUER_ORG_ID`, signing via `CLAWQL_ID_JAG_ISSUER_PRIVATE_KEY_PEM(_PATH)` (prefer dedicated; MCP OAuth key fallback is convenience only).
 

--- a/packages/clawql-auth/src/inbound/okta-id-jag.ts
+++ b/packages/clawql-auth/src/inbound/okta-id-jag.ts
@@ -1,7 +1,13 @@
 /**
  * Okta Cross App Access / ID-JAG trust presets for Enterprise-Managed Authorization.
  *
+ * OIDC verification preset only — configures IdP JWKS + issuer for finished ID-JAG
+ * assertions at the Resource App AS (`exchangeIdJag`). Does not implement the SAML
+ * interoperability layer (SAML assertion → OAuth refresh token → ID-JAG); that is
+ * handled by Okta/Auth0 and the Requesting App before the assertion reaches ClawQL.
+ *
  * @see https://blog.modelcontextprotocol.io/posts/enterprise-managed-auth/
+ * @see https://auth0.com/docs/ai-agents-mcp/cross-app-access
  */
 
 import type { EmaGroupScopeMapping, EmaOrgConfig } from "./id-jag.js";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents how `clawql-auth` maps to Cross App Access (XAA / ID-JAG) terminology after Auth0/Okta enterprise MCP auth announcements.

- Adds a three-role table (Requesting App, Enterprise IdP, Resource App AS) to spec §4.1.1
- Clarifies deployment modes: Resource-App-only (default), IdP-only, or both
- States explicitly that SAML→refresh→ID-JAG is an IdP/Requesting-App concern — `okta-id-jag.ts` is OIDC JWKS verification only
- §4.1.2 now distinguishes the optional IdP issuer role from the shipped Resource App AS path

## Context

PR #961 already implements the consumer side correctly (`urn:ietf:params:oauth:grant-type:jwt-bearer` at `/oauth/token`). This change is documentation/positioning only — no runtime behavior change.

## References

- [Auth0 Cross App Access](https://auth0.com/docs/ai-agents-mcp/cross-app-access)
- [MCP Enterprise-Managed Authorization](https://blog.modelcontextprotocol.io/posts/enterprise-managed-auth/)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03570-ad58-76e5-b7ec-872aeb2410f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03570-ad58-76e5-b7ec-872aeb2410f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

