### PR TITLE
feat(audit): MCP tool WORM fan-out + gateway auth sink wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -286,12 +286,36 @@
 # ClawQL is not an IdP — oidc mode verifies customer-issued JWTs.
 # CLAWQL_AUTH_MODE=apiKey
 # CLAWQL_API_KEY=your-secret
+# Issued org/team keys (cqk_…) + WORM auth events when CLAWQL_WORM_ENABLED=1:
+# CLAWQL_AUTH_API_KEY_STORE_PATH=/var/clawql/Auth/api-keys.json
+# CLAWQL_AUTH_ISSUED_API_KEYS=1
+# CLAWQL_HOME=/var/clawql
 # CLAWQL_AUTH_MODE=oidc
 # CLAWQL_AUTH_OIDC_JWKS_URL=https://idp.example.com/.well-known/jwks.json
 # CLAWQL_AUTH_OIDC_ISSUER=https://idp.example.com
 # CLAWQL_AUTH_OIDC_AUDIENCE=clawql-mcp
 # CLAWQL_AUTH_REQUIRE_MFA_FOR_FINANCIAL=1
 # Docs: docs/security/clawql-auth-oidc-stepup.md
+
+# Durable WORM audit trail (clawql-audit) — hash-chained dual-ack when enabled.
+# Dual-writes from execute, MCP tools, Panguard, web, payments, memory, auth.
+# CLAWQL_WORM_ENABLED=1
+# CLAWQL_WORM_LOCAL=memory
+# CLAWQL_WORM_SQLITE_PATH=./data/clawql-worm.sqlite
+# CLAWQL_WORM_POSTGRES_URL=postgres://user:pass@localhost:5432/clawql_worm
+# CLAWQL_WORM_REMOTE=memory
+# CLAWQL_WORM_S3_BUCKET=agent-audit-trail
+# CLAWQL_WORM_S3_ENDPOINT=https://…r2.cloudflarestorage.com
+# CLAWQL_WORM_S3_ACCESS_KEY_ID=
+# CLAWQL_WORM_S3_SECRET_ACCESS_KEY=
+# CLAWQL_WORM_SESSION_ID=prod-mcp-host-1
+# CLAWQL_WORM_AGENT_NAME=clawql-mcp
+# CLAWQL_WORM_RECONCILE_MS=2000
+# CLAWQL_WORM_MERKLE_BATCH=100
+# CLAWQL_WORM_HTTP_PORT=8787
+# CLAWQL_AUDIT_API_KEY=…
+# CLAWQL_WORM_PANGUARD_ALLOW=1
+# CLAWQL_WORM_DEBUG=1
 
 # Presidio PII redaction — opt-in; requires analyzer + anonymizer HTTP services.
 # CLAWQL_ENABLE_PRESIDIO=1

--- a/packages/clawql-api/src/plugins/panguard-proxy-plugin.ts
+++ b/packages/clawql-api/src/plugins/panguard-proxy-plugin.ts
@@ -4,7 +4,11 @@
  * Denies dual-write to process `clawql-audit` WORM when enabled.
  */
 
-import { appendProcessWormEffect, wormInputFromPanguardDeny } from "clawql-audit";
+import {
+  appendProcessWormEffect,
+  wormInputFromPanguardAllow,
+  wormInputFromPanguardDeny,
+} from "clawql-audit";
 import { ClawQLError, type Plugin } from "clawql-core";
 import { Effect } from "effect";
 
@@ -58,6 +62,12 @@ export function createPanguardProxyPlugin(options: PanguardProxyPluginOptions = 
             yield* appendProcessWormEffect(input);
           }).pipe(Effect.catchAll(() => Effect.void));
           return yield* Effect.fail(new ClawQLError({ reason }));
+        }
+        if (process.env.CLAWQL_WORM_PANGUARD_ALLOW?.trim() === "1") {
+          yield* Effect.gen(function* () {
+            const input = yield* wormInputFromPanguardAllow({ toolName });
+            yield* appendProcessWormEffect(input);
+          }).pipe(Effect.catchAll(() => Effect.void));
         }
       });
   }

