### PR TITLE
fix(mcp-ui): wrap field help and result text instead of overflowing

### DIFF
--- a/packages/mcp-api-adapter/CHANGELOG.md
+++ b/packages/mcp-api-adapter/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **`/mcp-ui` overflow fix:** schema descriptions render as wrapping `.field-help` (not truncating input placeholders); result snippets and card text use `overflow-wrap` so long vault snippets no longer spill out of columns.
+
 - **`/mcp-ui` nested forms:** `object` properties render as expandable `<fieldset>`s (`parent.child` names); `array` of scalars/objects get add/remove row controls (`items[0]`, `steps[0].tool`). Depth capped at 2; deeper schemas still fall back to the JSON bag.
 
 - **`/mcp-ui` ATR scoping:** catalog + execute filter by JWT `atr.scope` / `atr.tools` (default on). Internal `ouroboros_*` / `pageindex_*` require explicit or family grants. `--no-mcp-ui-atr-scoped` disables. API keys remain admin-equivalent.

--- a/packages/mcp-api-adapter/src/mcp-ui-form.test.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-form.test.ts
@@ -29,7 +29,8 @@ describe("mcp-ui-form", () => {
     expect(html).toContain('name="message"');
     expect(html).toContain("badge--required");
     expect(html).toContain("badge--optional");
-    expect(html).toContain('placeholder="Text to echo"');
+    expect(html).toContain('class="field-help">Text to echo</p>');
+    expect(html).not.toMatch(/placeholder="Text to echo"/);
   });
 
   it("prefills schema defaults and blank optional enums", () => {

--- a/packages/mcp-api-adapter/src/mcp-ui-form.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-form.ts
@@ -117,13 +117,6 @@ function inputTypeForString(propSchema: Record<string, unknown>): string {
   return "text";
 }
 
-function shortPlaceholder(description: string | undefined, max = 90): string {
-  if (!description) return "";
-  const oneLine = description.replace(/\s+/g, " ").trim();
-  if (oneLine.length <= max) return oneLine;
-  return `${oneLine.slice(0, max - 1)}…`;
-}
-
 /** True when a flat string field should render as `<input type="file">`. */
 export function looksLikeFileField(
   name: string,
@@ -195,11 +188,9 @@ export function renderFieldControl(options: RenderFieldOptions): string {
         : propSchema.default;
   const reqAttr = required && propSchema.type !== "boolean" ? " required" : "";
   const errClass = errorMessage ? " field--error" : "";
-  const placeholder = shortPlaceholder(description);
-  const placeholderAttr = placeholder ? ` placeholder="${escHtml(placeholder)}"` : "";
   const hintHtml = hint
     ? `<p class="field-help">${escHtml(hint)}</p>`
-    : description && description.length > 90
+    : description
       ? `<p class="field-help">${escHtml(description)}</p>`
       : "";
   const errHtml = errorMessage
@@ -277,7 +268,7 @@ export function renderFieldControl(options: RenderFieldOptions): string {
       defaultValue !== undefined && defaultValue !== null ? String(defaultValue) : "";
     return `<label class="field${errClass}">
   <span class="field-label">${escHtml(label)} ${labelBadge(required)}</span>
-  <textarea name="${escHtml(name)}" rows="4"${reqAttr}${placeholderAttr}>${escHtml(text)}</textarea>
+  <textarea name="${escHtml(name)}" rows="4"${reqAttr}>${escHtml(text)}</textarea>
   ${hintHtml}${errHtml}
 </label>`;
   }
@@ -290,7 +281,7 @@ export function renderFieldControl(options: RenderFieldOptions): string {
       : "";
   return `<label class="field${errClass}">
   <span class="field-label">${escHtml(label)} ${labelBadge(required)}</span>
-  <input type="${inputType}" name="${escHtml(name)}"${valueAttr}${placeholderAttr}${reqAttr} />
+  <input type="${inputType}" name="${escHtml(name)}"${valueAttr}${reqAttr} />
   ${hintHtml}${errHtml}
 </label>`;
 }

--- a/packages/mcp-api-adapter/src/mcp-ui-form.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-form.ts
@@ -256,11 +256,13 @@ export function renderFieldControl(options: RenderFieldOptions): string {
   const type = propSchema.type;
   if (type === "boolean") {
     const checked = defaultValue === true ? " checked" : "";
-    return `<label class="field field--checkbox${errClass}">
-  <input type="checkbox" name="${escHtml(name)}" value="true"${checked} />
-  <span class="field-label">${escHtml(label)} ${labelBadge(required)}</span>
+    return `<div class="field field--checkbox${errClass}">
+  <label class="field--checkbox__row">
+    <input type="checkbox" name="${escHtml(name)}" value="true"${checked} />
+    <span class="field-label">${escHtml(label)} ${labelBadge(required)}</span>
+  </label>
   ${hintHtml}${errHtml}
-</label>`;
+</div>`;
   }
 
   if (asTextarea || (typeof description === "string" && description.length > 160)) {

--- a/packages/mcp-api-adapter/src/mcp-ui-html.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-html.ts
@@ -163,11 +163,15 @@ const MCP_UI_STYLES = `
   }
   .field textarea { resize: vertical; min-height: 5rem; }
   .field--checkbox {
+    display: block;
+  }
+  .field--checkbox__row {
     display: flex;
     align-items: flex-start;
     gap: 0.45rem;
   }
-  .field--checkbox input { width: auto; margin-top: 0.2rem; }
+  .field--checkbox__row input { width: auto; margin-top: 0.2rem; flex-shrink: 0; }
+  .field--checkbox .field-help { margin-left: 1.4rem; }
   .field--error input,
   .field--error select,
   .field--error textarea {

--- a/packages/mcp-api-adapter/src/mcp-ui-html.ts
+++ b/packages/mcp-api-adapter/src/mcp-ui-html.ts
@@ -85,22 +85,29 @@ const MCP_UI_STYLES = `
     border-radius: 12px;
     padding: 1rem;
     box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+    min-width: 0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
   .tool-card h2 {
     margin: 0;
     font-size: 1rem;
     font-weight: 650;
+    overflow-wrap: anywhere;
   }
   .tool-card .tool-name {
     margin: 0.25rem 0 0.35rem;
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.82rem;
     color: var(--muted);
+    overflow-wrap: anywhere;
   }
   .tool-card .tool-desc {
     margin: 0 0 0.85rem;
     color: var(--muted);
     font-size: 0.92rem;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
   .template-pill {
     display: inline-block;
@@ -171,12 +178,17 @@ const MCP_UI_STYLES = `
     margin: 0.25rem 0 0;
     font-size: 0.8rem;
     color: var(--muted);
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    white-space: normal;
   }
   .field-error {
     margin: 0.3rem 0 0;
     font-size: 0.82rem;
     color: var(--err);
     font-weight: 600;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
   .advanced {
     margin: 0.5rem 0 0.85rem;
@@ -266,6 +278,9 @@ const MCP_UI_STYLES = `
     border-radius: 10px;
     padding: 0.75rem;
     font-size: 0.9rem;
+    min-width: 0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
   .result--success {
     background: var(--ok-bg);
@@ -288,6 +303,11 @@ const MCP_UI_STYLES = `
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     color: var(--ink);
   }
+  .result__content {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
   .result pre {
     margin: 0;
     overflow: auto;
@@ -296,29 +316,43 @@ const MCP_UI_STYLES = `
     background: rgba(15, 23, 42, 0.04);
     border-radius: 8px;
     font-size: 0.82rem;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
   .result-list {
     margin: 0;
     padding-left: 1.15rem;
     display: grid;
     gap: 0.55rem;
+    min-width: 0;
   }
   .result-list--compact { padding-left: 1rem; }
+  .result-item {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
   .result-item__title {
     font-weight: 650;
     display: flex;
     flex-wrap: wrap;
     gap: 0.35rem;
     align-items: center;
+    overflow-wrap: anywhere;
   }
   .result-item__meta {
     font-size: 0.78rem;
     color: var(--muted);
+    overflow-wrap: anywhere;
   }
   .result-item__desc {
     margin: 0.2rem 0 0;
     font-size: 0.84rem;
     color: var(--ink);
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
   .result-summary { margin: 0 0 0.5rem; }
   .result-empty { margin: 0 0 0.5rem; color: var(--muted); }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `/mcp-ui` text overflow from the nested-forms screenshots:

1. **Field descriptions** were put in `<input placeholder>` for short schema copy — placeholders cannot wrap, so text clipped mid-word at the card edge.
2. **Result snippets** needed explicit wrap CSS so long vault lines stay inside the result box.
3. **Checkbox help** no longer flex-wraps beside the label (help sits below the control row).

### Fix
- Always render schema / template copy as wrapping `.field-help` (no long placeholders).
- CSS: `min-width: 0`, `overflow-wrap: anywhere`, `word-break: break-word` on cards, help text, and result items; `pre-wrap` on result `<pre>`.

### Evidence
Playwright layout check: all `.result-item__desc` and `.field-help` nodes report `scrollWidth === clientWidth` (no overflow).

[memory_ingest help wraps](https://cursor.com/agents/bc-01a03b41-a8f7-766e-b8b6-1e0170a7356a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_ui_overflow_ingest_fixed.png)
[memory_recall results wrap](https://cursor.com/agents/bc-01a03b41-a8f7-766e-b8b6-1e0170a7356a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_ui_overflow_result_fixed.png)

## Test plan

- [x] `npm test` — 46/46
- [x] Playwright measure: no scrollWidth overflow on descs/helps
- [ ] CI green → merge


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03b41-a8f7-766e-b8b6-1e0170a7356a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03b41-a8f7-766e-b8b6-1e0170a7356a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

