### PR TITLE
Host executor-comparison methodology on clawql.com for blog CTA

### DIFF
--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -78,6 +78,7 @@ jobs:
           test -f out/enterprise/gtm/index.html
           test -f out/mcp-ui/trace/compare/executor/index.html
           test -f out/mcp-ui/trace/compare/executor/compare.json
+          test -f out/benchmarks/executor-comparison/index.html
           grep -qi 'Agentic Gateway for Auditable Production AI' out/llms.txt
           grep -q 'inference/gtm' out/llms.txt
           grep -q 'inference/gtm' out/sitemap.xml

--- a/landing-page/demo/public/benchmarks/executor-comparison/index.html
+++ b/landing-page/demo/public/benchmarks/executor-comparison/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Executor.sh comparison (executor-cmp-001) · ClawQL</title>
+  <link rel="canonical" href="https://clawql.com/benchmarks/executor-comparison"/>
+  <style>
+    body { margin: 0; font-family: ui-sans-serif, system-ui, sans-serif; color: #0f172a; background: #fff; }
+    .wrap { max-width: 720px; margin: 0 auto; padding: 1.5rem 1rem 3rem; line-height: 1.5; }
+    h1 { font-size: 1.5rem; margin: 0 0 0.5rem; }
+    h2 { font-size: 1.1rem; margin: 1.75rem 0 0.5rem; }
+    .lead { color: #334155; font-size: 1.05rem; }
+    .meta { color: #64748b; font-size: 0.9rem; }
+    a { color: #0f766e; }
+    table { width: 100%; border-collapse: collapse; font-size: 0.92rem; margin: 0.75rem 0 1rem; }
+    th, td { text-align: left; padding: 0.4rem 0.5rem; border-bottom: 1px solid #e2e8f0; vertical-align: top; }
+    th:nth-child(2), td:nth-child(2), th:nth-child(3), td:nth-child(3) { text-align: right; font-variant-numeric: tabular-nums; }
+    code, pre { background: #f1f5f9; border-radius: 4px; font-size: 0.85em; }
+    code { padding: 0.1rem 0.35rem; }
+    pre { padding: 0.85rem 1rem; overflow: auto; }
+    ul { padding-left: 1.2rem; }
+    .callout { background: #ecfdf5; border: 1px solid #6ee7b7; color: #065f46; padding: 0.85rem 1rem; border-radius: 8px; margin: 1rem 0; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <p class="meta"><a href="https://clawql.com/">← clawql.com</a> · <a href="https://pragmaticvectors.com/posts/both-sides-of-context-compression/">Both Sides of Context Compression</a></p>
+    <h1>Executor.sh comparison (executor-cmp-001)</h1>
+    <p class="lead">Side-by-side token comparison against <a href="https://executor.sh/">executor.sh</a> on a GitHub PR list — the benchmark behind the PragmaticVectors post.</p>
+    <p class="meta">Tokenizer: <code>cl100k_base</code>. <code>focus=input</code> (model output omitted from headline ratios).</p>
+
+    <h2>Headline numbers (live, <code>vercel/next.js</code>)</h2>
+    <table>
+      <thead><tr><th>Layer</th><th>Executor</th><th>ClawQL</th><th>Notes</th></tr></thead>
+      <tbody>
+        <tr><td><strong>Layer 1</strong></td><td>1,044 (homepage) / <strong>115</strong> (live <code>execute</code>)</td><td><strong>394</strong> (codemode)</td><td><strong>394 does not beat live 115</strong></td></tr>
+        <tr><td><strong>Layer 2</strong></td><td><strong>143,466</strong> (<code>pulls.list</code>, full REST)</td><td><strong>907</strong> (<code>execute</code> + <code>fields</code>)</td><td><strong>158×</strong> on tool result alone</td></tr>
+        <tr><td><strong>Combined</strong></td><td><strong>144,510</strong> (pub L1) / <strong>143,581</strong> (live L1)</td><td><strong>1,301</strong></td><td><strong>111×</strong> / <strong>110×</strong></td></tr>
+      </tbody>
+    </table>
+    <p>Layer 2 is <strong>100%</strong> of Executor's input and <strong>70%</strong> of ClawQL's on this task.</p>
+
+    <div class="callout">
+      <strong>Live flamegraph:</strong>
+      <a href="https://clawql.com/mcp-ui/trace/compare/executor"><code>clawql.com/mcp-ui/trace/compare/executor</code></a>
+      · <a href="https://clawql.com/mcp-ui/trace/compare/executor/compare.json">compare.json</a>
+    </div>
+
+    <h2>Reproduce</h2>
+<pre># Fixture (CI shape)
+npm run benchmark:executor-comparison
+
+# Live GitHub + ClawQL
+BENCHMARK_LIVE=1 CMP_GITHUB_REPO=vercel/next.js CMP_PER_PAGE=30 \
+  npm run benchmark:executor-comparison
+
+# Live both arms (Executor CLI + ClawQL)
+BENCHMARK_LIVE=1 CMP_GITHUB_REPO=vercel/next.js CMP_PER_PAGE=30 \
+  EXECUTOR_BIN=/path/to/executor EXECUTOR_CWD=/path/to/executor-cwd \
+  EXECUTOR_GITHUB_PULLS_PATH=github.user.githubMain.pulls.list \
+  npm run benchmark:executor-comparison</pre>
+    <p class="meta">Multi-turn: <code>npm run benchmark:executor-comparison:multiturn</code> · <code>npm run benchmark:executor-comparison:uniform</code></p>
+
+    <h2>Raw artifacts (repo)</h2>
+    <ul>
+      <li><a href="https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/benchmarks/executor-comparison/README.md">Methodology README</a></li>
+      <li><a href="https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/benchmarks/executor-comparison/executor-cmp-001.live.json">executor-cmp-001.live.json</a></li>
+      <li><a href="https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/benchmarks/executor-comparison/executor-cmp-002b.uniform-pulls.live.json">Uniform N=5</a></li>
+      <li><a href="https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/benchmarks/executor-comparison/executor-cmp-002.multiturn.live.json">Mixed N=5</a></li>
+      <li><a href="https://github.com/danielsmithdevelopment/ClawQL/tree/main/openbench/tasks/executor-github-pr-filter">OpenBench task</a></li>
+    </ul>
+
+    <h2>What not to claim</h2>
+    <ul>
+      <li><strong>862×</strong> multi-provider workflow — different metric; do not blend into this comparison</li>
+      <li>Fixture <strong>953 vs 23</strong> — harness sanity only, not for headlines</li>
+      <li>ClawQL <strong>883</strong> / <strong>3,548</strong> — context tiers, not Executor chart parity</li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/landing-page/demo/public/mcp-ui/trace/compare/executor/index.html
+++ b/landing-page/demo/public/mcp-ui/trace/compare/executor/index.html
@@ -48,7 +48,7 @@
 </head>
 <body>
   <div class="fg-wrap" style="max-width:1100px">
-    <p class="fg-nav"><a href="https://docs.clawql.com/mcp/mcp-ui">← MCP UI docs</a> · <a href="https://docs.clawql.com/benchmarks/executor-comparison">Methodology</a> · <a href="https://clawql.com/mcp-ui/trace/compare/executor">canonical URL</a></p>
+    <p class="fg-nav"><a href="https://docs.clawql.com/mcp/mcp-ui">← MCP UI docs</a> · <a href="https://clawql.com/benchmarks/executor-comparison">Methodology</a> · <a href="https://clawql.com/mcp-ui/trace/compare/executor">canonical URL</a></p>
     <h1>Executor.sh vs ClawQL — executor-cmp-001 (live)</h1>
     <p class="fg-meta">Same task · vercel/next.js pulls.list · cl100k_base · Layer 1 tool defs + Layer 2 tool result · focus=input by default</p>
     

--- a/packages/mcp-api-adapter/scripts/generate-executor-cmp-compare-static.mjs
+++ b/packages/mcp-api-adapter/scripts/generate-executor-cmp-compare-static.mjs
@@ -24,7 +24,7 @@ const ROOT = join(__dirname, "..", "..", "..");
 
 const CANONICAL = "https://clawql.com/mcp-ui/trace/compare/executor";
 const DOCS_CATALOG = "https://docs.clawql.com/mcp/mcp-ui";
-const METHODOLOGY = "https://docs.clawql.com/benchmarks/executor-comparison";
+const METHODOLOGY = "https://clawql.com/benchmarks/executor-comparison";
 
 const OUT_DIRS = [
   join(ROOT, "website", "public", "mcp-ui", "trace", "compare", "executor"),

--- a/website/public/mcp-ui/trace/compare/executor/index.html
+++ b/website/public/mcp-ui/trace/compare/executor/index.html
@@ -48,7 +48,7 @@
 </head>
 <body>
   <div class="fg-wrap" style="max-width:1100px">
-    <p class="fg-nav"><a href="https://docs.clawql.com/mcp/mcp-ui">← MCP UI docs</a> · <a href="https://docs.clawql.com/benchmarks/executor-comparison">Methodology</a> · <a href="https://clawql.com/mcp-ui/trace/compare/executor">canonical URL</a></p>
+    <p class="fg-nav"><a href="https://docs.clawql.com/mcp/mcp-ui">← MCP UI docs</a> · <a href="https://clawql.com/benchmarks/executor-comparison">Methodology</a> · <a href="https://clawql.com/mcp-ui/trace/compare/executor">canonical URL</a></p>
     <h1>Executor.sh vs ClawQL — executor-cmp-001 (live)</h1>
     <p class="fg-meta">Same task · vercel/next.js pulls.list · cl100k_base · Layer 1 tool defs + Layer 2 tool result · focus=input by default</p>
     


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

[#988](https://github.com/danielsmithdevelopment/ClawQL/pull/988) merged and the flamegraph is **live** on GitHub Pages:

- https://clawql.com/mcp-ui/trace/compare/executor ✅

`docs.clawql.com` deploy failed (Cloudflare Worker **3 MiB free-plan size limit** — pre-existing). This PR puts the methodology page on the landing static site so the blog’s second CTA works without waiting on docs Worker plan upgrades.

## Links after merge + landing deploy

| URL | Status |
| --- | --- |
| https://clawql.com/mcp-ui/trace/compare/executor | Already live |
| https://clawql.com/benchmarks/executor-comparison | This PR |
| https://docs.clawql.com/benchmarks/executor-comparison | Blocked until Worker size/plan fixed |

## Blog note

Prefer **clawql.com** for both CTAs until docs Worker deploys again. Flamegraph Methodology nav already points at `clawql.com/benchmarks/executor-comparison`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03b41-a8f7-766e-b8b6-1e0170a7356a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03b41-a8f7-766e-b8b6-1e0170a7356a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