--- a/packages/clawql-audit/src/index.ts
+++ b/packages/clawql-audit/src/index.ts
@@ -82,6 +82,7 @@ export {
   createMemoryWormSink,
   wormInputFromAuthEvent,
   wormInputFromMemoryEvent,
+  wormInputFromPanguardAllow,
   wormInputFromPanguardDeny,
   wormInputFromPaymentEvent,
   wormInputFromToolAttempt,

--- a/packages/clawql-audit/src/sinks.ts
+++ b/packages/clawql-audit/src/sinks.ts
@@ -114,13 +114,15 @@ export const wormInputFromToolAttempt = (input: {
   operationId?: string;
   sessionId?: string;
   argKeys?: string[];
+  /** Defaults to `execute` when operationId set, else `mcp`. */
+  source?: string;
 }): Effect.Effect<WORMAppendInput> =>
   Effect.sync(() => ({
     type: "TOOL_CALL_ATTEMPT",
     timestamp: new Date().toISOString(),
     sessionId: input.sessionId ?? "",
     metadata: {
-      source: "execute",
+      source: input.source ?? (input.operationId ? "execute" : "mcp"),
       toolName: input.toolName,
       operationId: input.operationId,
       argKeys: input.argKeys,
@@ -133,13 +135,14 @@ export const wormInputFromToolResult = (input: {
   sessionId?: string;
   ok: boolean;
   detail?: string;
+  source?: string;
 }): Effect.Effect<WORMAppendInput> =>
   Effect.sync(() => ({
     type: "TOOL_CALL_RESULT",
     timestamp: new Date().toISOString(),
     sessionId: input.sessionId ?? "",
     metadata: {
-      source: "execute",
+      source: input.source ?? (input.operationId ? "execute" : "mcp"),
       toolName: input.toolName,
       operationId: input.operationId,
       ok: input.ok,
@@ -159,6 +162,19 @@ export const wormInputFromPanguardDeny = (input: {
       source: "panguard",
       toolName: input.toolName,
       reason: input.reason ?? `Panguard policy blocked tool: ${input.toolName}`,
+    },
+  }));
+
+export const wormInputFromPanguardAllow = (input: {
+  toolName: string;
+}): Effect.Effect<WORMAppendInput> =>
+  Effect.sync(() => ({
+    type: "PANGUARD_ALLOW",
+    timestamp: new Date().toISOString(),
+    sessionId: "",
+    metadata: {
+      source: "panguard",
+      toolName: input.toolName,
     },
   }));
 

--- a/src/gateway-auth.test.ts
+++ b/src/gateway-auth.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect } from "effect";
+import { bootProcessWormFromEnvEffect, resetProcessWormForTests } from "clawql-audit";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildGatewayAuthConfig,
+  getClawqlGatewayAuth,
+  resetClawqlGatewayAuthForTests,
+} from "./gateway-auth.js";
+
+describe("gateway-auth WORM sink", () => {
+  afterEach(async () => {
+    resetClawqlGatewayAuthForTests();
+    await Effect.runPromise(resetProcessWormForTests());
+    delete process.env.CLAWQL_WORM_ENABLED;
+    delete process.env.CLAWQL_WORM_LOCAL;
+    delete process.env.CLAWQL_WORM_REMOTE;
+    delete process.env.CLAWQL_WORM_RECONCILE_MS;
+    delete process.env.CLAWQL_AUTH_API_KEY_STORE_PATH;
+    delete process.env.CLAWQL_AUTH_MODE;
+  });
+
+  it("wires authEventSink into issued API key store", async () => {
+    process.env.CLAWQL_WORM_ENABLED = "1";
+    process.env.CLAWQL_WORM_LOCAL = "memory";
+    process.env.CLAWQL_WORM_REMOTE = "memory";
+    process.env.CLAWQL_WORM_RECONCILE_MS = "0";
+    process.env.CLAWQL_AUTH_MODE = "apiKey";
+    const dir = mkdtempSync(join(tmpdir(), "clawql-auth-worm-"));
+    process.env.CLAWQL_AUTH_API_KEY_STORE_PATH = join(dir, "api-keys.json");
+
+    await Effect.runPromise(bootProcessWormFromEnvEffect());
+
+    const auth = getClawqlGatewayAuth();
+    expect(auth.apiKeys).toBeDefined();
+    expect(buildGatewayAuthConfig().mode).toBe("apiKey");
+
+    const { secret } = await auth.apiKeys!.issue({
+      subjectId: "alice@test",
+      role: "operator",
+      scope: ["search"],
+      label: "test",
+    });
+
+    const svc = await Effect.runPromise(bootProcessWormFromEnvEffect());
+    const issued = await Effect.runPromise(svc!.query({ type: "API_KEY_ISSUED" }));
+    expect(issued.length).toBeGreaterThanOrEqual(1);
+
+    const validated = auth.apiKeys!.validate(secret);
+    expect(validated.ok).toBe(true);
+    await new Promise((r) => setTimeout(r, 20));
+
+    const used = await Effect.runPromise(svc!.query({ type: "API_KEY_USED" }));
+    expect(used.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/gateway-auth.ts
+++ b/src/gateway-auth.ts
@@ -1,0 +1,79 @@
+/**
+ * Gateway auth composition for HTTP MCP — uses createClawQLAuth with WORM authEventSink.
+ */
+
+import { join } from "node:path";
+import {
+  createClawQLAuth,
+  loadGatewayAuthConfig,
+  type ApiKeyClaimsResolver,
+  type ClawQLAuth,
+  type GatewayAuthConfig,
+} from "clawql-auth";
+import { validateVirtualKey } from "clawql-inference";
+import { getProcessWormAuthEventSink } from "./process-worm-host.js";
+
+let gatewayAuth: ClawQLAuth | undefined;
+
+/**
+ * Map clawql-inference virtual keys to ATR claims (tenantId = key.team).
+ * Returns null when the secret is not a known virtual key so static CLAWQL_API_KEY can apply.
+ */
+export function createInferenceVirtualKeyClaimsResolver(
+  env: NodeJS.ProcessEnv = process.env
+): ApiKeyClaimsResolver {
+  return (presented) => {
+    const result = validateVirtualKey(presented, env);
+    if (!result.ok) {
+      if (result.status === 402 || result.status === 429) {
+        return { ok: false, error: result.message };
+      }
+      return null;
+    }
+    return {
+      ok: true,
+      claims: {
+        sub: result.context.id,
+        role: "operator",
+        scope: ["execute", "search", "memory"],
+        tenantId: result.context.team,
+        virtualKeyId: result.context.id,
+      },
+    };
+  };
+}
+
+function resolveIssuedApiKeyStorePath(env: NodeJS.ProcessEnv): string | undefined {
+  const explicit = env.CLAWQL_AUTH_API_KEY_STORE_PATH?.trim();
+  if (explicit) return explicit;
+  if (env.CLAWQL_AUTH_ISSUED_API_KEYS?.trim() === "1") {
+    const home = env.CLAWQL_HOME?.trim();
+    if (home) return join(home, "Auth", "api-keys.json");
+  }
+  return undefined;
+}
+
+/** Process-wide gateway auth (issued keys + WORM sink when configured). */
+export function getClawqlGatewayAuth(env: NodeJS.ProcessEnv = process.env): ClawQLAuth {
+  if (!gatewayAuth) {
+    const base = loadGatewayAuthConfig(env);
+    gatewayAuth = createClawQLAuth({
+      mode: base.mode,
+      apiKey: base.apiKey,
+      oidc: base.oidc,
+      apiKeyStorePath: resolveIssuedApiKeyStorePath(env),
+      authEventSink: getProcessWormAuthEventSink(),
+      apiKeyClaimsResolver: createInferenceVirtualKeyClaimsResolver(env),
+    });
+  }
+  return gatewayAuth;
+}
+
+export function buildGatewayAuthConfig(env: NodeJS.ProcessEnv = process.env): GatewayAuthConfig {
+  return getClawqlGatewayAuth(env).config;
+}
+
+/** Test helper — rebuild auth on next get. */
+export function resetClawqlGatewayAuthForTests(): void {
+  gatewayAuth = undefined;
+}

--- a/src/mcp-tool-worm.test.ts
+++ b/src/mcp-tool-worm.test.ts
@@ -1,0 +1,68 @@
+import { Effect } from "effect";
+import {
+  bootProcessWormFromEnvEffect,
+  resetProcessWormForTests,
+} from "clawql-audit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runMcpProxyBeforeCallTool } from "./clawql-api-adapters.js";
+import { wrapRegisteredMcpToolHandler } from "./mcp-tool-wrap.js";
+
+vi.mock("./clawql-api-adapters.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./clawql-api-adapters.js")>();
+  return {
+    ...actual,
+    runMcpProxyBeforeCallTool: vi.fn(async () => undefined),
+  };
+});
+
+describe("wrapRegisteredMcpToolHandler WORM audit", () => {
+  afterEach(async () => {
+    await Effect.runPromise(resetProcessWormForTests());
+    delete process.env.CLAWQL_WORM_ENABLED;
+    delete process.env.CLAWQL_WORM_LOCAL;
+    delete process.env.CLAWQL_WORM_REMOTE;
+    delete process.env.CLAWQL_WORM_RECONCILE_MS;
+  });
+
+  it("appends TOOL_CALL_ATTEMPT/RESULT for search when WORM enabled", async () => {
+    process.env.CLAWQL_WORM_ENABLED = "1";
+    process.env.CLAWQL_WORM_LOCAL = "memory";
+    process.env.CLAWQL_WORM_REMOTE = "memory";
+    process.env.CLAWQL_WORM_RECONCILE_MS = "0";
+
+    const svc = await Effect.runPromise(bootProcessWormFromEnvEffect());
+    expect(svc).not.toBeNull();
+
+    const wrapped = wrapRegisteredMcpToolHandler("search", async () => ({
+      content: [{ type: "text" as const, text: "ok" }],
+    }));
+
+    await wrapped({ query: "worm", limit: 1 });
+
+    const attempts = await Effect.runPromise(svc!.query({ type: "TOOL_CALL_ATTEMPT" }));
+    const results = await Effect.runPromise(svc!.query({ type: "TOOL_CALL_RESULT" }));
+    expect(attempts.some((e) => e.metadata?.toolName === "search")).toBe(true);
+    expect(attempts.some((e) => e.metadata?.source === "mcp")).toBe(true);
+    expect(results.some((e) => e.metadata?.toolName === "search" && e.metadata?.ok === true)).toBe(
+      true
+    );
+  });
+
+  it("skips WORM for execute (handled by ExecuteLive)", async () => {
+    process.env.CLAWQL_WORM_ENABLED = "1";
+    process.env.CLAWQL_WORM_LOCAL = "memory";
+    process.env.CLAWQL_WORM_REMOTE = "memory";
+    process.env.CLAWQL_WORM_RECONCILE_MS = "0";
+
+    const svc = await Effect.runPromise(bootProcessWormFromEnvEffect());
+
+    const wrapped = wrapRegisteredMcpToolHandler("execute", async () => ({
+      content: [{ type: "text" as const, text: "ok" }],
+    }));
+
+    await wrapped({ operationId: "x" });
+
+    const attempts = await Effect.runPromise(svc!.query({ type: "TOOL_CALL_ATTEMPT" }));
+    expect(attempts.some((e) => e.metadata?.toolName === "execute")).toBe(false);
+  });
+});

--- a/src/mcp-tool-wrap.ts
+++ b/src/mcp-tool-wrap.ts
@@ -1,7 +1,16 @@
+import {
+  appendProcessWormEffect,
+  wormInputFromToolAttempt,
+  wormInputFromToolResult,
+} from "clawql-audit";
+import { Effect } from "effect";
 import { isX402McpPaymentError } from "clawql-payments/x402";
 import { isMppMcpJsonRpcPaymentError } from "clawql-payments/mpp";
 import { runMcpProxyBeforeCallTool } from "./clawql-api-adapters.js";
 import { wrapMcpToolHandler } from "./otel-tracing.js";
+
+/** Meta tools — ring buffer only; skip durable WORM to avoid noise/recursion. */
+export const WORM_AUDIT_SKIP_TOOLS = new Set(["audit", "cache"]);
 
 function clawqlPolicyBlockMessage(err: unknown): string | null {
   if (!err || typeof err !== "object") return null;
@@ -12,31 +21,82 @@ function clawqlPolicyBlockMessage(err: unknown): string | null {
   if (typeof rec.message === "string" && rec.message.includes("Panguard policy blocked")) {
     return rec.message;
   }
-  // Effect.runPromise often wraps TaggedError; walk one cause level.
   if (rec.cause) return clawqlPolicyBlockMessage(rec.cause);
   return null;
 }
 
+function argKeysFromToolArgs(args: unknown): string[] {
+  if (!args || typeof args !== "object" || Array.isArray(args)) return [];
+  return Object.keys(args as Record<string, unknown>);
+}
+
+function toolResultLooksOk(result: unknown): boolean {
+  if (!result || typeof result !== "object") return true;
+  const rec = result as { isError?: boolean };
+  return rec.isError !== true;
+}
+
+function appendMcpToolAttemptEffect(toolName: string, args: unknown): Effect.Effect<void> {
+  if (WORM_AUDIT_SKIP_TOOLS.has(toolName) || toolName === "execute") {
+    return Effect.void;
+  }
+  return Effect.gen(function* () {
+    const input = yield* wormInputFromToolAttempt({
+      toolName,
+      argKeys: argKeysFromToolArgs(args),
+      source: "mcp",
+    });
+    yield* appendProcessWormEffect(input);
+  }).pipe(Effect.catchAll(() => Effect.void));
+}
+
+function appendMcpToolResultEffect(
+  toolName: string,
+  ok: boolean,
+  detail?: string
+): Effect.Effect<void> {
+  if (WORM_AUDIT_SKIP_TOOLS.has(toolName) || toolName === "execute") {
+    return Effect.void;
+  }
+  return Effect.gen(function* () {
+    const input = yield* wormInputFromToolResult({
+      toolName,
+      ok,
+      detail,
+      source: "mcp",
+    });
+    yield* appendProcessWormEffect(input);
+  }).pipe(Effect.catchAll(() => Effect.void));
+}
+
 /**
- * Wrap MCP tool handlers with mcp-proxy pipeline hooks (Panguard, x402, …)
- * and OpenTelemetry spans.
+ * Wrap MCP tool handlers with mcp-proxy pipeline hooks (Panguard, x402, …),
+ * durable WORM audit (when CLAWQL_WORM_ENABLED), and OpenTelemetry spans.
  */
 export function wrapRegisteredMcpToolHandler<TArgs extends unknown[], TResult>(
   toolName: string,
   handler: (...args: TArgs) => Promise<TResult>
 ): (...args: TArgs) => Promise<TResult> {
   return wrapMcpToolHandler(toolName, async (...args: TArgs): Promise<TResult> => {
+    await Effect.runPromise(appendMcpToolAttemptEffect(toolName, args[0]));
+
     try {
       await runMcpProxyBeforeCallTool(toolName, args[0]);
     } catch (err: unknown) {
+      await Effect.runPromise(
+        appendMcpToolResultEffect(
+          toolName,
+          false,
+          clawqlPolicyBlockMessage(err) ?? (err instanceof Error ? err.message : String(err))
+        )
+      );
+
       if (isMppMcpJsonRpcPaymentError(err)) {
         return err.toToolResult() as TResult;
       }
       if (isX402McpPaymentError(err)) {
         return err.toToolResult() as TResult;
       }
-      // Surface Panguard denials as MCP tool errors (OpenCode otherwise shows
-      // a generic "An error has occurred" and loses the policy reason).
       const blocked = clawqlPolicyBlockMessage(err);
       if (blocked) {
         return {
@@ -46,6 +106,27 @@ export function wrapRegisteredMcpToolHandler<TArgs extends unknown[], TResult>(
       }
       throw err;
     }
-    return handler(...args);
+
+    try {
+      const result = await handler(...args);
+      const ok = toolResultLooksOk(result);
+      await Effect.runPromise(
+        appendMcpToolResultEffect(
+          toolName,
+          ok,
+          ok ? undefined : JSON.stringify(result).slice(0, 500)
+        )
+      );
+      return result;
+    } catch (err: unknown) {
+      await Effect.runPromise(
+        appendMcpToolResultEffect(
+          toolName,
+          false,
+          err instanceof Error ? err.message : String(err)
+        )
+      );
+      throw err;
+    }
   });
 }

--- a/src/server-http.ts
+++ b/src/server-http.ts
@@ -45,13 +45,9 @@ import { handleIdpPipelineRunRequest } from "./idp-pipeline-run-http.js";
 import { handleLangfuseEvalWebhookRequest } from "./langfuse-eval-webhook.js";
 import { createWebhookRateLimiter } from "./webhook-rate-limit.js";
 import {
-  loadGatewayAuthConfig,
   resolveAtrClaimsFromHeadersEffect,
-  type ApiKeyClaimsResolver,
-  type GatewayAuthConfig,
 } from "clawql-auth";
 import { Effect } from "effect";
-import { validateVirtualKey } from "clawql-inference";
 import { attachCreditsHateoasRoutes } from "clawql-payments";
 import { attachPaymentsWellKnownRoutes } from "clawql-payments/discovery";
 import { attachMppOpenApiRoutes, isMppOpenApiEnabled } from "clawql-payments/mpp";
@@ -60,44 +56,13 @@ import {
   registerMcpX402TransportHooks,
   runWithMcpX402Context,
 } from "./mcp-x402-transport.js";
+import { buildGatewayAuthConfig } from "./gateway-auth.js";
 
 /**
- * Map clawql-inference virtual keys to ATR claims (tenantId = key.team).
- * Returns null when the secret is not a known virtual key so static CLAWQL_API_KEY can apply.
+ * @deprecated Use {@link buildGatewayAuthConfig} from `./gateway-auth.js`.
+ * Re-exported for tests that imported from server-http.
  */
-export function createInferenceVirtualKeyClaimsResolver(
-  env: NodeJS.ProcessEnv = process.env
-): ApiKeyClaimsResolver {
-  return (presented) => {
-    const result = validateVirtualKey(presented, env);
-    if (!result.ok) {
-      // Budget / rate-limit are hard failures for a recognized key path.
-      if (result.status === 402 || result.status === 429) {
-        return { ok: false, error: result.message };
-      }
-      return null;
-    }
-    return {
-      ok: true,
-      claims: {
-        sub: result.context.id,
-        role: "operator",
-        scope: ["execute", "search", "memory"],
-        tenantId: result.context.team,
-        virtualKeyId: result.context.id,
-      },
-    };
-  };
-}
-
-function buildGatewayAuthConfig(env: NodeJS.ProcessEnv = process.env): GatewayAuthConfig {
-  const config = loadGatewayAuthConfig(env);
-  if (config.mode !== "apiKey") return config;
-  return {
-    ...config,
-    apiKeyClaimsResolver: createInferenceVirtualKeyClaimsResolver(env),
-  };
-}
+export { createInferenceVirtualKeyClaimsResolver } from "./gateway-auth.js";
 
 const PORT = Number.parseInt(process.env.PORT ?? process.env.MCP_PORT ?? "8080", 10);
 const DEFAULT_MCP_PATH = "/mcp";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to process WORM wiring: completes **auth sink injection** and **generic MCP tool audit** onto the `clawql-audit` trail.

## Changes

### Auth (`src/gateway-auth.ts`)
- HTTP MCP gateway now uses `createClawQLAuth({ authEventSink: getProcessWormAuthEventSink() })`
- Issued API keys when `CLAWQL_AUTH_API_KEY_STORE_PATH` or `CLAWQL_AUTH_ISSUED_API_KEYS=1` + `CLAWQL_HOME`
- Auth events (`API_KEY_ISSUED`, `API_KEY_USED`, …) dual-write to process WORM when `CLAWQL_WORM_ENABLED=1`

### MCP tools (`src/mcp-tool-wrap.ts`)
- All wrapped MCP tools append `TOOL_CALL_ATTEMPT` / `TOOL_CALL_RESULT` with `metadata.source=mcp`
- Skips `execute` (already covered by `makeExecuteLive`), `audit`, and `cache` (meta/noise)

### Panguard
- Optional `PANGUARD_ALLOW` when `CLAWQL_WORM_PANGUARD_ALLOW=1` and block list is active

### Ops
- `.env.example` documents `CLAWQL_WORM_*` and issued API key store paths

## Test plan

- [x] `src/gateway-auth.test.ts` — issued key → WORM auth events
- [x] `src/mcp-tool-worm.test.ts` — search tool attempt/result on trail
- [x] Existing panguard + clawql-audit tests pass

[mcp_auth_worm_wiring_tests.log](https://cursor.com/agents/bc-01a03672-db3d-7c84-9767-5c0b5e1a4914/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_auth_worm_wiring_tests.log)

## Stack

Targets `cursor/clawql-audit-worm-package-4914` (parent WORM package + initial wiring PR #965).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03672-db3d-7c84-9767-5c0b5e1a4914?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03672-db3d-7c84-9767-5c0b5e1a4914&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

