### PR TITLE
feat(audit): Phase 3 ECDSA P-256 TEE signer and verifier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -316,6 +316,11 @@
 # CLAWQL_AUDIT_API_KEY=…
 # CLAWQL_WORM_PANGUARD_ALLOW=1
 # CLAWQL_WORM_DEBUG=1
+# TEE ECDSA P-256 signatures on each WORM entry (simulated until clawql-tee hardware):
+# CLAWQL_WORM_TEE=1
+# CLAWQL_WORM_TEE_PRIVATE_KEY_PEM="-----BEGIN PRIVATE KEY-----\n…\n-----END PRIVATE KEY-----"
+# CLAWQL_WORM_TEE_PUBLIC_KEY_PEM="-----BEGIN PUBLIC KEY-----\n…\n-----END PUBLIC KEY-----"
+# Omit PEMs with CLAWQL_WORM_TEE=1 for ephemeral simulated keys (dev only).
 
 # Presidio PII redaction — opt-in; requires analyzer + anonymizer HTTP services.
 # CLAWQL_ENABLE_PRESIDIO=1

--- a/packages/clawql-audit/README.md
+++ b/packages/clawql-audit/README.md
@@ -73,6 +73,35 @@ Prefer `makeWORMAuditTrailLayer` / `WORMAuditTrailService` inside ClawQL. The `W
 
 The MCP `audit` tool ring buffer is ephemeral operator breadcrumbs — a different product surface.
 
-## Phase 3 (not yet)
+## Phase 3 — TEE ECDSA (shipped; hardware later)
 
-Real TEE ECDSA signer/verifier (`clawql-tee` integration).
+Per-entry `teeSignature` via **ECDSA P-256** (`node:crypto`):
+
+```typescript
+import {
+  WORMAuditTrail,
+  MemoryBackend,
+  createSimulatedTeeSigner,
+  verifyTEESignature,
+} from "clawql-audit";
+import { Effect } from "effect";
+
+const tee = await Effect.runPromise(createSimulatedTeeSigner());
+const worm = await WORMAuditTrail.create({
+  local: new MemoryBackend(),
+  remote: new MemoryBackend(),
+  tee,
+});
+const entry = await worm.append({ /* … */ });
+console.log(await Effect.runPromise(verifyTEESignature(entry, tee.publicKeyPem, tee.attestation)));
+```
+
+Env (process trail): `CLAWQL_WORM_TEE=1` plus PEM keys, or omit PEMs for ephemeral simulated keys.
+
+| Variable | Role |
+| --- | --- |
+| `CLAWQL_WORM_TEE` | `1` enables signing on append |
+| `CLAWQL_WORM_TEE_PRIVATE_KEY_PEM` | PKCS8 PEM (use `\n` in env) |
+| `CLAWQL_WORM_TEE_PUBLIC_KEY_PEM` | SPKI PEM |
+
+`platform: "simulated"` until **clawql-tee** (SEV-SNP / TDX remote attestation) lands — ECDSA crypto is real; hardware attestation report verification is not.

--- a/packages/clawql-audit/src/env-config.ts
+++ b/packages/clawql-audit/src/env-config.ts
@@ -5,6 +5,7 @@
  * CLAWQL_WORM_LOCAL=memory|sqlite|postgres (default: sqlite when path set, else memory)
  * CLAWQL_WORM_REMOTE=memory|s3 (default: memory)
  * CLAWQL_WORM_SQLITE_PATH, CLAWQL_WORM_POSTGRES_URL, CLAWQL_WORM_S3_* for backends
+ * CLAWQL_WORM_TEE=1 enables ECDSA P-256 teeSignature on append (PEM or ephemeral)
  */
 
 import { Effect } from "effect";
@@ -14,6 +15,8 @@ import { PostgresBackend } from "./storage/postgres.js";
 import { S3Backend } from "./storage/s3.js";
 import { SQLiteBackend } from "./storage/sqlite.js";
 import type { LocalStorageBackend, StorageBackend } from "./storage/types.js";
+import type { TEESigner } from "./tee/signer.js";
+import { createEcdsaTeeSigner, createSimulatedTeeSigner } from "./tee/signer.js";
 import type { WORMAuditTrailConfig } from "./trail.js";
 
 function envTrim(env: NodeJS.ProcessEnv, key: string): string | undefined {
@@ -118,6 +121,33 @@ function makeRemote(
   });
 }
 
+function makeTee(
+  env: NodeJS.ProcessEnv
+): Effect.Effect<TEESigner | undefined, AuditError> {
+  return Effect.gen(function* () {
+    if (envTrim(env, "CLAWQL_WORM_TEE") !== "1") return undefined;
+    const privateKeyPem = envTrim(env, "CLAWQL_WORM_TEE_PRIVATE_KEY_PEM");
+    const publicKeyPem = envTrim(env, "CLAWQL_WORM_TEE_PUBLIC_KEY_PEM");
+    if (privateKeyPem && publicKeyPem) {
+      return yield* createEcdsaTeeSigner({
+        privateKeyPem: privateKeyPem.replace(/\\n/g, "\n"),
+        publicKeyPem: publicKeyPem.replace(/\\n/g, "\n"),
+        platform: "simulated",
+      });
+    }
+    // Ephemeral simulated key when enabled without PEM (dev / tests).
+    if (envTrim(env, "CLAWQL_WORM_TEE_EPHEMERAL") === "1" || (!privateKeyPem && !publicKeyPem)) {
+      return yield* createSimulatedTeeSigner();
+    }
+    return yield* Effect.fail(
+      new AuditError({
+        reason:
+          "CLAWQL_WORM_TEE=1 requires CLAWQL_WORM_TEE_PRIVATE_KEY_PEM + CLAWQL_WORM_TEE_PUBLIC_KEY_PEM, or omit both for ephemeral simulated keys",
+      })
+    );
+  });
+}
+
 /**
  * Build trail config from env, or `null` when `CLAWQL_WORM_ENABLED` is not `1`.
  */
@@ -128,10 +158,12 @@ export const createWormTrailConfigFromEnvEffect = (
     if (!(yield* wormEnabledFromEnv(env))) return null;
     const local = yield* makeLocal(env);
     const remote = yield* makeRemote(env);
+    const tee = yield* makeTee(env);
     const httpPort = parseIntEnv(env, "CLAWQL_WORM_HTTP_PORT");
     return {
       local,
       remote,
+      tee,
       retryMaxAttempts: parseIntEnv(env, "CLAWQL_WORM_RETRY_MAX"),
       retryBackoffMs: parseIntEnv(env, "CLAWQL_WORM_RETRY_BACKOFF_MS"),
       reconcileIntervalMs: parseIntEnv(env, "CLAWQL_WORM_RECONCILE_MS") ?? 2000,

--- a/packages/clawql-audit/src/index.ts
+++ b/packages/clawql-audit/src/index.ts
@@ -49,8 +49,17 @@ export { S3Backend, type S3BackendConfig } from "./storage/s3.js";
 export { PostgresBackend, type PostgresBackendOptions } from "./storage/postgres.js";
 export {
   verifyTEESignature,
+  createEcdsaTeeSigner,
+  createSimulatedTeeSigner,
+  generateTeeKeyPairPem,
+  signEntryHashEcdsa,
+  verifyEntryHashEcdsa,
+  TEE_ECDSA_CURVE,
   type TEEAttestationReport,
   type TEESigner,
+  type TEEKeyPairPem,
+  type CreateEcdsaTeeSignerOptions,
+  type VerifyTeeSignatureResult,
 } from "./tee/signer.js";
 export { handleAuditHttpRequest, authorizeApiKey, type HttpRequest, type HttpResponse } from "./http/routes.js";
 export { startAuditHttpServer, type AuditHttpServerHandle } from "./http/server.js";

--- a/packages/clawql-audit/src/tee/ecdsa.ts
+++ b/packages/clawql-audit/src/tee/ecdsa.ts
@@ -1,0 +1,177 @@
+/**
+ * ECDSA P-256 signing for WORM entry hashes (Phase 3).
+ * Simulated software keys for now; hardware clawql-tee plugs the same {@link TEESigner} surface later.
+ */
+
+import {
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  sign as nodeSign,
+  verify as nodeVerify,
+  type KeyObject,
+} from "node:crypto";
+import { Effect } from "effect";
+import { AuditError } from "../errors.js";
+import type { TEEAttestationReport, TEESigner } from "./signer.js";
+
+/** NIST P-256 / prime256v1 — common for TEE attestation tokens. */
+export const TEE_ECDSA_CURVE = "prime256v1" as const;
+
+export type TEEKeyPairPem = {
+  readonly privateKeyPem: string;
+  readonly publicKeyPem: string;
+};
+
+export const generateTeeKeyPairPem = (): Effect.Effect<TEEKeyPairPem, AuditError> =>
+  Effect.try({
+    try: () => {
+      const { privateKey, publicKey } = generateKeyPairSync("ec", {
+        namedCurve: TEE_ECDSA_CURVE,
+      });
+      return {
+        privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+        publicKeyPem: publicKey.export({ type: "spki", format: "pem" }).toString(),
+      };
+    },
+    catch: (cause) =>
+      new AuditError({
+        reason: `TEE keypair generation failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+        cause,
+      }),
+  });
+
+function loadPrivateKey(pem: string): Effect.Effect<KeyObject, AuditError> {
+  return Effect.try({
+    try: () => createPrivateKey(pem),
+    catch: (cause) =>
+      new AuditError({
+        reason: `Invalid TEE private key PEM: ${cause instanceof Error ? cause.message : String(cause)}`,
+        cause,
+      }),
+  });
+}
+
+function loadPublicKey(pem: string): Effect.Effect<KeyObject, AuditError> {
+  return Effect.try({
+    try: () => createPublicKey(pem),
+    catch: (cause) =>
+      new AuditError({
+        reason: `Invalid TEE public key PEM: ${cause instanceof Error ? cause.message : String(cause)}`,
+        cause,
+      }),
+  });
+}
+
+/** Sign a hex SHA-256 entry hash; returns base64 DER ECDSA signature. */
+export const signEntryHashEcdsa = (
+  hashHex: string,
+  privateKeyPem: string
+): Effect.Effect<string, AuditError> =>
+  Effect.gen(function* () {
+    if (!/^[a-fA-F0-9]{64}$/.test(hashHex)) {
+      return yield* Effect.fail(
+        new AuditError({ reason: `TEE sign expects 64-char hex hash, got length ${hashHex.length}` })
+      );
+    }
+    const key = yield* loadPrivateKey(privateKeyPem);
+    return yield* Effect.try({
+      try: () => {
+        const sig = nodeSign(null, Buffer.from(hashHex, "hex"), {
+          key,
+          dsaEncoding: "der",
+        });
+        return sig.toString("base64");
+      },
+      catch: (cause) =>
+        new AuditError({
+          reason: `TEE ECDSA sign failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+          cause,
+        }),
+    });
+  });
+
+/** Verify base64 DER ECDSA signature over hex entry hash. */
+export const verifyEntryHashEcdsa = (
+  hashHex: string,
+  signatureBase64: string,
+  publicKeyPem: string
+): Effect.Effect<boolean, AuditError> =>
+  Effect.gen(function* () {
+    if (!/^[a-fA-F0-9]{64}$/.test(hashHex)) return false;
+    const key = yield* loadPublicKey(publicKeyPem);
+    return yield* Effect.try({
+      try: () =>
+        nodeVerify(
+          null,
+          Buffer.from(hashHex, "hex"),
+          { key, dsaEncoding: "der" },
+          Buffer.from(signatureBase64, "base64")
+        ),
+      catch: (cause) =>
+        new AuditError({
+          reason: `TEE ECDSA verify failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+          cause,
+        }),
+    });
+  });
+
+export type CreateEcdsaTeeSignerOptions = {
+  readonly privateKeyPem: string;
+  readonly publicKeyPem: string;
+  readonly platform?: TEEAttestationReport["platform"];
+};
+
+/**
+ * Software ECDSA P-256 signer implementing {@link TEESigner}.
+ * `platform: "simulated"` until clawql-tee hardware attestation lands.
+ */
+export const createEcdsaTeeSigner = (
+  options: CreateEcdsaTeeSignerOptions
+): Effect.Effect<TEESigner & { readonly publicKeyPem: string; readonly attestation: TEEAttestationReport }, AuditError> =>
+  Effect.gen(function* () {
+    // Validate keys early
+    yield* loadPrivateKey(options.privateKeyPem);
+    yield* loadPublicKey(options.publicKeyPem);
+    const platform = options.platform ?? "simulated";
+    const attestation: TEEAttestationReport = {
+      platform,
+      reportBase64: Buffer.from(
+        JSON.stringify({
+          platform,
+          algo: "ECDSA_P256",
+          publicKeyPem: options.publicKeyPem,
+          note:
+            platform === "simulated"
+              ? "Software ECDSA — not hardware-attested. Replace with clawql-tee SEV-SNP/TDX when available."
+              : "Hardware attestation report placeholder",
+        }),
+        "utf8"
+      ).toString("base64"),
+    };
+
+    const signer: TEESigner & {
+      readonly publicKeyPem: string;
+      readonly attestation: TEEAttestationReport;
+    } = {
+      publicKeyPem: options.publicKeyPem,
+      attestation,
+      sign: (hash) => signEntryHashEcdsa(hash, options.privateKeyPem),
+    };
+    return signer;
+  });
+
+/** Generate an ephemeral simulated TEE signer (tests / local without key material). */
+export const createSimulatedTeeSigner = (): Effect.Effect<
+  TEESigner & { readonly publicKeyPem: string; readonly privateKeyPem: string; readonly attestation: TEEAttestationReport },
+  AuditError
+> =>
+  Effect.gen(function* () {
+    const pair = yield* generateTeeKeyPairPem();
+    const base = yield* createEcdsaTeeSigner({
+      privateKeyPem: pair.privateKeyPem,
+      publicKeyPem: pair.publicKeyPem,
+      platform: "simulated",
+    });
+    return { ...base, privateKeyPem: pair.privateKeyPem };
+  });

