### PR TITLE
feat(tee): simulated platform adapters, WORM env wiring, and cmd signer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -310,7 +310,17 @@
 # CLAWQL_ID_JAG_ISSUER_ORG_ID=acme
 # CLAWQL_ID_JAG_ISSUER_PRIVATE_KEY_PEM_PATH=/keys/id-jag-issuer.pem
 # CLAWQL_ID_JAG_TEE_SIGNER=1
-# CLAWQL_ID_JAG_TEE_SIGN_CMD=/usr/local/bin/clawql-tee-sign
+# CLAWQL_ID_JAG_TEE_SIGN_CMD=node ./node_modules/clawql-tee/bin/id-jag-sign-cmd.mjs
+# CLAWQL_TEE_PLATFORM=simulated
+# CLAWQL_TEE_STRICT=1
+# CLAWQL_TEE_DEBUG=1
+
+# Durable process WORM (clawql-audit) — see packages/clawql-audit/README.md
+# CLAWQL_WORM_ENABLED=1
+# CLAWQL_WORM_TEE=1
+# CLAWQL_WORM_TEE_PLATFORM=simulated
+# CLAWQL_WORM_TEE_PRIVATE_KEY_PEM_PATH=/keys/worm-tee-private.pem
+# CLAWQL_WORM_TEE_PUBLIC_KEY_PEM_PATH=/keys/worm-tee-public.pem
 # CLAWQL_TEE_DEBUG=1
 
 # Primary passkey HTTP (SimpleWebAuthn) — enroll/login under /oauth/passkey/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -15207,7 +15207,11 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "effect": "^3.21.4"
