### PR TITLE
feat(mcp-ui): ATR scope + file upload, SSE progress, generate workflows

### DIFF
--- a/docs/mcp/mcp-ui.md
+++ b/docs/mcp/mcp-ui.md
@@ -3,7 +3,7 @@
 **Status:** v0 shipped · August 2026 · **8th surface** of [`mcp-api-adapter`](./mcp-api-adapter.md)  
 **Path:** `GET /mcp-ui` (adapter HTTP process)  
 **Depends on:** `ListTools` + tool `inputSchema` (same catalog as `/docs` and `/graphiql`)  
-**Implementation:** `packages/mcp-api-adapter/src/mcp-ui-*.ts` — catalog page + execute fragment, form UX (required/optional/defaults/Advanced), templates for `search` / `memory_*` / `cache` / `audit`. Deferred: nested object/array UIs, file upload/IDP, SSE progress, agent-generated UIs, ATR scoping.
+**Implementation:** `packages/mcp-api-adapter/src/mcp-ui-*.ts` — catalog page + execute fragment, form UX (required/optional/defaults/Advanced), templates for `search` / `memory_*` / `cache` / `audit`, ATR-scoped catalog when JWT edge auth is configured. Deferred: nested object/array UIs, file upload/IDP, SSE progress, agent-generated UIs.
 
 ---
 
@@ -71,7 +71,18 @@ What nobody ships today:
 
 Disable with `--no-mcp-ui`. Override path with `--mcp-ui-path` / `MCP_API_ADAPTER_MCP_UI_PATH` (default `/mcp-ui`).
 
-Auth: same API key gate as `/docs` and `/graphiql` when configured.
+Auth: same API key gate as `/docs` and `/graphiql` when configured. With JWT edge auth, `/mcp-ui` **ATR-scopes** the catalog and execute path by default (`--no-mcp-ui-atr-scoped` to disable):
+
+| ATR grant | Visible tools |
+| --- | --- |
+| `role: admin` or scope/tools `*` | All tools |
+| Capability scopes `search` / `execute` / `memory` / `audit` / `cache` | Mapped public tools only |
+| Exact tool name in `scope` or `tools` | That tool |
+| Family scopes `pageindex` / `ouroboros` | Matching internal prefixes |
+| (default) | `ouroboros_*` and `pageindex_*` are **not** granted by generic capability scopes |
+
+API keys are treated as admin for `/mcp-ui` visibility.
+
 
 ### 3.2 Catalog → form mapping
 

--- a/docs/mcp/mcp-ui.md
+++ b/docs/mcp/mcp-ui.md
@@ -73,16 +73,15 @@ Disable with `--no-mcp-ui`. Override path with `--mcp-ui-path` / `MCP_API_ADAPTE
 
 Auth: same API key gate as `/docs` and `/graphiql` when configured. With JWT edge auth, `/mcp-ui` **ATR-scopes** the catalog and execute path by default (`--no-mcp-ui-atr-scoped` to disable):
 
-| ATR grant | Visible tools |
-| --- | --- |
-| `role: admin` or scope/tools `*` | All tools |
-| Capability scopes `search` / `execute` / `memory` / `audit` / `cache` | Mapped public tools only |
-| Exact tool name in `scope` or `tools` | That tool |
-| Family scopes `pageindex` / `ouroboros` | Matching internal prefixes |
-| (default) | `ouroboros_*` and `pageindex_*` are **not** granted by generic capability scopes |
+| ATR grant                                                             | Visible tools                                                                    |
+| --------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `role: admin` or scope/tools `*`                                      | All tools                                                                        |
+| Capability scopes `search` / `execute` / `memory` / `audit` / `cache` | Mapped public tools only                                                         |
+| Exact tool name in `scope` or `tools`                                 | That tool                                                                        |
+| Family scopes `pageindex` / `ouroboros`                               | Matching internal prefixes                                                       |
+| (default)                                                             | `ouroboros_*` and `pageindex_*` are **not** granted by generic capability scopes |
 
 API keys are treated as admin for `/mcp-ui` visibility.
-
 
 ### 3.2 Catalog → form mapping
 

--- a/docs/mcp/mcp-ui.md
+++ b/docs/mcp/mcp-ui.md
@@ -3,7 +3,7 @@
 **Status:** v0 shipped · August 2026 · **8th surface** of [`mcp-api-adapter`](./mcp-api-adapter.md)  
 **Path:** `GET /mcp-ui` (adapter HTTP process)  
 **Depends on:** `ListTools` + tool `inputSchema` (same catalog as `/docs` and `/graphiql`)  
-**Implementation:** `packages/mcp-api-adapter/src/mcp-ui-*.ts` — catalog page + execute fragment, form UX (required/optional/defaults/Advanced), templates for `search` / `memory_*` / `cache` / `audit`, ATR-scoped catalog when JWT edge auth is configured. Deferred: nested object/array UIs, file upload/IDP, SSE progress, agent-generated UIs.
+**Implementation:** `packages/mcp-api-adapter/src/mcp-ui-*.ts` — catalog page + execute fragment, form UX (required/optional/defaults/Advanced), templates for `search` / `memory_*` / `cache` / `audit` / `run_idp_pipeline`, ATR-scoped catalog when JWT edge auth is configured, multipart file upload (document-processing ATR), SSE progress for long tools, and `POST /mcp-ui/generate` multi-step custom UIs. Deferred: nested object/array UIs.
 
 ---
 
@@ -156,7 +156,9 @@ A new teammate can open one URL and call Salesforce, GitHub, internal gRPC, and 
 - **HTMX:** load from a pinned CDN or vendored static asset under `/mcp-ui/assets/htmx.min.js`.
 - **Reuse:** form field generation should share schema-walk helpers with OpenAPI/GraphQL builders where practical (one walk, multiple emitters).
 - **Safety:** HTML-escape all tool names, descriptions, and result text. Never eval result content as HTML unless explicitly marked safe structured content later.
-- **Streaming:** v1 is request/response fragments. SSE progress for long tools can reuse Streamable HTTP infrastructure in a later revision.
+- **Streaming:** Long-running tools return an HTMX/EventSource progress shell; `GET /mcp-ui/progress/:jobId` streams `progress` / `complete` / `error` SSE events with the final result HTML embedded.
+- **File upload / IDP:** Tools with `pdf_base64` / `base64` (or format binary) render `<input type="file">` with `multipart/form-data`. Uploads are base64-encoded into CallTool args. Document **processing** requires ATR scopes `documents` / `idp` (or admin / explicit IDP tool grant) — separate from catalog visibility.
+- **Generated UIs:** `POST /mcp-ui/generate` with `{ title, steps: [{ tool, label? }], slug? }` returns a `/mcp-ui/custom/:slug` multi-step form (in-memory, TTL).
 - **Proof:** clawql-payments `/credits/*` already demonstrates HTMX fragment UX inside ClawQL — generalize that pattern to arbitrary MCP catalogs.
 
 ### 5.1 Effect-TS

--- a/package-lock.json
+++ b/package-lock.json
@@ -6091,6 +6091,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/busboy": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-1.5.4.tgz",
+      "integrity": "sha512-kG7WrUuAKK0NoyxfQHsVE6j1m01s6kMma64E+OZenQABMQyTJop1DumUWcLwAQ2JzpefU7PDYoRDKl8uZosFjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -6950,6 +6960,17 @@
       },
       "peerDependencies": {
         "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -12789,6 +12810,14 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/streamx": {
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
@@ -14773,6 +14802,7 @@
       "dependencies": {
         "@grpc/grpc-js": "^1.14.4",
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "busboy": "^1.6.0",
         "express": "^5.2.1",
         "express-rate-limit": "^8.5.2",
         "graphql": "^16.14.0",
@@ -14785,6 +14815,7 @@
         "mcp-openapi-gateway": "bin/mcp-api-adapter.mjs"
       },
       "devDependencies": {
+        "@types/busboy": "^1.5.4",
         "@types/express": "^5.0.3",
         "@types/node": "^26.1.1",
         "@types/ws": "^8.18.1",

--- a/packages/mcp-api-adapter/CHANGELOG.md
+++ b/packages/mcp-api-adapter/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - **`/mcp-ui` ATR scoping:** catalog + execute filter by JWT `atr.scope` / `atr.tools` (default on). Internal `ouroboros_*` / `pageindex_*` require explicit or family grants. `--no-mcp-ui-atr-scoped` disables. API keys remain admin-equivalent.
+- **`/mcp-ui` file upload + IDP:** multipart forms for `pdf_base64` / `base64` (and format binary); uploads are base64-encoded into CallTool args. Document-processing ATR (`documents` / `idp` / explicit IDP tools) is separate from tool visibility. Template for `run_idp_pipeline`.
+- **`/mcp-ui` SSE progress:** long-running tools (`run_idp_pipeline`, `ouroboros_*`, …) return an EventSource shell; `GET /mcp-ui/progress/:jobId` streams progress/complete/error.
+- **`/mcp-ui` generate:** `POST /mcp-ui/generate` creates in-memory multi-step workflows; `GET /mcp-ui/custom/:slug` + step execute for agent-authored UIs.
 
 ## 0.6.x (mcp-ui v0)
 

--- a/packages/mcp-api-adapter/CHANGELOG.md
+++ b/packages/mcp-api-adapter/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- **`/mcp-ui` ATR scoping:** catalog + execute filter by JWT `atr.scope` / `atr.tools` (default on). Internal `ouroboros_*` / `pageindex_*` require explicit or family grants. `--no-mcp-ui-atr-scoped` disables. API keys remain admin-equivalent.
+
+## 0.6.x (mcp-ui v0)
+
 - **`/mcp-ui` surface (v0):** HTMX playground auto-generated from the tool catalog — `GET /mcp-ui`, `POST /mcp-ui/execute/{toolName}`. Flat forms for string/number/boolean/enum; JSON textarea fallback for complex schemas. `--mcp-ui-path`, `--no-mcp-ui`.
 - **Form UX:** Required/optional badges, schema default prefills, blank optional enums, Advanced disclosure for non-primary fields, empty optional omit, HTMX swaps non-2xx error fragments, field-level validation errors.
 - **Templates:** `search`, `memory_recall`, `memory_ingest`, `cache`, `audit` — primary fields + readable result lists (raw JSON still available).

--- a/packages/mcp-api-adapter/README.md
+++ b/packages/mcp-api-adapter/README.md
@@ -72,7 +72,7 @@ npx mcp-api-adapter gen-cli --out ./my-cli --stdio -- npx -y @modelcontextprotoc
 | `GET /tools`           | Catalog                          |
 | `GET /healthz`         | Liveness                         |
 
-Disable MCP with `--no-mcp`. Disable WebSocket with `--no-ws`. Disable `/mcp-ui` with `--no-mcp-ui`. Change paths with `--mcp-path` / `--ws-path` / `--mcp-ui-path`.
+Disable MCP with `--no-mcp`. Disable WebSocket with `--no-ws`. Disable `/mcp-ui` with `--no-mcp-ui`. Disable ATR catalog filtering with `--no-mcp-ui-atr-scoped`. Change paths with `--mcp-path` / `--ws-path` / `--mcp-ui-path`.
 
 ## Programmatic API
 

--- a/packages/mcp-api-adapter/README.md
+++ b/packages/mcp-api-adapter/README.md
@@ -68,7 +68,10 @@ npx mcp-api-adapter gen-cli --out ./my-cli --stdio -- npx -y @modelcontextprotoc
 | `POST/GET/DELETE /mcp` | Streamable HTTP MCP (same tools) |
 | `WS /ws`               | WebSocket JSON tool calls        |
 | `GET /mcp-ui`          | HTMX tool playground (auto-generated forms) |
-| `POST /mcp-ui/execute/{toolName}` | Run a tool from the UI |
+| `POST /mcp-ui/execute/{toolName}` | Run a tool from the UI (urlencoded or multipart) |
+| `GET /mcp-ui/progress/{jobId}` | SSE progress for long-running executes |
+| `POST /mcp-ui/generate` | Create a multi-step custom form (JSON) |
+| `GET /mcp-ui/custom/{slug}` | Render a generated multi-step form |
 | `GET /tools`           | Catalog                          |
 | `GET /healthz`         | Liveness                         |
 

--- a/packages/mcp-api-adapter/package.json
+++ b/packages/mcp-api-adapter/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.14.4",
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "busboy": "^1.6.0",
     "express": "^5.2.1",
     "express-rate-limit": "^8.5.2",
     "graphql": "^16.14.0",
@@ -55,6 +56,7 @@
     "ws": "^8.21.0"
   },
   "devDependencies": {
+    "@types/busboy": "^1.5.4",
     "@types/express": "^5.0.3",
     "@types/node": "^26.1.1",
     "@types/ws": "^8.18.1",

--- a/packages/mcp-api-adapter/src/cli.ts
+++ b/packages/mcp-api-adapter/src/cli.ts
@@ -37,6 +37,7 @@ HTTP APIs:
   --no-ws                Disable WebSocket surface
   --mcp-ui-path <path>   HTMX MCP UI playground path (default /mcp-ui)
   --no-mcp-ui            Disable /mcp-ui browser surface
+  --no-mcp-ui-atr-scoped  Show full catalog in /mcp-ui (ignore ATR tool filter)
   --api-key <key>        Optional edge API key
   --jwks-url <url>       Accept ClawQL MCP JWTs via JWKS (/.well-known/jwks.json)
   --jwt-issuer <iss>     Expected JWT iss when verifying MCP tokens
@@ -141,6 +142,7 @@ const sharedOpts = {
   "no-ws": { type: "boolean", default: false },
   "mcp-ui-path": { type: "string" },
   "no-mcp-ui": { type: "boolean", default: false },
+  "no-mcp-ui-atr-scoped": { type: "boolean", default: false },
   listen: { type: "string" },
   "api-key": { type: "string" },
   "jwks-url": { type: "string" },
@@ -260,6 +262,8 @@ async function runServe(argv: string[]): Promise<void> {
       envFirst("MCP_API_ADAPTER_MCP_UI_PATH") ||
       "/mcp-ui";
 
+  const mcpUiAtrScoped = !values["no-mcp-ui-atr-scoped"];
+
   const started = await startMcpApiAdapter({
     upstream,
     host,
@@ -272,6 +276,7 @@ async function runServe(argv: string[]): Promise<void> {
     mcpPath,
     wsPath,
     mcpUiPath,
+    mcpUiAtrScoped,
     protocolVersion: process.env.MCP_PROTOCOL_VERSION?.trim(),
   });
 

--- a/packages/mcp-api-adapter/src/edge-auth.ts
+++ b/packages/mcp-api-adapter/src/edge-auth.ts
@@ -29,7 +29,13 @@ export type McpApiAdapterEdgeAuthOptions = {
 export type VerifiedMcpAdapterAtr = {
   sub: string;
   role?: string;
+  /** Capability scopes and/or exact tool names (e.g. `search`, `memory`, `memory_recall`). */
   scope?: string[];