--- a/packages/clawql-audit/src/tee/signer.ts
+++ b/packages/clawql-audit/src/tee/signer.ts
@@ -1,13 +1,14 @@
 /**
- * Optional TEE attestation hooks (Phase 3). Types only for Phase 1 wiring.
+ * Optional TEE attestation hooks (Phase 3).
+ * ECDSA P-256 sign/verify ships in-package; hardware SEV-SNP/TDX via clawql-tee later.
  */
 
 import { Effect } from "effect";
 import type { WORMEntry } from "../entry.js";
-import { AuditError } from "../errors.js";
+import { verifyEntryHashEcdsa } from "./ecdsa.js";
 
 export type TEESigner = {
-  readonly sign: (hash: string) => Effect.Effect<string, AuditError>;
+  readonly sign: (hash: string) => Effect.Effect<string, import("../errors.js").AuditError>;
 };
 
 export type TEEAttestationReport = {
@@ -15,18 +16,63 @@ export type TEEAttestationReport = {
   readonly platform: "sev-snp" | "tdx" | "simulated";
 };
 
+export type VerifyTeeSignatureResult = {
+  readonly valid: boolean;
+  readonly reason?: string;
+};
+
+/**
+ * Verify {@link WORMEntry.teeSignature} (base64 DER ECDSA-P256) over {@link WORMEntry.hash}.
+ * Attestation report is recorded for auditors; hardware KDS/PCS validation is clawql-tee follow-up.
+ */
 export const verifyTEESignature = (
   entry: WORMEntry,
-  _publicKeyPem: string,
-  _attestationReport: TEEAttestationReport
-): Effect.Effect<{ valid: boolean; reason?: string }> =>
-  Effect.sync(() => {
+  publicKeyPem: string,
+  attestationReport?: TEEAttestationReport
+): Effect.Effect<VerifyTeeSignatureResult> =>
+  Effect.gen(function* () {
     if (!entry.teeSignature) {
       return { valid: false, reason: "No TEE signature present" };
     }
-    // Phase 3: ECDSA verify + attestation report validation.
-    return {
-      valid: false,
-      reason: "TEE verification ships in Phase 3 (clawql-tee integration)",
-    };
+    const verified = yield* verifyEntryHashEcdsa(
+      entry.hash,
+      entry.teeSignature,
+      publicKeyPem
+    ).pipe(
+      Effect.map((ok) => ({ ok, error: undefined as string | undefined })),
+      Effect.catchAll((err) => Effect.succeed({ ok: false, error: err.reason }))
+    );
+    if (verified.error) {
+      return { valid: false, reason: verified.error };
+    }
+    if (!verified.ok) {
+      return { valid: false, reason: "ECDSA signature mismatch" };
+    }
+    if (attestationReport?.platform === "simulated") {
+      return {
+        valid: true,
+        reason: "ECDSA valid (simulated TEE — not hardware-attested)",
+      };
+    }
+    if (
+      attestationReport?.platform === "sev-snp" ||
+      attestationReport?.platform === "tdx"
+    ) {
+      return {
+        valid: true,
+        reason: `ECDSA valid; hardware attestation (${attestationReport.platform}) not yet verified by clawql-tee`,
+      };
+    }
+    return { valid: true };
   });
+
+export {
+  createEcdsaTeeSigner,
+  createSimulatedTeeSigner,
+  generateTeeKeyPairPem,
+  signEntryHashEcdsa,
+  TEE_ECDSA_CURVE,
+  verifyEntryHashEcdsa,
+  type CreateEcdsaTeeSignerOptions,
+  type TEEKeyPairPem,
+} from "./ecdsa.js";

--- a/packages/clawql-audit/src/tee/tee.test.ts
+++ b/packages/clawql-audit/src/tee/tee.test.ts
@@ -1,0 +1,84 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import {
+  MemoryBackend,
+  WORMAuditTrail,
+  createSimulatedTeeSigner,
+  generateTeeKeyPairPem,
+  verifyTEESignature,
+} from "../index.js";
+
+describe("Phase 3 TEE ECDSA", () => {
+  it("signs and verifies entry hashes with simulated signer", async () => {
+    const signer = await Effect.runPromise(createSimulatedTeeSigner());
+    const hash = "a".repeat(64);
+    const sig = await Effect.runPromise(signer.sign(hash));
+    expect(sig.length).toBeGreaterThan(40);
+
+    const entry = {
+      id: "00000000-0000-7000-8000-000000000099",
+      hash,
+      prevHash: "0".repeat(64),
+      chainIndex: 0,
+      writtenAt: new Date().toISOString(),
+      backendAcks: [],
+      type: "SESSION_START",
+      timestamp: new Date().toISOString(),
+      sessionId: "tee-test",
+      teeSignature: sig,
+    } as const;
+
+    const ok = await Effect.runPromise(
+      verifyTEESignature(entry, signer.publicKeyPem, signer.attestation)
+    );
+    expect(ok.valid).toBe(true);
+    expect(ok.reason).toMatch(/simulated/i);
+  });
+
+  it("rejects wrong public key", async () => {
+    const a = await Effect.runPromise(createSimulatedTeeSigner());
+    const b = await Effect.runPromise(generateTeeKeyPairPem());
+    const hash = "b".repeat(64);
+    const sig = await Effect.runPromise(a.sign(hash));
+    const result = await Effect.runPromise(
+      verifyTEESignature(
+        {
+          id: "x",
+          hash,
+          prevHash: "0".repeat(64),
+          chainIndex: 0,
+          writtenAt: new Date().toISOString(),
+          backendAcks: [],
+          type: "SESSION_START",
+          timestamp: new Date().toISOString(),
+          sessionId: "s",
+          teeSignature: sig,
+        },
+        b.publicKeyPem
+      )
+    );
+    expect(result.valid).toBe(false);
+  });
+
+  it("WORMAuditTrail appends teeSignature when tee configured", async () => {
+    const signer = await Effect.runPromise(createSimulatedTeeSigner());
+    const worm = await WORMAuditTrail.create({
+      local: new MemoryBackend(),
+      remote: new MemoryBackend(),
+      tee: signer,
+      reconcileIntervalMs: 0,
+      merkleBatchSize: 0,
+    });
+    const entry = await worm.append({
+      type: "SESSION_START",
+      timestamp: new Date().toISOString(),
+      sessionId: "tee-trail",
+    });
+    expect(entry.teeSignature).toBeTruthy();
+    const verified = await Effect.runPromise(
+      verifyTEESignature(entry, signer.publicKeyPem, signer.attestation)
+    );
+    expect(verified.valid).toBe(true);
+    await worm.stop();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Phase 3** for `clawql-audit`: real **ECDSA P-256** per-entry `teeSignature` + verify. Hardware SEV-SNP/TDX attestation (clawql-tee package) remains a later plug-in on the same `TEESigner` interface.

## What shipped

| Piece | Behavior |
| --- | --- |
| `createSimulatedTeeSigner` / `createEcdsaTeeSigner` | Sign entry hashes (base64 DER) |
| `verifyTEESignature` | ECDSA verify (was a stub) |
| `CLAWQL_WORM_TEE=1` | Process trail / env boot signs every append |
| PEM env | `CLAWQL_WORM_TEE_PRIVATE_KEY_PEM` + `_PUBLIC_KEY_PEM` |
| No PEM | Ephemeral simulated keypair (dev) |

`platform: "simulated"` in attestation reports until clawql-tee exists. Standalone gate unchanged (no new clawql-* deps — `node:crypto` only).

## Enable

```bash
CLAWQL_WORM_ENABLED=1
CLAWQL_WORM_TEE=1
# optional stable keys:
# CLAWQL_WORM_TEE_PRIVATE_KEY_PEM=…
# CLAWQL_WORM_TEE_PUBLIC_KEY_PEM=…
```

## Test plan

- [x] `src/tee/tee.test.ts` — sign/verify, wrong key reject, trail append with teeSignature
- [x] Full `clawql-audit` suite (18 tests)

## Stack

`…` → #974 (inference) → **this PR**

## Not in this PR

- AMD KDS / Intel PCS remote attestation verification
- New `clawql-tee` package / cellrt attestation crate
- Ed25519 session signatures over Merkle roots (air-gap QR session layer — separate from per-entry `teeSignature`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03672-db3d-7c84-9767-5c0b5e1a4914?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03672-db3d-7c84-9767-5c0b5e1a4914&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

