### PR TITLE
docs(website): Authentication + Audit Trail pages (/auth, /audit)

### DIFF
--- a/packages/clawql-audit/README.md
+++ b/packages/clawql-audit/README.md
@@ -2,6 +2,8 @@
 
 Tamper-evident **WORM** audit trail for AI agent deployments. Standalone — no dependency on `clawql-core`, `clawql-memory`, or other ClawQL packages (only `clawql-merkle` + Effect + AWS SDK / CBOR / QR / RaptorQ; optional `pg`).
 
+**Public docs:** [docs.clawql.com/audit](https://docs.clawql.com/audit) — hash chain, Merkle batch roots, dual-ack replication, and external verification.
+
 ## Capabilities
 
 - Hash-chained append (`sealHashChainRecord`)

--- a/packages/clawql-auth/README.md
+++ b/packages/clawql-auth/README.md
@@ -2,7 +2,9 @@
 
 Gateway authentication, **issued API keys** (org/team), outbound OAuth token refresh, and shared step-up primitives for the Agentic Gateway.
 
-**ClawQL is not an IdP.** Human SSO, account recovery, and phishing-resistant MFA stay with the customer’s identity provider. This package **consumes** IdP tokens, **issues and validates** ClawQL API keys, maps them to ATR claims, and provides reusable step-up helpers for high-impact tools (e.g. payments).
+**Public docs:** [docs.clawql.com/auth](https://docs.clawql.com/auth) — inbound vs outbound authentication (the page to link when answering “has MCP daily re-auth been solved?”).
+
+**ClawQL is not a human login IdP.** Human SSO, account recovery, and phishing-resistant MFA stay with the customer’s identity provider. This package **consumes** IdP tokens, **issues and validates** ClawQL API keys and MCP access JWTs, can **mint ID-JAG assertions** when the self-hosted EMA issuer is enabled, maps them to ATR claims, and provides reusable step-up helpers for high-impact tools (e.g. payments).
 
 ## Modes
 

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -28,6 +28,8 @@ This file helps AI agents and crawlers find canonical documentation. For full-te
 
 ## Deployment & security
 - [Deployment](https://docs.clawql.com/deployment): Docker, Kubernetes, and operations
+- [Authentication](https://docs.clawql.com/auth): Inbound vs outbound auth — OAuth refresh, EMA / ID-JAG, signing
+- [Audit Trail](https://docs.clawql.com/audit): Append-only WORM trail — hash chain, Merkle roots, dual-ack replication
 - [Defense in depth](https://docs.clawql.com/security/defense-in-depth): Layered MCP security model
 - [Security best practices](https://docs.clawql.com/security/best-practices): 32-module agentic AI security series
 

--- a/website/src/app/audit/layout.tsx
+++ b/website/src/app/audit/layout.tsx
@@ -1,0 +1,18 @@
+import { docsPageMetadata } from '@/lib/seo'
+
+export const metadata = docsPageMetadata({
+  title: 'Audit Trail',
+  description:
+    'ClawQL append-only WORM audit trail: hash chain, Merkle batch roots, dual-ack replication, and external verification.',
+  path: '/audit',
+})
+
+import type { ReactNode } from 'react'
+
+export default function DocsSegmentLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return children
+}

--- a/website/src/app/audit/page.mdx
+++ b/website/src/app/audit/page.mdx
@@ -1,0 +1,70 @@
+# Audit Trail
+
+Every consequential action ClawQL takes — a tool call, an authentication event, a scope denial, a document extraction, a payment, a model inference — is written to an append-only audit trail before that action is considered complete. This is not a logging feature added for compliance checkboxes. It's the mechanism that makes every other claim ClawQL makes about an agent's behavior checkable after the fact, rather than merely asserted at the time. {{ className: 'lead' }}
+
+**Package:** [`clawql-audit`](https://github.com/danielsmithdevelopment/ClawQL/tree/main/packages/clawql-audit) · [README](https://github.com/danielsmithdevelopment/ClawQL/blob/main/packages/clawql-audit/README.md) · companion [`clawql-merkle`](https://github.com/danielsmithdevelopment/ClawQL/tree/main/packages/clawql-merkle)
+
+**Related:** [Authentication](/auth) (auth events dual-write into this trail) · [Audit tool & observability](/learn/audit-tool-and-observability) (in-process MCP `audit` ring buffer — different surface)
+
+---
+
+## What gets recorded
+
+Anything with a consequence gets an entry: which tool was called, with what arguments, by which session, at what time, and what happened as a result. This includes actions that don't involve a model call at all — a scheduled job firing, a file write, a credential refresh, a scope enforcement decision blocking a request. If an action changed something or was denied, it's in the trail.
+
+Entries carry enough context to answer, after the fact: what was this session authorized to do, what did it actually do, and did those match.
+
+---
+
+## How integrity is guaranteed
+
+Two distinct mechanisms are used here, deliberately kept separate because they prove two different things.
+
+**A hash chain proves the log itself hasn't been tampered with.** Every entry embeds the hash of the entry before it. If any entry is altered, deleted, or reordered after the fact, recomputing the chain from any earlier known-good point immediately reveals it. This is what makes the trail append-only in practice, not just by policy — modifying history breaks verifiably.
+
+**A Merkle root, computed periodically over a batch of entries, proves a specific entry belongs to a specific batch without needing the whole batch to check it.** This is what makes external verification cheap: rather than handing someone your entire log to confirm one entry, you hand them the entry and a short proof, and they can confirm it against a root that's been published independently of you.
+
+These aren't the same thing solving the same problem twice. The hash chain protects the log's internal order over time. The Merkle root is what makes a single entry externally checkable without trusting whoever operates the log.
+
+---
+
+## Replication
+
+An entry is written locally and queued for remote replication in the same operation — not written locally and then separately, optionally, sent elsewhere. A background process drains that queue to remote storage. If the remote write is delayed, the entry that produced it is already durable locally (with an outbox record); nothing is lost, and callers are not failed solely because remote is temporarily down.
+
+On restart, the outbox drains and the trail's current position is loaded from durable storage before anything new is accepted. A process that restarted with no memory of where the log left off would risk starting a second, conflicting sequence — this is checked for explicitly rather than assumed away.
+
+---
+
+## External verification
+
+Because the trail is Merkle-batched, its integrity doesn't depend on trusting the operator. A batch root can be published somewhere outside ClawQL's own infrastructure — anchored across multiple public chains chosen for stability and low cost rather than any single one — so that a specific entry's existence at a specific time is checkable by anyone, using only that entry and a short proof, against a root they didn't get from ClawQL.
+
+ClawQL computes and exposes those batch roots as the handoff for that external anchoring. Publishing a root onto public chains is an operator / integrator step on top of the trail (not a single hard-wired vendor chain).
+
+This matters for exactly the situations where "trust our logs" isn't good enough: an audit by a party that doesn't want to rely on the vendor's word, a dispute where both sides need to agree on what happened, a regulatory requirement that records be tamper-evident independent of who's holding them.
+
+---
+
+## What this enables
+
+**Incident review.** If an agent did something unexpected, the trail shows exactly what it was authorized to do, what it attempted, and where enforcement did or didn't intervene — not a reconstruction from memory or logs that could have been edited after the fact.
+
+**Scope enforcement is itself audited.** When a tool call is blocked because it falls outside a session's authorized scope, that denial is recorded with the same rigor as anything that succeeds. A pattern of denials against one session or one credential is visible, not silent.
+
+**Correlated chains across systems.** Where one action leads to another — an identity assertion issued, then exchanged for an access token, then used to call a tool — each step's entry carries a reference to the step before it, so the full sequence can be reconstructed from any point in it, not just inferred from timestamps.
+
+**Standalone use.** The audit trail has no dependency on the rest of ClawQL's stack. It can be adopted on its own, in front of any agent framework, by a team that wants tamper-evident logging without adopting anything else ClawQL does.
+
+---
+
+## Summary
+
+| Property                                          | Mechanism                                                                        |
+| ------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Log can't be silently altered                     | Hash chain — every entry references the one before it                            |
+| One entry verifiable without the whole log        | Merkle batch root + short inclusion proof                                        |
+| No entry lost between local write and remote copy | Local write and replication outbox in one operation                              |
+| Restart can't fork the sequence                   | Chain position / outbox loaded from durable storage before accepting new entries |
+| Verifiable without trusting the operator          | Batch roots computed for external anchoring (multi-location publish)             |
+| Works without the rest of ClawQL                  | No dependency on other ClawQL components                                         |

--- a/website/src/app/auth/layout.tsx
+++ b/website/src/app/auth/layout.tsx
@@ -1,0 +1,18 @@
+import { docsPageMetadata } from '@/lib/seo'
+
+export const metadata = docsPageMetadata({
+  title: 'Authentication',
+  description:
+    'ClawQL inbound and outbound auth: proactive OAuth refresh with a mutex, API keys, EMA / ID-JAG (consumer and issuer), signing, and audit.',
+  path: '/auth',
+})
+
+import type { ReactNode } from 'react'
+
+export default function DocsSegmentLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return children
+}

--- a/website/src/app/auth/page.mdx
+++ b/website/src/app/auth/page.mdx
@@ -71,7 +71,7 @@ Where ClawQL acts as both a Resource App Authorization Server and an Enterprise 
 
 ## Audit
 
-Every authentication event — a token issued, a token refused, a refresh that succeeded or failed, a re-authorization requested — is emitted through ClawQL's auth event sink into the append-only audit trail when a host has wired one (for example process WORM via `clawql-audit`). See [Audit tool & observability](/learn/audit-tool-and-observability) and [`clawql-audit`](https://github.com/danielsmithdevelopment/ClawQL/tree/main/packages/clawql-audit) for how that trail is structured and verified.
+Every authentication event — a token issued, a token refused, a refresh that succeeded or failed, a re-authorization requested — is emitted through ClawQL's auth event sink into the append-only audit trail when a host has wired one (for example process WORM via `clawql-audit`). See **[Audit Trail](/audit)** for how that trail is structured and verified.
 
 ---
 

--- a/website/src/app/auth/page.mdx
+++ b/website/src/app/auth/page.mdx
@@ -77,11 +77,11 @@ Every authentication event — a token issued, a token refused, a refresh that s
 
 ## Summary
 
-| Problem | Mechanism |
-| --- | --- |
-| Outbound token expired overnight | Proactive refresh, 60 seconds before expiry |
-| Concurrent sessions invalidating each other's refresh token | Mutex — one refresh per provider, others queue |
-| Per-user OAuth consent screens at enterprise scale | EMA / ID-JAG, consumer role |
-| Third-party identity provider holding session-token custody | EMA / ID-JAG, issuer role — ClawQL as the IdP |
-| Legacy SAML-based internal SSO | Out of scope — handled upstream by the org's IdP before reaching ClawQL |
-| Verifying who did what, when | Every auth event in the audit trail |
+| Problem                                                     | Mechanism                                                               |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Outbound token expired overnight                            | Proactive refresh, 60 seconds before expiry                             |
+| Concurrent sessions invalidating each other's refresh token | Mutex — one refresh per provider, others queue                          |
+| Per-user OAuth consent screens at enterprise scale          | EMA / ID-JAG, consumer role                                             |
+| Third-party identity provider holding session-token custody | EMA / ID-JAG, issuer role — ClawQL as the IdP                           |
+| Legacy SAML-based internal SSO                              | Out of scope — handled upstream by the org's IdP before reaching ClawQL |
+| Verifying who did what, when                                | Every auth event in the audit trail                                     |

--- a/website/src/app/auth/page.mdx
+++ b/website/src/app/auth/page.mdx
@@ -1,0 +1,87 @@
+# Authentication
+
+ClawQL handles two distinct authentication problems. **Inbound** is how clients and human operators authenticate to ClawQL's own MCP gateway. **Outbound** is how ClawQL authenticates to upstream services — Slack, Google, GitHub, and anything else an agent needs to call — on an agent's behalf. Most confusion about MCP auth comes from treating these as one problem. They are handled separately here. {{ className: 'lead' }}
+
+**Package:** [`clawql-auth`](https://github.com/danielsmithdevelopment/ClawQL/tree/main/packages/clawql-auth) · [README](https://github.com/danielsmithdevelopment/ClawQL/blob/main/packages/clawql-auth/README.md) · [token store](https://github.com/danielsmithdevelopment/ClawQL/blob/main/packages/clawql-auth/src/oauth/token-store.ts)
+
+**Agent discovery:** [`/auth.md`](/auth.md) is the machine-readable registration skill. This page is the human mechanism guide.
+
+---
+
+## Outbound: token refresh
+
+The most common MCP auth complaint is a token that worked yesterday and doesn't today. This usually happens for one of two reasons: the token expired before anything tried to refresh it, or multiple concurrent sessions raced to refresh the same token and invalidated each other.
+
+ClawQL's outbound token store addresses both directly.
+
+**Refresh is proactive, not reactive.** A token is refreshed once it comes within 60 seconds of expiry, not after a call fails with a 401. Nothing in a normal session should ever hit an expired token.
+
+**Refresh is mutex-protected.** When several concurrent agent sessions share a credential for the same provider, only one refresh runs at a time. Every other session waiting on that credential queues behind the in-flight refresh instead of calling the provider's token endpoint independently. This matters because most OAuth providers issue single-use refresh tokens — two simultaneous refresh attempts against the same refresh token typically means one succeeds and the other fails with `invalid_grant`, taking a session down for no reason other than timing. ClawQL's token store makes that race structurally impossible rather than relying on retry logic to paper over it.
+
+```
+getValidToken(providerId, sessionId)
+  → token still valid?          → return it
+  → refresh already in flight?  → wait on that refresh, don't start another
+  → otherwise                   → own the refresh, others queue behind it
+```
+
+**Failure is explicit, not silent.** If a refresh token is dead (`invalid_grant`), the credential is marked as requiring re-authorization and the calling session receives a typed error rather than a generic failure. This is a real state change a human needs to act on — a stale credential doesn't quietly keep retrying in the background.
+
+This covers any provider ClawQL calls on an agent's behalf: Google, Microsoft, Slack, GitHub, and others. All of it applies whether ClawQL is calling one provider from one session or many sessions calling many providers concurrently.
+
+---
+
+## Inbound: connecting to ClawQL itself
+
+Inbound authentication is how something connects to ClawQL's MCP gateway — a human operator, a CI pipeline, or a client like Claude Desktop, Cursor, or Cline.
+
+### API keys
+
+The default for programmatic and machine-to-machine access. Issued keys (`cqk_…`) are hashed on storage, validated with a constant-time comparison, and scoped — a key can be limited to specific tools and a specific owner (a single developer, a team, or an organization). Keys are revocable; optional expiry is set at issue time.
+
+### Enterprise-Managed Authorization (EMA)
+
+ClawQL implements the open ID-JAG (Identity Assertion JWT Authorization Grant) extension to OAuth — the same mechanism behind Claude's, VS Code's, and other MCP hosts' Enterprise-Managed Authorization. This is not a proprietary integration; it's an open, IETF-track specification that any identity provider or MCP server can implement.
+
+ClawQL supports both roles independently:
+
+**As a Resource App Authorization Server (consumer role).** An enterprise's identity provider — Okta today, others as they add support — mints an ID-JAG assertion when an employee logs in. ClawQL verifies that assertion against the org's JWKS, maps the employee's IdP groups to a scoped access token, and the employee gets access with no individual OAuth consent screen. This is the standard EMA flow: the org's existing IdP stays the source of truth, ClawQL is the connector accepting its assertions.
+
+**As an Enterprise Identity Provider (issuer role).** ClawQL can also mint ID-JAG assertions itself, for organizations that want zero-touch provisioning without routing session-token custody through a third-party identity SaaS. In this mode, ClawQL is the org's IdP for the purposes of MCP connector access — any EMA-compliant connector, not just ClawQL's own, can accept assertions ClawQL issues.
+
+An organization can run either role alone or both simultaneously, with no third-party identity provider involved in the AI/MCP path at all.
+
+### What EMA does not cover
+
+ID-JAG assumes the underlying enterprise SSO already produced a standard identity assertion by the time it reaches an MCP connector. If an organization's internal SSO is SAML rather than OIDC, that exchange — SAML assertion to OAuth token to ID-JAG — happens entirely on the identity provider's side, before anything reaches ClawQL. ClawQL does not implement a SAML server itself; this is a deliberate scope boundary, not a missing feature.
+
+### Session tokens
+
+Once a client is authenticated by any of the above methods, it holds a short-lived session JWT (MCP OAuth access tokens default to **5 minutes**; refresh tokens default to **1 hour** — both configurable) carrying the scope it's authorized for — which tools it can call, what budget it has, how long the session lasts. This token is what gets checked on every subsequent tool call, not the original credential.
+
+---
+
+## Signing
+
+Production deployments sign tokens with RS256 and publish a JWKS endpoint, so a resource server can verify tokens without holding the signing key. A development-only HS256 fallback exists for local testing and is not intended for production use; ClawQL warns at startup if a production-shaped deployment is running on the development signing path.
+
+Where ClawQL acts as both a Resource App Authorization Server and an Enterprise Identity Provider in the same deployment, each role should use its own signing key. Sharing one key between the two roles is supported for convenience but means a compromise of either role compromises both; ClawQL warns at startup when this configuration is in use.
+
+---
+
+## Audit
+
+Every authentication event — a token issued, a token refused, a refresh that succeeded or failed, a re-authorization requested — is emitted through ClawQL's auth event sink into the append-only audit trail when a host has wired one (for example process WORM via `clawql-audit`). See [Audit tool & observability](/learn/audit-tool-and-observability) and [`clawql-audit`](https://github.com/danielsmithdevelopment/ClawQL/tree/main/packages/clawql-audit) for how that trail is structured and verified.
+
+---
+
+## Summary
+
+| Problem | Mechanism |
+| --- | --- |
+| Outbound token expired overnight | Proactive refresh, 60 seconds before expiry |
+| Concurrent sessions invalidating each other's refresh token | Mutex — one refresh per provider, others queue |
+| Per-user OAuth consent screens at enterprise scale | EMA / ID-JAG, consumer role |
+| Third-party identity provider holding session-token custody | EMA / ID-JAG, issuer role — ClawQL as the IdP |
+| Legacy SAML-based internal SSO | Out of scope — handled upstream by the org's IdP before reaching ClawQL |
+| Verifying who did what, when | Every auth event in the audit trail |

--- a/website/src/app/learn/page.mdx
+++ b/website/src/app/learn/page.mdx
@@ -7,7 +7,7 @@ import { Note } from '@/components/mdx'
 
 <Note>
   Structured modules and hub links: [Reference](/reference) ·
-  [Examples](/examples) · [Security](/security).
+  [Examples](/examples) · [Authentication](/auth) · [Security](/security).
 </Note>
 
 ## Start here

--- a/website/src/app/security/page.mdx
+++ b/website/src/app/security/page.mdx
@@ -2,6 +2,8 @@
 
 This page summarizes how ClawQL **builds**, **proves**, and **enforces** container images from CI through Kubernetes admission. For every detail, use the repo docs linked below. {{ className: 'lead' }}
 
+**Looking for OAuth / MCP authentication?** See **[Authentication](/auth)** — inbound vs outbound, token refresh, EMA / ID-JAG, and how that differs from supply-chain controls on this page.
+
 ## Agentic AI security curriculum (32 modules)
 
 **On this site:** [Security best practices — module series](/security/best-practices) — vendor-neutral guides (supply chain through quarterly review), synced from [`docs/security/security-best-practices-series/`](https://github.com/danielsmithdevelopment/ClawQL/tree/main/docs/security/security-best-practices-series) at build time for static HTML and search.

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -293,6 +293,7 @@ const ENTRIES: Array<Entry> = [
   { path: '/spec-configuration', changeFrequency: 'monthly', priority: 0.85 },
   { path: '/troubleshooting', changeFrequency: 'monthly', priority: 0.9 },
   { path: '/auth', changeFrequency: 'weekly', priority: 0.95 },
+  { path: '/audit', changeFrequency: 'weekly', priority: 0.95 },
   { path: '/security', changeFrequency: 'monthly', priority: 0.9 },
   {
     path: '/security/defense-in-depth',

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -292,6 +292,7 @@ const ENTRIES: Array<Entry> = [
   { path: '/ouroboros/build-plan', changeFrequency: 'monthly', priority: 0.55 },
   { path: '/spec-configuration', changeFrequency: 'monthly', priority: 0.85 },
   { path: '/troubleshooting', changeFrequency: 'monthly', priority: 0.9 },
+  { path: '/auth', changeFrequency: 'weekly', priority: 0.95 },
   { path: '/security', changeFrequency: 'monthly', priority: 0.9 },
   {
     path: '/security/defense-in-depth',

--- a/website/src/lib/auth-md-content.ts
+++ b/website/src/lib/auth-md-content.ts
@@ -108,6 +108,7 @@ Revoke tokens at the \`revocation_endpoint\` from authorization server metadata 
 
 ## Related docs
 
+- [Authentication (human guide)](${origin}/auth) — inbound vs outbound OAuth, EMA / ID-JAG
 - [Agent setup](${origin}/agent-setup)
 - [MCP tools](${origin}/tools)
 - [Spec configuration](${origin}/spec-configuration)

--- a/website/src/lib/docs-hub-data.ts
+++ b/website/src/lib/docs-hub-data.ts
@@ -430,6 +430,13 @@ export const resourcesHubCards: Array<ReferenceCard> = [
     icon: ShapesIcon,
   }),
   card({
+    href: '/audit',
+    name: 'Audit Trail',
+    description:
+      'Append-only WORM trail — hash chain, Merkle roots, dual-ack replication.',
+    icon: ListIcon,
+  }),
+  card({
     href: '/troubleshooting',
     name: 'Troubleshooting',
     description: 'Common MCP, spec, auth, and deploy failure modes.',

--- a/website/src/lib/docs-hub-data.ts
+++ b/website/src/lib/docs-hub-data.ts
@@ -423,6 +423,13 @@ export const resourcesHubCards: Array<ReferenceCard> = [
     icon: TagIcon,
   }),
   card({
+    href: '/auth',
+    name: 'Authentication',
+    description:
+      'Inbound vs outbound MCP auth — token refresh, EMA / ID-JAG, signing.',
+    icon: ShapesIcon,
+  }),
+  card({
     href: '/troubleshooting',
     name: 'Troubleshooting',
     description: 'Common MCP, spec, auth, and deploy failure modes.',

--- a/website/src/lib/docs-nav-data.ts
+++ b/website/src/lib/docs-nav-data.ts
@@ -155,6 +155,7 @@ export const docsNavigation: Array<NavGroup> = [
     links: [
       { title: 'Reference', href: '/reference' },
       { title: 'MCP tools', href: '/tools' },
+      { title: 'Authentication', href: '/auth' },
       { title: 'mcp-api-adapter', href: '/mcp/mcp-api-adapter' },
       {
         title: '/mcp-ui',

--- a/website/src/lib/docs-nav-data.ts
+++ b/website/src/lib/docs-nav-data.ts
@@ -156,6 +156,7 @@ export const docsNavigation: Array<NavGroup> = [
       { title: 'Reference', href: '/reference' },
       { title: 'MCP tools', href: '/tools' },
       { title: 'Authentication', href: '/auth' },
+      { title: 'Audit Trail', href: '/audit' },
       { title: 'mcp-api-adapter', href: '/mcp/mcp-api-adapter' },
       {
         title: '/mcp-ui',

--- a/website/src/lib/docs-site-card-data.ts
+++ b/website/src/lib/docs-site-card-data.ts
@@ -288,6 +288,20 @@ export const learnRelatedGuideSiteCards: Array<ReferenceCard> = [
     },
   },
   {
+    href: '/audit',
+    name: 'Audit Trail',
+    description:
+      'Append-only WORM trail — hash chain, Merkle batch roots, dual-ack replication.',
+    icon: ListIcon,
+    pattern: {
+      y: 16,
+      squares: [
+        [0, 0],
+        [1, 2],
+      ],
+    },
+  },
+  {
     href: '/security',
     name: 'Security',
     description:
@@ -456,6 +470,20 @@ export const referenceSiteCards: Array<ReferenceCard> = [
       squares: [
         [1, 0],
         [0, 2],
+      ],
+    },
+  },
+  {
+    href: '/audit',
+    name: 'Audit Trail',
+    description:
+      'Append-only WORM trail — hash chain, Merkle batch roots, dual-ack replication.',
+    icon: ListIcon,
+    pattern: {
+      y: 14,
+      squares: [
+        [0, 1],
+        [2, 0],
       ],
     },
   },

--- a/website/src/lib/docs-site-card-data.ts
+++ b/website/src/lib/docs-site-card-data.ts
@@ -274,6 +274,20 @@ export const learnRelatedGuideSiteCards: Array<ReferenceCard> = [
     },
   },
   {
+    href: '/auth',
+    name: 'Authentication',
+    description:
+      'Inbound vs outbound MCP auth — proactive OAuth refresh, API keys, EMA / ID-JAG.',
+    icon: ShapesIcon,
+    pattern: {
+      y: 12,
+      squares: [
+        [0, 1],
+        [1, 0],
+      ],
+    },
+  },
+  {
     href: '/security',
     name: 'Security',
     description:
@@ -429,6 +443,20 @@ export const referenceSiteCards: Array<ReferenceCard> = [
     pattern: {
       y: 22,
       squares: [[0, 1]],
+    },
+  },
+  {
+    href: '/auth',
+    name: 'Authentication',
+    description:
+      'Inbound vs outbound MCP auth — proactive OAuth refresh, API keys, EMA / ID-JAG.',
+    icon: ShapesIcon,
+    pattern: {
+      y: 6,
+      squares: [
+        [1, 0],
+        [0, 2],
+      ],
     },
   },
   {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Dedicated public mechanism pages for the two claims people need to verify:

| Path | Page | Link for |
| --- | --- | --- |
| [`/auth`](https://docs.clawql.com/auth) | **Authentication** | “MCP re-auth every morning” / outbound refresh + inbound EMA |
| [`/audit`](https://docs.clawql.com/audit) | **Audit Trail** | tamper-evident WORM — hash chain, Merkle roots, dual-ack |

### Wiring
- Sidebar **Reference → Authentication** and **Audit Trail**
- Sitemap, `llms.txt`, hub cards, package READMEs
- `/auth` Audit section points at `/audit`

### Accuracy softens (match shipped code)
- Auth: access JWT default **5 min**; no key-rotation grace / per-key rate limits; auth event sink best-effort
- Audit: dual-ack = local + outbox in one op (remote eventual); multi-chain publish is operator handoff on computed roots

## Preview

### Authentication
[Authentication page hero](https://cursor.com/agents/bc-01a03570-ad58-76e5-b7ec-872aeb2410f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth_page_hero.webp)

### Audit Trail
[Audit Trail page hero](https://cursor.com/agents/bc-01a03570-ad58-76e5-b7ec-872aeb2410f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faudit_page_hero.png)
[Hash chain and Merkle integrity](https://cursor.com/agents/bc-01a03570-ad58-76e5-b7ec-872aeb2410f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faudit_integrity_guaranteed.png)
[Audit summary table](https://cursor.com/agents/bc-01a03570-ad58-76e5-b7ec-872aeb2410f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faudit_summary_table.png)

## Test plan
- [x] `website` build includes `○ /auth` and `○ /audit`
- [x] Prettier on changed files
- [x] Manual render of `/auth` and `/audit`
- [ ] CI green → merge


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03570-ad58-76e5-b7ec-872aeb2410f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03570-ad58-76e5-b7ec-872aeb2410f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

