### PR TITLE
feat(core): WebMCP custom source adapter (sources side)

### DIFF
--- a/docs/getting-started/custom-sources.md
+++ b/docs/getting-started/custom-sources.md
@@ -83,14 +83,14 @@ In **ClawQL Desktop** mode, the dashboard exposes **`GET/POST/DELETE /api/local/
 
 ## Source kinds
 
-| Kind                | How it loads                                                   |
-| ------------------- | -------------------------------------------------------------- |
-| OpenAPI / Discovery | Cached spec under `~/.ClawQL/sources/<id>/`                    |
-| GraphQL             | SDL or introspection file + `graphqlEndpoint`                  |
-| gRPC                | `.proto` on disk + `grpcEndpoint`                              |
-| **MCP**             | Proxies `tools/list` / `tools/call` from the remote MCP server |
+| Kind                | How it loads                                                                |
+| ------------------- | --------------------------------------------------------------------------- |
+| OpenAPI / Discovery | Cached spec under `~/.ClawQL/sources/<id>/`                                 |
+| GraphQL             | SDL or introspection file + `graphqlEndpoint`                               |
+| gRPC                | `.proto` on disk + `grpcEndpoint`                                           |
+| **MCP**             | Proxies `tools/list` / `tools/call` from the remote MCP server              |
 | **WebMCP**          | Discovers page tools via `navigator.modelContext` over CDP (Chrome preview) |
-| CLI                 | One `execute` op runs configured command + args                |
+| CLI                 | One `execute` op runs configured command + args                             |
 
 Bundled providers and custom sources share the same **`search` / `execute`** index. Custom sources extend that index; they do not require a second MCP client entry in Cursor/Claude.
 

--- a/docs/getting-started/custom-sources.md
+++ b/docs/getting-started/custom-sources.md
@@ -42,6 +42,9 @@ Related lockdown surfaces:
 # Streamable HTTP MCP endpoint
 clawql sources add https://remote.example/mcp --kind mcp --name "Other MCP"
 
+# WebMCP page source (Chrome preview + CDP required)
+clawql sources add https://docs.clawql.com --kind webmcp --name "ClawQL Docs"
+
 # Auto-detect OpenAPI, Discovery, GraphQL, gRPC proto, or MCP HTTP
 clawql sources add https://example.com/openapi.json --name "Example API"
 
@@ -62,6 +65,18 @@ What happens on startup for `kind: mcp`:
 
 Stdio MCP packages can be registered by editing `~/.ClawQL/sources.json` with `mcpCommand` / `mcpArgs` / optional `mcpEnv` (same shape as the types in `clawql-api`). Prefer HTTP when the upstream already exposes Streamable HTTP.
 
+### WebMCP page sources (preview)
+
+WebMCP is the **inverse** of `/mcp-ui`: websites register tools in the browser via [`navigator.modelContext`](https://webmachinelearning.github.io/webmcp/); ClawQL Core **ingests** those tools as searchable/executable operations (left side of Protocol Fabric).
+
+Requirements:
+
+1. **Chromium with WebMCP** (Chrome preview flag) listening on CDP — default `http://127.0.0.1:9222`, override with `CLAWQL_WEBMCP_CDP_URL` or per-source `webmcpCdpUrl`.
+2. **HTTPS page** that registers tools (e.g. [docs.clawql.com](https://docs.clawql.com) via `WebMcpRegister`).
+3. `clawql sources add https://docs.clawql.com --kind webmcp --name "ClawQL Docs"`
+
+On startup ClawQL opens the page in CDP, calls `document.modelContext.getTools()`, indexes each tool (`webmcp/<sourceId>/<toolName>`), and proxies `execute` back via `executeTool()`.
+
 ## Desktop / dashboard
 
 In **ClawQL Desktop** mode, the dashboard exposes **`GET/POST/DELETE /api/local/sources`** (same JSON shape as `sources.json`).
@@ -74,6 +89,7 @@ In **ClawQL Desktop** mode, the dashboard exposes **`GET/POST/DELETE /api/local/
 | GraphQL             | SDL or introspection file + `graphqlEndpoint`                  |
 | gRPC                | `.proto` on disk + `grpcEndpoint`                              |
 | **MCP**             | Proxies `tools/list` / `tools/call` from the remote MCP server |
+| **WebMCP**          | Discovers page tools via `navigator.modelContext` over CDP (Chrome preview) |
 | CLI                 | One `execute` op runs configured command + args                |
 
 Bundled providers and custom sources share the same **`search` / `execute`** index. Custom sources extend that index; they do not require a second MCP client entry in Cursor/Claude.

--- a/packages/clawql-api/src/execute/execute-core.ts
+++ b/packages/clawql-api/src/execute/execute-core.ts
@@ -14,6 +14,7 @@ import { executeNativeGraphQL } from "./native-graphql.js";
 import { executeNativeGrpc } from "./native-grpc.js";
 import { executeNativeMcp } from "./native-mcp.js";
 import { executeNativeCli } from "./native-cli.js";
+import { executeNativeWebmcp } from "./native-webmcp.js";
 import { executeRestOperation } from "./rest-operation.js";
 import type { ExecuteClawqlOperationParams, McpTextContent } from "./types.js";
 
@@ -121,6 +122,22 @@ export function executeClawqlOperationEffect(
             error: exec.error,
             specLabel: op.specLabel ?? null,
             hint: "CLI source execute failed (check command, args, and env).",
+          })
+        );
+      }
+      return yield* textContentEffect(
+        JSON.stringify(projectRestByFields(exec.data, outputFields), null, 2)
+      );
+    }
+
+    if (op.protocolKind === "webmcp" && op.nativeWebmcp) {
+      const exec = yield* fromPromise(() => executeNativeWebmcp(op as Operation, args));
+      if (!exec.ok) {
+        return yield* textContentEffect(
+          JSON.stringify({
+            error: exec.error,
+            specLabel: op.specLabel ?? null,
+            hint: "WebMCP execute failed (check CDP browser, page URL, and tool arguments).",
           })
         );
       }

--- a/packages/clawql-api/src/execute/native-webmcp.ts
+++ b/packages/clawql-api/src/execute/native-webmcp.ts
@@ -1,0 +1,54 @@
+/**
+ * Execute proxied WebMCP tool calls for user-added WebMCP page sources.
+ */
+
+import { Effect } from "effect";
+import type { Operation } from "../spec/operation-types.js";
+import { getWebmcpSourceBinding } from "../spec/webmcp-source-registry.js";
+import { executeWebmcpToolEffect } from "../webmcp/webmcp-browser.js";
+import type { ExecuteOperationResult } from "./types.js";
+
+function parseToolArgs(args: Record<string, unknown>): Record<string, unknown> {
+  const raw = args.arguments ?? args;
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>;
+  }
+  return {};
+}
+
+export function executeNativeWebmcpEffect(
+  op: Operation,
+  args: Record<string, unknown>
+): Effect.Effect<ExecuteOperationResult, never> {
+  return Effect.gen(function* () {
+    const meta = op.nativeWebmcp;
+    if (!meta) {
+      return { ok: false as const, error: "Internal error: missing nativeWebmcp metadata" };
+    }
+
+    const binding = getWebmcpSourceBinding(meta.sourceId);
+    if (!binding) {
+      return {
+        ok: false as const,
+        error: `WebMCP source not connected: ${meta.sourceId} (restart MCP after adding sources)`,
+      };
+    }
+
+    const toolArgs = parseToolArgs(args);
+    const result = yield* executeWebmcpToolEffect(binding.session, meta.toolName, toolArgs).pipe(
+      Effect.match({
+        onFailure: (e) => ({ ok: false as const, error: e.message }),
+        onSuccess: (data) => ({ ok: true as const, data }),
+      })
+    );
+    return result;
+  });
+}
+
+/** Thin Promise façade for execute-core host boundary. */
+export async function executeNativeWebmcp(
+  op: Operation,
+  args: Record<string, unknown>
+): Promise<ExecuteOperationResult> {
+  return Effect.runPromise(executeNativeWebmcpEffect(op, args));
+}

--- a/packages/clawql-api/src/spec/custom-sources-merge.ts
+++ b/packages/clawql-api/src/spec/custom-sources-merge.ts
@@ -10,6 +10,7 @@ import { loadOpenAPIFromAbsolutePath } from "./spec-loader.js";
 import type { Operation } from "./operation-types.js";
 import { loadCliSourceOperations } from "./cli-source-loader.js";
 import { loadMcpSourceOperations } from "./mcp-source-loader.js";
+import { loadWebmcpSourceOperations } from "./webmcp-source-loader.js";
 import { loadGraphqlNativeOperationsFromConfigs } from "./graphql-native-loader.js";
 import { loadGrpcNativeOperationsFromConfigs } from "./grpc-native-loader.js";
 import {
@@ -136,6 +137,9 @@ export async function mergeCustomSourceOperations(loaded: LoadedSpec): Promise<L
 
   const cliOps = await loadCliSourceOperations(file.sources);
   operations = mergeOps(operations, cliOps);
+
+  const webmcpOps = await loadWebmcpSourceOperations(file.sources);
+  operations = mergeOps(operations, webmcpOps);
 
   const added = operations.length - loaded.operations.length;
   if (added > 0) {

--- a/packages/clawql-api/src/spec/custom-sources-types.ts
+++ b/packages/clawql-api/src/spec/custom-sources-types.ts
@@ -5,7 +5,7 @@
 
 import { assertSafeSourceId } from "./custom-sources-security.js";
 
-export type CustomSourceKind = "openapi" | "discovery" | "graphql" | "grpc" | "mcp" | "cli";
+export type CustomSourceKind = "openapi" | "discovery" | "graphql" | "grpc" | "mcp" | "cli" | "webmcp";
 
 export type CustomSourceEntry = {
   /** Stable slug (directory name under ~/.ClawQL/sources/). */
@@ -36,6 +36,12 @@ export type CustomSourceEntry = {
   cliArgs?: string[];
   cliEnv?: Record<string, string>;
   cliDescription?: string;
+  /** WebMCP page URL (HTTPS) where tools are registered via navigator.modelContext. */
+  webmcpPageUrl?: string;
+  /** Chromium CDP endpoint (default CLAWQL_WEBMCP_CDP_URL or http://127.0.0.1:9222). */
+  webmcpCdpUrl?: string;
+  /** Milliseconds to wait after page load for client-side tool registration. */
+  webmcpReadyMs?: number;
 };
 
 export type CustomSourcesFile = {

--- a/packages/clawql-api/src/spec/custom-sources-types.ts
+++ b/packages/clawql-api/src/spec/custom-sources-types.ts
@@ -5,7 +5,8 @@
 
 import { assertSafeSourceId } from "./custom-sources-security.js";
 
-export type CustomSourceKind = "openapi" | "discovery" | "graphql" | "grpc" | "mcp" | "cli" | "webmcp";
+export type CustomSourceKind =
+  "openapi" | "discovery" | "graphql" | "grpc" | "mcp" | "cli" | "webmcp";
 
 export type CustomSourceEntry = {
   /** Stable slug (directory name under ~/.ClawQL/sources/). */

--- a/packages/clawql-api/src/spec/detect-source-from-url.ts
+++ b/packages/clawql-api/src/spec/detect-source-from-url.ts
@@ -85,6 +85,15 @@ export async function detectSourceFromUrl(
   const fetchFn = options.fetchFn ?? fetch;
   const kindHint = options.kindHint;
 
+  if (kindHint === "webmcp") {
+    return {
+      kind: "webmcp",
+      name: new URL(url).hostname,
+      bodyText: "",
+      parsed: null,
+    };
+  }
+
   if (kindHint === "mcp" || (kindHint === undefined && looksLikeMcpEndpoint(url))) {
     return {
       kind: "mcp",
@@ -177,6 +186,6 @@ export async function detectSourceFromUrl(
   }
 
   throw new Error(
-    "Could not detect source kind. Use --kind openapi|discovery|graphql|grpc|mcp|cli."
+    "Could not detect source kind. Use --kind openapi|discovery|graphql|grpc|mcp|cli|webmcp."
   );
 }

--- a/packages/clawql-api/src/spec/index.ts
+++ b/packages/clawql-api/src/spec/index.ts
@@ -19,3 +19,4 @@ export * from "./detect-source-from-url.js";
 export * from "./custom-sources-merge.js";
 export * from "./mcp-source-loader.js";
 export * from "./cli-source-loader.js";
+export * from "./webmcp-source-loader.js";

--- a/packages/clawql-api/src/spec/operation-types.ts
+++ b/packages/clawql-api/src/spec/operation-types.ts
@@ -6,7 +6,7 @@
 export const INLINE_OPENAPI_REQUEST_BODY = "__clawql_inline_request_body__";
 
 /** Execution path for merged operations (defaults to OpenAPI-derived REST / in-process GraphQL-from-OAI). */
-export type ProtocolKind = "openapi" | "graphql" | "grpc" | "mcp" | "cli";
+export type ProtocolKind = "openapi" | "graphql" | "grpc" | "mcp" | "cli" | "webmcp";
 
 export interface Operation {
   id: string;
@@ -57,6 +57,12 @@ export interface Operation {
     command: string;
     args: string[];
     env: Record<string, string>;
+  };
+  /** Proxied WebMCP tool from a page registered via navigator.modelContext. */
+  nativeWebmcp?: {
+    sourceId: string;
+    toolName: string;
+    pageUrl: string;
   };
 }
 

--- a/packages/clawql-api/src/spec/spec-loader.ts
+++ b/packages/clawql-api/src/spec/spec-loader.ts
@@ -32,6 +32,7 @@ import {
 } from "./native-protocol-env.js";
 import { resetNativeProtocolRegistry } from "./native-protocol-registry.js";
 import { resetMcpSourceRegistry } from "./mcp-source-registry.js";
+import { resetWebmcpSourceRegistry } from "./webmcp-source-registry.js";
 import { operationsFromOpenAPI } from "./openapi-operations.js";
 import { getPackageRoot } from "./package-root.js";
 import {
@@ -812,6 +813,7 @@ export function resetSpecCache(): void {
   loadGeneration++;
   resetNativeProtocolRegistry();
   resetMcpSourceRegistry();
+  resetWebmcpSourceRegistry();
 }
 
 let specCacheShutdownHooksRegistered = false;

--- a/packages/clawql-api/src/spec/webmcp-source-loader.test.ts
+++ b/packages/clawql-api/src/spec/webmcp-source-loader.test.ts
@@ -1,0 +1,102 @@
+import { Effect } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as webmcpBrowser from "../webmcp/webmcp-browser.js";
+import { loadWebmcpSourceOperations } from "./webmcp-source-loader.js";
+import {
+  getWebmcpSourceBinding,
+  registerWebmcpSourceBinding,
+  resetWebmcpSourceRegistry,
+} from "./webmcp-source-registry.js";
+import type { CustomSourceEntry } from "./custom-sources-types.js";
+import { executeNativeWebmcp } from "../execute/native-webmcp.js";
+import type { Operation } from "./operation-types.js";
+
+describe("webmcp source adapter", () => {
+  const openSpy = vi.spyOn(webmcpBrowser, "openWebmcpPageSessionEffect");
+  const discoverSpy = vi.spyOn(webmcpBrowser, "discoverWebmcpToolsEffect");
+  const executeSpy = vi.spyOn(webmcpBrowser, "executeWebmcpToolEffect");
+
+  beforeEach(() => {
+    openSpy.mockReset();
+    discoverSpy.mockReset();
+    executeSpy.mockReset();
+    resetWebmcpSourceRegistry();
+  });
+
+  afterEach(() => {
+    resetWebmcpSourceRegistry();
+  });
+
+  it("loads WebMCP tools as operations with webmcp protocolKind", async () => {
+    const mockSession = {
+      send: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    openSpy.mockReturnValue(Effect.succeed(mockSession));
+    discoverSpy.mockReturnValue(
+      Effect.succeed([
+        {
+          name: "clawql.docs.page_context",
+          title: "Current documentation page",
+          description: "Returns pathname and title",
+          inputSchema: { type: "object" },
+        },
+      ])
+    );
+
+    const entries: CustomSourceEntry[] = [
+      {
+        id: "docs",
+        name: "ClawQL Docs",
+        kind: "webmcp",
+        addedAt: new Date().toISOString(),
+        url: "https://docs.clawql.com/",
+      },
+    ];
+
+    const ops = await loadWebmcpSourceOperations(entries);
+    expect(ops).toHaveLength(1);
+    expect(ops[0]?.protocolKind).toBe("webmcp");
+    expect(ops[0]?.id).toBe("webmcp__docs__clawql_docs_page_context");
+    expect(ops[0]?.nativeWebmcp?.toolName).toBe("clawql.docs.page_context");
+    expect(getWebmcpSourceBinding("docs")).toBeDefined();
+  });
+
+  it("executes a WebMCP tool via the registered session", async () => {
+    const mockSession = {
+      send: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    registerWebmcpSourceBinding({
+      sourceId: "docs",
+      pageUrl: "https://docs.clawql.com/",
+      cdpUrl: "http://127.0.0.1:9222",
+      session: mockSession,
+    });
+
+    executeSpy.mockReturnValue(Effect.succeed({ pathname: "/learn", title: "Learn" }));
+
+    const op: Operation = {
+      id: "webmcp__docs__clawql_docs_page_context",
+      method: "WEBMCP",
+      path: "/webmcp/docs/clawql.docs.page_context",
+      flatPath: "webmcp/docs/clawql.docs.page_context",
+      description: "page context",
+      resource: "docs",
+      parameters: {},
+      scopes: [],
+      protocolKind: "webmcp",
+      nativeWebmcp: {
+        sourceId: "docs",
+        toolName: "clawql.docs.page_context",
+        pageUrl: "https://docs.clawql.com/",
+      },
+    };
+
+    const result = await executeNativeWebmcp(op, { arguments: {} });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual({ pathname: "/learn", title: "Learn" });
+    }
+  });
+});

--- a/packages/clawql-api/src/spec/webmcp-source-loader.ts
+++ b/packages/clawql-api/src/spec/webmcp-source-loader.ts
@@ -17,7 +17,11 @@ import {
 } from "../webmcp/webmcp-browser.js";
 import { registerWebmcpSourceBinding } from "./webmcp-source-registry.js";
 
-function toolToOperation(entry: CustomSourceEntry, toolName: string, description: string): Operation {
+function toolToOperation(
+  entry: CustomSourceEntry,
+  toolName: string,
+  description: string
+): Operation {
   const id = normalizeOperationId("webmcp", entry.id, toolName);
   return {
     id,
@@ -80,9 +84,10 @@ function loadWebmcpSourceOperationsEffect(
           `[spec-loader] WebMCP source "${entry.id}" discovery failed:`,
           toolsResult.left.message
         );
-        yield* Effect.tryPromise({ try: () => session.close(), catch: () => new Error("close failed") }).pipe(
-          Effect.catchAll(() => Effect.void)
-        );
+        yield* Effect.tryPromise({
+          try: () => session.close(),
+          catch: () => new Error("close failed"),
+        }).pipe(Effect.catchAll(() => Effect.void));
         continue;
       }
 
@@ -108,6 +113,8 @@ function loadWebmcpSourceOperationsEffect(
 }
 
 /** Load WebMCP page tools into the operation index (async host boundary). */
-export async function loadWebmcpSourceOperations(entries: CustomSourceEntry[]): Promise<Operation[]> {
+export async function loadWebmcpSourceOperations(
+  entries: CustomSourceEntry[]
+): Promise<Operation[]> {
   return Effect.runPromise(loadWebmcpSourceOperationsEffect(entries));
 }

--- a/packages/clawql-api/src/spec/webmcp-source-loader.ts
+++ b/packages/clawql-api/src/spec/webmcp-source-loader.ts
@@ -1,0 +1,113 @@
+/**
+ * Load WebMCP page tools as searchable/executable operations (WebMCP-as-source).
+ * Pages register tools via `navigator.modelContext.registerTool()`; Core discovers
+ * them over CDP and proxies execute calls back into the browser.
+ *
+ * @see https://webmachinelearning.github.io/webmcp/
+ */
+
+import { Effect } from "effect";
+import type { Operation } from "./operation-types.js";
+import { normalizeOperationId } from "./spec-kind.js";
+import type { CustomSourceEntry } from "./custom-sources-types.js";
+import {
+  discoverWebmcpToolsEffect,
+  openWebmcpPageSessionEffect,
+  resolveWebmcpCdpUrl,
+} from "../webmcp/webmcp-browser.js";
+import { registerWebmcpSourceBinding } from "./webmcp-source-registry.js";
+
+function toolToOperation(entry: CustomSourceEntry, toolName: string, description: string): Operation {
+  const id = normalizeOperationId("webmcp", entry.id, toolName);
+  return {
+    id,
+    method: "WEBMCP",
+    path: `/webmcp/${entry.id}/${toolName}`,
+    flatPath: `webmcp/${entry.id}/${toolName}`,
+    description: description || `WebMCP tool ${toolName} from ${entry.name}`,
+    resource: entry.id,
+    parameters: {
+      arguments: {
+        type: "object",
+        location: "query",
+        required: false,
+        description: "JSON object passed to the page WebMCP tool",
+      },
+    },
+    scopes: [],
+    specLabel: entry.id,
+    protocolKind: "webmcp",
+    nativeWebmcp: {
+      sourceId: entry.id,
+      toolName,
+      pageUrl: entry.url?.trim() ?? entry.webmcpPageUrl?.trim() ?? "",
+    },
+  };
+}
+
+function loadWebmcpSourceOperationsEffect(
+  entries: CustomSourceEntry[]
+): Effect.Effect<Operation[], Error> {
+  return Effect.gen(function* () {
+    const webmcpEntries = entries.filter((e) => e.kind === "webmcp");
+    const ops: Operation[] = [];
+
+    for (const entry of webmcpEntries) {
+      const pageUrl = entry.url?.trim() || entry.webmcpPageUrl?.trim();
+      if (!pageUrl) {
+        console.error(`[spec-loader] WebMCP source "${entry.id}" skipped: missing page URL`);
+        continue;
+      }
+
+      const cdpUrl = resolveWebmcpCdpUrl(entry.webmcpCdpUrl);
+      const readyMs = entry.webmcpReadyMs ?? 2_000;
+
+      const sessionResult = yield* Effect.either(
+        openWebmcpPageSessionEffect({ cdpUrl, pageUrl, readyMs })
+      );
+      if (sessionResult._tag === "Left") {
+        console.error(
+          `[spec-loader] WebMCP source "${entry.id}" connect failed:`,
+          sessionResult.left.message
+        );
+        continue;
+      }
+
+      const session = sessionResult.right;
+      const toolsResult = yield* Effect.either(discoverWebmcpToolsEffect(session));
+      if (toolsResult._tag === "Left") {
+        console.error(
+          `[spec-loader] WebMCP source "${entry.id}" discovery failed:`,
+          toolsResult.left.message
+        );
+        yield* Effect.tryPromise({ try: () => session.close(), catch: () => new Error("close failed") }).pipe(
+          Effect.catchAll(() => Effect.void)
+        );
+        continue;
+      }
+
+      const tools = toolsResult.right;
+      registerWebmcpSourceBinding({
+        sourceId: entry.id,
+        pageUrl,
+        cdpUrl,
+        session,
+      });
+
+      for (const tool of tools) {
+        ops.push(toolToOperation(entry, tool.name, tool.description || tool.title || ""));
+      }
+
+      console.error(
+        `[spec-loader] WebMCP source "${entry.id}": ${tools.length} tool(s) from ${pageUrl} via ${cdpUrl}`
+      );
+    }
+
+    return ops;
+  });
+}
+
+/** Load WebMCP page tools into the operation index (async host boundary). */
+export async function loadWebmcpSourceOperations(entries: CustomSourceEntry[]): Promise<Operation[]> {
+  return Effect.runPromise(loadWebmcpSourceOperationsEffect(entries));
+}

--- a/packages/clawql-api/src/spec/webmcp-source-registry.ts
+++ b/packages/clawql-api/src/spec/webmcp-source-registry.ts
@@ -1,0 +1,33 @@
+/**
+ * Registry for WebMCP page sessions (cleared with spec cache).
+ */
+
+import type { WebmcpBrowserSession } from "../webmcp/webmcp-browser.js";
+
+export type WebmcpSourceBinding = {
+  sourceId: string;
+  pageUrl: string;
+  cdpUrl: string;
+  session: WebmcpBrowserSession;
+};
+
+const bindings = new Map<string, WebmcpSourceBinding>();
+
+export function registerWebmcpSourceBinding(binding: WebmcpSourceBinding): void {
+  bindings.set(binding.sourceId, binding);
+}
+
+export function getWebmcpSourceBinding(sourceId: string): WebmcpSourceBinding | undefined {
+  return bindings.get(sourceId);
+}
+
+export function resetWebmcpSourceRegistry(): void {
+  for (const b of bindings.values()) {
+    try {
+      void b.session.close();
+    } catch {
+      /* noop */
+    }
+  }
+  bindings.clear();
+}

--- a/packages/clawql-api/src/webmcp/webmcp-browser.ts
+++ b/packages/clawql-api/src/webmcp/webmcp-browser.ts
@@ -68,7 +68,11 @@ export function resolveCdpWebSocketUrlEffect(
 }
 
 async function connectCdp(wsUrl: string): Promise<{
-  send(method: string, params?: Record<string, unknown>, sessionId?: string): Promise<Record<string, unknown>>;
+  send(
+    method: string,
+    params?: Record<string, unknown>,
+    sessionId?: string
+  ): Promise<Record<string, unknown>>;
   on(event: string, handler: (params: Record<string, unknown>) => void): void;
   close(): Promise<void>;
 }> {
@@ -181,7 +185,9 @@ export function openWebmcpPageSessionEffect(
     const wsUrl = yield* resolveCdpWebSocketUrlEffect(cdpUrl, fetchImpl);
     const browser = yield* fromPromise(() => connectCdp(wsUrl));
 
-    const created = yield* fromPromise(() => browser.send("Target.createTarget", { url: "about:blank" }));
+    const created = yield* fromPromise(() =>
+      browser.send("Target.createTarget", { url: "about:blank" })
+    );
     const targetId = String(created.targetId ?? "");
     if (!targetId) {
       yield* fromPromise(() => browser.close());
@@ -245,12 +251,13 @@ export function discoverWebmcpToolsEffect(
         returnByValue: true,
       })
     );
-    const value = (evaluated.result as { value?: { ok?: boolean; error?: string; tools?: WebmcpDiscoveredTool[] } })
-      ?.value;
+    const value = (
+      evaluated.result as {
+        value?: { ok?: boolean; error?: string; tools?: WebmcpDiscoveredTool[] };
+      }
+    )?.value;
     if (!value?.ok) {
-      return yield* Effect.fail(
-        new Error(value?.error ?? "WebMCP tool discovery failed")
-      );
+      return yield* Effect.fail(new Error(value?.error ?? "WebMCP tool discovery failed"));
     }
     return value.tools ?? [];
   });

--- a/packages/clawql-api/src/webmcp/webmcp-browser.ts
+++ b/packages/clawql-api/src/webmcp/webmcp-browser.ts
@@ -1,0 +1,302 @@
+/**
+ * Minimal CDP client for WebMCP page tool discovery and execution.
+ * Requires Chromium with WebMCP enabled (Chrome preview) and a CDP endpoint.
+ *
+ * @see https://webmachinelearning.github.io/webmcp/
+ */
+
+import { Effect } from "effect";
+
+export type WebmcpDiscoveredTool = {
+  name: string;
+  title: string;
+  description: string;
+  inputSchema: object | null;
+};
+
+export type WebmcpBrowserSession = {
+  send(method: string, params?: Record<string, unknown>): Promise<Record<string, unknown>>;
+  close(): Promise<void>;
+};
+
+type CdpResponse = {
+  id?: number;
+  method?: string;
+  params?: Record<string, unknown>;
+  result?: Record<string, unknown>;
+  error?: { message?: string; code?: number };
+  sessionId?: string;
+};
+
+const DEFAULT_CDP_URL = "http://127.0.0.1:9222";
+const DEFAULT_READY_MS = 2_000;
+
+export function resolveWebmcpCdpUrl(explicit?: string): string {
+  const fromEnv = process.env.CLAWQL_WEBMCP_CDP_URL?.trim();
+  return explicit?.trim() || fromEnv || DEFAULT_CDP_URL;
+}
+
+function fromPromise<A>(fn: () => Promise<A>): Effect.Effect<A, Error> {
+  return Effect.tryPromise({
+    try: fn,
+    catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+  });
+}
+
+/** Resolve `http(s)://host:9222` → browser WebSocket debugger URL, or pass through `ws(s):`. */
+export function resolveCdpWebSocketUrlEffect(
+  cdpUrl: string,
+  fetchImpl: typeof fetch = fetch
+): Effect.Effect<string, Error> {
+  return fromPromise(async () => {
+    const trimmed = cdpUrl.trim();
+    if (trimmed.startsWith("ws://") || trimmed.startsWith("wss://")) {
+      return trimmed;
+    }
+    const base = trimmed.replace(/\/$/, "");
+    const versionUrl = /\/json(\/|$)/.test(base) ? base : `${base}/json/version`;
+    const res = await fetchImpl(versionUrl, { signal: AbortSignal.timeout(10_000) });
+    if (!res.ok) {
+      throw new Error(`CDP version endpoint failed: HTTP ${res.status}`);
+    }
+    const body = (await res.json()) as { webSocketDebuggerUrl?: string };
+    if (!body.webSocketDebuggerUrl?.trim()) {
+      throw new Error("CDP /json/version missing webSocketDebuggerUrl");
+    }
+    return body.webSocketDebuggerUrl.trim();
+  });
+}
+
+async function connectCdp(wsUrl: string): Promise<{
+  send(method: string, params?: Record<string, unknown>, sessionId?: string): Promise<Record<string, unknown>>;
+  on(event: string, handler: (params: Record<string, unknown>) => void): void;
+  close(): Promise<void>;
+}> {
+  const ws = new WebSocket(wsUrl);
+  await new Promise<void>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error("CDP WebSocket connect timeout")), 15_000);
+    ws.addEventListener("open", () => {
+      clearTimeout(t);
+      resolve();
+    });
+    ws.addEventListener("error", () => {
+      clearTimeout(t);
+      reject(new Error("CDP WebSocket connection failed"));
+    });
+  });
+
+  let nextId = 1;
+  const pending = new Map<
+    number,
+    { resolve: (v: Record<string, unknown>) => void; reject: (e: Error) => void }
+  >();
+  const listeners = new Map<string, Set<(params: Record<string, unknown>) => void>>();
+
+  ws.addEventListener("message", (ev) => {
+    const data = typeof ev.data === "string" ? ev.data : String(ev.data);
+    let msg: CdpResponse;
+    try {
+      msg = JSON.parse(data) as CdpResponse;
+    } catch {
+      return;
+    }
+    if (msg.id != null && pending.has(msg.id)) {
+      const p = pending.get(msg.id)!;
+      pending.delete(msg.id);
+      if (msg.error) {
+        p.reject(new Error(msg.error.message ?? `CDP error ${msg.error.code ?? "?"}`));
+      } else {
+        p.resolve(msg.result ?? {});
+      }
+      return;
+    }
+    if (msg.method) {
+      const set = listeners.get(msg.method);
+      if (set) {
+        for (const h of set) h(msg.params ?? {});
+      }
+    }
+  });
+
+  const sendRaw = (
+    method: string,
+    params?: Record<string, unknown>,
+    sessionId?: string
+  ): Promise<Record<string, unknown>> => {
+    const id = nextId++;
+    return new Promise((resolve, reject) => {
+      pending.set(id, { resolve, reject });
+      const payload: Record<string, unknown> = { id, method, params: params ?? {} };
+      if (sessionId) payload.sessionId = sessionId;
+      ws.send(JSON.stringify(payload));
+    });
+  };
+
+  return {
+    send(method, params, sessionId) {
+      return sendRaw(method, params, sessionId);
+    },
+    on(event, handler) {
+      let set = listeners.get(event);
+      if (!set) {
+        set = new Set();
+        listeners.set(event, set);
+      }
+      set.add(handler);
+    },
+    async close() {
+      ws.close();
+    },
+  };
+}
+
+function waitForLoadEvent(
+  browser: { on(event: string, handler: (params: Record<string, unknown>) => void): void },
+  timeoutMs: number
+): Promise<void> {
+  return new Promise((resolve) => {
+    const t = setTimeout(() => resolve(), timeoutMs);
+    browser.on("Page.loadEventFired", () => {
+      clearTimeout(t);
+      resolve();
+    });
+  });
+}
+
+export type OpenWebmcpSessionOptions = {
+  cdpUrl?: string;
+  pageUrl: string;
+  readyMs?: number;
+  fetchImpl?: typeof fetch;
+};
+
+/** Open a persistent CDP page session navigated to a WebMCP-enabled page. */
+export function openWebmcpPageSessionEffect(
+  options: OpenWebmcpSessionOptions
+): Effect.Effect<WebmcpBrowserSession, Error> {
+  return Effect.gen(function* () {
+    const cdpUrl = resolveWebmcpCdpUrl(options.cdpUrl);
+    const readyMs = options.readyMs ?? DEFAULT_READY_MS;
+    const fetchImpl = options.fetchImpl ?? fetch;
+    const wsUrl = yield* resolveCdpWebSocketUrlEffect(cdpUrl, fetchImpl);
+    const browser = yield* fromPromise(() => connectCdp(wsUrl));
+
+    const created = yield* fromPromise(() => browser.send("Target.createTarget", { url: "about:blank" }));
+    const targetId = String(created.targetId ?? "");
+    if (!targetId) {
+      yield* fromPromise(() => browser.close());
+      return yield* Effect.fail(new Error("Target.createTarget missing targetId"));
+    }
+
+    const attached = yield* fromPromise(() =>
+      browser.send("Target.attachToTarget", { targetId, flatten: true })
+    );
+    const sessionId = String(attached.sessionId ?? "");
+    const send = (method: string, params?: Record<string, unknown>) =>
+      sessionId ? browser.send(method, params, sessionId) : browser.send(method, params);
+
+    yield* fromPromise(() => send("Page.enable"));
+    const loadPromise = waitForLoadEvent(browser, 30_000);
+    yield* fromPromise(() => send("Page.navigate", { url: options.pageUrl }));
+    yield* fromPromise(() => loadPromise);
+    if (readyMs > 0) {
+      yield* fromPromise(() => new Promise((r) => setTimeout(r, readyMs)));
+    }
+
+    return {
+      send,
+      async close() {
+        try {
+          await browser.send("Target.closeTarget", { targetId });
+        } catch {
+          /* ignore */
+        }
+        await browser.close();
+      },
+    };
+  });
+}
+
+const DISCOVER_TOOLS_EXPRESSION = `(async () => {
+  const mc = document.modelContext;
+  if (!mc || typeof mc.getTools !== "function") {
+    return { ok: false, error: "WebMCP not available (needs Chrome preview with WebMCP + secure context)", tools: [] };
+  }
+  const tools = await mc.getTools();
+  return {
+    ok: true,
+    tools: tools.map((t) => ({
+      name: t.name,
+      title: t.title || "",
+      description: t.description || "",
+      inputSchema: t.inputSchema || null,
+    })),
+  };
+})()`;
+
+export function discoverWebmcpToolsEffect(
+  session: WebmcpBrowserSession
+): Effect.Effect<WebmcpDiscoveredTool[], Error> {
+  return Effect.gen(function* () {
+    const evaluated = yield* fromPromise(() =>
+      session.send("Runtime.evaluate", {
+        expression: DISCOVER_TOOLS_EXPRESSION,
+        awaitPromise: true,
+        returnByValue: true,
+      })
+    );
+    const value = (evaluated.result as { value?: { ok?: boolean; error?: string; tools?: WebmcpDiscoveredTool[] } })
+      ?.value;
+    if (!value?.ok) {
+      return yield* Effect.fail(
+        new Error(value?.error ?? "WebMCP tool discovery failed")
+      );
+    }
+    return value.tools ?? [];
+  });
+}
+
+export function executeWebmcpToolEffect(
+  session: WebmcpBrowserSession,
+  toolName: string,
+  input: Record<string, unknown>
+): Effect.Effect<unknown, Error> {
+  return Effect.gen(function* () {
+    const inputJson = JSON.stringify(input);
+    const toolNameJson = JSON.stringify(toolName);
+    const expression = `(async () => {
+      const mc = document.modelContext;
+      if (!mc?.getTools || !mc?.executeTool) throw new Error("WebMCP not available");
+      const toolName = ${toolNameJson};
+      const input = ${inputJson};
+      const tools = await mc.getTools();
+      const tool = tools.find((t) => t.name === toolName);
+      if (!tool) throw new Error("Tool not found: " + toolName);
+      const result = await mc.executeTool(tool, input);
+      try {
+        return { ok: true, data: JSON.parse(result) };
+      } catch {
+        return { ok: true, data: result };
+      }
+    })()`;
+
+    const evaluated = yield* fromPromise(() =>
+      session.send("Runtime.evaluate", {
+        expression,
+        awaitPromise: true,
+        returnByValue: true,
+      })
+    );
+
+    const remoteError = (evaluated.exceptionDetails as { text?: string } | undefined)?.text;
+    if (remoteError) {
+      return yield* Effect.fail(new Error(remoteError));
+    }
+
+    const value = (evaluated.result as { value?: { ok?: boolean; data?: unknown } })?.value;
+    if (!value?.ok) {
+      return yield* Effect.fail(new Error("WebMCP executeTool returned no result"));
+    }
+    return value.data;
+  });
+}