+  /**
+   * Optional explicit tool-name allowlist (unioned with `scope` mapping).
+   * Use for least-privilege demos: `tools: ["search", "memory_recall"]`.
+   */
+  tools?: string[];
   orgId?: string;
 };
 
@@ -71,7 +77,19 @@ export function createJwtVerifier(
     if (!atr || typeof atr !== "object" || typeof atr.sub !== "string" || !atr.sub.trim()) {
       throw new Error("missing atr claim");
     }
-    return atr;
+    const scope = Array.isArray(atr.scope)
+      ? atr.scope.map((s) => String(s))
+      : undefined;
+    const tools = Array.isArray(atr.tools)
+      ? atr.tools.map((s) => String(s))
+      : undefined;
+    return {
+      sub: atr.sub.trim(),
+      ...(atr.role != null ? { role: String(atr.role) } : {}),
+      ...(scope ? { scope } : {}),
+      ...(tools ? { tools } : {}),
+      ...(atr.orgId != null ? { orgId: String(atr.orgId) } : {}),
+    };
   };
 }
 
@@ -85,6 +103,33 @@ export function edgeAuthConfigured(options: McpApiAdapterEdgeAuthOptions): boole
 
 /**
  * Accept static API key (exact match) or a ClawQL-issued MCP Bearer JWT.
+ * Returns verified ATR for JWT, a sentinel admin ATR for API key, or null.
+ */
+export async function resolveEdgeCredential(
+  presented: string | undefined,
+  options: McpApiAdapterEdgeAuthOptions,
+  verifyJwt?: ((token: string) => Promise<VerifiedMcpAdapterAtr>) | null
+): Promise<VerifiedMcpAdapterAtr | null> {
+  if (!presented?.trim()) return null;
+  const token = presented.trim();
+  const apiKey = options.apiKey?.trim();
+  if (apiKey && token === apiKey) {
+    return {
+      sub: "api-key",
+      role: "admin",
+      scope: ["*"],
+    };
+  }
+  if (!verifyJwt) return null;
+  try {
+    return await verifyJwt(token);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Accept static API key (exact match) or a ClawQL-issued MCP Bearer JWT.
  * Returns true when the credential is valid.
  */
 export async function verifyEdgeCredential(
@@ -92,15 +137,5 @@ export async function verifyEdgeCredential(
   options: McpApiAdapterEdgeAuthOptions,
   verifyJwt?: ((token: string) => Promise<VerifiedMcpAdapterAtr>) | null
 ): Promise<boolean> {
-  if (!presented?.trim()) return false;
-  const token = presented.trim();
-  const apiKey = options.apiKey?.trim();
-  if (apiKey && token === apiKey) return true;
-  if (!verifyJwt) return false;
-  try {
-    await verifyJwt(token);
-    return true;
-  } catch {
-    return false;
-  }
+  return (await resolveEdgeCredential(presented, options, verifyJwt)) != null;
 }

--- a/packages/mcp-api-adapter/src/index.ts
+++ b/packages/mcp-api-adapter/src/index.ts
@@ -41,12 +41,19 @@ export {
   createJwtVerifier,
   edgeAuthConfigured,
   verifyEdgeCredential,
+  resolveEdgeCredential,
 } from "./edge-auth.js";
 export type {
   McpApiAdapterJwtAuthOptions,
   McpApiAdapterEdgeAuthOptions,
   VerifiedMcpAdapterAtr,
 } from "./edge-auth.js";
+export {
+  filterToolsForAtr,
+  isInternalToolName,
+  isToolAuthorizedForAtr,
+  INTERNAL_TOOL_PREFIXES,
+} from "./mcp-ui-atr.js";
 export type {
   McpApiAdapterOptions,
   McpApiAdapterHttpOptions,

--- a/packages/mcp-api-adapter/src/index.ts
+++ b/packages/mcp-api-adapter/src/index.ts
@@ -49,11 +49,24 @@ export type {
   VerifiedMcpAdapterAtr,
 } from "./edge-auth.js";
 export {
+  canProcessDocuments,
   filterToolsForAtr,
   isInternalToolName,
   isToolAuthorizedForAtr,
   INTERNAL_TOOL_PREFIXES,
 } from "./mcp-ui-atr.js";
+export {
+  createGeneratedUi,
+  getGeneratedUiBySlug,
+  listGeneratedUis,
+} from "./mcp-ui-generate.js";
+export {
+  createProgressJob,
+  getProgressJob,
+  isLongRunningTool,
+  DEFAULT_LONG_RUNNING_TOOLS,
+} from "./mcp-ui-progress.js";
+export { mergeFilesIntoArgs, isMultipartRequest } from "./mcp-ui-multipart.js";
 export type {
   McpApiAdapterOptions,
   McpApiAdapterHttpOptions,

--- a/packages/mcp-api-adapter/src/mcp-ui-atr.e2e.test.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-atr.e2e.test.ts
@@ -1,0 +1,133 @@
+import { SignJWT } from "jose";
+import { afterEach, describe, expect, it } from "vitest";
+import { createMcpApiAdapterApp } from "./server.js";
+import type { ListedMcpTool, ToolCatalog } from "./types.js";
+
+const catalogTools: ListedMcpTool[] = [
+  { name: "search", description: "Search ops", inputSchema: { type: "object", properties: { query: { type: "string" } }, required: ["query"] } },
+  { name: "execute", description: "Execute op", inputSchema: { type: "object", properties: {} } },
+  { name: "memory_recall", description: "Recall", inputSchema: { type: "object", properties: { query: { type: "string" } }, required: ["query"] } },
+  { name: "pageindex_build_tree", description: "Internal", inputSchema: { type: "object", properties: {} } },
+  { name: "ouroboros_run_evolutionary_loop", description: "Internal", inputSchema: { type: "object", properties: {} } },
+];
+
+function catalog(): ToolCatalog {
+  return {
+    tools: catalogTools,
+    fetchedAt: new Date().toISOString(),
+    upstream: "test",
+    upstreamKind: "http",
+    surfaces: ["openapi", "mcp-ui"],
+    mcpUiPath: "/mcp-ui",
+  };
+}
+
+describe("mcp-ui ATR scoping", () => {
+  const secret = "test-mcp-ui-atr-hs256-secret-32chars!!";
+  const issuer = "https://auth.clawql.test";
+  let closeServer: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    await closeServer?.();
+    closeServer = undefined;
+  });
+
+  async function mintJwt(atr: Record<string, unknown>): Promise<string> {
+    return new SignJWT({ atr })
+      .setProtectedHeader({ alg: "HS256" })
+      .setSubject(String(atr.sub ?? "user"))
+      .setIssuer(issuer)
+      .setExpirationTime("5m")
+      .sign(new TextEncoder().encode(secret));
+  }
+
+  async function startApp(atrScoped = true): Promise<string> {
+    const app = createMcpApiAdapterApp({
+      getCatalog: catalog,
+      callTool: async () => ({ text: "{}", content: [], isError: false }),
+      jwtAuth: { hs256Secret: secret, issuer },
+      mcpUiPath: "/mcp-ui",
+      mcpUiAtrScoped: atrScoped,
+      title: "ATR scope test",
+    });
+    const server = app.listen(0, "127.0.0.1");
+    closeServer = () =>
+      new Promise((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    await new Promise<void>((resolve, reject) => {
+      server.once("listening", () => resolve());
+      server.once("error", reject);
+    });
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("no port");
+    return `http://127.0.0.1:${addr.port}`;
+  }
+
+  it("two ATR scopes see different /mcp-ui tool cards", async () => {
+    const base = await startApp(true);
+
+    const memoryJwt = await mintJwt({
+      sub: "memory-user",
+      role: "operator",
+      scope: ["search", "memory"],
+    });
+    const execJwt = await mintJwt({
+      sub: "exec-user",
+      role: "operator",
+      scope: ["execute", "audit"],
+    });
+
+    const memoryPage = await fetch(`${base}/mcp-ui`, {
+      headers: { authorization: `Bearer ${memoryJwt}` },
+    });
+    expect(memoryPage.status).toBe(200);
+    const memoryHtml = await memoryPage.text();
+    expect(memoryHtml).toContain('id="tool-search"');
+    expect(memoryHtml).toContain('id="tool-memory_recall"');
+    expect(memoryHtml).not.toContain('id="tool-execute"');
+    expect(memoryHtml).not.toContain("pageindex_build_tree");
+    expect(memoryHtml).not.toContain("ouroboros_run_evolutionary_loop");
+
+    const execPage = await fetch(`${base}/mcp-ui`, {
+      headers: { authorization: `Bearer ${execJwt}` },
+    });
+    expect(execPage.status).toBe(200);
+    const execHtml = await execPage.text();
+    expect(execHtml).toContain('id="tool-execute"');
+    expect(execHtml).not.toContain('id="tool-search"');
+    expect(execHtml).not.toContain('id="tool-memory_recall"');
+    expect(execHtml).not.toContain("pageindex_build_tree");
+    expect(execHtml).not.toContain("ouroboros_run_evolutionary_loop");
+  });
+
+  it("forbids execute of tools outside ATR even if known in catalog", async () => {
+    const base = await startApp(true);
+    const jwt = await mintJwt({
+      sub: "memory-user",
+      scope: ["memory"],
+    });
+
+    const denied = await fetch(`${base}/mcp-ui/execute/execute`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${jwt}`,
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: "",
+    });
+    expect(denied.status).toBe(403);
+    expect(await denied.text()).toContain("outside your ATR scope");
+
+    const allowed = await fetch(`${base}/mcp-ui/execute/memory_recall`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${jwt}`,
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({ query: "hello" }).toString(),
+    });
+    expect(allowed.status).toBe(200);
+    expect(await allowed.text()).toContain("result--success");
+  });
+});

--- a/packages/mcp-api-adapter/src/mcp-ui-atr.test.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-atr.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { ListedMcpTool } from "mcp-grpc-transport";
+import {
+  filterToolsForAtr,
+  isInternalToolName,
+  isToolAuthorizedForAtr,
+} from "./mcp-ui-atr.js";
+
+const tools: ListedMcpTool[] = [
+  { name: "search", inputSchema: { type: "object", properties: {} } },
+  { name: "execute", inputSchema: { type: "object", properties: {} } },
+  { name: "memory_recall", inputSchema: { type: "object", properties: {} } },
+  { name: "memory_ingest", inputSchema: { type: "object", properties: {} } },
+  { name: "cache", inputSchema: { type: "object", properties: {} } },
+  { name: "audit", inputSchema: { type: "object", properties: {} } },
+  { name: "pageindex_build_tree", inputSchema: { type: "object", properties: {} } },
+  { name: "ouroboros_run_evolutionary_loop", inputSchema: { type: "object", properties: {} } },
+];
+
+describe("mcp-ui-atr", () => {
+  it("identifies internal tool prefixes", () => {
+    expect(isInternalToolName("ouroboros_run_evolutionary_loop")).toBe(true);
+    expect(isInternalToolName("pageindex_build_tree")).toBe(true);
+    expect(isInternalToolName("memory_recall")).toBe(false);
+  });
+
+  it("admin / * sees everything including internal tools", () => {
+    expect(
+      filterToolsForAtr(tools, { sub: "a", role: "admin" }, true).map((t) => t.name)
+    ).toEqual(tools.map((t) => t.name));
+    expect(
+      filterToolsForAtr(tools, { sub: "a", scope: ["*"] }, true).map((t) => t.name)
+    ).toEqual(tools.map((t) => t.name));
+  });
+
+  it("memory+search scope excludes execute and internal tools", () => {
+    const atr = { sub: "staff", role: "operator", scope: ["search", "memory"] };
+    const names = filterToolsForAtr(tools, atr, true).map((t) => t.name).sort();
+    expect(names).toEqual(["memory_ingest", "memory_recall", "search"]);
+    expect(isToolAuthorizedForAtr("ouroboros_run_evolutionary_loop", atr)).toBe(false);
+    expect(isToolAuthorizedForAtr("pageindex_build_tree", atr)).toBe(false);
+    expect(isToolAuthorizedForAtr("execute", atr)).toBe(false);
+  });
+
+  it("explicit tools list can grant internal tools without family scope", () => {
+    const atr = {
+      sub: "dev",
+      scope: ["search"],
+      tools: ["pageindex_build_tree"],
+    };
+    expect(isToolAuthorizedForAtr("search", atr)).toBe(true);
+    expect(isToolAuthorizedForAtr("pageindex_build_tree", atr)).toBe(true);
+    expect(isToolAuthorizedForAtr("ouroboros_run_evolutionary_loop", atr)).toBe(false);
+  });
+
+  it("family scopes pageindex / ouroboros grant internal prefixes", () => {
+    expect(
+      isToolAuthorizedForAtr("pageindex_build_tree", {
+        sub: "x",
+        scope: ["pageindex"],
+      })
+    ).toBe(true);
+    expect(
+      isToolAuthorizedForAtr("ouroboros_run_evolutionary_loop", {
+        sub: "x",
+        scope: ["ouroboros"],
+      })
+    ).toBe(true);
+  });
+
+  it("atrScoped=false returns the full catalog", () => {
+    expect(
+      filterToolsForAtr(tools, { sub: "x", scope: ["search"] }, false).map((t) => t.name)
+    ).toEqual(tools.map((t) => t.name));
+  });
+});

--- a/packages/mcp-api-adapter/src/mcp-ui-atr.test.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-atr.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { ListedMcpTool } from "mcp-grpc-transport";
 import {
+  canProcessDocuments,
   filterToolsForAtr,
   isInternalToolName,
   isToolAuthorizedForAtr,
@@ -72,5 +73,28 @@ describe("mcp-ui-atr", () => {
     expect(
       filterToolsForAtr(tools, { sub: "x", scope: ["search"] }, false).map((t) => t.name)
     ).toEqual(tools.map((t) => t.name));
+  });
+
+  it("documents/idp capability scopes grant IDP tools", () => {
+    expect(
+      isToolAuthorizedForAtr("run_idp_pipeline", { sub: "ops", scope: ["documents"] })
+    ).toBe(true);
+    expect(
+      isToolAuthorizedForAtr("run_idp_pipeline", { sub: "ops", scope: ["idp"] })
+    ).toBe(true);
+    expect(
+      isToolAuthorizedForAtr("run_idp_pipeline", { sub: "ops", scope: ["memory"] })
+    ).toBe(false);
+  });
+
+  it("canProcessDocuments is separate from generic capability scopes", () => {
+    expect(canProcessDocuments({ sub: "a", role: "admin" })).toBe(true);
+    expect(canProcessDocuments({ sub: "a", scope: ["*"] })).toBe(true);
+    expect(canProcessDocuments({ sub: "a", scope: ["documents"] })).toBe(true);
+    expect(canProcessDocuments({ sub: "a", scope: ["idp"] })).toBe(true);
+    expect(canProcessDocuments({ sub: "a", scope: ["memory", "search"] })).toBe(false);
+    expect(
+      canProcessDocuments({ sub: "a", scope: ["search"], tools: ["run_idp_pipeline"] })
+    ).toBe(true);
   });
 });

--- a/packages/mcp-api-adapter/src/mcp-ui-atr.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-atr.ts
@@ -12,7 +12,46 @@ const CAPABILITY_TOOLS: Record<string, readonly string[]> = {
   audit: ["audit"],
   cache: ["cache"],
   ingest: ["ingest_external_knowledge"],
+  /** Document tools visibility (separate from file-processing gate). */
+  documents: [
+    "run_idp_pipeline",
+    "classify_document",
+    "extract_document",
+    "convert_document",
+    "inspect_pdf",
+  ],
+  idp: [
+    "run_idp_pipeline",
+    "classify_document",
+    "extract_document",
+    "convert_document",
+    "inspect_pdf",
+  ],
 };
+
+/** Scopes that may trigger document/file processing (Batch 2 IDP gate). */
+const DOCUMENT_PROCESSING_SCOPES = new Set(["documents", "idp", "*"]);
+
+export function canProcessDocuments(atr: VerifiedMcpAdapterAtr): boolean {
+  const role = atr.role?.trim().toLowerCase();
+  if (role === "admin") return true;
+  const scopes = scopesOf(atr);
+  const tools = toolsOf(atr);
+  if (scopes.includes("*") || tools.includes("*")) return true;
+  if (scopes.some((s) => DOCUMENT_PROCESSING_SCOPES.has(s))) return true;
+  // Explicit grant of an IDP tool implies processing for that operator
+  if (
+    tools.some((t) =>
+      ["run_idp_pipeline", "convert_document", "inspect_pdf"].includes(t)
+    ) ||
+    scopes.some((t) =>
+      ["run_idp_pipeline", "convert_document", "inspect_pdf"].includes(t)
+    )
+  ) {
+    return true;
+  }
+  return false;
+}
 
 export function isInternalToolName(toolName: string): boolean {
   return INTERNAL_TOOL_PREFIXES.some((prefix) => toolName.startsWith(prefix));

--- a/packages/mcp-api-adapter/src/mcp-ui-atr.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-atr.ts
@@ -1,0 +1,79 @@
+import type { ListedMcpTool } from "mcp-grpc-transport";
+import type { VerifiedMcpAdapterAtr } from "./edge-auth.js";
+
+/** Tool-name prefixes that must be explicitly granted (not via generic memory/search scopes). */
+export const INTERNAL_TOOL_PREFIXES = ["ouroboros_", "pageindex_"] as const;
+
+/** Capability scope → tool names (non-internal). */
+const CAPABILITY_TOOLS: Record<string, readonly string[]> = {
+  search: ["search"],
+  execute: ["execute"],
+  memory: ["memory_recall", "memory_ingest", "memory_sync"],
+  audit: ["audit"],
+  cache: ["cache"],
+  ingest: ["ingest_external_knowledge"],
+};
+
+export function isInternalToolName(toolName: string): boolean {
+  return INTERNAL_TOOL_PREFIXES.some((prefix) => toolName.startsWith(prefix));
+}
+
+function scopesOf(atr: VerifiedMcpAdapterAtr): string[] {
+  return Array.isArray(atr.scope) ? atr.scope.map((s) => String(s).trim()).filter(Boolean) : [];
+}
+
+function toolsOf(atr: VerifiedMcpAdapterAtr): string[] {
+  return Array.isArray(atr.tools) ? atr.tools.map((s) => String(s).trim()).filter(Boolean) : [];
+}
+
+/**
+ * Whether a tool is visible/executable for this ATR.
+ *
+ * - `role: admin` or scope/tools `*` → all tools
+ * - Exact tool name in `scope` or `tools` → that tool (including internal)
+ * - Capability scopes (`search`, `memory`, …) → mapped public tools only
+ * - Family scopes `pageindex` / `ouroboros` → matching internal prefixes
+ * - Internal tools are never granted by generic capability scopes alone
+ */
+export function isToolAuthorizedForAtr(
+  toolName: string,
+  atr: VerifiedMcpAdapterAtr
+): boolean {
+  const role = atr.role?.trim().toLowerCase();
+  if (role === "admin") return true;
+
+  const scopes = scopesOf(atr);
+  const tools = toolsOf(atr);
+  if (scopes.includes("*") || tools.includes("*")) return true;
+
+  if (scopes.includes(toolName) || tools.includes(toolName)) return true;
+
+  if (isInternalToolName(toolName)) {
+    if (toolName.startsWith("pageindex_") && scopes.includes("pageindex")) return true;
+    if (toolName.startsWith("ouroboros_") && scopes.includes("ouroboros")) return true;
+    return false;
+  }
+
+  for (const scope of scopes) {
+    const mapped = CAPABILITY_TOOLS[scope];
+    if (mapped?.includes(toolName)) return true;
+  }
+
+  return false;
+}
+
+/** Admin-equivalent ATR used for static API-key edge auth. */
+export const API_KEY_ADMIN_ATR: VerifiedMcpAdapterAtr = {
+  sub: "api-key",
+  role: "admin",
+  scope: ["*"],
+};
+
+export function filterToolsForAtr(
+  tools: ListedMcpTool[],
+  atr: VerifiedMcpAdapterAtr | undefined,
+  atrScoped: boolean
+): ListedMcpTool[] {
+  if (!atrScoped || !atr) return tools;
+  return tools.filter((tool) => isToolAuthorizedForAtr(tool.name, atr));
+}

--- a/packages/mcp-api-adapter/src/mcp-ui-batches.e2e.test.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-batches.e2e.test.ts
@@ -1,0 +1,237 @@
+import { SignJWT } from "jose";
+import { afterEach, describe, expect, it } from "vitest";
+import { createMcpApiAdapterApp } from "./server.js";
+import type { ListedMcpTool, ToolCatalog } from "./types.js";
+
+const catalogTools: ListedMcpTool[] = [
+  {
+    name: "search",
+    description: "Search ops",
+    inputSchema: {
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+    },
+  },
+  {
+    name: "run_idp_pipeline",
+    description: "IDP",
+    inputSchema: {
+      type: "object",
+      properties: {
+        pdf_base64: { type: "string", description: "Optional seed PDF (base64)" },
+        dry_run: { type: "boolean", default: true },
+      },
+    },
+  },
+  {
+    name: "memory_recall",
+    description: "Recall",
+    inputSchema: {
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+    },
+  },
+];
+
+function catalog(): ToolCatalog {
+  return {
+    tools: catalogTools,
+    fetchedAt: new Date().toISOString(),
+    upstream: "test",
+    upstreamKind: "http",
+    surfaces: ["openapi", "mcp-ui"],
+    mcpUiPath: "/mcp-ui",
+  };
+}
+
+function multipartBody(
+  boundary: string,
+  parts: Array<{ name: string; filename?: string; contentType?: string; body: string | Buffer }>
+): Buffer {
+  const chunks: Buffer[] = [];
+  for (const part of parts) {
+    chunks.push(Buffer.from(`--${boundary}\r\n`));
+    if (part.filename) {
+      chunks.push(
+        Buffer.from(
+          `Content-Disposition: form-data; name="${part.name}"; filename="${part.filename}"\r\nContent-Type: ${part.contentType ?? "application/octet-stream"}\r\n\r\n`
+        )
+      );
+    } else {
+      chunks.push(
+        Buffer.from(`Content-Disposition: form-data; name="${part.name}"\r\n\r\n`)
+      );
+    }
+    chunks.push(typeof part.body === "string" ? Buffer.from(part.body) : part.body);
+    chunks.push(Buffer.from("\r\n"));
+  }
+  chunks.push(Buffer.from(`--${boundary}--\r\n`));
+  return Buffer.concat(chunks);
+}
+
+describe("mcp-ui batches 2-4 e2e", () => {
+  const secret = "test-mcp-ui-batches-hs256-secret-32ch!!";
+  const issuer = "https://auth.clawql.test";
+  let closeServer: (() => Promise<void>) | undefined;
+  let lastArgs: Record<string, unknown> | undefined;
+
+  afterEach(async () => {
+    await closeServer?.();
+    closeServer = undefined;
+    lastArgs = undefined;
+  });
+
+  async function mintJwt(atr: Record<string, unknown>): Promise<string> {
+    return new SignJWT({ atr })
+      .setProtectedHeader({ alg: "HS256" })
+      .setSubject(String(atr.sub ?? "user"))
+      .setIssuer(issuer)
+      .setExpirationTime("5m")
+      .sign(new TextEncoder().encode(secret));
+  }
+
+  async function startApp(): Promise<string> {
+    const app = createMcpApiAdapterApp({
+      getCatalog: catalog,
+      callTool: async (_tool, args) => {
+        lastArgs = args;
+        // Simulate a slightly slow IDP call
+        await new Promise((r) => setTimeout(r, 30));
+        return { text: JSON.stringify({ ok: true, dry_run: args.dry_run }), content: [], isError: false };
+      },
+      jwtAuth: { hs256Secret: secret, issuer },
+      mcpUiPath: "/mcp-ui",
+      mcpUiAtrScoped: true,
+    });
+    const server = await new Promise<import("node:http").Server>((resolve) => {
+      const s = app.listen(0, "127.0.0.1", () => resolve(s));
+    });
+    closeServer = () =>
+      new Promise((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("no addr");
+    return `http://127.0.0.1:${addr.port}`;
+  }
+
+  it("multipart upload maps to pdf_base64 when ATR allows documents", async () => {
+    const base = await startApp();
+    const token = await mintJwt({ sub: "ops", role: "operator", scope: ["documents"] });
+    const boundary = "----clawqlboundary";
+    const body = multipartBody(boundary, [
+      { name: "dry_run", body: "true" },
+      {
+        name: "pdf_base64",
+        filename: "sample.pdf",
+        contentType: "application/pdf",
+        body: Buffer.from("%PDF-demo"),
+      },
+    ]);
+    const res = await fetch(`${base}/mcp-ui/execute/run_idp_pipeline`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": `multipart/form-data; boundary=${boundary}`,
+      },
+      body,
+    });
+    // long-running → SSE shell
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("EventSource");
+    expect(html).toContain("/mcp-ui/progress/");
+    const jobMatch = html.match(/\/mcp-ui\/progress\/([a-f0-9-]+)/i);
+    expect(jobMatch?.[1]).toBeTruthy();
+
+    // Wait for background job to finish and args to be captured
+    for (let i = 0; i < 40 && !lastArgs; i++) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(lastArgs?.pdf_base64).toBe(Buffer.from("%PDF-demo").toString("base64"));
+    expect(lastArgs?.dry_run).toBe(true);
+
+    const sse = await fetch(`${base}/mcp-ui/progress/${jobMatch![1]}`);
+    expect(sse.status).toBe(200);
+    expect(sse.headers.get("content-type")).toMatch(/text\/event-stream/);
+    const sseText = await sse.text();
+    expect(sseText).toMatch(/event: (progress|complete)/);
+  });
+
+  it("denies multipart upload without document-processing ATR", async () => {
+    const base = await startApp();
+    const boundary = "----denyboundary";
+    const body = multipartBody(boundary, [
+      { name: "query", body: "hello" },
+      {
+        name: "upload",
+        filename: "x.bin",
+        contentType: "application/octet-stream",
+        body: Buffer.from("secret"),
+      },
+    ]);
+
+    const deniedTool = await fetch(`${base}/mcp-ui/execute/run_idp_pipeline`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${await mintJwt({ sub: "m", scope: ["memory"] })}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: "dry_run=true",
+    });
+    expect(deniedTool.status).toBe(403);
+
+    const memoryOnly = await mintJwt({ sub: "m2", scope: ["memory", "search"] });
+    const deniedUpload = await fetch(`${base}/mcp-ui/execute/search`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${memoryOnly}`,
+        "Content-Type": `multipart/form-data; boundary=${boundary}`,
+      },
+      body,
+    });
+    expect(deniedUpload.status).toBe(403);
+    expect(await deniedUpload.text()).toMatch(/document\/file processing/i);
+  });
+
+  it("POST /mcp-ui/generate creates a custom multi-step form", async () => {
+    const base = await startApp();
+    const token = await mintJwt({ sub: "ops", scope: ["search", "memory"] });
+    const created = await fetch(`${base}/mcp-ui/generate`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        title: "Search then recall",
+        steps: [{ tool: "search" }, { tool: "memory_recall" }],
+      }),
+    });
+    expect(created.status).toBe(201);
+    const json = (await created.json()) as { slug: string; url: string };
+    expect(json.url).toContain(`/mcp-ui/custom/${json.slug}`);
+
+    const page = await fetch(`${base}/mcp-ui/custom/${json.slug}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(page.status).toBe(200);
+    const html = await page.text();
+    expect(html).toContain("Search then recall");
+    expect(html).toContain("Step 1 of 2");
+    expect(html).toContain(`hx-post="/mcp-ui/custom/${json.slug}/step"`);
+
+    const step = await fetch(`${base}/mcp-ui/custom/${json.slug}/step`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: "query=repos",
+    });
+    expect(step.status).toBe(200);
+    expect(await step.text()).toMatch(/search|Next/i);
+  });
+});

--- a/packages/mcp-api-adapter/src/mcp-ui-batches.test.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-batches.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { mergeFilesIntoArgs } from "./mcp-ui-multipart.js";
+import {
+  createProgressJob,
+  getProgressJob,
+  isLongRunningTool,
+  pushProgressEvent,
+  subscribeProgress,
+} from "./mcp-ui-progress.js";
+import { createGeneratedUi, getGeneratedUiBySlug } from "./mcp-ui-generate.js";
+import type { ListedMcpTool } from "mcp-grpc-transport";
+import { formHintsForTool, resolveMcpUiTemplate } from "./mcp-ui-templates.js";
+import { renderToolFormFields } from "./mcp-ui-form.js";
+
+describe("mcp-ui-multipart mergeFilesIntoArgs", () => {
+  it("maps upload into preferred pdf_base64 field", () => {
+    const merged = mergeFilesIntoArgs(
+      { dry_run: "true" },
+      {
+        file: {
+          filename: "doc.pdf",
+          mimeType: "application/pdf",
+          buffer: Buffer.from("%PDF-1.4"),
+        },
+      },
+      "pdf_base64"
+    );
+    expect(merged.dry_run).toBe("true");
+    expect(merged.pdf_base64).toBe(Buffer.from("%PDF-1.4").toString("base64"));
+    expect(merged.base64).toBeUndefined();
+    expect(merged.__upload_filename).toBe("doc.pdf");
+  });
+
+  it("uses field name when file input is named pdf_base64", () => {
+    const merged = mergeFilesIntoArgs(
+      {},
+      {
+        pdf_base64: {
+          filename: "a.pdf",
+          mimeType: "application/pdf",
+          buffer: Buffer.from("abc"),
+        },
+      }
+    );
+    expect(merged.pdf_base64).toBe(Buffer.from("abc").toString("base64"));
+  });
+});
+
+describe("mcp-ui-progress", () => {
+  it("recognizes long-running tools", () => {
+    expect(isLongRunningTool("run_idp_pipeline")).toBe(true);
+    expect(isLongRunningTool("ouroboros_run_evolutionary_loop")).toBe(true);
+    expect(isLongRunningTool("search")).toBe(false);
+  });
+
+  it("fans out progress events to subscribers", async () => {
+    const job = createProgressJob("run_idp_pipeline");
+    expect(getProgressJob(job.id)?.id).toBe(job.id);
+    const seen: string[] = [];
+    const unsub = subscribeProgress(job, (e) => seen.push(e.type));
+    pushProgressEvent(job, { type: "progress", message: "go", percent: 10 });
+    pushProgressEvent(job, { type: "complete", message: "done", percent: 100 });
+    expect(seen).toEqual(["progress", "complete"]);
+    expect(job.done).toBe(true);
+    unsub();
+  });
+});
+
+describe("mcp-ui-generate", () => {
+  const tools: ListedMcpTool[] = [
+    { name: "search", inputSchema: { type: "object", properties: { query: { type: "string" } } } },
+    {
+      name: "memory_recall",
+      inputSchema: { type: "object", properties: { query: { type: "string" } } },
+    },
+  ];
+
+  it("creates a slug and rejects unknown tools", () => {
+    const form = createGeneratedUi(
+      {
+        title: "Search then recall",
+        steps: [{ tool: "search", label: "Search" }, { tool: "memory_recall" }],
+      },
+      tools
+    );
+    expect(form.slug).toMatch(/search-then-recall/);
+    expect(getGeneratedUiBySlug(form.slug)?.id).toBe(form.id);
+    expect(() =>
+      createGeneratedUi({ title: "Bad", steps: [{ tool: "nope" }] }, tools)
+    ).toThrow(/Unknown tool/);
+  });
+});
+
+describe("mcp-ui IDP template", () => {
+  it("marks pdf_base64 as a file field with multipart form", () => {
+    const tool: ListedMcpTool = {
+      name: "run_idp_pipeline",
+      inputSchema: {
+        type: "object",
+        properties: {
+          pdf_base64: { type: "string", description: "Optional seed PDF (base64)" },
+          dry_run: { type: "boolean", default: true },
+        },
+      },
+    };
+    expect(resolveMcpUiTemplate(tool)?.fileFields).toContain("pdf_base64");
+    const hints = formHintsForTool(tool);
+    const rendered = renderToolFormFields(tool, hints);
+    expect(rendered.hasFileFields).toBe(true);
+    expect(rendered.html).toContain('type="file"');
+    expect(rendered.html).toContain('name="pdf_base64"');
+  });
+});

--- a/packages/mcp-api-adapter/src/mcp-ui-form.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-form.ts
@@ -77,6 +77,21 @@ function shortPlaceholder(description: string | undefined, max = 90): string {
   return `${oneLine.slice(0, max - 1)}…`;
 }
 
+/** True when a flat string field should render as `<input type="file">`. */
+export function looksLikeFileField(
+  name: string,
+  propSchema: Record<string, unknown>,
+  asFile?: boolean
+): boolean {
+  if (asFile) return true;
+  if (propSchema.format === "binary" || propSchema.format === "byte") return true;
+  if (propSchema.contentMediaType != null) return true;
+  // Exact arg names used by IDP / document tools (not *File path strings).
+  if (/^(file|upload|pdf_base64|base64)$/i.test(name)) return true;
+  if (/_base64$/i.test(name)) return true;
+  return false;
+}
+
 function labelBadge(required: boolean): string {
   return required
     ? `<span class="badge badge--required">Required</span>`
@@ -118,16 +133,7 @@ export function renderFieldControl(options: RenderFieldOptions): string {
     ? `<p class="field-error" role="alert">${escHtml(errorMessage)}</p>`
     : "";
 
-  if (
-    asFile ||
-    propSchema.format === "binary" ||
-    propSchema.format === "byte" ||
-    propSchema.contentMediaType != null ||
-    /^(file|upload|pdf_base64|base64)$/i.test(name) ||
-    (typeof description === "string" &&
-      /\b(upload|file|document|pdf|image)\b/i.test(description) &&
-      /base64|binary|path/i.test(name + (description || "")))
-  ) {
+  if (looksLikeFileField(name, propSchema, asFile)) {
     return `<label class="field${errClass}">
   <span class="field-label">${escHtml(label)} ${labelBadge(required)}</span>
   <input type="file" name="${escHtml(name)}" accept="*/*"${reqAttr} />
@@ -302,16 +308,9 @@ export function renderToolFormFields(
 
   const hasFileFields =
     (hints.fileFields?.length ?? 0) > 0 ||
-    Object.entries(flatProps).some(([key, schema]) => {
-      if (hints.fileFields?.includes(key)) return true;
-      if (schema.format === "binary" || schema.format === "byte") return true;
-      if (/^(file|upload|pdf_base64|base64)$/i.test(key)) return true;
-      const desc = typeof schema.description === "string" ? schema.description : "";
-      return (
-        /\b(upload|file|document|pdf|image)\b/i.test(desc) &&
-        /base64|binary|pdf_base64|file/i.test(key + desc)
-      );
-    });
+    Object.entries(flatProps).some(([key, schema]) =>
+      looksLikeFileField(key, schema, hints.fileFields?.includes(key))
+    );
 
   return { mode, hasFileFields, html: `${primaryHtml}\n${advancedHtml}\n${omitNote}` };
 }

--- a/packages/mcp-api-adapter/src/mcp-ui-form.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-form.ts
@@ -91,6 +91,8 @@ export type RenderFieldOptions = {
   prefills?: Record<string, unknown>;
   /** Force textarea for long text. */
   asTextarea?: boolean;
+  /** Render as file upload. */
+  asFile?: boolean;
   /** Extra hint under the field (template op guidance). */
   hint?: string;
   /** Highlight this field after a validation error. */
@@ -98,7 +100,7 @@ export type RenderFieldOptions = {
 };
 
 export function renderFieldControl(options: RenderFieldOptions): string {
-  const { name, propSchema, required, prefills, asTextarea, hint, errorMessage } = options;
+  const { name, propSchema, required, prefills, asTextarea, asFile, hint, errorMessage } = options;
   const label = typeof propSchema.title === "string" ? propSchema.title : name;
   const description =
     typeof propSchema.description === "string" ? propSchema.description : undefined;
@@ -115,6 +117,23 @@ export function renderFieldControl(options: RenderFieldOptions): string {
   const errHtml = errorMessage
     ? `<p class="field-error" role="alert">${escHtml(errorMessage)}</p>`
     : "";
+
+  if (
+    asFile ||
+    propSchema.format === "binary" ||
+    propSchema.format === "byte" ||
+    propSchema.contentMediaType != null ||
+    /^(file|upload|pdf_base64|base64)$/i.test(name) ||
+    (typeof description === "string" &&
+      /\b(upload|file|document|pdf|image)\b/i.test(description) &&
+      /base64|binary|path/i.test(name + (description || "")))
+  ) {
+    return `<label class="field${errClass}">
+  <span class="field-label">${escHtml(label)} ${labelBadge(required)}</span>
+  <input type="file" name="${escHtml(name)}" accept="*/*"${reqAttr} />
+  ${hintHtml || `<p class="field-help">Uploaded files are base64-encoded into the tool arguments before CallTool.</p>`}${errHtml}
+</label>`;
+  }
 
   const enumValues = Array.isArray(propSchema.enum) ? propSchema.enum : undefined;
   if (enumValues && enumValues.length > 0) {
@@ -188,6 +207,8 @@ export type FormRenderHints = {
   defaults?: Record<string, unknown>;
   /** Force textarea for these field names. */
   textareas?: string[];
+  /** Force file input for these field names. */
+  fileFields?: string[];
   /** Per-field helper copy. */
   hints?: Record<string, string>;
   /** Field-level errors to highlight. */
@@ -220,7 +241,7 @@ function partitionFields(
 export function renderToolFormFields(
   tool: ListedMcpTool,
   hints: FormRenderHints = {}
-): { mode: McpUiFormMode; html: string } {
+): { mode: McpUiFormMode; html: string; hasFileFields: boolean } {
   const inputSchema = tool.inputSchema ?? { type: "object", properties: {} };
   const mode = formModeFromInputSchema(inputSchema);
 
@@ -228,6 +249,7 @@ export function renderToolFormFields(
     const err = hints.fieldErrors?.__json_args;
     return {
       mode,
+      hasFileFields: false,
       html: `<label class="field${err ? " field--error" : ""}">
   <span class="field-label">Arguments (JSON object) ${labelBadge(true)}</span>
   <textarea name="__json_args" rows="6" placeholder="{}">{}</textarea>
@@ -255,6 +277,7 @@ export function renderToolFormFields(
           required: requiredList.includes(key),
           prefills,
           asTextarea: hints.textareas?.includes(key),
+          asFile: hints.fileFields?.includes(key),
           hint: hints.hints?.[key],
           errorMessage: hints.fieldErrors?.[key],
         })
@@ -277,7 +300,20 @@ export function renderToolFormFields(
       ? `<p class="field-help">Complex fields omitted: ${escHtml(omitted.join(", "))}. Use REST <code>POST /${escHtml(tool.name)}</code> for full args.</p>`
       : "";
 
-  return { mode, html: `${primaryHtml}\n${advancedHtml}\n${omitNote}` };
+  const hasFileFields =
+    (hints.fileFields?.length ?? 0) > 0 ||
+    Object.entries(flatProps).some(([key, schema]) => {
+      if (hints.fileFields?.includes(key)) return true;
+      if (schema.format === "binary" || schema.format === "byte") return true;
+      if (/^(file|upload|pdf_base64|base64)$/i.test(key)) return true;
+      const desc = typeof schema.description === "string" ? schema.description : "";
+      return (
+        /\b(upload|file|document|pdf|image)\b/i.test(desc) &&
+        /base64|binary|pdf_base64|file/i.test(key + desc)
+      );
+    });
+
+  return { mode, hasFileFields, html: `${primaryHtml}\n${advancedHtml}\n${omitNote}` };
 }
 
 function parseFieldValue(

--- a/packages/mcp-api-adapter/src/mcp-ui-generate.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-generate.ts
@@ -1,0 +1,114 @@
+import { randomUUID } from "node:crypto";
+import type { ListedMcpTool } from "mcp-grpc-transport";
+
+export type GeneratedUiStep = {
+  tool: string;
+  label?: string;
+  dependsOn?: string;
+};
+
+export type GeneratedUiDefinition = {
+  title: string;
+  description?: string;
+  steps: GeneratedUiStep[];
+  /** URL path segment under /mcp-ui/custom/ */
+  slug?: string;
+};
+
+export type GeneratedUiForm = {
+  id: string;
+  slug: string;
+  title: string;
+  description?: string;
+  steps: GeneratedUiStep[];
+  createdAt: number;
+  /** Collected outputs keyed by tool name. */
+  stepOutputs: Record<string, unknown>;
+  currentStepIndex: number;
+};
+
+const forms = new Map<string, GeneratedUiForm>();
+const bySlug = new Map<string, string>();
+const TTL_MS = 60 * 60 * 1000;
+const MAX_FORMS = 100;
+
+function sweep(): void {
+  const now = Date.now();
+  for (const [id, form] of forms) {
+    if (now - form.createdAt > TTL_MS) {
+      forms.delete(id);
+      bySlug.delete(form.slug);
+    }
+  }
+  while (forms.size > MAX_FORMS) {
+    const oldest = forms.keys().next().value;
+    if (!oldest) break;
+    const form = forms.get(oldest);
+    forms.delete(oldest);
+    if (form) bySlug.delete(form.slug);
+  }
+}
+
+function slugify(title: string): string {
+  return (
+    title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "")
+      .slice(0, 48) || "custom-form"
+  );
+}
+
+export function createGeneratedUi(
+  def: GeneratedUiDefinition,
+  catalogTools: ListedMcpTool[]
+): GeneratedUiForm {
+  sweep();
+  if (!def.title?.trim()) throw new Error("title is required");
+  if (!Array.isArray(def.steps) || def.steps.length === 0) {
+    throw new Error("steps must be a non-empty array");
+  }
+
+  const known = new Set(catalogTools.map((t) => t.name));
+  for (const step of def.steps) {
+    if (!step.tool?.trim()) throw new Error("each step needs a tool name");
+    if (!known.has(step.tool)) {
+      throw new Error(`Unknown tool in workflow: ${step.tool}`);
+    }
+  }
+
+  let slug = (def.slug?.trim() || slugify(def.title)).replace(/^\/+|\/+$/g, "");
+  if (bySlug.has(slug)) slug = `${slug}-${randomUUID().slice(0, 8)}`;
+
+  const form: GeneratedUiForm = {
+    id: randomUUID(),
+    slug,
+    title: def.title.trim(),
+    description: def.description?.trim(),
+    steps: def.steps.map((s) => ({
+      tool: s.tool,
+      label: s.label?.trim() || s.tool,
+      dependsOn: s.dependsOn,
+    })),
+    createdAt: Date.now(),
+    stepOutputs: {},
+    currentStepIndex: 0,
+  };
+  forms.set(form.id, form);
+  bySlug.set(form.slug, form.id);
+  return form;
+}
+
+export function getGeneratedUiBySlug(slug: string): GeneratedUiForm | undefined {
+  const id = bySlug.get(slug);
+  return id ? forms.get(id) : undefined;
+}
+
+export function getGeneratedUiById(id: string): GeneratedUiForm | undefined {
+  return forms.get(id);
+}
+
+export function listGeneratedUis(): GeneratedUiForm[] {
+  sweep();
+  return [...forms.values()];
+}

--- a/packages/mcp-api-adapter/src/mcp-ui-html.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-html.ts
@@ -430,6 +430,7 @@ export function renderMcpUiProgressShell(options: {
 }): string {
   const base = options.basePath.replace(/\/$/, "") || "/mcp-ui";
   const sseUrl = `${base}/progress/${encodeURIComponent(options.jobId)}`;
+  const resultUrl = `${sseUrl}/result`;
   return `<div class="result result--progress" data-job="${escapeMcpUiHtml(options.jobId)}">
   <header class="result__header">
     <span class="result__tool">${escapeMcpUiHtml(options.toolName)}</span>
@@ -447,7 +448,26 @@ export function renderMcpUiProgressShell(options: {
   var barEl = root.querySelector('[data-role="bar"]');
   var logEl = root.querySelector('[data-role="log"]');
   var finalEl = root.querySelector('[data-role="final"]');
+  var resultUrl = ${JSON.stringify(resultUrl)};
   var es = new EventSource(${JSON.stringify(sseUrl)});
+  function loadResult() {
+    if (!finalEl) return;
+    fetch(resultUrl, { credentials: 'same-origin' })
+      .then(function (r) { return r.text(); })
+      .then(function (html) {
+        if (window.htmx && typeof htmx.swap === 'function') {
+          htmx.swap(finalEl, html, { swapStyle: 'innerHTML' });
+        } else {
+          finalEl.replaceChildren();
+          var tpl = document.createElement('template');
+          tpl.innerHTML = html;
+          finalEl.appendChild(tpl.content);
+        }
+      })
+      .catch(function () {
+        if (finalEl) finalEl.textContent = 'Failed to load result fragment.';
+      });
+  }
   function onEvent(ev) {
     var data;
     try { data = JSON.parse(ev.data); } catch (e) { return; }
@@ -458,8 +478,8 @@ export function renderMcpUiProgressShell(options: {
       li.textContent = (data.at ? data.at + " — " : "") + data.message;
       logEl.appendChild(li);
     }
-    if ((ev.type === "complete" || ev.type === "error") && data.resultHtml && finalEl) {
-      finalEl.innerHTML = data.resultHtml;
+    if (ev.type === "complete" || ev.type === "error") {
+      loadResult();
       es.close();
     }
   }

--- a/packages/mcp-api-adapter/src/mcp-ui-html.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-html.ts
@@ -4,6 +4,7 @@ import {
   renderToolFormFields,
   type FormFieldError,
 } from "./mcp-ui-form.js";
+import type { GeneratedUiForm } from "./mcp-ui-generate.js";
 import { renderResultContent } from "./mcp-ui-results.js";
 import { formHintsForTool, resultKindForTool, resolveMcpUiTemplate } from "./mcp-ui-templates.js";
 
@@ -273,6 +274,7 @@ const MCP_UI_STYLES = `
   .result-empty { margin: 0 0 0.5rem; color: var(--muted); }
   .result-raw { margin-top: 0.65rem; font-size: 0.82rem; color: var(--muted); }
   .result-raw summary { cursor: pointer; }
+  .result--progress progress { width: 100%; margin: 0.35rem 0 0.75rem; }
   .pill {
     display: inline-block;
     padding: 0.05rem 0.4rem;
@@ -297,7 +299,7 @@ function renderToolCard(
   fieldErrors?: Record<string, string>
 ): string {
   const hints = formHintsForTool(tool, fieldErrors);
-  const { html: fieldsHtml } = renderToolFormFields(tool, hints);
+  const { html: fieldsHtml, hasFileFields } = renderToolFormFields(tool, hints);
   const template = resolveMcpUiTemplate(tool);
   const title = tool.title?.trim() || tool.description?.trim() || tool.name;
   const description =
@@ -306,6 +308,9 @@ function renderToolCard(
       : "";
   const templatePill = template
     ? `<span class="template-pill">Template · ${escapeMcpUiHtml(template.id)}</span>`
+    : "";
+  const multipartAttrs = hasFileFields
+    ? ` enctype="multipart/form-data" hx-encoding="multipart/form-data"`
     : "";
 
   return `<article class="tool-card" id="tool-${escapeMcpUiHtml(tool.name)}">
@@ -317,7 +322,7 @@ function renderToolCard(
     hx-post="${escapeMcpUiHtml(basePath)}/execute/${escapeMcpUiHtml(tool.name)}"
     hx-target="#result-${escapeMcpUiHtml(tool.name)}"
     hx-swap="innerHTML"
-    hx-indicator="#spinner-${escapeMcpUiHtml(tool.name)}"
+    hx-indicator="#spinner-${escapeMcpUiHtml(tool.name)}"${multipartAttrs}
   >
     ${fieldsHtml}
     <button type="submit" class="submit">
@@ -416,4 +421,135 @@ export function renderMcpUiErrorResult(options: {
   ${fieldList}
   ${details}
 </div>`;
+}
+
+export function renderMcpUiProgressShell(options: {
+  jobId: string;
+  toolName: string;
+  basePath: string;
+}): string {
+  const base = options.basePath.replace(/\/$/, "") || "/mcp-ui";
+  const sseUrl = `${base}/progress/${encodeURIComponent(options.jobId)}`;
+  return `<div class="result result--progress" data-job="${escapeMcpUiHtml(options.jobId)}">
+  <header class="result__header">
+    <span class="result__tool">${escapeMcpUiHtml(options.toolName)}</span>
+    <span class="result__time">SSE</span>
+  </header>
+  <p class="progress-status" data-role="status">Starting…</p>
+  <progress max="100" value="0" data-role="bar"></progress>
+  <ul class="result-list result-list--compact" data-role="log"></ul>
+  <div data-role="final"></div>
+  <script>
+(function () {
+  var root = document.currentScript && document.currentScript.parentElement;
+  if (!root) return;
+  var statusEl = root.querySelector('[data-role="status"]');
+  var barEl = root.querySelector('[data-role="bar"]');
+  var logEl = root.querySelector('[data-role="log"]');
+  var finalEl = root.querySelector('[data-role="final"]');
+  var es = new EventSource(${JSON.stringify(sseUrl)});
+  function onEvent(ev) {
+    var data;
+    try { data = JSON.parse(ev.data); } catch (e) { return; }
+    if (statusEl) statusEl.textContent = data.message || ev.type;
+    if (barEl && typeof data.percent === "number") barEl.value = data.percent;
+    if (logEl && data.message) {
+      var li = document.createElement("li");
+      li.textContent = (data.at ? data.at + " — " : "") + data.message;
+      logEl.appendChild(li);
+    }
+    if ((ev.type === "complete" || ev.type === "error") && data.resultHtml && finalEl) {
+      finalEl.innerHTML = data.resultHtml;
+      es.close();
+    }
+  }
+  es.addEventListener("progress", onEvent);
+  es.addEventListener("complete", onEvent);
+  es.addEventListener("error", function (ev) {
+    if (ev.data) onEvent(ev);
+  });
+})();
+  </script>
+</div>`;
+}
+
+export function renderMcpUiCustomFormPage(options: {
+  form: GeneratedUiForm;
+  tool: ListedMcpTool | undefined;
+  fieldsHtml: string;
+  hasFileFields: boolean;
+  basePath: string;
+  title: string;
+  done: boolean;
+}): string {
+  const basePath = options.basePath.replace(/\/$/, "") || "/mcp-ui";
+  const form = options.form;
+  const stepIndex = form.currentStepIndex;
+  const total = form.steps.length;
+  const stepMeta = form.steps
+    .map((s, i) => {
+      const state = i < stepIndex ? "done" : i === stepIndex ? "current" : "todo";
+      return `<li class="step step--${state}">${i + 1}. ${escapeMcpUiHtml(s.label ?? s.tool)}</li>`;
+    })
+    .join("");
+
+  let body: string;
+  if (options.done || !options.tool) {
+    body = `<div class="result result--success"><p>Workflow complete.</p>
+<pre>${escapeMcpUiHtml(JSON.stringify(form.stepOutputs, null, 2))}</pre></div>`;
+  } else {
+    const multipartAttrs = options.hasFileFields
+      ? ` enctype="multipart/form-data" hx-encoding="multipart/form-data"`
+      : "";
+    body = `<article class="tool-card">
+  <h2>${escapeMcpUiHtml(options.tool.title?.trim() || options.tool.name)}</h2>
+  <p class="tool-name">Step ${stepIndex + 1} of ${total}: ${escapeMcpUiHtml(options.tool.name)}</p>
+  <form
+    hx-post="${escapeMcpUiHtml(basePath)}/custom/${escapeMcpUiHtml(form.slug)}/step"
+    hx-target="#custom-result"
+    hx-swap="innerHTML"
+    hx-indicator="#custom-spinner"${multipartAttrs}
+  >
+    ${options.fieldsHtml}
+    <button type="submit" class="submit">
+      Run step
+      <span id="custom-spinner" class="htmx-indicator">…</span>
+    </button>
+  </form>
+  <div id="custom-result" class="result-pane"></div>
+</article>`;
+  }
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${escapeMcpUiHtml(form.title)} — MCP UI</title>
+  <script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js"></script>
+  <meta name="htmx-config" content='{"responseHandling":[{"code":".*", "swap": true}]}' />
+  <style>${MCP_UI_STYLES}
+  .steps { list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 0 0 1rem; }
+  .step { font-size: 0.82rem; color: var(--muted); }
+  .step--current { color: var(--ink); font-weight: 650; }
+  .step--done { text-decoration: line-through; }
+  progress { width: 100%; margin: 0.35rem 0 0.75rem; }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <header class="hero">
+      <div>
+        <h1>${escapeMcpUiHtml(form.title)}</h1>
+        <p>${escapeMcpUiHtml(form.description || "Generated multi-step MCP UI workflow.")}</p>
+      </div>
+      <div class="meta">
+        <div><a href="${escapeMcpUiHtml(basePath)}">← Catalog</a></div>
+      </div>
+    </header>
+    <ol class="steps">${stepMeta}</ol>
+    <main>${body}</main>
+  </div>
+</body>
+</html>`;
 }

--- a/packages/mcp-api-adapter/src/mcp-ui-http.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-http.ts
@@ -1,10 +1,12 @@
 import express, { type Express, type Request } from "express";
 import { httpBodyFromCollapsed } from "./call.js";
+import type { VerifiedMcpAdapterAtr } from "./edge-auth.js";
 import {
   FormValidationError,
   fieldErrorFromMessage,
   parseFormArgs,
 } from "./mcp-ui-form.js";
+import { filterToolsForAtr } from "./mcp-ui-atr.js";
 import {
   renderMcpUiCatalogPage,
   renderMcpUiErrorResult,
@@ -20,7 +22,11 @@ export type AttachMcpUiOptions = {
   callTool: CallToolFn;
   title?: string;
   path?: string;
+  /** Filter catalog/execute by `req.mcpAtr` (default true). */
+  atrScoped?: boolean;
 };
+
+type RequestWithAtr = Request & { mcpAtr?: VerifiedMcpAdapterAtr };
 
 function asFormBody(req: Request): Record<string, unknown> {
   const body = req.body;
@@ -30,19 +36,26 @@ function asFormBody(req: Request): Record<string, unknown> {
   return {};
 }
 
+function atrFromRequest(req: Request): VerifiedMcpAdapterAtr | undefined {
+  return (req as RequestWithAtr).mcpAtr;
+}
+
 export function attachMcpUiRoutes(app: Express, options: AttachMcpUiOptions): string {
   const basePath =
     (options.path?.trim() || DEFAULT_MCP_UI_PATH).replace(/\/$/, "") || DEFAULT_MCP_UI_PATH;
+  const atrScoped = options.atrScoped !== false;
   const router = express.Router();
 
   router.use(express.urlencoded({ extended: false, limit: "2mb" }));
 
-  router.get("/", (_req, res) => {
+  router.get("/", (req, res) => {
     const catalog = options.getCatalog();
+    const atr = atrFromRequest(req);
+    const tools = filterToolsForAtr(catalog.tools, atr, atrScoped);
     res.type("html").send(
       renderMcpUiCatalogPage({
         title: options.title ?? "MCP API Adapter",
-        tools: catalog.tools,
+        tools,
         fetchedAt: catalog.fetchedAt,
         upstream: catalog.upstream,
         basePath,
@@ -61,12 +74,22 @@ export function attachMcpUiRoutes(app: Express, options: AttachMcpUiOptions): st
     }
 
     const catalog = options.getCatalog();
-    const tool = catalog.tools.find((t) => t.name === toolName);
+    const atr = atrFromRequest(req);
+    const authorized = filterToolsForAtr(catalog.tools, atr, atrScoped);
+    const tool = authorized.find((t) => t.name === toolName);
     if (!tool) {
+      const exists = catalog.tools.some((t) => t.name === toolName);
       res
-        .status(404)
+        .status(exists ? 403 : 404)
         .type("html")
-        .send(renderMcpUiErrorResult({ toolName, message: "Unknown tool" }));
+        .send(
+          renderMcpUiErrorResult({
+            toolName,
+            message: exists
+              ? "Forbidden — this tool is outside your ATR scope"
+              : "Unknown tool",
+          })
+        );
       return;
     }
 

--- a/packages/mcp-api-adapter/src/mcp-ui-http.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-http.ts
@@ -1,19 +1,40 @@
-import express, { type Express, type Request } from "express";
+import express, { type Express, type Request, type Response } from "express";
 import { httpBodyFromCollapsed } from "./call.js";
 import type { VerifiedMcpAdapterAtr } from "./edge-auth.js";
 import {
   FormValidationError,
   fieldErrorFromMessage,
   parseFormArgs,
+  renderToolFormFields,
 } from "./mcp-ui-form.js";
-import { filterToolsForAtr } from "./mcp-ui-atr.js";
+import { canProcessDocuments, filterToolsForAtr } from "./mcp-ui-atr.js";
+import {
+  createGeneratedUi,
+  getGeneratedUiBySlug,
+  type GeneratedUiDefinition,
+} from "./mcp-ui-generate.js";
 import {
   renderMcpUiCatalogPage,
+  renderMcpUiCustomFormPage,
   renderMcpUiErrorResult,
+  renderMcpUiProgressShell,
   renderMcpUiSuccessResult,
 } from "./mcp-ui-html.js";
+import {
+  isMultipartRequest,
+  mergeFilesIntoArgs,
+  parseMultipartRequest,
+} from "./mcp-ui-multipart.js";
+import {
+  createProgressJob,
+  getProgressJob,
+  isLongRunningTool,
+  pushProgressEvent,
+  subscribeProgress,
+} from "./mcp-ui-progress.js";
+import { formHintsForTool } from "./mcp-ui-templates.js";
 import { isSafeToolPathName } from "./schema-convert.js";
-import type { CallToolFn, ToolCatalog } from "./types.js";
+import type { CallToolFn, ListedMcpTool, ToolCatalog } from "./types.js";
 
 export const DEFAULT_MCP_UI_PATH = "/mcp-ui";
 
@@ -24,6 +45,8 @@ export type AttachMcpUiOptions = {
   path?: string;
   /** Filter catalog/execute by `req.mcpAtr` (default true). */
   atrScoped?: boolean;
+  /** Max uploaded file size in bytes (default 25 MiB). */
+  maxUploadBytes?: number;
 };
 
 type RequestWithAtr = Request & { mcpAtr?: VerifiedMcpAdapterAtr };
@@ -40,13 +63,177 @@ function atrFromRequest(req: Request): VerifiedMcpAdapterAtr | undefined {
   return (req as RequestWithAtr).mcpAtr;
 }
 
+function documentsProcessingAllowed(
+  atr: VerifiedMcpAdapterAtr | undefined,
+  atrScoped: boolean
+): boolean {
+  if (!atrScoped || !atr) return true;
+  return canProcessDocuments(atr);
+}
+
+function preferredBase64Field(inputSchema: Record<string, unknown>): string | undefined {
+  const props = inputSchema.properties as Record<string, unknown> | undefined;
+  if (!props || typeof props !== "object") return undefined;
+  if ("pdf_base64" in props) return "pdf_base64";
+  if ("base64" in props) return "base64";
+  if ("file" in props) return "file";
+  return undefined;
+}
+
+function stripUploadMeta(args: Record<string, unknown>): Record<string, unknown> {
+  const out = { ...args };
+  delete out.__upload_filename;
+  delete out.__upload_mime;
+  delete out.__sse;
+  return out;
+}
+
+async function resolveExecuteArgs(
+  req: Request,
+  tool: ListedMcpTool,
+  options: {
+    atr: VerifiedMcpAdapterAtr | undefined;
+    atrScoped: boolean;
+    maxUploadBytes: number;
+  }
+): Promise<Record<string, unknown>> {
+  const inputSchema = (tool.inputSchema ?? {
+    type: "object",
+    properties: {},
+  }) as Record<string, unknown>;
+
+  let rawBody: Record<string, unknown>;
+  let hadFiles = false;
+
+  if (isMultipartRequest(req)) {
+    const parsed = await parseMultipartRequest(req, { maxFileBytes: options.maxUploadBytes });
+    hadFiles = Object.keys(parsed.files).length > 0;
+    if (hadFiles && !documentsProcessingAllowed(options.atr, options.atrScoped)) {
+      throw new FormValidationError(
+        "Forbidden — document/file processing is outside your ATR scope",
+        [{ message: "Forbidden — document/file processing is outside your ATR scope" }]
+      );
+    }
+    const merged = mergeFilesIntoArgs(
+      parsed.fields,
+      parsed.files,
+      preferredBase64Field(inputSchema)
+    );
+    rawBody = merged;
+  } else {
+    rawBody = asFormBody(req);
+  }
+
+  const args = parseFormArgs(rawBody, inputSchema);
+  return stripUploadMeta(args);
+}
+
+function renderExecuteError(
+  res: Response,
+  toolName: string,
+  err: unknown,
+  status: number
+): void {
+  if (err instanceof FormValidationError) {
+    res.status(status).type("html").send(
+      renderMcpUiErrorResult({
+        toolName,
+        message: err.message,
+        fieldErrors: err.fields,
+      })
+    );
+    return;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  res.status(status).type("html").send(renderMcpUiErrorResult({ toolName, message }));
+}
+
+async function runToolAndRender(
+  options: AttachMcpUiOptions,
+  tool: ListedMcpTool,
+  args: Record<string, unknown>
+): Promise<{ html: string; ok: boolean }> {
+  const started = Date.now();
+  try {
+    const result = await options.callTool(tool, args);
+    const body = httpBodyFromCollapsed(result);
+    return {
+      ok: true,
+      html: renderMcpUiSuccessResult({
+        toolName: tool.name,
+        executionMs: Date.now() - started,
+        body,
+      }),
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const withResult = err as Error & { result?: unknown };
+    const details =
+      withResult.result !== undefined
+        ? JSON.stringify(withResult.result, null, 2)
+        : undefined;
+    const fieldErr = fieldErrorFromMessage(message);
+    return {
+      ok: false,
+      html: renderMcpUiErrorResult({
+        toolName: tool.name,
+        message,
+        details,
+        fieldErrors: fieldErr.field ? [fieldErr] : undefined,
+      }),
+    };
+  }
+}
+
+function startBackgroundJob(
+  options: AttachMcpUiOptions,
+  tool: ListedMcpTool,
+  args: Record<string, unknown>,
+  basePath: string
+): string {
+  const job = createProgressJob(tool.name);
+  pushProgressEvent(job, { type: "progress", message: "Queued…", percent: 0 });
+
+  void (async () => {
+    pushProgressEvent(job, {
+      type: "progress",
+      message: `Calling ${tool.name}…`,
+      percent: 15,
+    });
+    const { html, ok } = await runToolAndRender(options, tool, args);
+    if (ok) {
+      pushProgressEvent(job, {
+        type: "complete",
+        message: "Done",
+        percent: 100,
+        resultHtml: html,
+      });
+    } else {
+      pushProgressEvent(job, {
+        type: "error",
+        message: "Tool failed",
+        percent: 100,
+        resultHtml: html,
+      });
+    }
+  })();
+
+  return renderMcpUiProgressShell({
+    jobId: job.id,
+    toolName: tool.name,
+    basePath,
+  });
+}
+
 export function attachMcpUiRoutes(app: Express, options: AttachMcpUiOptions): string {
   const basePath =
     (options.path?.trim() || DEFAULT_MCP_UI_PATH).replace(/\/$/, "") || DEFAULT_MCP_UI_PATH;
   const atrScoped = options.atrScoped !== false;
+  const maxUploadBytes = options.maxUploadBytes ?? 25 * 1024 * 1024;
   const router = express.Router();
 
   router.use(express.urlencoded({ extended: false, limit: "2mb" }));
+  router.use(express.json({ limit: "1mb" }));
 
   router.get("/", (req, res) => {
     const catalog = options.getCatalog();
@@ -61,6 +248,176 @@ export function attachMcpUiRoutes(app: Express, options: AttachMcpUiOptions): st
         basePath,
       })
     );
+  });
+
+  router.get("/progress/:jobId", (req, res) => {
+    const jobId = String(req.params.jobId ?? "");
+    const job = getProgressJob(jobId);
+    if (!job) {
+      res.status(404).type("text").send("Unknown progress job");
+      return;
+    }
+
+    res.status(200);
+    res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+    res.setHeader("Cache-Control", "no-cache, no-transform");
+    res.setHeader("Connection", "keep-alive");
+    res.flushHeaders?.();
+
+    const send = (event: {
+      type: string;
+      message: string;
+      percent?: number;
+      resultHtml?: string;
+      at: string;
+    }) => {
+      res.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
+      if (event.type === "complete" || event.type === "error") {
+        res.end();
+      }
+    };
+
+    const unsub = subscribeProgress(job, send);
+    req.on("close", () => {
+      unsub();
+    });
+  });
+
+  router.post("/generate", (req, res) => {
+    const atr = atrFromRequest(req);
+    const catalog = options.getCatalog();
+    const authorized = filterToolsForAtr(catalog.tools, atr, atrScoped);
+    const body = (req.body ?? {}) as GeneratedUiDefinition;
+    try {
+      const form = createGeneratedUi(body, authorized);
+      res.status(201).json({
+        id: form.id,
+        slug: form.slug,
+        title: form.title,
+        description: form.description,
+        steps: form.steps,
+        url: `${basePath}/custom/${form.slug}`,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(400).json({ error: message });
+    }
+  });
+
+  router.get("/custom/:slug", (req, res) => {
+    const slug = String(req.params.slug ?? "");
+    const form = getGeneratedUiBySlug(slug);
+    if (!form) {
+      res.status(404).type("html").send("<p>Unknown custom form</p>");
+      return;
+    }
+    const atr = atrFromRequest(req);
+    const catalog = options.getCatalog();
+    const authorized = filterToolsForAtr(catalog.tools, atr, atrScoped);
+    const step = form.steps[form.currentStepIndex];
+    if (!step) {
+      res.type("html").send(
+        renderMcpUiCustomFormPage({
+          form,
+          tool: undefined,
+          fieldsHtml: "",
+          hasFileFields: false,
+          basePath,
+          title: options.title ?? "MCP API Adapter",
+          done: true,
+        })
+      );
+      return;
+    }
+    const tool = authorized.find((t) => t.name === step.tool);
+    if (!tool) {
+      res
+        .status(403)
+        .type("html")
+        .send(
+          renderMcpUiErrorResult({
+            toolName: step.tool,
+            message: "Forbidden — this step tool is outside your ATR scope",
+          })
+        );
+      return;
+    }
+    const hints = formHintsForTool(tool);
+    const { html: fieldsHtml, hasFileFields } = renderToolFormFields(tool, hints);
+    res.type("html").send(
+      renderMcpUiCustomFormPage({
+        form,
+        tool,
+        fieldsHtml,
+        hasFileFields,
+        basePath,
+        title: options.title ?? "MCP API Adapter",
+        done: false,
+      })
+    );
+  });
+
+  router.post("/custom/:slug/step", async (req, res) => {
+    const slug = String(req.params.slug ?? "");
+    const form = getGeneratedUiBySlug(slug);
+    if (!form) {
+      res.status(404).type("html").send(renderMcpUiErrorResult({ toolName: slug, message: "Unknown custom form" }));
+      return;
+    }
+    const step = form.steps[form.currentStepIndex];
+    if (!step) {
+      res.status(400).type("html").send(renderMcpUiErrorResult({ toolName: slug, message: "Workflow already complete" }));
+      return;
+    }
+
+    const atr = atrFromRequest(req);
+    const catalog = options.getCatalog();
+    const authorized = filterToolsForAtr(catalog.tools, atr, atrScoped);
+    const tool = authorized.find((t) => t.name === step.tool);
+    if (!tool) {
+      res
+        .status(403)
+        .type("html")
+        .send(
+          renderMcpUiErrorResult({
+            toolName: step.tool,
+            message: "Forbidden — this step tool is outside your ATR scope",
+          })
+        );
+      return;
+    }
+
+    let args: Record<string, unknown>;
+    try {
+      args = await resolveExecuteArgs(req, tool, { atr, atrScoped, maxUploadBytes });
+    } catch (err) {
+      const status =
+        err instanceof FormValidationError && /Forbidden/.test(err.message) ? 403 : 400;
+      renderExecuteError(res, tool.name, err, status);
+      return;
+    }
+
+    const started = Date.now();
+    try {
+      const result = await options.callTool(tool, args);
+      const body = httpBodyFromCollapsed(result);
+      form.stepOutputs[tool.name] = body;
+      form.currentStepIndex += 1;
+      const next = form.steps[form.currentStepIndex];
+      const nextHint = next
+        ? `<p class="field-help">Next: <a href="${basePath}/custom/${form.slug}">${next.label ?? next.tool}</a></p>`
+        : `<p class="field-help">Workflow complete.</p>`;
+      res.status(200).type("html").send(
+        `${renderMcpUiSuccessResult({
+          toolName: tool.name,
+          executionMs: Date.now() - started,
+          body,
+        })}${nextHint}`
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(502).type("html").send(renderMcpUiErrorResult({ toolName: tool.name, message }));
+    }
   });
 
   router.post("/execute/:toolName", async (req, res) => {
@@ -95,54 +452,21 @@ export function attachMcpUiRoutes(app: Express, options: AttachMcpUiOptions): st
 
     let args: Record<string, unknown>;
     try {
-      args = parseFormArgs(asFormBody(req), tool.inputSchema ?? { type: "object", properties: {} });
+      args = await resolveExecuteArgs(req, tool, { atr, atrScoped, maxUploadBytes });
     } catch (err) {
-      if (err instanceof FormValidationError) {
-        res.status(400).type("html").send(
-          renderMcpUiErrorResult({
-            toolName,
-            message: err.message,
-            fieldErrors: err.fields,
-          })
-        );
-        return;
-      }
-      const message = err instanceof Error ? err.message : String(err);
-      res
-        .status(400)
-        .type("html")
-        .send(renderMcpUiErrorResult({ toolName, message }));
+      const status =
+        err instanceof FormValidationError && /Forbidden/.test(err.message) ? 403 : 400;
+      renderExecuteError(res, toolName, err, status);
       return;
     }
 
-    const started = Date.now();
-    try {
-      const result = await options.callTool(tool, args);
-      const body = httpBodyFromCollapsed(result);
-      res.status(200).type("html").send(
-        renderMcpUiSuccessResult({
-          toolName,
-          executionMs: Date.now() - started,
-          body,
-        })
-      );
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      const withResult = err as Error & { result?: unknown };
-      const details =
-        withResult.result !== undefined
-          ? JSON.stringify(withResult.result, null, 2)
-          : undefined;
-      const fieldErr = fieldErrorFromMessage(message);
-      res.status(502).type("html").send(
-        renderMcpUiErrorResult({
-          toolName,
-          message,
-          details,
-          fieldErrors: fieldErr.field ? [fieldErr] : undefined,
-        })
-      );
+    if (isLongRunningTool(toolName)) {
+      res.status(200).type("html").send(startBackgroundJob(options, tool, args, basePath));
+      return;
     }
+
+    const { html, ok } = await runToolAndRender(options, tool, args);
+    res.status(ok ? 200 : 502).type("html").send(html);
   });
 
   app.use(basePath, router);

--- a/packages/mcp-api-adapter/src/mcp-ui-http.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-http.ts
@@ -3,6 +3,7 @@ import { httpBodyFromCollapsed } from "./call.js";
 import type { VerifiedMcpAdapterAtr } from "./edge-auth.js";
 import {
   FormValidationError,
+  escapeMcpUiHtml,
   fieldErrorFromMessage,
   parseFormArgs,
   renderToolFormFields,
@@ -250,6 +251,16 @@ export function attachMcpUiRoutes(app: Express, options: AttachMcpUiOptions): st
     );
   });
 
+  router.get("/progress/:jobId/result", (req, res) => {
+    const jobId = String(req.params.jobId ?? "");
+    const job = getProgressJob(jobId);
+    if (!job?.resultHtml) {
+      res.status(404).type("text").send("Result not ready");
+      return;
+    }
+    res.status(200).type("html").send(job.resultHtml);
+  });
+
   router.get("/progress/:jobId", (req, res) => {
     const jobId = String(req.params.jobId ?? "");
     const job = getProgressJob(jobId);
@@ -268,7 +279,6 @@ export function attachMcpUiRoutes(app: Express, options: AttachMcpUiOptions): st
       type: string;
       message: string;
       percent?: number;
-      resultHtml?: string;
       at: string;
     }) => {
       res.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
@@ -405,7 +415,7 @@ export function attachMcpUiRoutes(app: Express, options: AttachMcpUiOptions): st
       form.currentStepIndex += 1;
       const next = form.steps[form.currentStepIndex];
       const nextHint = next
-        ? `<p class="field-help">Next: <a href="${basePath}/custom/${form.slug}">${next.label ?? next.tool}</a></p>`
+        ? `<p class="field-help">Next: <a href="${escapeMcpUiHtml(`${basePath}/custom/${encodeURIComponent(form.slug)}`)}">${escapeMcpUiHtml(next.label ?? next.tool)}</a></p>`
         : `<p class="field-help">Workflow complete.</p>`;
       res.status(200).type("html").send(
         `${renderMcpUiSuccessResult({

--- a/packages/mcp-api-adapter/src/mcp-ui-multipart.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-multipart.ts
@@ -1,0 +1,121 @@
+import Busboy from "busboy";
+import type { Request } from "express";
+
+export type ParsedMultipart = {
+  fields: Record<string, string>;
+  files: Record<string, { filename: string; mimeType: string; buffer: Buffer }>;
+};
+
+/**
+ * Parse multipart/form-data from an Express request into fields + in-memory files.
+ */
+export function parseMultipartRequest(
+  req: Request,
+  options?: { maxFileBytes?: number }
+): Promise<ParsedMultipart> {
+  const maxFileBytes = options?.maxFileBytes ?? 25 * 1024 * 1024;
+  return new Promise((resolve, reject) => {
+    const fields: Record<string, string> = {};
+    const files: ParsedMultipart["files"] = {};
+    let settled = false;
+
+    const bb = Busboy({
+      headers: req.headers,
+      limits: { fileSize: maxFileBytes, files: 8, fields: 64 },
+    });
+
+    bb.on("file", (name, stream, info) => {
+      const chunks: Buffer[] = [];
+      let truncated = false;
+      stream.on("data", (chunk: Buffer) => {
+        chunks.push(chunk);
+      });
+      stream.on("limit", () => {
+        truncated = true;
+      });
+      stream.on("end", () => {
+        if (truncated) {
+          if (!settled) {
+            settled = true;
+            reject(new Error(`File too large (max ${maxFileBytes} bytes)`));
+          }
+          return;
+        }
+        files[name] = {
+          filename: info.filename || "upload.bin",
+          mimeType: info.mimeType || "application/octet-stream",
+          buffer: Buffer.concat(chunks),
+        };
+      });
+      stream.on("error", (err) => {
+        if (!settled) {
+          settled = true;
+          reject(err);
+        }
+      });
+    });
+
+    bb.on("field", (name, value) => {
+      fields[name] = value;
+    });
+
+    bb.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+
+    bb.on("finish", () => {
+      if (!settled) {
+        settled = true;
+        resolve({ fields, files });
+      }
+    });
+
+    req.pipe(bb);
+  });
+}
+
+export function isMultipartRequest(req: Request): boolean {
+  const ct = req.headers["content-type"];
+  return typeof ct === "string" && ct.toLowerCase().includes("multipart/form-data");
+}
+
+/** Map uploaded files into MCP tool args (pdf_base64 / base64 / field name). */
+export function mergeFilesIntoArgs(
+  fields: Record<string, string>,
+  files: ParsedMultipart["files"],
+  preferredBase64Field?: string
+): Record<string, unknown> {
+  const args: Record<string, unknown> = { ...fields };
+  const entries = Object.entries(files);
+  if (entries.length === 0) return args;
+
+  const [firstName, firstFile] = entries[0]!;
+  const b64 = firstFile.buffer.toString("base64");
+
+  let target = preferredBase64Field;
+  if (!target) {
+    if (firstName === "pdf_base64" || firstName === "base64") {
+      target = firstName;
+    } else if (firstName === "file" || firstName === "upload") {
+      target = "pdf_base64" in args || "pdf_base64" in fields ? "pdf_base64" : "pdf_base64";
+    } else if (/base64|pdf|file|upload/i.test(firstName)) {
+      target = firstName;
+    } else {
+      target = "pdf_base64";
+    }
+  }
+
+  args[target] = b64;
+  args.__upload_filename = firstFile.filename;
+  args.__upload_mime = firstFile.mimeType;
+
+  for (const [name, file] of entries.slice(1)) {
+    args[name] = file.buffer.toString("base64");
+    args[`${name}_filename`] = file.filename;
+  }
+
+  return args;
+}

--- a/packages/mcp-api-adapter/src/mcp-ui-progress.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-progress.ts
@@ -15,6 +15,8 @@ export type ProgressJob = {
   events: ProgressEvent[];
   done: boolean;
   listeners: Set<(event: ProgressEvent) => void>;
+  /** Escaped HTML fragment for the final tool result (set on complete/error). */
+  resultHtml?: string;
 };
 
 const jobs = new Map<string, ProgressJob>();
@@ -54,7 +56,10 @@ export function getProgressJob(id: string): ProgressJob | undefined {
 export function pushProgressEvent(job: ProgressJob, event: Omit<ProgressEvent, "at">): void {
   const full: ProgressEvent = { ...event, at: new Date().toISOString() };
   job.events.push(full);
-  if (event.type === "complete" || event.type === "error") job.done = true;
+  if (event.type === "complete" || event.type === "error") {
+    job.done = true;
+    if (event.resultHtml) job.resultHtml = event.resultHtml;
+  }
   for (const listener of job.listeners) listener(full);
 }
 

--- a/packages/mcp-api-adapter/src/mcp-ui-progress.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-progress.ts
@@ -1,0 +1,85 @@
+import { randomUUID } from "node:crypto";
+
+export type ProgressEvent = {
+  type: "progress" | "complete" | "error";
+  message: string;
+  percent?: number;
+  resultHtml?: string;
+  at: string;
+};
+
+export type ProgressJob = {
+  id: string;
+  toolName: string;
+  createdAt: number;
+  events: ProgressEvent[];
+  done: boolean;
+  listeners: Set<(event: ProgressEvent) => void>;
+};
+
+const jobs = new Map<string, ProgressJob>();
+const MAX_JOBS = 200;
+const TTL_MS = 30 * 60 * 1000;
+
+function sweep(): void {
+  const now = Date.now();
+  for (const [id, job] of jobs) {
+    if (now - job.createdAt > TTL_MS) jobs.delete(id);
+  }
+  while (jobs.size > MAX_JOBS) {
+    const oldest = jobs.keys().next().value;
+    if (oldest) jobs.delete(oldest);
+    else break;
+  }
+}
+
+export function createProgressJob(toolName: string): ProgressJob {
+  sweep();
+  const job: ProgressJob = {
+    id: randomUUID(),
+    toolName,
+    createdAt: Date.now(),
+    events: [],
+    done: false,
+    listeners: new Set(),
+  };
+  jobs.set(job.id, job);
+  return job;
+}
+
+export function getProgressJob(id: string): ProgressJob | undefined {
+  return jobs.get(id);
+}
+
+export function pushProgressEvent(job: ProgressJob, event: Omit<ProgressEvent, "at">): void {
+  const full: ProgressEvent = { ...event, at: new Date().toISOString() };
+  job.events.push(full);
+  if (event.type === "complete" || event.type === "error") job.done = true;
+  for (const listener of job.listeners) listener(full);
+}
+
+export function subscribeProgress(
+  job: ProgressJob,
+  listener: (event: ProgressEvent) => void
+): () => void {
+  job.listeners.add(listener);
+  for (const event of job.events) listener(event);
+  return () => {
+    job.listeners.delete(listener);
+  };
+}
+
+/** Tools that use SSE progress by default (known long-running). */
+export const DEFAULT_LONG_RUNNING_TOOLS = new Set([
+  "run_idp_pipeline",
+  "ouroboros_run_evolutionary_loop",
+  "ouroboros_create_seed_from_document",
+]);
+
+export function isLongRunningTool(toolName: string): boolean {
+  return (
+    DEFAULT_LONG_RUNNING_TOOLS.has(toolName) ||
+    toolName.startsWith("ouroboros_") ||
+    toolName === "run_idp_pipeline"
+  );
+}

--- a/packages/mcp-api-adapter/src/mcp-ui-templates.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-templates.ts
@@ -1,7 +1,7 @@
 import type { ListedMcpTool } from "mcp-grpc-transport";
 import type { FormRenderHints } from "./mcp-ui-form.js";
 
-export type McpUiResultKind = "json" | "search" | "memory" | "cache" | "audit";
+export type McpUiResultKind = "json" | "search" | "memory" | "cache" | "audit" | "idp";
 
 export type McpUiTemplate = {
   /** Tool name or tag match. */
@@ -9,6 +9,7 @@ export type McpUiTemplate = {
   primary: string[];
   defaults?: Record<string, unknown>;
   textareas?: string[];
+  fileFields?: string[];
   hints?: Record<string, string>;
   resultKind: McpUiResultKind;
 };
@@ -70,6 +71,37 @@ const TEMPLATES: Record<string, McpUiTemplate> = {
     },
     resultKind: "audit",
   },
+  run_idp_pipeline: {
+    id: "run_idp_pipeline",
+    primary: ["pdf_base64", "dry_run", "document_path", "document_url", "correlation_id"],
+    fileFields: ["pdf_base64"],
+    defaults: { dry_run: true },
+    hints: {
+      pdf_base64: "Upload a PDF — encoded to pdf_base64 before CallTool.",
+      dry_run: "Keep true to plan hops without executing providers.",
+      document_path: "Nextcloud relative path when using inbox download instead of upload.",
+      document_url: "HTTP(S) URL for Docling when not using pdf_base64.",
+    },
+    resultKind: "idp",
+  },
+  convert_document: {
+    id: "convert_document",
+    primary: ["base64", "path", "format"],
+    fileFields: ["base64"],
+    hints: {
+      base64: "Upload a document — encoded to base64 before CallTool.",
+    },
+    resultKind: "idp",
+  },
+  inspect_pdf: {
+    id: "inspect_pdf",
+    primary: ["base64", "path"],
+    fileFields: ["base64"],
+    hints: {
+      base64: "Upload a PDF — encoded to base64 before CallTool.",
+    },
+    resultKind: "idp",
+  },
 };
 
 export function resolveMcpUiTemplate(tool: ListedMcpTool): McpUiTemplate | undefined {
@@ -89,6 +121,7 @@ export function formHintsForTool(
     primary: template.primary,
     defaults: template.defaults,
     textareas: template.textareas,
+    fileFields: template.fileFields,
     hints: template.hints,
     fieldErrors,
   };

--- a/packages/mcp-api-adapter/src/server.ts
+++ b/packages/mcp-api-adapter/src/server.ts
@@ -93,8 +93,14 @@ export function createMcpApiAdapterApp(options: CreateMcpApiAdapterAppOptions): 
   const verifyJwt = createJwtVerifier(options.jwtAuth ?? {});
   if (edgeAuthConfigured({ apiKey: options.apiKey, jwt: options.jwtAuth })) {
     app.use(createEdgeAuthRateLimiter());
+    const mcpUiProgressPrefix =
+      typeof options.mcpUiPath === "string" && options.mcpUiPath.trim()
+        ? `${options.mcpUiPath.replace(/\/$/, "")}/progress/`
+        : "/mcp-ui/progress/";
     app.use((req: Request, res: Response, next: NextFunction) => {
       if (req.path === "/healthz") return next();
+      // EventSource cannot set Authorization; opaque job UUIDs + TTL are the capability.
+      if (req.method === "GET" && req.path.startsWith(mcpUiProgressPrefix)) return next();
       void resolveEdgeCredential(
         readApiKey(req),
         { apiKey: options.apiKey, jwt: options.jwtAuth },

--- a/packages/mcp-api-adapter/src/server.ts
+++ b/packages/mcp-api-adapter/src/server.ts
@@ -6,8 +6,9 @@ import { swaggerDocsHtml } from "./docs-html.js";
 import {
   createJwtVerifier,
   edgeAuthConfigured,
-  verifyEdgeCredential,
+  resolveEdgeCredential,
   type McpApiAdapterJwtAuthOptions,
+  type VerifiedMcpAdapterAtr,
 } from "./edge-auth.js";
 import { createEdgeAuthRateLimiter } from "./edge-rate-limit.js";
 import { attachGraphqlRoutes } from "./graphql-http.js";
@@ -24,6 +25,10 @@ import type {
 } from "./types.js";
 import { buildCatalogFromUpstream, connectUpstream, type UpstreamConnection } from "./upstream.js";
 import { attachWebSocketSurface, DEFAULT_WS_PATH } from "./websocket.js";
+
+export type McpApiAdapterRequest = Request & {
+  mcpAtr?: VerifiedMcpAdapterAtr;
+};
 
 function readApiKey(req: Request): string | undefined {
   const headerKey = req.header("x-api-key")?.trim();
@@ -73,6 +78,11 @@ export type CreateMcpApiAdapterAppOptions = {
   wsPath?: string;
   /** HTMX MCP UI path when enabled (advertised on /healthz). */
   mcpUiPath?: string;
+  /**
+   * When true, `/mcp-ui` filters the catalog (and execute) by the caller's ATR.
+   * Default true. Disable with `--no-mcp-ui-atr-scoped` for open demos.
+   */
+  mcpUiAtrScoped?: boolean;
   createBridgedMcpServer?: () => import("@modelcontextprotocol/sdk/server/mcp.js").McpServer;
 };
 
@@ -85,16 +95,17 @@ export function createMcpApiAdapterApp(options: CreateMcpApiAdapterAppOptions): 
     app.use(createEdgeAuthRateLimiter());
     app.use((req: Request, res: Response, next: NextFunction) => {
       if (req.path === "/healthz") return next();
-      void verifyEdgeCredential(
+      void resolveEdgeCredential(
         readApiKey(req),
         { apiKey: options.apiKey, jwt: options.jwtAuth },
         verifyJwt
       )
-        .then((ok) => {
-          if (!ok) {
+        .then((atr) => {
+          if (!atr) {
             res.status(401).json({ error: "unauthorized" });
             return;
           }
+          (req as McpApiAdapterRequest).mcpAtr = atr;
           next();
         })
         .catch(() => {
@@ -158,6 +169,7 @@ export function createMcpApiAdapterApp(options: CreateMcpApiAdapterAppOptions): 
       callTool: options.callTool,
       title: options.title,
       path: options.mcpUiPath,
+      atrScoped: options.mcpUiAtrScoped !== false,
     });
   }
 
@@ -297,6 +309,7 @@ export async function startMcpApiAdapter(
     mcpPath,
     wsPath,
     mcpUiPath,
+    mcpUiAtrScoped: options.mcpUiAtrScoped,
     createBridgedMcpServer: mcpPath ? upstream.createBridgedMcpServer : undefined,
   });
 

--- a/packages/mcp-api-adapter/src/server.ts
+++ b/packages/mcp-api-adapter/src/server.ts
@@ -99,7 +99,7 @@ export function createMcpApiAdapterApp(options: CreateMcpApiAdapterAppOptions): 
         : "/mcp-ui/progress/";
     app.use((req: Request, res: Response, next: NextFunction) => {
       if (req.path === "/healthz") return next();
-      // EventSource cannot set Authorization; opaque job UUIDs + TTL are the capability.
+      // EventSource/fetch cannot set Authorization; opaque job UUIDs + TTL are the capability.
       if (req.method === "GET" && req.path.startsWith(mcpUiProgressPrefix)) return next();
       void resolveEdgeCredential(
         readApiKey(req),

--- a/packages/mcp-api-adapter/src/types.ts
+++ b/packages/mcp-api-adapter/src/types.ts
@@ -105,6 +105,12 @@ export type McpApiAdapterOptions = McpApiAdapterHttpOptions & {
    * Set `false` to disable the browser UI surface.
    */
   mcpUiPath?: string | false;
+  /**
+   * When true (default), `/mcp-ui` filters catalog + execute by the caller's ATR.
+   * JWT scopes/tools control visibility; API keys are treated as admin.
+   * Set `false` to show the full catalog regardless of ATR (open demos).
+   */
+  mcpUiAtrScoped?: boolean;
 };
 
 export type StartedMcpApiAdapter = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Expands `/mcp-ui` beyond ATR scoping (Batch 1) with Batches 2–4:

1. **ATR scoping** — catalog + execute filtered by JWT `atr.scope` / `atr.tools` (default on). Internal `ouroboros_*` / `pageindex_*` need explicit or family grants. `--no-mcp-ui-atr-scoped` disables. API keys remain admin-equivalent.

2. **File upload + IDP** — multipart forms for `pdf_base64` / `base64` (busboy). Uploads are base64-encoded into CallTool args. **Document-processing ATR** (`documents` / `idp` / admin / explicit IDP tool grant) is separate from tool visibility. Templates for `run_idp_pipeline`, `convert_document`, `inspect_pdf`. File-field detection is name/format-based (no false multipart on `execute` / `memory_ingest`).

3. **SSE progress** — long-running tools (`run_idp_pipeline`, `ouroboros_*`, …) return an EventSource shell; `GET /mcp-ui/progress/:jobId` streams progress/complete/error. Progress GETs are auth-exempt (EventSource cannot send Bearer; opaque UUID + TTL is the capability).

4. **Generate workflows** — `POST /mcp-ui/generate` creates in-memory multi-step UIs; `GET /mcp-ui/custom/:slug` + step POST for agent-authored forms.

## Evidence

- Package tests: **44/44** (`npm test` in `packages/mcp-api-adapter`)
- Live smoke vs ClawQL on `:8080` / adapter `:8099`: generate → custom form; long-running execute → SSE progress shell; catalog multipart_count=0 without IDP tools

## Test plan

- [x] `cd packages/mcp-api-adapter && npm run build && npm test`
- [x] Unit: multipart→`pdf_base64`, `canProcessDocuments`, progress fan-out, generate slug, IDP template file fields
- [x] E2E: JWT documents ATR multipart execute → SSE job; memory/search ATR denied on file upload; generate → custom step
- [x] Live: `POST /mcp-ui/generate`, `GET /mcp-ui/custom/...`, SSE shell for `ouroboros_run_evolutionary_loop`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03b41-a8f7-766e-b8b6-1e0170a7356a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03b41-a8f7-766e-b8b6-1e0170a7356a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