+        "effect": "^3.21.4",
+        "jose": "^6.2.8"
+      },
+      "bin": {
+        "clawql-tee-id-jag-sign": "bin/id-jag-sign-cmd.mjs"
       },
       "devDependencies": {
         "@types/node": "^26.1.1",
@@ -15226,6 +15230,15 @@
         "clawql-auth": {
           "optional": true
         }
+      }
+    },
+    "packages/clawql-tee/node_modules/jose": {
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "packages/clawql-web": {

--- a/packages/clawql-audit/README.md
+++ b/packages/clawql-audit/README.md
@@ -53,19 +53,19 @@ Set `CLAWQL_AUDIT_QR_ENCRYPTION_KEY` and `CLAWQL_AUDIT_QR_HMAC_KEY` (32-byte hex
 
 Set `CLAWQL_WORM_ENABLED=1` to boot a process-scoped trail. Callers dual-write via `appendProcessWormEffect` / sink helpers:
 
-| Variable                                     | Role                                          |
-| -------------------------------------------- | --------------------------------------------- |
-| `CLAWQL_WORM_LOCAL`                          | `memory` \| `sqlite` \| `postgres`            |
-| `CLAWQL_WORM_SQLITE_PATH`                    | SQLite file (implies local=sqlite when unset) |
-| `CLAWQL_WORM_POSTGRES_URL`                   | Postgres DSN                                  |
-| `CLAWQL_WORM_REMOTE`                         | `memory` \| `s3`                              |
-| `CLAWQL_WORM_S3_BUCKET` / `_ENDPOINT` / `_…` | S3/R2 remote                                  |
-| `CLAWQL_WORM_SESSION_ID`                     | Default `sessionId` on append                 |
-| `CLAWQL_WORM_RECONCILE_MS`                   | Outbox drain interval (`0` disables)          |
-| `CLAWQL_WORM_TEE`                            | `1` = ECDSA P-256 `teeSignature` on append  |
+| Variable                                     | Role                                                                    |
+| -------------------------------------------- | ----------------------------------------------------------------------- |
+| `CLAWQL_WORM_LOCAL`                          | `memory` \| `sqlite` \| `postgres`                                      |
+| `CLAWQL_WORM_SQLITE_PATH`                    | SQLite file (implies local=sqlite when unset)                           |
+| `CLAWQL_WORM_POSTGRES_URL`                   | Postgres DSN                                                            |
+| `CLAWQL_WORM_REMOTE`                         | `memory` \| `s3`                                                        |
+| `CLAWQL_WORM_S3_BUCKET` / `_ENDPOINT` / `_…` | S3/R2 remote                                                            |
+| `CLAWQL_WORM_SESSION_ID`                     | Default `sessionId` on append                                           |
+| `CLAWQL_WORM_RECONCILE_MS`                   | Outbox drain interval (`0` disables)                                    |
+| `CLAWQL_WORM_TEE`                            | `1` = ECDSA P-256 `teeSignature` on append                              |
 | `CLAWQL_WORM_TEE_PLATFORM`                   | `simulated` (default); `sev-snp`/`tdx` need clawql-tee hardware adapter |
-| `CLAWQL_WORM_TEE_PRIVATE_KEY_PEM` / `_PATH`  | Optional PEM pair; ephemeral if omitted (simulated only) |
-| `CLAWQL_WORM_TEE_PUBLIC_KEY_PEM` / `_PATH`   | Public half of TEE signing key              |
+| `CLAWQL_WORM_TEE_PRIVATE_KEY_PEM` / `_PATH`  | Optional PEM pair; ephemeral if omitted (simulated only)                |
+| `CLAWQL_WORM_TEE_PUBLIC_KEY_PEM` / `_PATH`   | Public half of TEE signing key                                          |
 
 Host boots via `bootProcessWormFromEnv` / `ensureProcessWormHostBooted` (MCP). Auth injects `createAuthEventWormSink()`; memory uses `createMemoryWormSink()` + `registerMemoryWormSink`.
 

--- a/packages/clawql-audit/README.md
+++ b/packages/clawql-audit/README.md
@@ -62,6 +62,10 @@ Set `CLAWQL_WORM_ENABLED=1` to boot a process-scoped trail. Callers dual-write v
 | `CLAWQL_WORM_S3_BUCKET` / `_ENDPOINT` / `_…` | S3/R2 remote                                  |
 | `CLAWQL_WORM_SESSION_ID`                     | Default `sessionId` on append                 |
 | `CLAWQL_WORM_RECONCILE_MS`                   | Outbox drain interval (`0` disables)          |
+| `CLAWQL_WORM_TEE`                            | `1` = ECDSA P-256 `teeSignature` on append  |
+| `CLAWQL_WORM_TEE_PLATFORM`                   | `simulated` (default); `sev-snp`/`tdx` need clawql-tee hardware adapter |
+| `CLAWQL_WORM_TEE_PRIVATE_KEY_PEM` / `_PATH`  | Optional PEM pair; ephemeral if omitted (simulated only) |
+| `CLAWQL_WORM_TEE_PUBLIC_KEY_PEM` / `_PATH`   | Public half of TEE signing key              |
 
 Host boots via `bootProcessWormFromEnv` / `ensureProcessWormHostBooted` (MCP). Auth injects `createAuthEventWormSink()`; memory uses `createMemoryWormSink()` + `registerMemoryWormSink`.
 
@@ -69,10 +73,22 @@ Host boots via `bootProcessWormFromEnv` / `ensureProcessWormHostBooted` (MCP). A
 
 Prefer `makeWORMAuditTrailLayer` / `WORMAuditTrailService` inside ClawQL. The `WORMAuditTrail` class is a thin host façade.
 
+## Phase 3 TEE (simulated)
+
+ECDSA P-256 signatures over entry content hashes (`teeSignature`, excluded from hash body). Software simulated keys ship in-package; verify with `verifyTEESignature`. Hardware attestation (SEV-SNP / TDX) is a `clawql-tee` follow-up.
+
+```typescript
+import { WORMAuditTrail, MemoryBackend, createSimulatedTeeSigner } from "clawql-audit";
+import { Effect } from "effect";
+
+const tee = await Effect.runPromise(createSimulatedTeeSigner());
+const worm = await WORMAuditTrail.create({
+  local: new MemoryBackend(),
+  remote: new MemoryBackend(),
+  tee,
+});
+```
+
 ## Not this package
 
 The MCP `audit` tool ring buffer is ephemeral operator breadcrumbs — a different product surface.
-
-## Phase 3 (not yet)
-
-Real TEE ECDSA signer/verifier (`clawql-tee` integration).

--- a/packages/clawql-audit/src/env-config.ts
+++ b/packages/clawql-audit/src/env-config.ts
@@ -14,6 +14,7 @@ import { PostgresBackend } from "./storage/postgres.js";
 import { S3Backend } from "./storage/s3.js";
 import { SQLiteBackend } from "./storage/sqlite.js";
 import type { LocalStorageBackend, StorageBackend } from "./storage/types.js";
+import { createWormTeeSignerFromEnvEffect } from "./tee/env.js";
 import type { WORMAuditTrailConfig } from "./trail.js";
 
 function envTrim(env: NodeJS.ProcessEnv, key: string): string | undefined {
@@ -114,10 +115,12 @@ export const createWormTrailConfigFromEnvEffect = (
     if (!(yield* wormEnabledFromEnv(env))) return null;
     const local = yield* makeLocal(env);
     const remote = yield* makeRemote(env);
+    const tee = yield* createWormTeeSignerFromEnvEffect(env);
     const httpPort = parseIntEnv(env, "CLAWQL_WORM_HTTP_PORT");
     return {
       local,
       remote,
+      ...(tee ? { tee } : {}),
       retryMaxAttempts: parseIntEnv(env, "CLAWQL_WORM_RETRY_MAX"),
       retryBackoffMs: parseIntEnv(env, "CLAWQL_WORM_RETRY_BACKOFF_MS"),
       reconcileIntervalMs: parseIntEnv(env, "CLAWQL_WORM_RECONCILE_MS") ?? 2000,

--- a/packages/clawql-audit/src/index.ts
+++ b/packages/clawql-audit/src/index.ts
@@ -53,6 +53,7 @@ export {
   type CreateEcdsaTeeSignerOptions,
   type VerifyTeeSignatureResult,
 } from "./tee/signer.js";
+export { createWormTeeSignerFromEnvEffect } from "./tee/env.js";
 export {
   handleAuditHttpRequest,
   authorizeApiKey,

--- a/packages/clawql-audit/src/process-worm.test.ts
+++ b/packages/clawql-audit/src/process-worm.test.ts
@@ -20,6 +20,8 @@ describe("process WORM boot + append", () => {
     delete process.env.CLAWQL_WORM_LOCAL;
     delete process.env.CLAWQL_WORM_REMOTE;
     delete process.env.CLAWQL_WORM_SESSION_ID;
+    delete process.env.CLAWQL_WORM_TEE;
+    delete process.env.CLAWQL_WORM_TEE_PLATFORM;
   });
 
   it("no-ops when CLAWQL_WORM_ENABLED is unset", async () => {
@@ -92,5 +94,25 @@ describe("process WORM boot + append", () => {
 
     const verify = await Effect.runPromise(svc!.verify());
     expect(verify.valid).toBe(true);
+  });
+
+  it("appends teeSignature when CLAWQL_WORM_TEE=1", async () => {
+    process.env.CLAWQL_WORM_ENABLED = "1";
+    process.env.CLAWQL_WORM_LOCAL = "memory";
+    process.env.CLAWQL_WORM_REMOTE = "memory";
+    process.env.CLAWQL_WORM_RECONCILE_MS = "0";
+    process.env.CLAWQL_WORM_TEE = "1";
+
+    const svc = await Effect.runPromise(bootProcessWormFromEnvEffect());
+    expect(svc).not.toBeNull();
+
+    const entry = await Effect.runPromise(
+      appendProcessWormEffect({
+        type: "SESSION_START",
+        timestamp: new Date().toISOString(),
+        sessionId: "tee-env",
+      })
+    );
+    expect(entry?.teeSignature).toBeTruthy();
   });
 });

--- a/packages/clawql-audit/src/tee/env.test.ts
+++ b/packages/clawql-audit/src/tee/env.test.ts
@@ -1,0 +1,53 @@
+import { Effect } from "effect";
+import { afterEach, describe, expect, it } from "vitest";
+import { createWormTeeSignerFromEnvEffect } from "./env.js";
+import { verifyTEESignature } from "./signer.js";
+
+describe("createWormTeeSignerFromEnvEffect", () => {
+  afterEach(() => {
+    delete process.env.CLAWQL_WORM_TEE;
+    delete process.env.CLAWQL_WORM_TEE_PLATFORM;
+    delete process.env.CLAWQL_WORM_TEE_PRIVATE_KEY_PEM;
+    delete process.env.CLAWQL_WORM_TEE_PUBLIC_KEY_PEM;
+  });
+
+  it("returns undefined when CLAWQL_WORM_TEE unset", async () => {
+    delete process.env.CLAWQL_WORM_TEE;
+    const signer = await Effect.runPromise(createWormTeeSignerFromEnvEffect(process.env));
+    expect(signer).toBeUndefined();
+  });
+
+  it("creates ephemeral simulated signer when CLAWQL_WORM_TEE=1", async () => {
+    process.env.CLAWQL_WORM_TEE = "1";
+    const signer = await Effect.runPromise(createWormTeeSignerFromEnvEffect(process.env));
+    expect(signer).toBeDefined();
+    const hash = "c".repeat(64);
+    const sig = await Effect.runPromise(signer!.sign(hash));
+    const entry = {
+      id: "00000000-0000-7000-8000-000000000001",
+      hash,
+      prevHash: "0".repeat(64),
+      chainIndex: 0,
+      writtenAt: new Date().toISOString(),
+      backendAcks: [] as string[],
+      type: "SESSION_START" as const,
+      timestamp: new Date().toISOString(),
+      sessionId: "env-tee",
+      teeSignature: sig,
+    };
+    const withKeys = signer as { publicKeyPem: string; attestation: { platform: string } };
+    const ok = await Effect.runPromise(
+      verifyTEESignature(entry, withKeys.publicKeyPem, withKeys.attestation)
+    );
+    expect(ok.valid).toBe(true);
+  });
+
+  it("rejects hardware platform until clawql-tee adapter is wired", async () => {
+    process.env.CLAWQL_WORM_TEE = "1";
+    process.env.CLAWQL_WORM_TEE_PLATFORM = "sev-snp";
+    const err = await Effect.runPromise(
+      createWormTeeSignerFromEnvEffect(process.env).pipe(Effect.flip)
+    );
+    expect(err.reason).toContain("sev-snp");
+  });
+});

--- a/packages/clawql-audit/src/tee/env.ts
+++ b/packages/clawql-audit/src/tee/env.ts
@@ -1,0 +1,97 @@
+/**
+ * Resolve optional TEE signer from process env for WORM trail boot.
+ *
+ * CLAWQL_WORM_TEE=1 — attach ECDSA P-256 signatures on append (`teeSignature`).
+ * CLAWQL_WORM_TEE_PLATFORM=simulated|sev-snp|tdx (default simulated).
+ * CLAWQL_WORM_TEE_PRIVATE_KEY_PEM / CLAWQL_WORM_TEE_PUBLIC_KEY_PEM — optional PEM pair;
+ * when omitted under simulated, an ephemeral keypair is generated at boot.
+ */
+
+import { readFileSync } from "node:fs";
+import { Effect } from "effect";
+import { AuditError } from "../errors.js";
+import { createEcdsaTeeSigner, createSimulatedTeeSigner } from "./ecdsa.js";
+import type { TEEAttestationReport, TEESigner } from "./signer.js";
+
+function envTrim(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const v = env[key]?.trim();
+  return v || undefined;
+}
+
+function envFlag(env: NodeJS.ProcessEnv, key: string): boolean {
+  const v = envTrim(env, key)?.toLowerCase();
+  return v === "1" || v === "true" || v === "yes";
+}
+
+function readPemFromEnv(env: NodeJS.ProcessEnv, pemKey: string, pathKey: string): string | undefined {
+  const inline = envTrim(env, pemKey);
+  if (inline) return inline;
+  const path = envTrim(env, pathKey);
+  if (!path) return undefined;
+  return readFileSync(path, "utf8");
+}
+
+const PLATFORMS = new Set<TEEAttestationReport["platform"]>(["simulated", "sev-snp", "tdx"]);
+
+function parsePlatform(env: NodeJS.ProcessEnv): TEEAttestationReport["platform"] | undefined {
+  const raw = envTrim(env, "CLAWQL_WORM_TEE_PLATFORM") ?? "simulated";
+  if (!PLATFORMS.has(raw as TEEAttestationReport["platform"])) {
+    return undefined;
+  }
+  return raw as TEEAttestationReport["platform"];
+}
+
+/** Build a {@link TEESigner} from env, or `undefined` when TEE is disabled. */
+export const createWormTeeSignerFromEnvEffect = (
+  env: NodeJS.ProcessEnv = process.env
+): Effect.Effect<TEESigner | undefined, AuditError> =>
+  Effect.gen(function* () {
+    if (!envFlag(env, "CLAWQL_WORM_TEE")) return undefined;
+
+    const platform = parsePlatform(env);
+    if (!platform) {
+      return yield* Effect.fail(
+        new AuditError({
+          reason: `Unknown CLAWQL_WORM_TEE_PLATFORM (expected simulated|sev-snp|tdx)`,
+        })
+      );
+    }
+
+    if (platform !== "simulated") {
+      return yield* Effect.fail(
+        new AuditError({
+          reason: `CLAWQL_WORM_TEE_PLATFORM=${platform} requires clawql-tee hardware adapter (not wired in-process yet)`,
+        })
+      );
+    }
+
+    const privateKeyPem = readPemFromEnv(
+      env,
+      "CLAWQL_WORM_TEE_PRIVATE_KEY_PEM",
+      "CLAWQL_WORM_TEE_PRIVATE_KEY_PEM_PATH"
+    );
+    const publicKeyPem = readPemFromEnv(
+      env,
+      "CLAWQL_WORM_TEE_PUBLIC_KEY_PEM",
+      "CLAWQL_WORM_TEE_PUBLIC_KEY_PEM_PATH"
+    );
+
+    if (privateKeyPem && publicKeyPem) {
+      return yield* createEcdsaTeeSigner({
+        privateKeyPem,
+        publicKeyPem,
+        platform: "simulated",
+      });
+    }
+
+    if (privateKeyPem || publicKeyPem) {
+      return yield* Effect.fail(
+        new AuditError({
+          reason:
+            "CLAWQL_WORM_TEE requires both private and public PEM (or neither for ephemeral simulated keys)",
+        })
+      );
+    }
+
+    return yield* createSimulatedTeeSigner();
+  });

--- a/packages/clawql-audit/src/tee/env.ts
+++ b/packages/clawql-audit/src/tee/env.ts
@@ -23,7 +23,11 @@ function envFlag(env: NodeJS.ProcessEnv, key: string): boolean {
   return v === "1" || v === "true" || v === "yes";
 }
 
-function readPemFromEnv(env: NodeJS.ProcessEnv, pemKey: string, pathKey: string): string | undefined {
+function readPemFromEnv(
+  env: NodeJS.ProcessEnv,
+  pemKey: string,
+  pathKey: string
+): string | undefined {
   const inline = envTrim(env, pemKey);
   if (inline) return inline;
   const path = envTrim(env, pathKey);

--- a/packages/clawql-auth/src/inbound/id-jag-issuer-env.test.ts
+++ b/packages/clawql-auth/src/inbound/id-jag-issuer-env.test.ts
@@ -81,4 +81,37 @@ describe("createIdJagIssuerFromEnv Layer C", () => {
     );
     expect(jwt).toBe("hdr.payload.sig");
   });
+
+  it("uses reference clawql-tee id-jag-sign-cmd binary", async () => {
+    const { privateKey } = await generateKeyPair("RS256", { extractable: true });
+    const pem = await exportPKCS8(privateKey);
+    const { dirname, join } = await import("node:path");
+    const { fileURLToPath } = await import("node:url");
+    const bin = join(
+      dirname(fileURLToPath(import.meta.url)),
+      "../../../clawql-tee/bin/id-jag-sign-cmd.mjs"
+    );
+    process.env.CLAWQL_ID_JAG_ISSUER_PRIVATE_KEY_PEM = pem;
+    const runtime = await Effect.runPromise(
+      createIdJagIssuerFromEnv({
+        secretStore: createMemorySecretStore(),
+        eventSink: noopAuthEventSink,
+        env: {
+          CLAWQL_ID_JAG_ISSUER_ENABLED: "1",
+          CLAWQL_ID_JAG_ISSUER_ORG_ID: "acme",
+          CLAWQL_ID_JAG_ISSUER_PRIVATE_KEY_PEM: pem,
+          CLAWQL_ID_JAG_TEE_SIGN_CMD: `node ${bin}`,
+        },
+      })
+    );
+    expect(runtime!.assertionSigner?.kind).toBe("tee");
+    const jwt = await Effect.runPromise(
+      runtime!.assertionSigner!.sign({
+        claims: { sub: "cmd-bin" },
+        header: { alg: "RS256", kid: "ref" },
+      })
+    );
+    expect(jwt.split(".")).toHaveLength(3);
+    delete process.env.CLAWQL_ID_JAG_ISSUER_PRIVATE_KEY_PEM;
+  });
 });

--- a/packages/clawql-tee/README.md
+++ b/packages/clawql-tee/README.md
@@ -21,7 +21,7 @@ import { createSimulatedIdJagSigner } from "clawql-tee";
 import { loadMcpOAuthSigningMaterialEffect } from "clawql-auth";
 import { Effect } from "effect";
 
-const signing = await Effect.runPromise(loadMcpOAuthSigningMaterialEffect({ /* … */ }));
+const signing = await Effect.runPromise(loadMcpOAuthSigningMaterialEffect({/* … */}));
 const assertionSigner = await Effect.runPromise(createSimulatedIdJagSigner(signing));
 // inject as assertionSigner in createIdJagIssuerFromEnv options
 ```
@@ -38,13 +38,13 @@ Contract: stdin JSON `{ claims, header }` → stdout compact JWS. Key from `CLAW
 
 ## Env
 
-| Variable | Role |
-| -------- | ---- |
-| `CLAWQL_ID_JAG_TEE_SIGNER=1` | In `clawql-auth` issuer env: wrap local jose as `kind: "tee"` (no attestation) |
-| `CLAWQL_ID_JAG_TEE_SIGN_CMD` | Shell out to external signer (see bin above) |
-| `CLAWQL_TEE_PLATFORM` | `simulated` (default), `sev-snp`, `tdx`, `nitro` |
-| `CLAWQL_TEE_STRICT=1` | Reject simulated attestation on ID-JAG sign |
-| `CLAWQL_TEE_DEBUG=1` | Log attestation / platform on sign |
-| `CLAWQL_WORM_TEE=1` | In `clawql-audit`: ECDSA P-256 `teeSignature` on WORM append (see clawql-audit README) |
+| Variable                     | Role                                                                                   |
+| ---------------------------- | -------------------------------------------------------------------------------------- |
+| `CLAWQL_ID_JAG_TEE_SIGNER=1` | In `clawql-auth` issuer env: wrap local jose as `kind: "tee"` (no attestation)         |
+| `CLAWQL_ID_JAG_TEE_SIGN_CMD` | Shell out to external signer (see bin above)                                           |
+| `CLAWQL_TEE_PLATFORM`        | `simulated` (default), `sev-snp`, `tdx`, `nitro`                                       |
+| `CLAWQL_TEE_STRICT=1`        | Reject simulated attestation on ID-JAG sign                                            |
+| `CLAWQL_TEE_DEBUG=1`         | Log attestation / platform on sign                                                     |
+| `CLAWQL_WORM_TEE=1`          | In `clawql-audit`: ECDSA P-256 `teeSignature` on WORM append (see clawql-audit README) |
 
 Hardware platforms fail closed until cloud TEE integration lands.

--- a/packages/clawql-tee/README.md
+++ b/packages/clawql-tee/README.md
@@ -1,22 +1,50 @@
 # clawql-tee
 
-TEE-shaped signing bridge for ClawQL ID-JAG issuer (Layer C).
+TEE-shaped signing bridge for ClawQL ID-JAG issuer (Layer C) and future hardware attestation adapters.
 
 ## API
 
-- **`createTeeIdJagSignerBridge`** — wraps host `sign` Effect as `IdJagAssertionSigner` for `clawql-auth` issuer deps
-- **`createDevTeeIdJagSigner`** — local/dev stub (`attestationId: "dev-stub"`)
+### Bridge (legacy / host inject)
+
+- **`createTeeIdJagSignerBridge`** — wraps host `sign` Effect as `IdJagAssertionSigner`
+- **`createDevTeeIdJagSigner`** — dev stub (`attestationId: "dev-stub"`)
+
+### Platform adapters
+
+- **`createSimulatedPlatformAdapter`** — software attestation report (not hardware-backed)
+- **`createHardwarePlatformAdapter`** — placeholder for `sev-snp` / `tdx` / `nitro` (fail closed until wired)
+- **`resolveTeePlatformFromEnv`** — reads `CLAWQL_TEE_PLATFORM` (default `simulated`)
+- **`createIdJagSignerFromPlatform`** / **`createSimulatedIdJagSigner`** — ID-JAG signer with attestation gate
 
 ```ts
-import { createDevTeeIdJagSigner } from "clawql-tee";
-import { createLocalIdJagAssertionSigner } from "clawql-auth";
+import { createSimulatedIdJagSigner } from "clawql-tee";
+import { loadMcpOAuthSigningMaterialEffect } from "clawql-auth";
+import { Effect } from "effect";
 
-const local = createLocalIdJagAssertionSigner(signing);
-const tee = createDevTeeIdJagSigner((req) => local.sign(req));
-// pass tee as assertionSigner to createIdJagIssuerService / createIdJagIssuerFromEnv
+const signing = await Effect.runPromise(loadMcpOAuthSigningMaterialEffect({ /* … */ }));
+const assertionSigner = await Effect.runPromise(createSimulatedIdJagSigner(signing));
+// inject as assertionSigner in createIdJagIssuerFromEnv options
 ```
 
-Env:
+## External cmd signer
 
-- `CLAWQL_ID_JAG_TEE_SIGNER=1` — issuer env bootstrap wraps local jose as TEE-shaped (`kind: "tee"`) without importing this package
-- `CLAWQL_TEE_DEBUG=1` — log attestation ids on sign when using this bridge
+Reference binary for `CLAWQL_ID_JAG_TEE_SIGN_CMD`:
+
+```bash
+CLAWQL_ID_JAG_TEE_SIGN_CMD="node $(npm root)/clawql-tee/bin/id-jag-sign-cmd.mjs"
+```
+
+Contract: stdin JSON `{ claims, header }` → stdout compact JWS. Key from `CLAWQL_ID_JAG_ISSUER_PRIVATE_KEY_PEM` or `_PATH`.
+
+## Env
+
+| Variable | Role |
+| -------- | ---- |
+| `CLAWQL_ID_JAG_TEE_SIGNER=1` | In `clawql-auth` issuer env: wrap local jose as `kind: "tee"` (no attestation) |
+| `CLAWQL_ID_JAG_TEE_SIGN_CMD` | Shell out to external signer (see bin above) |
+| `CLAWQL_TEE_PLATFORM` | `simulated` (default), `sev-snp`, `tdx`, `nitro` |
+| `CLAWQL_TEE_STRICT=1` | Reject simulated attestation on ID-JAG sign |
+| `CLAWQL_TEE_DEBUG=1` | Log attestation / platform on sign |
+| `CLAWQL_WORM_TEE=1` | In `clawql-audit`: ECDSA P-256 `teeSignature` on WORM append (see clawql-audit README) |
+
+Hardware platforms fail closed until cloud TEE integration lands.

--- a/packages/clawql-tee/bin/id-jag-sign-cmd.mjs
+++ b/packages/clawql-tee/bin/id-jag-sign-cmd.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Reference external ID-JAG signer for CLAWQL_ID_JAG_TEE_SIGN_CMD.
+ *
+ * Contract:
+ * - stdin: JSON `{ "claims": JWTPayload, "header": { alg, kid?, typ? } }`
+ * - stdout: compact JWS (three dot-separated segments)
+ * - stderr: optional diagnostics (ignored by parent on success)
+ *
+ * Key material (first match):
+ * - CLAWQL_ID_JAG_ISSUER_PRIVATE_KEY_PEM
+ * - CLAWQL_ID_JAG_ISSUER_PRIVATE_KEY_PEM_PATH
+ * - CLAWQL_MCP_OAUTH_PRIVATE_KEY_PEM
+ * - CLAWQL_MCP_OAUTH_PRIVATE_KEY_PEM_PATH
+ */
+
+import { readFileSync } from "node:fs";
+import { SignJWT, importPKCS8 } from "jose";
+
+function readPem() {
+  const inline =
+    process.env.CLAWQL_ID_JAG_ISSUER_PRIVATE_KEY_PEM?.trim() ||
+    process.env.CLAWQL_MCP_OAUTH_PRIVATE_KEY_PEM?.trim();
+  if (inline) return inline;
+  const path =
+    process.env.CLAWQL_ID_JAG_ISSUER_PRIVATE_KEY_PEM_PATH?.trim() ||
+    process.env.CLAWQL_MCP_OAUTH_PRIVATE_KEY_PEM_PATH?.trim();
+  if (path) return readFileSync(path, "utf8");
+  throw new Error(
+    "missing_signing_key: set CLAWQL_ID_JAG_ISSUER_PRIVATE_KEY_PEM or _PATH (or MCP OAuth PEM vars)"
+  );
+}
+
+async function main() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  const raw = Buffer.concat(chunks).toString("utf8").trim();
+  if (!raw) {
+    throw new Error("empty_stdin");
+  }
+  const body = JSON.parse(raw);
+  if (!body.header?.alg) {
+    throw new Error("missing_header_alg");
+  }
+  const pem = readPem();
+  const key = await importPKCS8(pem, body.header.alg);
+  const jwt = await new SignJWT(body.claims)
+    .setProtectedHeader({
+      alg: body.header.alg,
+      ...(body.header.kid ? { kid: body.header.kid } : {}),
+      ...(body.header.typ ? { typ: body.header.typ } : {}),
+    })
+    .sign(key);
+  process.stdout.write(jwt);
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/clawql-tee/package.json
+++ b/packages/clawql-tee/package.json
@@ -15,6 +15,9 @@
     },
     "./package.json": "./package.json"
   },
+  "bin": {
+    "clawql-tee-id-jag-sign": "./bin/id-jag-sign-cmd.mjs"
+  },
   "scripts": {
     "clean": "rm -rf dist",
     "build": "npm run clean && tsup",
@@ -23,7 +26,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "effect": "^3.21.4"
+    "effect": "^3.21.4",
+    "jose": "^6.2.8"
   },
   "peerDependencies": {
     "clawql-auth": "0.1.0"
@@ -42,6 +46,7 @@
   },
   "files": [
     "dist",
+    "bin",
     "README.md"
   ],
   "engines": {

--- a/packages/clawql-tee/src/bridge.ts
+++ b/packages/clawql-tee/src/bridge.ts
@@ -1,0 +1,46 @@
+/**
+ * TEE-shaped ID-JAG signing bridge for Layer C.
+ * Production hosts swap `sign` for attestation-gated HSM / enclave calls.
+ */
+
+import { Effect } from "effect";
+import {
+  createTeeIdJagAssertionSigner,
+  type IdJagAssertionSigner,
+  type IdJagSignRequest,
+} from "clawql-auth";
+
+export type TeeSignFn = (request: IdJagSignRequest) => Effect.Effect<string, unknown>;
+
+export type TeeIdJagSignerOptions = {
+  /** Attestation quote or measurement id logged on each sign (optional). */
+  attestationId?: string;
+  sign: TeeSignFn;
+};
+
+/**
+ * Wrap an attestation-gated sign function as a clawql-auth {@link IdJagAssertionSigner}.
+ */
+export function createTeeIdJagSignerBridge(options: TeeIdJagSignerOptions): IdJagAssertionSigner {
+  return createTeeIdJagAssertionSigner({
+    teeSign: (request) =>
+      options.sign(request).pipe(
+        Effect.tap(() =>
+          options.attestationId
+            ? Effect.sync(() => {
+                if (process.env.CLAWQL_TEE_DEBUG?.trim() === "1") {
+                  process.stderr.write(
+                    `[clawql-tee] signed ID-JAG attestation=${options.attestationId}\n`
+                  );
+                }
+              })
+            : Effect.void
+        )
+      ),
+  });
+}
+
+/** Local dev stub — delegates to host-provided sign without attestation. */
+export function createDevTeeIdJagSigner(sign: TeeSignFn): IdJagAssertionSigner {
+  return createTeeIdJagSignerBridge({ sign, attestationId: "dev-stub" });
+}

--- a/packages/clawql-tee/src/cmd-signer.test.ts
+++ b/packages/clawql-tee/src/cmd-signer.test.ts
@@ -1,0 +1,85 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { exportPKCS8, generateKeyPair } from "jose";
+import { describe, expect, it } from "vitest";
+
+const binDir = join(dirname(fileURLToPath(import.meta.url)), "..", "bin");
+const signCmd = join(binDir, "id-jag-sign-cmd.mjs");
+
+function runSignCmd(
+  pem: string,
+  payload: { claims: Record<string, unknown>; header: { alg: string; kid?: string } }
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [signCmd], {
+      env: {
+        ...process.env,
+        CLAWQL_ID_JAG_ISSUER_PRIVATE_KEY_PEM: pem,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (c) => {
+      stdout += c.toString();
+    });
+    child.stderr.on("data", (c) => {
+      stderr += c.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+    child.stdin.write(JSON.stringify(payload));
+    child.stdin.end();
+  });
+}
+
+describe("id-jag-sign-cmd.mjs contract", () => {
+  it("signs stdin JSON to compact JWS on stdout", async () => {
+    const { privateKey } = await generateKeyPair("RS256", { extractable: true });
+    const pem = await exportPKCS8(privateKey);
+    const result = await runSignCmd(pem, {
+      claims: { sub: "user-1", iss: "https://issuer.test" },
+      header: { alg: "RS256", kid: "cmd-kid" },
+    });
+    expect(result.code).toBe(0);
+    expect(result.stdout.trim().split(".")).toHaveLength(3);
+  });
+
+  it("reads PEM from path env", async () => {
+    const { privateKey } = await generateKeyPair("RS256", { extractable: true });
+    const pem = await exportPKCS8(privateKey);
+    const dir = await mkdtemp(join(tmpdir(), "clawql-tee-cmd-"));
+    const keyPath = join(dir, "key.pem");
+    await writeFile(keyPath, pem);
+
+    const result = await new Promise<{ code: number | null; stdout: string }>((resolve, reject) => {
+      const child = spawn(process.execPath, [signCmd], {
+        env: {
+          ...process.env,
+          CLAWQL_ID_JAG_ISSUER_PRIVATE_KEY_PEM: "",
+          CLAWQL_ID_JAG_ISSUER_PRIVATE_KEY_PEM_PATH: keyPath,
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      let stdout = "";
+      child.stdout.on("data", (c) => {
+        stdout += c.toString();
+      });
+      child.on("error", reject);
+      child.on("close", (code) => resolve({ code, stdout }));
+      child.stdin.write(
+        JSON.stringify({
+          claims: { sub: "path-key" },
+          header: { alg: "RS256" },
+        })
+      );
+      child.stdin.end();
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout.trim().split(".")).toHaveLength(3);
+  });
+});

--- a/packages/clawql-tee/src/id-jag.ts
+++ b/packages/clawql-tee/src/id-jag.ts
@@ -1,0 +1,89 @@
+/**
+ * ID-JAG Layer C helpers built on {@link TeePlatformAdapter}.
+ */
+
+import {
+  createLocalIdJagAssertionSigner,
+  type IdJagAssertionSigner,
+  type IdJagSignRequest,
+  type McpOAuthSigningMaterial,
+} from "clawql-auth";
+import { Effect } from "effect";
+
+import { createTeeIdJagSignerBridge, type TeeSignFn } from "./bridge.js";
+import {
+  resolveTeePlatformFromEnv,
+  teeStrictFromEnv,
+  TeePlatformError,
+  type ResolveTeePlatformFromEnvOptions,
+  type TeePlatformAdapter,
+} from "./platform.js";
+
+export type CreateIdJagSignerFromPlatformOptions = {
+  readonly adapter: TeePlatformAdapter;
+  readonly sign: TeeSignFn;
+  readonly env?: NodeJS.ProcessEnv;
+};
+
+/**
+ * Wrap a host sign function with platform attestation metadata.
+ * When `CLAWQL_TEE_STRICT=1`, rejects simulated platforms.
+ */
+export const createIdJagSignerFromPlatform = (
+  options: CreateIdJagSignerFromPlatformOptions
+): IdJagAssertionSigner => {
+  const env = options.env ?? process.env;
+  return createTeeIdJagSignerBridge({
+    attestationId: options.adapter.platform,
+    sign: (request: IdJagSignRequest) =>
+      Effect.gen(function* () {
+        const attestation = yield* options.adapter.getAttestation().pipe(
+          Effect.mapError(
+            (err: TeePlatformError) =>
+              new Error(err.message, err.cause ? { cause: err.cause } : undefined)
+          )
+        );
+        if (teeStrictFromEnv(env) && attestation.platform === "simulated") {
+          return yield* Effect.fail(
+            new Error("CLAWQL_TEE_STRICT=1 rejects simulated attestation")
+          );
+        }
+        if (process.env.CLAWQL_TEE_DEBUG?.trim() === "1") {
+          process.stderr.write(
+            `[clawql-tee] id-jag sign platform=${attestation.platform} measurement=${attestation.measurementId ?? "n/a"}\n`
+          );
+        }
+        return yield* options.sign(request);
+      }),
+  });
+};
+
+/** Simulated platform + local jose sign (dev / homelab). */
+export const createSimulatedIdJagSigner = (
+  signing: McpOAuthSigningMaterial,
+  env?: NodeJS.ProcessEnv
+): Effect.Effect<IdJagAssertionSigner, TeePlatformError> =>
+  Effect.gen(function* () {
+    const adapter = yield* resolveTeePlatformFromEnv({ env });
+    const local = createLocalIdJagAssertionSigner(signing);
+    return createIdJagSignerFromPlatform({
+      adapter,
+      sign: (req) => local.sign(req),
+      env,
+    });
+  });
+
+/** Env-resolved platform adapter + local jose sign. Hardware platforms fail on attestation until wired. */
+export const createIdJagSignerFromEnvEffect = (
+  signing: McpOAuthSigningMaterial,
+  options: ResolveTeePlatformFromEnvOptions = {}
+): Effect.Effect<IdJagAssertionSigner, TeePlatformError> =>
+  Effect.gen(function* () {
+    const adapter = yield* resolveTeePlatformFromEnv(options);
+    const local = createLocalIdJagAssertionSigner(signing);
+    return createIdJagSignerFromPlatform({
+      adapter,
+      sign: (req) => local.sign(req),
+      env: options.env,
+    });
+  });

--- a/packages/clawql-tee/src/id-jag.ts
+++ b/packages/clawql-tee/src/id-jag.ts
@@ -37,16 +37,16 @@ export const createIdJagSignerFromPlatform = (
     attestationId: options.adapter.platform,
     sign: (request: IdJagSignRequest) =>
       Effect.gen(function* () {
-        const attestation = yield* options.adapter.getAttestation().pipe(
-          Effect.mapError(
-            (err: TeePlatformError) =>
-              new Error(err.message, err.cause ? { cause: err.cause } : undefined)
-          )
-        );
-        if (teeStrictFromEnv(env) && attestation.platform === "simulated") {
-          return yield* Effect.fail(
-            new Error("CLAWQL_TEE_STRICT=1 rejects simulated attestation")
+        const attestation = yield* options.adapter
+          .getAttestation()
+          .pipe(
+            Effect.mapError(
+              (err: TeePlatformError) =>
+                new Error(err.message, err.cause ? { cause: err.cause } : undefined)
+            )
           );
+        if (teeStrictFromEnv(env) && attestation.platform === "simulated") {
+          return yield* Effect.fail(new Error("CLAWQL_TEE_STRICT=1 rejects simulated attestation"));
         }
         if (process.env.CLAWQL_TEE_DEBUG?.trim() === "1") {
           process.stderr.write(

--- a/packages/clawql-tee/src/index.test.ts
+++ b/packages/clawql-tee/src/index.test.ts
@@ -3,7 +3,7 @@ import { Effect } from "effect";
 import { exportPKCS8, generateKeyPair } from "jose";
 import { describe, expect, it } from "vitest";
 
-import { createDevTeeIdJagSigner, createTeeIdJagSignerBridge } from "./index.js";
+import { createDevTeeIdJagSigner, createTeeIdJagSignerBridge } from "./bridge.js";
 
 describe("clawql-tee ID-JAG bridge", () => {
   it("createDevTeeIdJagSigner wraps host sign as kind tee", async () => {

--- a/packages/clawql-tee/src/index.ts
+++ b/packages/clawql-tee/src/index.ts
@@ -1,46 +1,23 @@
-/**
- * TEE-shaped ID-JAG signing bridge for Layer C.
- * Production hosts swap `sign` for attestation-gated HSM / enclave calls.
- */
-
-import { Effect } from "effect";
-import {
-  createTeeIdJagAssertionSigner,
-  type IdJagAssertionSigner,
-  type IdJagSignRequest,
-} from "clawql-auth";
-
-export type TeeSignFn = (request: IdJagSignRequest) => Effect.Effect<string, unknown>;
-
-export type TeeIdJagSignerOptions = {
-  /** Attestation quote or measurement id logged on each sign (optional). */
-  attestationId?: string;
-  sign: TeeSignFn;
-};
-
-/**
- * Wrap an attestation-gated sign function as a clawql-auth {@link IdJagAssertionSigner}.
- */
-export function createTeeIdJagSignerBridge(options: TeeIdJagSignerOptions): IdJagAssertionSigner {
-  return createTeeIdJagAssertionSigner({
-    teeSign: (request) =>
-      options.sign(request).pipe(
-        Effect.tap(() =>
-          options.attestationId
-            ? Effect.sync(() => {
-                if (process.env.CLAWQL_TEE_DEBUG?.trim() === "1") {
-                  process.stderr.write(
-                    `[clawql-tee] signed ID-JAG attestation=${options.attestationId}\n`
-                  );
-                }
-              })
-            : Effect.void
-        )
-      ),
-  });
-}
-
-/** Local dev stub — delegates to host-provided sign without attestation. */
-export function createDevTeeIdJagSigner(sign: TeeSignFn): IdJagAssertionSigner {
-  return createTeeIdJagSignerBridge({ sign, attestationId: "dev-stub" });
-}
+export {
+  createDevTeeIdJagSigner,
+  createTeeIdJagSignerBridge,
+  type TeeIdJagSignerOptions,
+  type TeeSignFn,
+} from "./bridge.js";
+export {
+  createHardwarePlatformAdapter,
+  createSimulatedPlatformAdapter,
+  resolveTeePlatformFromEnv,
+  teeStrictFromEnv,
+  TeePlatformError,
+  type ResolveTeePlatformFromEnvOptions,
+  type SimulatedPlatformAdapterOptions,
+  type TeeAttestationSnapshot,
+  type TeePlatformAdapter,
+  type TeePlatformId,
+} from "./platform.js";
+export {
+  createIdJagSignerFromEnvEffect,
+  createIdJagSignerFromPlatform,
+  createSimulatedIdJagSigner,
+} from "./id-jag.js";

--- a/packages/clawql-tee/src/platform.test.ts
+++ b/packages/clawql-tee/src/platform.test.ts
@@ -62,9 +62,7 @@ describe("clawql-tee platform adapter", () => {
       env: { CLAWQL_TEE_STRICT: "1" } as NodeJS.ProcessEnv,
     });
     await expect(
-      Effect.runPromise(
-        signer.sign({ claims: { sub: "x" }, header: { alg: "RS256" } })
-      )
+      Effect.runPromise(signer.sign({ claims: { sub: "x" }, header: { alg: "RS256" } }))
     ).rejects.toThrow(/CLAWQL_TEE_STRICT/);
     expect(teeStrictFromEnv({ CLAWQL_TEE_STRICT: "1" } as NodeJS.ProcessEnv)).toBe(true);
   });

--- a/packages/clawql-tee/src/platform.test.ts
+++ b/packages/clawql-tee/src/platform.test.ts
@@ -1,0 +1,71 @@
+import { loadMcpOAuthSigningMaterialEffect } from "clawql-auth";
+import { Effect } from "effect";
+import { exportPKCS8, generateKeyPair } from "jose";
+import { describe, expect, it } from "vitest";
+
+import {
+  createHardwarePlatformAdapter,
+  createSimulatedPlatformAdapter,
+  resolveTeePlatformFromEnv,
+  teeStrictFromEnv,
+} from "./platform.js";
+import { createIdJagSignerFromPlatform, createSimulatedIdJagSigner } from "./id-jag.js";
+
+describe("clawql-tee platform adapter", () => {
+  it("simulated adapter returns base64 JSON report", async () => {
+    const adapter = createSimulatedPlatformAdapter({ measurementId: "m1" });
+    const att = await Effect.runPromise(adapter.getAttestation());
+    expect(att.platform).toBe("simulated");
+    expect(att.measurementId).toBe("m1");
+    const decoded = JSON.parse(Buffer.from(att.reportBase64, "base64").toString("utf8"));
+    expect(decoded.platform).toBe("simulated");
+  });
+
+  it("hardware adapter fails closed on attestation", async () => {
+    const adapter = createHardwarePlatformAdapter("sev-snp");
+    await expect(Effect.runPromise(adapter.getAttestation())).rejects.toMatchObject({
+      message: expect.stringContaining("sev-snp"),
+    });
+  });
+
+  it("resolveTeePlatformFromEnv defaults to simulated", async () => {
+    const adapter = await Effect.runPromise(
+      resolveTeePlatformFromEnv({ env: {} as NodeJS.ProcessEnv })
+    );
+    expect(adapter.platform).toBe("simulated");
+  });
+
+  it("createSimulatedIdJagSigner produces valid JWT", async () => {
+    const { privateKey } = await generateKeyPair("RS256", { extractable: true });
+    const signing = await Effect.runPromise(
+      loadMcpOAuthSigningMaterialEffect({
+        privateKeyPem: await exportPKCS8(privateKey),
+        keyId: "sim-kid",
+      })
+    );
+    const signer = await Effect.runPromise(createSimulatedIdJagSigner(signing));
+    expect(signer.kind).toBe("tee");
+    const jwt = await Effect.runPromise(
+      signer.sign({
+        claims: { sub: "org-user" },
+        header: { alg: "RS256", kid: "sim-kid" },
+      })
+    );
+    expect(jwt.split(".")).toHaveLength(3);
+  });
+
+  it("CLAWQL_TEE_STRICT rejects simulated on sign", async () => {
+    const adapter = createSimulatedPlatformAdapter();
+    const signer = createIdJagSignerFromPlatform({
+      adapter,
+      sign: () => Effect.succeed("a.b.c"),
+      env: { CLAWQL_TEE_STRICT: "1" } as NodeJS.ProcessEnv,
+    });
+    await expect(
+      Effect.runPromise(
+        signer.sign({ claims: { sub: "x" }, header: { alg: "RS256" } })
+      )
+    ).rejects.toThrow(/CLAWQL_TEE_STRICT/);
+    expect(teeStrictFromEnv({ CLAWQL_TEE_STRICT: "1" } as NodeJS.ProcessEnv)).toBe(true);
+  });
+});

--- a/packages/clawql-tee/src/platform.ts
+++ b/packages/clawql-tee/src/platform.ts
@@ -1,0 +1,110 @@
+/**
+ * Platform adapters for Layer C TEE signing.
+ * `simulated` is software-only; hardware platforms fail closed until host wiring lands.
+ */
+
+import { Data, Effect } from "effect";
+
+export type TeePlatformId = "simulated" | "sev-snp" | "tdx" | "nitro";
+
+export type TeeAttestationSnapshot = {
+  readonly platform: TeePlatformId;
+  readonly reportBase64: string;
+  readonly measurementId?: string;
+};
+
+export class TeePlatformError extends Data.TaggedError("TeePlatformError")<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+export type TeePlatformAdapter = {
+  readonly platform: TeePlatformId;
+  getAttestation: () => Effect.Effect<TeeAttestationSnapshot, TeePlatformError>;
+};
+
+export type SimulatedPlatformAdapterOptions = {
+  readonly measurementId?: string;
+  readonly note?: string;
+};
+
+/** Software-only attestation for dev/CI — not hardware-backed. */
+export const createSimulatedPlatformAdapter = (
+  options: SimulatedPlatformAdapterOptions = {}
+): TeePlatformAdapter => {
+  const measurementId = options.measurementId ?? "simulated-measurement";
+  const report = {
+    platform: "simulated" as const,
+    measurementId,
+    note:
+      options.note ??
+      "Software simulated TEE — replace with clawql-tee hardware adapter when SEV-SNP/TDX/Nitro is available.",
+    generatedAt: new Date().toISOString(),
+  };
+  return {
+    platform: "simulated",
+    getAttestation: () =>
+      Effect.succeed({
+        platform: "simulated",
+        measurementId,
+        reportBase64: Buffer.from(JSON.stringify(report), "utf8").toString("base64"),
+      }),
+  };
+};
+
+const unsupportedHardware = (platform: Exclude<TeePlatformId, "simulated">): TeePlatformAdapter => ({
+  platform,
+  getAttestation: () =>
+    Effect.fail(
+      new TeePlatformError({
+        message: `${platform} attestation requires clawql-tee hardware integration (not available in this build)`,
+      })
+    ),
+});
+
+/** Placeholder adapters — explicit fail until hardware paths ship. */
+export const createHardwarePlatformAdapter = (
+  platform: Exclude<TeePlatformId, "simulated">
+): TeePlatformAdapter => unsupportedHardware(platform);
+
+export type ResolveTeePlatformFromEnvOptions = {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly simulated?: SimulatedPlatformAdapterOptions;
+};
+
+function envTrim(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const v = env[key]?.trim();
+  return v || undefined;
+}
+
+/** Resolve platform adapter from `CLAWQL_TEE_PLATFORM` (default `simulated`). */
+export const resolveTeePlatformFromEnv = (
+  options: ResolveTeePlatformFromEnvOptions = {}
+): Effect.Effect<TeePlatformAdapter, TeePlatformError> => {
+  const env = options.env ?? process.env;
+  const raw = envTrim(env, "CLAWQL_TEE_PLATFORM") ?? "simulated";
+  switch (raw) {
+    case "simulated":
+      return Effect.succeed(
+        createSimulatedPlatformAdapter({
+          measurementId: envTrim(env, "CLAWQL_TEE_MEASUREMENT_ID"),
+          ...options.simulated,
+        })
+      );
+    case "sev-snp":
+      return Effect.succeed(createHardwarePlatformAdapter("sev-snp"));
+    case "tdx":
+      return Effect.succeed(createHardwarePlatformAdapter("tdx"));
+    case "nitro":
+      return Effect.succeed(createHardwarePlatformAdapter("nitro"));
+    default:
+      return Effect.fail(
+        new TeePlatformError({
+          message: `Unknown CLAWQL_TEE_PLATFORM=${raw} (expected simulated|sev-snp|tdx|nitro)`,
+        })
+      );
+  }
+};
+
+export const teeStrictFromEnv = (env: NodeJS.ProcessEnv = process.env): boolean =>
+  envTrim(env, "CLAWQL_TEE_STRICT") === "1";

--- a/packages/clawql-tee/src/platform.ts
+++ b/packages/clawql-tee/src/platform.ts
@@ -52,7 +52,9 @@ export const createSimulatedPlatformAdapter = (
   };
 };
 
-const unsupportedHardware = (platform: Exclude<TeePlatformId, "simulated">): TeePlatformAdapter => ({
+const unsupportedHardware = (
+  platform: Exclude<TeePlatformId, "simulated">
+): TeePlatformAdapter => ({
   platform,
   getAttestation: () =>
     Effect.fail(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements simulated TEE support across the three priority tracks (excluding live hardware attestation):

### A — Audit WORM Phase 3 env wiring
- `createWormTeeSignerFromEnvEffect` resolves ECDSA signing from `CLAWQL_WORM_TEE` and related env vars
- Simulated platform with optional PEM keys; hardware platforms (`sev-snp`, `tdx`) fail closed
- Integration tests and README Phase 3 docs updated

### B — clawql-tee platform adapter
- `TeePlatformAdapter` with `createSimulatedPlatformAdapter` and fail-closed hardware stubs
- `createIdJagSignerFromEnvEffect` / `createSimulatedIdJagSigner` for Auth Layer C
- Bridge helpers moved to dedicated module; expanded README

### C — Reference cmd signer
- `packages/clawql-tee/bin/id-jag-sign-cmd.mjs` for `CLAWQL_ID_JAG_TEE_SIGN_CMD`
- Contract tests + auth env integration coverage
- `.env.example` TEE/WORM env documentation

## Out of scope (deferred)
- Live SEV-SNP / TDX / Nitro attestation verification
- Real WebAuthn authenticator E2E
- Live Okta/Auth0 tenant E2E

## Test plan
- [x] `npx vitest run packages/clawql-audit packages/clawql-tee` (22 tests)
- [x] `npx vitest run packages/clawql-auth/src/inbound/id-jag-issuer-env.test.ts` (4 tests)
- [x] ESLint on changed files
- [ ] CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03570-ad58-76e5-b7ec-872aeb2410f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03570-ad58-76e5-b7ec-872aeb2410f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