--- a/src/onboarding/cli.ts
+++ b/src/onboarding/cli.ts
@@ -428,8 +428,9 @@ Usage:
   clawql secrets list
   clawql secrets set <github|slack|linear|…> [value]
   clawql mcp-config [--json] [--write cursor|claude-desktop] [--http] [--url http://host/mcp]
-  clawql sources list | add <url> [--name NAME] [--kind openapi|discovery|graphql|grpc|mcp|cli] | remove <id>
+  clawql sources list | add <url> [--name NAME] [--kind openapi|discovery|graphql|grpc|mcp|cli|webmcp] | remove <id>
   clawql sources add --kind cli --command <bin> [--args a,b] [--name NAME]
+  clawql sources add --kind webmcp <https-url> [--name NAME] [--webmcp-cdp-url http://127.0.0.1:9222]
   clawql release init | collect | manifest | publish | verify <path>
   clawql ontology lint [--dir PATH] [files...] | generate --out DIR [--dir PATH]
   clawql ontology init | create-entity <Name> | import --pack legal
@@ -729,6 +730,12 @@ async function main(): Promise<void> {
         id: typeof flags.id === "string" ? flags.id : undefined,
         command: typeof flags.command === "string" ? flags.command : undefined,
         args: argsList,
+        webmcpCdpUrl:
+          typeof flags["webmcp-cdp-url"] === "string" ? flags["webmcp-cdp-url"] : undefined,
+        webmcpReadyMs:
+          typeof flags["webmcp-ready-ms"] === "string"
+            ? Number.parseInt(flags["webmcp-ready-ms"], 10)
+            : undefined,
         home,
       });
       return;

--- a/src/onboarding/sources-cli.ts
+++ b/src/onboarding/sources-cli.ts
@@ -29,13 +29,15 @@ export type SourcesAddOptions = {
   grpcEndpoint?: string;
   protoPath?: string;
   mcpUrl?: string;
+  webmcpCdpUrl?: string;
+  webmcpReadyMs?: number;
   home?: string;
 };
 
 function parseKind(raw: string | undefined): CustomSourceKind | undefined {
   if (!raw?.trim()) return undefined;
   const k = raw.trim().toLowerCase();
-  const allowed: CustomSourceKind[] = ["openapi", "discovery", "graphql", "grpc", "mcp", "cli"];
+  const allowed: CustomSourceKind[] = ["openapi", "discovery", "graphql", "grpc", "mcp", "cli", "webmcp"];
   if (allowed.includes(k as CustomSourceKind)) return k as CustomSourceKind;
   throw new Error(`Unknown kind: ${raw}. Use ${allowed.join("|")}`);
 }
@@ -112,6 +114,13 @@ export async function runSourcesAdd(options: SourcesAddOptions): Promise<number>
 
   if (detected.kind === "mcp") {
     entry = { ...entry, mcpUrl: url };
+  } else if (detected.kind === "webmcp") {
+    entry = {
+      ...entry,
+      webmcpPageUrl: url,
+      ...(options.webmcpCdpUrl?.trim() ? { webmcpCdpUrl: options.webmcpCdpUrl.trim() } : {}),
+      ...(options.webmcpReadyMs != null ? { webmcpReadyMs: options.webmcpReadyMs } : {}),
+    };
   } else if (detected.kind === "graphql") {
     entry = {
       ...entry,

--- a/src/onboarding/sources-cli.ts
+++ b/src/onboarding/sources-cli.ts
@@ -37,7 +37,15 @@ export type SourcesAddOptions = {
 function parseKind(raw: string | undefined): CustomSourceKind | undefined {
   if (!raw?.trim()) return undefined;
   const k = raw.trim().toLowerCase();
-  const allowed: CustomSourceKind[] = ["openapi", "discovery", "graphql", "grpc", "mcp", "cli", "webmcp"];
+  const allowed: CustomSourceKind[] = [
+    "openapi",
+    "discovery",
+    "graphql",
+    "grpc",
+    "mcp",
+    "cli",
+    "webmcp",
+  ];
   if (allowed.includes(k as CustomSourceKind)) return k as CustomSourceKind;
   throw new Error(`Unknown kind: ${raw}. Use ${allowed.join("|")}`);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **WebMCP as a Core custom source** — the left (sources) side of Protocol Fabric. Pages that register tools via `navigator.modelContext.registerTool()` are discovered over CDP and exposed through gateway `search` / `execute`.

**Does not touch `/mcp-ui` or `mcp-api-adapter`** (right/surfaces side).

## Architecture

| Side | Technology | Package |
|------|------------|---------|
| **Left (sources)** | WebMCP (`navigator.modelContext`) | `clawql-api` custom source (`kind: webmcp`) |
| **Right (surfaces)** | HTMX / MCP-UI | `mcp-api-adapter` only |

## What changed

- New `webmcp` custom source kind in `packages/clawql-api`
- CDP browser session opens page → `document.modelContext.getTools()` for discovery
- `execute` proxies to `document.modelContext.executeTool()` in-page
- Registry holds persistent CDP sessions per source (cleared on spec cache reset)
- CLI: `clawql sources add https://docs.clawql.com --kind webmcp --name "ClawQL Docs"`
- Docs updated in `docs/getting-started/custom-sources.md`

## Usage

```bash
# Start Chromium with WebMCP + CDP (Chrome preview)
# export CLAWQL_WEBMCP_CDP_URL=http://127.0.0.1:9222

clawql sources add https://docs.clawql.com --kind webmcp --name "ClawQL Docs"
# Restart clawql-mcp, then search/execute webmcp__docs__*
```

## Testing

```
npx vitest run packages/clawql-api/src/spec/webmcp-source-loader.test.ts
# 2 passed
```

Unit tests mock CDP/WebMCP discovery and execute paths. End-to-end requires Chrome preview with WebMCP enabled.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9b5e-4d74-72e6-90bb-d0c2100f09d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9b5e-4d74-72e6-90bb-d0c2100f09d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

