### PR TITLE
Record iPhone Safari HEIC verification for PixelDrop demo

### DIFF
--- a/examples/mcp-api-adapter/pixeldrop/README.md
+++ b/examples/mcp-api-adapter/pixeldrop/README.md
@@ -78,6 +78,8 @@ The harness **bypasses WebMCP discovery** and calls `uploadToBackend()` in the i
 
 Do not use "we fixed iPhone HEIC" in public framing until [`VERIFICATION.md`](VERIFICATION.md) Priority 1 passes.
 
+**Update (2026-08-28):** Priority 1 passed — real iPhone Safari test with `IMG_6432.HEIC` on clawql.com. HEIC headline is now fair game; WebMCP CDP (Priority 2) still open.
+
 ## Before flagship demo (Act 2/3)
 
 1. **iPhone Safari + camera-roll HEIC** (~5 min, any iPhone) — determines whether the tweet's pain point is actually solved

--- a/examples/mcp-api-adapter/pixeldrop/README.md
+++ b/examples/mcp-api-adapter/pixeldrop/README.md
@@ -2,22 +2,20 @@
 
 Side-by-side demo of a **deliberately broken** photo upload UI vs a **/mcp-ui smart-upload template** that fixes it client-side, then calls the **same backend** via WebMCP.
 
-Inspired by the OpenRouter/HEIC upload failure class (Wes Bos tweet, Aug 2026). The demo concept targets HEIC + resize + drag — but **only resize is verified today**. See [`VERIFICATION.md`](VERIFICATION.md) for the full proven/unproven matrix.
+Inspired by the OpenRouter/HEIC upload failure class (Wes Bos tweet, Aug 2026). **HEIC + resize verified on real iPhone** (Safari and iOS Chrome, 2026-08-28). See [`VERIFICATION.md`](VERIFICATION.md).
 
 ## What is verified vs unproven
 
 | Claim | Status |
 | --- | --- |
-| Large image resize/compress before upload (desktop) | **Verified** — 18MB PNG 8000×6000 → 2048×1536, uploaded via same `uploadToBackend()` |
+| HEIC from iPhone camera roll (Safari + iOS Chrome) | **Verified** — `IMG_6432.HEIC` → `up_7vjocs3`, native decode, no polyfill |
+| Large image resize/compress (desktop + iPhone) | **Verified** — 18MB PNG; 3.7MB JPEG on iPhone |
 | Same backend path as broken frontend (`up_…` IDs) | **Verified** |
-| HEIC from iPhone camera roll in Safari | **Unproven** — `createImageBitmap` never tested on real device |
-| WebMCP discovery → execute (bolt-on path) | **Unproven** — harness bypasses WebMCP; use `webmcp-cdp-smoke.mjs` when Chrome preview available |
+| WebMCP discovery → execute (bolt-on path) | **Open** — Priority 2; desktop Chrome preview only |
 
-**Safe public lead:** resize/compression wrapper calling the site's own backend without code changes.
+**Safe public lead:** "We fixed the iPhone HEIC upload problem — tested on Safari and iOS Chrome with real camera-roll files, client-side conversion, same backend."
 
-**Do not claim yet:** "We fixed the iPhone HEIC problem" or "WebMCP bolt-on works end-to-end."
-
-**Interim HEIC framing:** "Expected to work on Safari where HEIC decodes natively — pending device verification."
+**Do not claim yet:** "WebMCP bolt-on works end-to-end" until Priority 2 passes.
 
 ## Files
 
@@ -44,7 +42,7 @@ Open: [http://127.0.0.1:8765/smart-upload-test-harness.html](http://127.0.0.1:87
 
 1. **Large JPEG/PNG (>2MB)** — left rejects size; right resizes/compresses under 2MB. **(Verified on desktop.)**
 2. **Drag-and-drop (desktop)** — left ignores drops; right handles drop on the smart-upload pane.
-3. **HEIC from iPhone** — left rejects with "Unsupported binary file"; right *may* convert to JPEG and upload **if** the browser decodes HEIC. **Not verified — see [`VERIFICATION.md`](VERIFICATION.md) Priority 1.**
+3. **HEIC from iPhone** — left rejects with "Unsupported binary file"; right converts to JPEG and uploads. **Verified on Safari and iOS Chrome (2026-08-28).**
 
 Both sides should show the **same upload ID format** (`up_…`) and timestamp when the smart side succeeds — proof it's the identical `uploadToBackend()` call path.
 
@@ -72,20 +70,17 @@ The harness **bypasses WebMCP discovery** and calls `uploadToBackend()` in the i
 
 | Fix | Desktop | Mobile |
 | --- | --- | --- |
-| Resize / canvas / JPEG encode | **Verified** (18MB PNG test) | Expected to work (standard Web APIs) |
+| Resize / canvas / JPEG encode | **Verified** (desktop + iPhone Safari) | **Verified** — 3.7MB JPEG + HEIC on clawql.com |
 | Drag-and-drop anywhere | Works in template scope | **N/A** — no drag gesture; use file picker |
-| HEIC conversion (`createImageBitmap`) | Untested even on desktop | **Unproven** — tweet's core pain point; needs real iPhone Safari test |
+| HEIC conversion (`createImageBitmap`) | Untested on desktop Chrome | **Verified** — Safari + iOS Chrome, same device, `IMG_6432.HEIC` (2026-08-28) |
 
-Do not use "we fixed iPhone HEIC" in public framing until [`VERIFICATION.md`](VERIFICATION.md) Priority 1 passes.
-
-**Update (2026-08-28):** Priority 1 passed — real iPhone Safari test with `IMG_6432.HEIC` on clawql.com. HEIC headline is now fair game; WebMCP CDP (Priority 2) still open.
+**iPhone HEIC claim is verified on both mobile browsers.** WebMCP CDP (Priority 2) is the only open item — see [`VERIFICATION.md`](VERIFICATION.md).
 
 ## Before flagship demo (Act 2/3)
 
-1. **iPhone Safari + camera-roll HEIC** (~5 min, any iPhone) — determines whether the tweet's pain point is actually solved
-2. **WebMCP CDP smoke** — `node webmcp-cdp-smoke.mjs` with Chrome preview; exercises discovery → execute, not the harness bypass
-
-Neither blocks merging this folder as an example artifact on `main`.
+1. ~~**iPhone Safari + camera-roll HEIC**~~ — **Done** (Safari + iOS Chrome, 2026-08-28)
+2. **WebMCP CDP smoke** — `node webmcp-cdp-smoke.mjs` with Chrome preview
+3. **Optional:** ~30s iPhone screen recording of HEIC rejection-then-fix for public demo clip (recommended in VERIFICATION.md)
 
 ## Deliberate JS exception
 

--- a/examples/mcp-api-adapter/pixeldrop/VERIFICATION.md
+++ b/examples/mcp-api-adapter/pixeldrop/VERIFICATION.md
@@ -2,21 +2,33 @@
 
 Use this file to decide **what you can claim publicly** vs what still needs a real test.
 
-## Verified
+## Mobile claim — current honest state (2026-08-28)
+
+| Environment | HEIC decode | Resize oversized JPEG | Result |
+| --- | --- | --- | --- |
+| **iPhone Safari** | Native, no polyfill | Verified | `IMG_6432.HEIC` → `up_7vjocs3`; `IMG_6370.jpeg` 3.7MB → `up_p4yvp4nc` |
+| **iOS Chrome** | Native, no polyfill | Verified (same session) | Same device, same `IMG_6432.HEIC`, same clean pass as Safari |
+| **Desktop** | Not tested with real `.heic` | Verified | 18MB PNG 8000×6000 → resize/compress → `up_4yuzrboy` |
+| **WebMCP CDP discovery→execute** | — | — | **Still open** (Priority 2; desktop Chrome preview only) |
+
+**Plain statement:** iOS Chrome using WebKit under the hood was a reasonable inference until tested on the same device with the same camera-roll HEIC. It is now a **tested fact** — same file type, same outcome, no polyfill, both browsers anyone actually uses on iPhone.
+
+The claim **"we fixed the iPhone HEIC problem"** is solid on iPhone Safari and iOS Chrome, with real camera-roll files. No caveats needed on that specific point.
+
+---
+
+## Verified (detail)
 
 | Claim | Evidence | Date |
 | --- | --- | --- |
-| Broken demo rejects files >2MB | 18MB PNG → left pane error: "File too large (17.9MB)…" (desktop) | 2026-08-28 |
-| Smart template resizes oversized images | 8000×6000 → 2048×1536 (desktop); 5712×4284 → 2048×1536 (iPhone Safari) | 2026-08-28 |
-| Smart template compresses under 2MB backend limit | Processed output enabled submit + upload | 2026-08-28 |
+| Broken demo rejects HEIC | `IMG_6432.HEIC` → left: `Unsupported binary file: "image/heic"` | 2026-08-28 |
+| Smart template converts HEIC → JPEG (Safari) | Same file → `Converted from image/heic to JPEG · Resized from 2316×3088 to 1536×2048` → `up_7vjocs3` | 2026-08-28 |
+| Smart template converts HEIC → JPEG (iOS Chrome) | Same device, same `IMG_6432.HEIC`, same pass (second browser, same session) | 2026-08-28 |
+| Broken demo rejects files >2MB | 18MB PNG (desktop); `IMG_6370.jpeg` 3.7MB (iPhone Safari) | 2026-08-28 |
+| Smart template resizes oversized images | 8000×6000 → 2048×1536 (desktop); 5712×4284 → 2048×1536 (iPhone) | 2026-08-28 |
 | Same backend path as broken frontend | Upload IDs `up_4yuzrboy`, `up_p4yvp4nc`, `up_7vjocs3` via `uploadToBackend()` | 2026-08-28 |
-| Harness loads; template injects correctly | `smoke-test.mjs` + browser inspection | 2026-08-28 |
-| **HEIC from iPhone camera roll in Safari** | `IMG_6432.HEIC` → left: "Unsupported binary file: image/heic"; right: "Converted from image/heic to JPEG · Resized from 2316×3088 to 1536×2048" → `up_7vjocs3` on clawql.com harness | 2026-08-28 |
-| **Large JPEG on iPhone Safari** | `IMG_6370.jpeg` 3.7MB → left rejects 2MB limit; right resizes and uploads `up_p4yvp4nc` | 2026-08-28 |
 
-**Safe public lead:** "We wrapped a broken upload with a /mcp-ui template that converts HEIC, resizes oversized photos, and calls the site's own backend — tested on real iPhone Safari, no changes to their code."
-
-**Also safe:** "Same HEIC the broken UI rejects (`image/heic`) uploads successfully after client-side conversion to JPEG."
+**Safe public lead:** "We wrapped a broken upload with a /mcp-ui template that converts HEIC and resizes oversized photos client-side, then calls the site's own backend — tested on real iPhone Safari and iOS Chrome with camera-roll HEIC, no code changes on their side, no polyfill."
 
 ## Still unverified
 
@@ -24,46 +36,61 @@ Use this file to decide **what you can claim publicly** vs what still needs a re
 | --- | --- | --- |
 | **WebMCP discovery → execute path** | Harness bypasses WebMCP; calls `uploadToBackend()` directly | **Yes** — bolt-on pitch depends on this mechanism |
 | Drag-and-drop on mobile | N/A by platform (no drag gesture) | No — desktop-only feature |
-| HEIC on desktop Chrome | Browser-dependent; not tested with real `.heic` on desktop | No — iPhone story is the primary claim |
+| HEIC on desktop Chrome | Not tested with real `.heic` on desktop | No — iPhone story is the primary claim |
 
 **Do not claim yet:** "WebMCP bolt-on works end-to-end" until Priority 2 below passes.
 
 ---
 
-## Priority 1: iPhone Safari HEIC test — **PASSED**
+## Priority 1: iPhone mobile HEIC + resize — **PASSED**
 
-**Result (2026-08-28):** Real device test on clawql.com harness in iPhone Safari.
+### Safari (screenshot evidence)
+
+**URL:** https://clawql.com/mcp-ui/pixeldrop/smart-upload-test-harness.html  
+**Date:** 2026-08-28
 
 | Pane | File | Outcome |
 | --- | --- | --- |
 | Left (broken) | `IMG_6432.HEIC` | `Unsupported binary file: "image/heic"` |
-| Right (smart-upload) | same HEIC | `Converted from image/heic to JPEG · Resized from 2316×3088 to 1536×2048` → Upload ID `up_7vjocs3` |
+| Right (smart-upload) | same HEIC | `Converted from image/heic to JPEG · Resized from 2316×3088 to 1536×2048` → `up_7vjocs3` |
 
-**Also verified same session:** `IMG_6370.jpeg` (3.7MB) — left rejects size; right resizes 5712×4284 → 2048×1536 → `up_p4yvp4nc`.
+**Also same session (Safari):** `IMG_6370.jpeg` (3.7MB) — left rejects 2MB limit; right resizes 5712×4284 → 2048×1536 → `up_p4yvp4nc`.
 
-No heic2any polyfill required on iPhone Safari — native `createImageBitmap` decoded the camera-roll HEIC.
+### iOS Chrome (same device, same session)
+
+**Date:** 2026-08-28 — immediately after Safari pass, same iPhone, same `IMG_6432.HEIC`.
+
+| Browser | File | Outcome |
+| --- | --- | --- |
+| iOS Chrome | `IMG_6432.HEIC` | Same clean pass as Safari — native decode, conversion to JPEG, successful upload |
+
+No `heic2any` polyfill required on either iPhone browser.
+
+---
+
+## Demo video — public vs private
+
+| Artifact | Contents | Recommendation |
+| --- | --- | --- |
+| Desktop recording (`pixeldrop_smart_upload_demo.mp4`) | 18MB PNG resize; left reject / right fix | **Public** — good for resize/compress story on desktop |
+| iPhone screenshots (Safari HEIC + JPEG) | Rejection-then-fix moments | **Public** — embed in README / landing page today |
+| **iPhone ~30s screen recording (HEIC)** | Live rejection on left, conversion note + upload on right | **Strongly recommend public** — stronger than a table for this visual demo; record on device (Settings → Control Center → Screen Recording), same harness URL, same `IMG_6432.HEIC` flow |
+
+**Decision:** Use the iPhone screen recording as **primary public demo material** for the HEIC story (blog, landing page, social clip). Keep screenshots in `VERIFICATION.md` as dated audit trail. Desktop video remains supplementary for the resize path.
+
+**To add:** Drop `pixeldrop-iphone-heic-demo.mp4` (or similar) under `landing-page/demo/public/mcp-ui/pixeldrop/` and link from README when recorded.
 
 ---
 
 ## Priority 2: WebMCP CDP test (Chrome preview) — **OPEN**
 
-**Goal:** Exercise the real discovery → execute path that production `clawql sources add --kind webmcp` uses — not the harness iframe bypass.
+**Goal:** Exercise the real discovery → execute path that production `clawql sources add --kind webmcp` uses — not the harness iframe bypass. Unrelated to mobile; isolated remaining task.
 
 **Prerequisites**
 
-- Chrome **preview** (or build) with WebMCP enabled and `document.modelContext` available
-- CDP endpoint, e.g. `http://127.0.0.1:9222`
-- Demo served over HTTP:  
-  `cd examples/mcp-api-adapter/pixeldrop && python3 -m http.server 8765`
-
-**Option A — ClawQL source registration (full stack)**
-
-```bash
-clawql sources add http://127.0.0.1:8765/pixeldrop-broken-demo.html \
-  --kind webmcp --name pixeldrop --webmcp-cdp-url http://127.0.0.1:9222
-```
-
-**Option B — CDP smoke script**
+- Chrome **preview** with WebMCP + `document.modelContext`
+- CDP on `http://127.0.0.1:9222`
+- Demo served: `cd examples/mcp-api-adapter/pixeldrop && python3 -m http.server 8765`
 
 ```bash
 node examples/mcp-api-adapter/pixeldrop/webmcp-cdp-smoke.mjs \
@@ -80,5 +107,6 @@ node examples/mcp-api-adapter/pixeldrop/webmcp-cdp-smoke.mjs \
 | Milestone | Status |
 | --- | --- |
 | Merge to `main` as example artifact | **Done** (PR #997) |
-| **"Fixed iPhone HEIC" headline** | **Done** — Priority 1 passed on real iPhone Safari |
+| **"Fixed iPhone HEIC" headline** | **Done** — Safari + iOS Chrome, real camera-roll HEIC |
+| Public demo video (HEIC moment) | **Recommended** — record ~30s iPhone screen capture; not blocking the claim |
 | Flagship demo (full WebMCP bolt-on story) | **Blocked** on Priority 2 only |

--- a/examples/mcp-api-adapter/pixeldrop/VERIFICATION.md
+++ b/examples/mcp-api-adapter/pixeldrop/VERIFICATION.md
@@ -2,86 +2,68 @@
 
 Use this file to decide **what you can claim publicly** vs what still needs a real test.
 
-## Verified (desktop, this thread)
+## Verified
 
 | Claim | Evidence | Date |
 | --- | --- | --- |
-| Broken demo rejects files >2MB | 18MB PNG → left pane error: "File too large (17.9MB)…" | 2026-08-28 |
-| Smart template resizes oversized images | 8000×6000 → 2048×1536 conversion note | 2026-08-28 |
+| Broken demo rejects files >2MB | 18MB PNG → left pane error: "File too large (17.9MB)…" (desktop) | 2026-08-28 |
+| Smart template resizes oversized images | 8000×6000 → 2048×1536 (desktop); 5712×4284 → 2048×1536 (iPhone Safari) | 2026-08-28 |
 | Smart template compresses under 2MB backend limit | Processed output enabled submit + upload | 2026-08-28 |
-| Same backend path as broken frontend | Upload ID `up_4yuzrboy` via `uploadToBackend()` in iframe | 2026-08-28 |
+| Same backend path as broken frontend | Upload IDs `up_4yuzrboy`, `up_p4yvp4nc`, `up_7vjocs3` via `uploadToBackend()` | 2026-08-28 |
 | Harness loads; template injects correctly | `smoke-test.mjs` + browser inspection | 2026-08-28 |
+| **HEIC from iPhone camera roll in Safari** | `IMG_6432.HEIC` → left: "Unsupported binary file: image/heic"; right: "Converted from image/heic to JPEG · Resized from 2316×3088 to 1536×2048" → `up_7vjocs3` on clawql.com harness | 2026-08-28 |
+| **Large JPEG on iPhone Safari** | `IMG_6370.jpeg` 3.7MB → left rejects 2MB limit; right resizes and uploads `up_p4yvp4nc` | 2026-08-28 |
 
-**Safe public lead:** "We wrapped a broken upload with a /mcp-ui template that resizes and compresses large images client-side, then calls the site's own backend capability — without changing their code."
+**Safe public lead:** "We wrapped a broken upload with a /mcp-ui template that converts HEIC, resizes oversized photos, and calls the site's own backend — tested on real iPhone Safari, no changes to their code."
 
-## Unverified — do not imply these are proven
+**Also safe:** "Same HEIC the broken UI rejects (`image/heic`) uploads successfully after client-side conversion to JPEG."
+
+## Still unverified
 
 | Claim | Why unproven | Blocks flagship demo? |
 | --- | --- | --- |
-| **HEIC from iPhone camera roll decodes in Safari** | `createImageBitmap` on real `.heic` never tested on physical iPhone | **Yes** — this is the tweet's exact pain point |
 | **WebMCP discovery → execute path** | Harness bypasses WebMCP; calls `uploadToBackend()` directly | **Yes** — bolt-on pitch depends on this mechanism |
 | Drag-and-drop on mobile | N/A by platform (no drag gesture) | No — desktop-only feature |
-| HEIC on desktop Chrome | Browser-dependent; no real HEIC file tested here | Partial — secondary to iPhone story |
+| HEIC on desktop Chrome | Browser-dependent; not tested with real `.heic` on desktop | No — iPhone story is the primary claim |
 
-**Unsafe framing:** "We fixed the iPhone HEIC problem" or "WebMCP bolt-on works end-to-end" until the two tests below pass.
-
-**Acceptable interim framing:** "Resize/compression verified on desktop; HEIC expected to work on Safari where `createImageBitmap` decodes HEIC — **pending device verification**."
+**Do not claim yet:** "WebMCP bolt-on works end-to-end" until Priority 2 below passes.
 
 ---
 
-## Priority 1: iPhone Safari HEIC test (~5 minutes)
+## Priority 1: iPhone Safari HEIC test — **PASSED**
 
-**Goal:** Confirm `createImageBitmap` decodes a real camera-roll HEIC and the smart template uploads successfully.
+**Result (2026-08-28):** Real device test on clawql.com harness in iPhone Safari.
 
-**Prerequisites**
+| Pane | File | Outcome |
+| --- | --- | --- |
+| Left (broken) | `IMG_6432.HEIC` | `Unsupported binary file: "image/heic"` |
+| Right (smart-upload) | same HEIC | `Converted from image/heic to JPEG · Resized from 2316×3088 to 1536×2048` → Upload ID `up_7vjocs3` |
 
-- iPhone with at least one HEIC photo in Photos (default on modern iPhones)
-- Mac or LAN access to serve the demo (or deploy to HTTPS host)
-- Same Wi‑Fi if using local IP (Safari requires secure context for some APIs; `http://127.0.0.1` works on-device only when served on the phone itself — use `python3 -m http.server 8765 --bind 0.0.0.0` and open `http://<your-lan-ip>:8765/smart-upload-test-harness.html`, or use ngrok/cloudflare tunnel for HTTPS)
+**Also verified same session:** `IMG_6370.jpeg` (3.7MB) — left rejects size; right resizes 5712×4284 → 2048×1536 → `up_p4yvp4nc`.
 
-**Steps**
-
-1. Serve the demo folder over HTTP(S) reachable from the iPhone.
-2. Open `smart-upload-test-harness.html` in **Safari** on the iPhone.
-3. On the **left (broken)** pane: select a camera-roll HEIC.  
-   **Expected:** "Unsupported binary file" (or similar) — confirms the bug reproduces.
-4. On the **right (smart-upload)** pane: select the **same** HEIC via "Or click to choose a file".  
-   **Expected (pass):** preview appears, conversion note mentions JPEG, Upload enables, success with `up_…` ID.  
-   **Expected (fail):** "Could not read … as an image" — HEIC decode not available; need polyfill (e.g. heic2any).
-5. Record: iOS version, Safari version, filename, conversion note text, upload ID or error message.
-6. Update the **Verified** table in this file with results.
-
-**Pass criteria:** Right pane uploads a real camera-roll HEIC that left pane rejects.
+No heic2any polyfill required on iPhone Safari — native `createImageBitmap` decoded the camera-roll HEIC.
 
 ---
 
-## Priority 2: WebMCP CDP test (Chrome preview)
+## Priority 2: WebMCP CDP test (Chrome preview) — **OPEN**
 
 **Goal:** Exercise the real discovery → execute path that production `clawql sources add --kind webmcp` uses — not the harness iframe bypass.
 
 **Prerequisites**
 
 - Chrome **preview** (or build) with WebMCP enabled and `document.modelContext` available
-- CDP endpoint, e.g. `http://127.0.0.1:9222`  
-  Launch example:  
-  `google-chrome --remote-debugging-port=9222 --enable-features=...` (see current WebMCP preview docs)
+- CDP endpoint, e.g. `http://127.0.0.1:9222`
 - Demo served over HTTP:  
   `cd examples/mcp-api-adapter/pixeldrop && python3 -m http.server 8765`
 
 **Option A — ClawQL source registration (full stack)**
 
 ```bash
-# Terminal 1: serve PixelDrop
-cd examples/mcp-api-adapter/pixeldrop && python3 -m http.server 8765
-
-# Terminal 2: register WebMCP source (from repo root, ClawQL built)
 clawql sources add http://127.0.0.1:8765/pixeldrop-broken-demo.html \
   --kind webmcp --name pixeldrop --webmcp-cdp-url http://127.0.0.1:9222
-
-# Discover and execute upload_photo via ClawQL search/execute or /mcp-ui catalog
 ```
 
-**Option B — CDP smoke script (this folder)**
+**Option B — CDP smoke script**
 
 ```bash
 node examples/mcp-api-adapter/pixeldrop/webmcp-cdp-smoke.mjs \
@@ -89,20 +71,14 @@ node examples/mcp-api-adapter/pixeldrop/webmcp-cdp-smoke.mjs \
   --cdp-url http://127.0.0.1:9222
 ```
 
-**Pass criteria**
-
-1. `upload_photo` discovered via `document.modelContext.getTools()`
-2. Execute with a small base64 JPEG returns `{ uploadId, timestamp }`
-3. Gallery on the page updates (same as broken frontend success path)
-
-**On failure:** Script prints CDP/WebMCP availability errors; do not claim bolt-on works until green.
+**Pass criteria:** `upload_photo` discovered + execute returns `{ uploadId, timestamp }`.
 
 ---
 
-## Merge vs demo-ready
+## Demo-ready status
 
-| Milestone | Requirement |
+| Milestone | Status |
 | --- | --- |
-| **Merge to `main` as example artifact** | Desktop resize test + harness — **done** (PR #997) |
-| **Flagship "we fixed your upload" demo (Act 2/3)** | Priority 1 **and** Priority 2 above |
-| **"Fixed iPhone HEIC" headline** | Priority 1 pass only |
+| Merge to `main` as example artifact | **Done** (PR #997) |
+| **"Fixed iPhone HEIC" headline** | **Done** — Priority 1 passed on real iPhone Safari |
+| Flagship demo (full WebMCP bolt-on story) | **Blocked** on Priority 2 only |

--- a/examples/mcp-api-adapter/pixeldrop/VERIFICATION.md
+++ b/examples/mcp-api-adapter/pixeldrop/VERIFICATION.md
@@ -82,17 +82,31 @@ No `heic2any` polyfill required on either iPhone browser.
 
 ---
 
-## Priority 2: WebMCP CDP test (Chrome preview) — **OPEN**
+## Priority 2: WebMCP CDP / judge-environment test — **OPEN** (API surface fixed; runtime gate pending)
 
-**Goal:** Exercise the real discovery → execute path that production `clawql sources add --kind webmcp` uses — not the harness iframe bypass. Unrelated to mobile; isolated remaining task.
+**Goal:** Exercise real discovery → execute on Chrome 149+ (or ChatGPT desktop browser) — not the harness iframe bypass.
 
-**Prerequisites**
+### API surface (fixed 2026-08-28, before runtime gate)
 
-- Chrome **preview** with WebMCP + `document.modelContext`
-- CDP on `http://127.0.0.1:9222`
-- Demo served: `cd examples/mcp-api-adapter/pixeldrop && python3 -m http.server 8765`
+| Item | Status |
+| --- | --- |
+| Register via `document.modelContext ?? navigator.modelContext` | **Fixed** in PixelDrop + landing `WebMcpRegister` |
+| `execute` returns `JSON.stringify(...)` (DOMString) | **Fixed** — Chrome Imperative API returns string from `executeTool` |
+| CDP `executeTool(tool, jsonString)` | **Fixed** in `webmcp-browser.ts` |
+| Runtime verify on Chrome 149+ | **Blocked in cloud VM** — environment has Chrome **148.0.7778.96**; WebMCP flag/OT needs **149+** |
+
+### Console probe (run on your Mac — the actual gate)
+
+1. Chrome **149+** → `chrome://flags/#enable-webmcp-testing` → Enabled → **relaunch**
+2. Open https://clawql.com/mcp-ui/pixeldrop/pixeldrop-broken-demo.html (hard-refresh after deploy)
+3. Paste contents of `webmcp-console-probe.js` into DevTools console
+
+**Pass:** `documentMC: true`, `tools` includes `upload_photo`, `executeParsed.uploadId` like `up_…`, `galleryGrew: true`, `executeRawType: "string"`.
+
+**Fail modes to fear:** tools empty with no error (dead registration path); execute throws; result is object ChatGPT cannot parse as text.
 
 ```bash
+# Optional local serve + CDP (still needs Chrome 149+ with flag + CDP port)
 node examples/mcp-api-adapter/pixeldrop/webmcp-cdp-smoke.mjs \
   --page-url http://127.0.0.1:8765/pixeldrop-broken-demo.html \
   --cdp-url http://127.0.0.1:9222

--- a/examples/mcp-api-adapter/pixeldrop/pixeldrop-broken-demo.html
+++ b/examples/mcp-api-adapter/pixeldrop/pixeldrop-broken-demo.html
@@ -186,13 +186,14 @@
     // this tool directly bypasses BUG 3 and BUG 4 entirely, because those
     // bugs live in handleFileSelect(), not in uploadToBackend() itself.
     //
-    // NOTE: navigator.modelContext is the current (early 2026) WebMCP
-    // API surface. Per ongoing spec discussion this entry point may
-    // migrate to document.modelContext — check current spec status
-    // before wiring a production integration against this.
+    // WebMCP — Chrome 149+ / ChatGPT browser expect document.modelContext.
+    // navigator.modelContext is a deprecated alias (Chrome 150+); prefer document
+    // first so a dead navigator stub cannot swallow registration silently.
+    // execute must return a DOMString (Chrome Imperative API); agents/ChatGPT
+    // parse text — JSON.stringify keeps structured fields readable.
     // ---------------------------------------------------------------------
 
-    const modelContext = navigator.modelContext ?? document.modelContext
+    const modelContext = document.modelContext ?? navigator.modelContext
     if (modelContext?.registerTool) {
       modelContext.registerTool({
         name: 'upload_photo',
@@ -226,19 +227,20 @@
           // like a normal one would — proving it's the same code path.
           addToGallery(`data:image/jpeg;base64,${file}`)
           logUpload(result, 'webmcp')
-          return {
+          return JSON.stringify({
             uploadId: result.uploadId,
             timestamp: result.timestamp,
             caption: caption ?? null,
-          }
+          })
         },
       })
-      console.log('[PixelDrop] WebMCP tool "upload_photo" registered.')
+      console.log('[PixelDrop] WebMCP tool "upload_photo" registered via',
+        document.modelContext ? 'document.modelContext' : 'navigator.modelContext')
     } else {
       console.warn(
         '[PixelDrop] modelContext not available in this browser. ' +
-        'WebMCP tool was not registered. Requires a browser with the ' +
-        'WebMCP preview enabled (e.g. Chrome behind a flag as of early 2026).'
+        'WebMCP tool was not registered. Requires Chrome 149+ with ' +
+        'chrome://flags/#enable-webmcp-testing (or ChatGPT desktop browser).'
       )
     }
   </script>

--- a/examples/mcp-api-adapter/pixeldrop/smart-upload-test-harness.html
+++ b/examples/mcp-api-adapter/pixeldrop/smart-upload-test-harness.html
@@ -180,15 +180,25 @@
     function ensureFixedGallery() {
       const pane = document.getElementById('fixed-pane');
       if (!document.getElementById('fixed-gallery')) {
-        pane.insertAdjacentHTML('beforeend',
-          '<div class="fixed-gallery" id="fixed-gallery"></div>' +
-          '<div class="fixed-upload-log" id="fixed-upload-log"></div>');
+        const gallery = document.createElement('div');
+        gallery.className = 'fixed-gallery';
+        gallery.id = 'fixed-gallery';
+        const log = document.createElement('div');
+        log.className = 'fixed-upload-log';
+        log.id = 'fixed-upload-log';
+        pane.append(gallery, log);
       }
     }
 
-    function addToFixedGallery(dataUrl) {
+    function addToFixedGallery(fileBase64) {
+      if (!/^[A-Za-z0-9+/=]+$/.test(fileBase64)) {
+        console.error('Invalid base64 payload for gallery preview');
+        return;
+      }
       const img = document.createElement('img');
-      img.src = dataUrl;
+      const bytes = Uint8Array.from(atob(fileBase64), (c) => c.charCodeAt(0));
+      const blob = new Blob([bytes], { type: 'image/jpeg' });
+      img.src = URL.createObjectURL(blob);
       img.alt = 'Uploaded photo';
       document.getElementById('fixed-gallery').appendChild(img);
     }
@@ -235,7 +245,7 @@
         // broken iframe's DOM (that would imply the broken UI succeeded).
         try {
           const result = await targetWindow.uploadToBackend(fileBase64, filename);
-          addToFixedGallery(`data:image/jpeg;base64,${fileBase64}`);
+          addToFixedGallery(fileBase64);
           logFixedUpload(result, 'smart-upload-harness');
 
           renderResultMessage(

--- a/examples/mcp-api-adapter/pixeldrop/smart-upload-test-harness.html
+++ b/examples/mcp-api-adapter/pixeldrop/smart-upload-test-harness.html
@@ -81,8 +81,8 @@
   <h1>ClawQL Smart Upload — Left/Right Comparison</h1>
   <div class="instructions">
     Drop or select <strong>the same image</strong> on both sides.
-    Try a large image over 2MB or a camera-roll HEIC to see the difference.
-    HEIC + resize verified on iPhone Safari (see VERIFICATION.md).
+    Try a camera-roll HEIC or a large image over 2MB on both sides.
+    HEIC verified on iPhone Safari and iOS Chrome (2026-08-28) — see VERIFICATION.md.
     <br><br>
     <strong>Mobile:</strong> drag-and-drop is desktop-only; use the file picker on both sides.
     HEIC decode on iPhone Safari needs a real device test before demo claims.

--- a/examples/mcp-api-adapter/pixeldrop/smart-upload-test-harness.html
+++ b/examples/mcp-api-adapter/pixeldrop/smart-upload-test-harness.html
@@ -122,6 +122,25 @@
   </div>
 
   <script>
+    function renderResultMessage(containerId, variant, message) {
+      const host = document.getElementById(containerId);
+      if (!host) return;
+      host.replaceChildren();
+      const div = document.createElement('div');
+      div.style.cssText =
+        variant === 'error'
+          ? 'background:#fee2e2;color:#991b1b;padding:10px 14px;border-radius:6px;margin-top:12px;'
+          : 'background:#dcfce7;color:#166534;padding:10px 14px;border-radius:6px;margin-top:12px;';
+      div.textContent = message;
+      host.appendChild(div);
+    }
+
+    function mountTemplateHtml(container, html) {
+      container.replaceChildren();
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+      container.append(...doc.body.childNodes);
+    }
+
     // -------------------------------------------------------------------
     // Inject the smart-upload template into the right pane, with its
     // {{toolName}} placeholder resolved and its hx-post form replaced
@@ -133,14 +152,16 @@
     async function loadSmartUploadTemplate() {
       const res = await fetch('file-upload-smart.htmx.html');
       if (!res.ok) {
-        document.getElementById('fixed-pane').innerHTML =
-          `<p style="color:#991b1b">Failed to load template: ${res.status}. ` +
-          `Serve this folder over HTTP (python3 -m http.server), not file://.</p>`;
+        renderResultMessage(
+          'fixed-pane',
+          'error',
+          `Failed to load template: ${res.status}. Serve this folder over HTTP (python3 -m http.server), not file://.`
+        );
         return;
       }
       let html = await res.text();
       html = html.replaceAll('{{toolName}}', 'upload_photo');
-      document.getElementById('fixed-pane').innerHTML = html;
+      mountTemplateHtml(document.getElementById('fixed-pane'), html);
 
       // Re-run any <script> tags injected via innerHTML (browsers don't
       // execute these automatically when set via innerHTML).
@@ -217,18 +238,19 @@
           addToFixedGallery(`data:image/jpeg;base64,${fileBase64}`);
           logFixedUpload(result, 'smart-upload-harness');
 
-          document.getElementById('result-upload_photo').innerHTML =
-            `<div style="background:#dcfce7;color:#166534;padding:10px 14px;` +
-            `border-radius:6px;margin-top:12px;">` +
+          renderResultMessage(
+            'result-upload_photo',
+            'success',
             `Uploaded via smart-upload template. Upload ID: ${result.uploadId}` +
-            (caption ? ` · Caption: ${caption}` : '') +
-            `</div>`;
+              (caption ? ` · Caption: ${caption}` : '')
+          );
         } catch (err) {
           console.error('Direct backend call failed:', err);
-          document.getElementById('result-upload_photo').innerHTML =
-            `<div style="background:#fee2e2;color:#991b1b;padding:10px 14px;` +
-            `border-radius:6px;margin-top:12px;">` +
-            `Upload failed: ${err.message}</div>`;
+          renderResultMessage(
+            'result-upload_photo',
+            'error',
+            `Upload failed: ${err instanceof Error ? err.message : String(err)}`
+          );
         }
       });
     }

--- a/examples/mcp-api-adapter/pixeldrop/smart-upload-test-harness.html
+++ b/examples/mcp-api-adapter/pixeldrop/smart-upload-test-harness.html
@@ -72,6 +72,24 @@
       display: block;
     }
     .fixed-pane-content { padding: 16px; min-height: 500px; }
+    .fixed-gallery {
+      display: flex;
+      gap: 8px;
+      margin-top: 16px;
+      flex-wrap: wrap;
+    }
+    .fixed-gallery img {
+      width: 100px;
+      height: 100px;
+      object-fit: cover;
+      border-radius: 4px;
+      border: 1px solid #d1d5db;
+    }
+    .fixed-upload-log {
+      font-size: 12px;
+      color: #6b7280;
+      margin-top: 8px;
+    }
     @media (max-width: 800px) {
       .panes { flex-direction: column; }
     }
@@ -85,7 +103,6 @@
     HEIC verified on iPhone Safari and iOS Chrome (2026-08-28) — see VERIFICATION.md.
     <br><br>
     <strong>Mobile:</strong> drag-and-drop is desktop-only; use the file picker on both sides.
-    HEIC decode on iPhone Safari needs a real device test before demo claims.
   </div>
 
   <div class="panes">
@@ -136,6 +153,28 @@
         });
 
       wireFormToIframe();
+      ensureFixedGallery();
+    }
+
+    function ensureFixedGallery() {
+      const pane = document.getElementById('fixed-pane');
+      if (!document.getElementById('fixed-gallery')) {
+        pane.insertAdjacentHTML('beforeend',
+          '<div class="fixed-gallery" id="fixed-gallery"></div>' +
+          '<div class="fixed-upload-log" id="fixed-upload-log"></div>');
+      }
+    }
+
+    function addToFixedGallery(dataUrl) {
+      const img = document.createElement('img');
+      img.src = dataUrl;
+      img.alt = 'Uploaded photo';
+      document.getElementById('fixed-gallery').appendChild(img);
+    }
+
+    function logFixedUpload(result, source) {
+      document.getElementById('fixed-upload-log').textContent =
+        `Last upload: ${result.uploadId} · ${result.timestamp} · via ${source}`;
     }
 
     function wireFormToIframe() {
@@ -170,10 +209,13 @@
         // registered tool invocation, not a direct function reference -
         // this is a stand-in specifically for testing conversion logic
         // without requiring a WebMCP-preview browser.
+        // Backend only — same uploadToBackend() the broken UI would call if it
+        // worked. Gallery + log stay on the fixed pane; do not mutate the
+        // broken iframe's DOM (that would imply the broken UI succeeded).
         try {
           const result = await targetWindow.uploadToBackend(fileBase64, filename);
-          targetWindow.addToGallery(`data:image/jpeg;base64,${fileBase64}`);
-          targetWindow.logUpload(result, 'smart-upload-harness');
+          addToFixedGallery(`data:image/jpeg;base64,${fileBase64}`);
+          logFixedUpload(result, 'smart-upload-harness');
 
           document.getElementById('result-upload_photo').innerHTML =
             `<div style="background:#dcfce7;color:#166534;padding:10px 14px;` +

--- a/examples/mcp-api-adapter/pixeldrop/smart-upload-test-harness.html
+++ b/examples/mcp-api-adapter/pixeldrop/smart-upload-test-harness.html
@@ -81,8 +81,8 @@
   <h1>ClawQL Smart Upload — Left/Right Comparison</h1>
   <div class="instructions">
     Drop or select <strong>the same image</strong> on both sides.
-    Try a large image over 2MB to see the verified resize path (left rejects, right succeeds).
-    HEIC from iPhone is the target use case but is <strong>not yet verified</strong> — see VERIFICATION.md.
+    Try a large image over 2MB or a camera-roll HEIC to see the difference.
+    HEIC + resize verified on iPhone Safari (see VERIFICATION.md).
     <br><br>
     <strong>Mobile:</strong> drag-and-drop is desktop-only; use the file picker on both sides.
     HEIC decode on iPhone Safari needs a real device test before demo claims.

--- a/examples/mcp-api-adapter/pixeldrop/webmcp-console-probe.js
+++ b/examples/mcp-api-adapter/pixeldrop/webmcp-console-probe.js
@@ -1,0 +1,72 @@
+/**
+ * Paste into DevTools console on:
+ *   https://clawql.com/mcp-ui/pixeldrop/pixeldrop-broken-demo.html
+ * (or local http://127.0.0.1:8765/pixeldrop-broken-demo.html)
+ *
+ * Prerequisites:
+ *   - Chrome 149+ (not 148)
+ *   - chrome://flags/#enable-webmcp-testing → Enabled → full relaunch
+ *   - Hard-refresh the page after deploy of document-first registration
+ *
+ * This is the judge-environment gate: discovery + execute + return shape.
+ */
+;(async () => {
+  const out = {
+    chromeHint: navigator.userAgent,
+    documentMC: !!document.modelContext,
+    navigatorMC: !!navigator.modelContext,
+    sameRef: document.modelContext === navigator.modelContext,
+    tools: /** @type {string[]|null} */ (null),
+    executeRaw: /** @type {unknown} */ (null),
+    executeRawType: /** @type {string|null} */ (null),
+    executeParsed: /** @type {unknown} */ (null),
+    galleryGrew: /** @type {boolean|null} */ (null),
+    error: /** @type {string|null} */ (null),
+  }
+
+  try {
+    const mc = document.modelContext ?? navigator.modelContext
+    if (!mc?.getTools || !mc?.executeTool) {
+      throw new Error('modelContext missing getTools/executeTool — flag off or Chrome < 149?')
+    }
+
+    const tools = await mc.getTools()
+    out.tools = tools.map((t) => t.name)
+    const tool = tools.find((t) => t.name === 'upload_photo')
+    if (!tool) {
+      throw new Error(
+        'upload_photo not in getTools(): [' + out.tools.join(', ') + '] — registration failed or wrong API surface'
+      )
+    }
+
+    // 1×1 red JPEG (base64 payload only)
+    const tiny =
+      '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAX/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AJ/4AD//2Q=='
+
+    const before = document.querySelectorAll('#gallery img').length
+
+    // Chrome Imperative API: second arg is a JSON *string*
+    const raw = await mc.executeTool(
+      tool,
+      JSON.stringify({
+        file: tiny,
+        filename: 'probe.jpg',
+        caption: 'webmcp-console-probe',
+      })
+    )
+    out.executeRaw = raw
+    out.executeRawType = typeof raw
+    try {
+      out.executeParsed = typeof raw === 'string' ? JSON.parse(raw) : raw
+    } catch {
+      out.executeParsed = { unparsed: raw }
+    }
+
+    out.galleryGrew = document.querySelectorAll('#gallery img').length > before
+  } catch (e) {
+    out.error = e instanceof Error ? e.message : String(e)
+  }
+
+  console.log('[PixelDrop WebMCP probe]', out)
+  return out
+})()

--- a/landing-page/demo/public/mcp-ui/pixeldrop/README.md
+++ b/landing-page/demo/public/mcp-ui/pixeldrop/README.md
@@ -78,6 +78,8 @@ The harness **bypasses WebMCP discovery** and calls `uploadToBackend()` in the i
 
 Do not use "we fixed iPhone HEIC" in public framing until [`VERIFICATION.md`](VERIFICATION.md) Priority 1 passes.
 
+**Update (2026-08-28):** Priority 1 passed — real iPhone Safari test with `IMG_6432.HEIC` on clawql.com. HEIC headline is now fair game; WebMCP CDP (Priority 2) still open.
+
 ## Before flagship demo (Act 2/3)
 
 1. **iPhone Safari + camera-roll HEIC** (~5 min, any iPhone) — determines whether the tweet's pain point is actually solved

--- a/landing-page/demo/public/mcp-ui/pixeldrop/README.md
+++ b/landing-page/demo/public/mcp-ui/pixeldrop/README.md
@@ -2,22 +2,20 @@
 
 Side-by-side demo of a **deliberately broken** photo upload UI vs a **/mcp-ui smart-upload template** that fixes it client-side, then calls the **same backend** via WebMCP.
 
-Inspired by the OpenRouter/HEIC upload failure class (Wes Bos tweet, Aug 2026). The demo concept targets HEIC + resize + drag — but **only resize is verified today**. See [`VERIFICATION.md`](VERIFICATION.md) for the full proven/unproven matrix.
+Inspired by the OpenRouter/HEIC upload failure class (Wes Bos tweet, Aug 2026). **HEIC + resize verified on real iPhone** (Safari and iOS Chrome, 2026-08-28). See [`VERIFICATION.md`](VERIFICATION.md).
 
 ## What is verified vs unproven
 
 | Claim | Status |
 | --- | --- |
-| Large image resize/compress before upload (desktop) | **Verified** — 18MB PNG 8000×6000 → 2048×1536, uploaded via same `uploadToBackend()` |
+| HEIC from iPhone camera roll (Safari + iOS Chrome) | **Verified** — `IMG_6432.HEIC` → `up_7vjocs3`, native decode, no polyfill |
+| Large image resize/compress (desktop + iPhone) | **Verified** — 18MB PNG; 3.7MB JPEG on iPhone |
 | Same backend path as broken frontend (`up_…` IDs) | **Verified** |
-| HEIC from iPhone camera roll in Safari | **Unproven** — `createImageBitmap` never tested on real device |
-| WebMCP discovery → execute (bolt-on path) | **Unproven** — harness bypasses WebMCP; use `webmcp-cdp-smoke.mjs` when Chrome preview available |
+| WebMCP discovery → execute (bolt-on path) | **Open** — Priority 2; desktop Chrome preview only |
 
-**Safe public lead:** resize/compression wrapper calling the site's own backend without code changes.
+**Safe public lead:** "We fixed the iPhone HEIC upload problem — tested on Safari and iOS Chrome with real camera-roll files, client-side conversion, same backend."
 
-**Do not claim yet:** "We fixed the iPhone HEIC problem" or "WebMCP bolt-on works end-to-end."
-
-**Interim HEIC framing:** "Expected to work on Safari where HEIC decodes natively — pending device verification."
+**Do not claim yet:** "WebMCP bolt-on works end-to-end" until Priority 2 passes.
 
 ## Files
 
@@ -44,7 +42,7 @@ Open: [http://127.0.0.1:8765/smart-upload-test-harness.html](http://127.0.0.1:87
 
 1. **Large JPEG/PNG (>2MB)** — left rejects size; right resizes/compresses under 2MB. **(Verified on desktop.)**
 2. **Drag-and-drop (desktop)** — left ignores drops; right handles drop on the smart-upload pane.
-3. **HEIC from iPhone** — left rejects with "Unsupported binary file"; right *may* convert to JPEG and upload **if** the browser decodes HEIC. **Not verified — see [`VERIFICATION.md`](VERIFICATION.md) Priority 1.**
+3. **HEIC from iPhone** — left rejects with "Unsupported binary file"; right converts to JPEG and uploads. **Verified on Safari and iOS Chrome (2026-08-28).**
 
 Both sides should show the **same upload ID format** (`up_…`) and timestamp when the smart side succeeds — proof it's the identical `uploadToBackend()` call path.
 
@@ -72,20 +70,17 @@ The harness **bypasses WebMCP discovery** and calls `uploadToBackend()` in the i
 
 | Fix | Desktop | Mobile |
 | --- | --- | --- |
-| Resize / canvas / JPEG encode | **Verified** (18MB PNG test) | Expected to work (standard Web APIs) |
+| Resize / canvas / JPEG encode | **Verified** (desktop + iPhone Safari) | **Verified** — 3.7MB JPEG + HEIC on clawql.com |
 | Drag-and-drop anywhere | Works in template scope | **N/A** — no drag gesture; use file picker |
-| HEIC conversion (`createImageBitmap`) | Untested even on desktop | **Unproven** — tweet's core pain point; needs real iPhone Safari test |
+| HEIC conversion (`createImageBitmap`) | Untested on desktop Chrome | **Verified** — Safari + iOS Chrome, same device, `IMG_6432.HEIC` (2026-08-28) |
 
-Do not use "we fixed iPhone HEIC" in public framing until [`VERIFICATION.md`](VERIFICATION.md) Priority 1 passes.
-
-**Update (2026-08-28):** Priority 1 passed — real iPhone Safari test with `IMG_6432.HEIC` on clawql.com. HEIC headline is now fair game; WebMCP CDP (Priority 2) still open.
+**iPhone HEIC claim is verified on both mobile browsers.** WebMCP CDP (Priority 2) is the only open item — see [`VERIFICATION.md`](VERIFICATION.md).
 
 ## Before flagship demo (Act 2/3)
 
-1. **iPhone Safari + camera-roll HEIC** (~5 min, any iPhone) — determines whether the tweet's pain point is actually solved
-2. **WebMCP CDP smoke** — `node webmcp-cdp-smoke.mjs` with Chrome preview; exercises discovery → execute, not the harness bypass
-
-Neither blocks merging this folder as an example artifact on `main`.
+1. ~~**iPhone Safari + camera-roll HEIC**~~ — **Done** (Safari + iOS Chrome, 2026-08-28)
+2. **WebMCP CDP smoke** — `node webmcp-cdp-smoke.mjs` with Chrome preview
+3. **Optional:** ~30s iPhone screen recording of HEIC rejection-then-fix for public demo clip (recommended in VERIFICATION.md)
 
 ## Deliberate JS exception
 

--- a/landing-page/demo/public/mcp-ui/pixeldrop/VERIFICATION.md
+++ b/landing-page/demo/public/mcp-ui/pixeldrop/VERIFICATION.md
@@ -2,21 +2,33 @@
 
 Use this file to decide **what you can claim publicly** vs what still needs a real test.
 
-## Verified
+## Mobile claim — current honest state (2026-08-28)
+
+| Environment | HEIC decode | Resize oversized JPEG | Result |
+| --- | --- | --- | --- |
+| **iPhone Safari** | Native, no polyfill | Verified | `IMG_6432.HEIC` → `up_7vjocs3`; `IMG_6370.jpeg` 3.7MB → `up_p4yvp4nc` |
+| **iOS Chrome** | Native, no polyfill | Verified (same session) | Same device, same `IMG_6432.HEIC`, same clean pass as Safari |
+| **Desktop** | Not tested with real `.heic` | Verified | 18MB PNG 8000×6000 → resize/compress → `up_4yuzrboy` |
+| **WebMCP CDP discovery→execute** | — | — | **Still open** (Priority 2; desktop Chrome preview only) |
+
+**Plain statement:** iOS Chrome using WebKit under the hood was a reasonable inference until tested on the same device with the same camera-roll HEIC. It is now a **tested fact** — same file type, same outcome, no polyfill, both browsers anyone actually uses on iPhone.
+
+The claim **"we fixed the iPhone HEIC problem"** is solid on iPhone Safari and iOS Chrome, with real camera-roll files. No caveats needed on that specific point.
+
+---
+
+## Verified (detail)
 
 | Claim | Evidence | Date |
 | --- | --- | --- |
-| Broken demo rejects files >2MB | 18MB PNG → left pane error: "File too large (17.9MB)…" (desktop) | 2026-08-28 |
-| Smart template resizes oversized images | 8000×6000 → 2048×1536 (desktop); 5712×4284 → 2048×1536 (iPhone Safari) | 2026-08-28 |
-| Smart template compresses under 2MB backend limit | Processed output enabled submit + upload | 2026-08-28 |
+| Broken demo rejects HEIC | `IMG_6432.HEIC` → left: `Unsupported binary file: "image/heic"` | 2026-08-28 |
+| Smart template converts HEIC → JPEG (Safari) | Same file → `Converted from image/heic to JPEG · Resized from 2316×3088 to 1536×2048` → `up_7vjocs3` | 2026-08-28 |
+| Smart template converts HEIC → JPEG (iOS Chrome) | Same device, same `IMG_6432.HEIC`, same pass (second browser, same session) | 2026-08-28 |
+| Broken demo rejects files >2MB | 18MB PNG (desktop); `IMG_6370.jpeg` 3.7MB (iPhone Safari) | 2026-08-28 |
+| Smart template resizes oversized images | 8000×6000 → 2048×1536 (desktop); 5712×4284 → 2048×1536 (iPhone) | 2026-08-28 |
 | Same backend path as broken frontend | Upload IDs `up_4yuzrboy`, `up_p4yvp4nc`, `up_7vjocs3` via `uploadToBackend()` | 2026-08-28 |
-| Harness loads; template injects correctly | `smoke-test.mjs` + browser inspection | 2026-08-28 |
-| **HEIC from iPhone camera roll in Safari** | `IMG_6432.HEIC` → left: "Unsupported binary file: image/heic"; right: "Converted from image/heic to JPEG · Resized from 2316×3088 to 1536×2048" → `up_7vjocs3` on clawql.com harness | 2026-08-28 |
-| **Large JPEG on iPhone Safari** | `IMG_6370.jpeg` 3.7MB → left rejects 2MB limit; right resizes and uploads `up_p4yvp4nc` | 2026-08-28 |
 
-**Safe public lead:** "We wrapped a broken upload with a /mcp-ui template that converts HEIC, resizes oversized photos, and calls the site's own backend — tested on real iPhone Safari, no changes to their code."
-
-**Also safe:** "Same HEIC the broken UI rejects (`image/heic`) uploads successfully after client-side conversion to JPEG."
+**Safe public lead:** "We wrapped a broken upload with a /mcp-ui template that converts HEIC and resizes oversized photos client-side, then calls the site's own backend — tested on real iPhone Safari and iOS Chrome with camera-roll HEIC, no code changes on their side, no polyfill."
 
 ## Still unverified
 
@@ -24,46 +36,61 @@ Use this file to decide **what you can claim publicly** vs what still needs a re
 | --- | --- | --- |
 | **WebMCP discovery → execute path** | Harness bypasses WebMCP; calls `uploadToBackend()` directly | **Yes** — bolt-on pitch depends on this mechanism |
 | Drag-and-drop on mobile | N/A by platform (no drag gesture) | No — desktop-only feature |
-| HEIC on desktop Chrome | Browser-dependent; not tested with real `.heic` on desktop | No — iPhone story is the primary claim |
+| HEIC on desktop Chrome | Not tested with real `.heic` on desktop | No — iPhone story is the primary claim |
 
 **Do not claim yet:** "WebMCP bolt-on works end-to-end" until Priority 2 below passes.
 
 ---
 
-## Priority 1: iPhone Safari HEIC test — **PASSED**
+## Priority 1: iPhone mobile HEIC + resize — **PASSED**
 
-**Result (2026-08-28):** Real device test on clawql.com harness in iPhone Safari.
+### Safari (screenshot evidence)
+
+**URL:** https://clawql.com/mcp-ui/pixeldrop/smart-upload-test-harness.html  
+**Date:** 2026-08-28
 
 | Pane | File | Outcome |
 | --- | --- | --- |
 | Left (broken) | `IMG_6432.HEIC` | `Unsupported binary file: "image/heic"` |
-| Right (smart-upload) | same HEIC | `Converted from image/heic to JPEG · Resized from 2316×3088 to 1536×2048` → Upload ID `up_7vjocs3` |
+| Right (smart-upload) | same HEIC | `Converted from image/heic to JPEG · Resized from 2316×3088 to 1536×2048` → `up_7vjocs3` |
 
-**Also verified same session:** `IMG_6370.jpeg` (3.7MB) — left rejects size; right resizes 5712×4284 → 2048×1536 → `up_p4yvp4nc`.
+**Also same session (Safari):** `IMG_6370.jpeg` (3.7MB) — left rejects 2MB limit; right resizes 5712×4284 → 2048×1536 → `up_p4yvp4nc`.
 
-No heic2any polyfill required on iPhone Safari — native `createImageBitmap` decoded the camera-roll HEIC.
+### iOS Chrome (same device, same session)
+
+**Date:** 2026-08-28 — immediately after Safari pass, same iPhone, same `IMG_6432.HEIC`.
+
+| Browser | File | Outcome |
+| --- | --- | --- |
+| iOS Chrome | `IMG_6432.HEIC` | Same clean pass as Safari — native decode, conversion to JPEG, successful upload |
+
+No `heic2any` polyfill required on either iPhone browser.
+
+---
+
+## Demo video — public vs private
+
+| Artifact | Contents | Recommendation |
+| --- | --- | --- |
+| Desktop recording (`pixeldrop_smart_upload_demo.mp4`) | 18MB PNG resize; left reject / right fix | **Public** — good for resize/compress story on desktop |
+| iPhone screenshots (Safari HEIC + JPEG) | Rejection-then-fix moments | **Public** — embed in README / landing page today |
+| **iPhone ~30s screen recording (HEIC)** | Live rejection on left, conversion note + upload on right | **Strongly recommend public** — stronger than a table for this visual demo; record on device (Settings → Control Center → Screen Recording), same harness URL, same `IMG_6432.HEIC` flow |
+
+**Decision:** Use the iPhone screen recording as **primary public demo material** for the HEIC story (blog, landing page, social clip). Keep screenshots in `VERIFICATION.md` as dated audit trail. Desktop video remains supplementary for the resize path.
+
+**To add:** Drop `pixeldrop-iphone-heic-demo.mp4` (or similar) under `landing-page/demo/public/mcp-ui/pixeldrop/` and link from README when recorded.
 
 ---
 
 ## Priority 2: WebMCP CDP test (Chrome preview) — **OPEN**
 
-**Goal:** Exercise the real discovery → execute path that production `clawql sources add --kind webmcp` uses — not the harness iframe bypass.
+**Goal:** Exercise the real discovery → execute path that production `clawql sources add --kind webmcp` uses — not the harness iframe bypass. Unrelated to mobile; isolated remaining task.
 
 **Prerequisites**
 
-- Chrome **preview** (or build) with WebMCP enabled and `document.modelContext` available
-- CDP endpoint, e.g. `http://127.0.0.1:9222`
-- Demo served over HTTP:  
-  `cd examples/mcp-api-adapter/pixeldrop && python3 -m http.server 8765`
-
-**Option A — ClawQL source registration (full stack)**
-
-```bash
-clawql sources add http://127.0.0.1:8765/pixeldrop-broken-demo.html \
-  --kind webmcp --name pixeldrop --webmcp-cdp-url http://127.0.0.1:9222
-```
-
-**Option B — CDP smoke script**
+- Chrome **preview** with WebMCP + `document.modelContext`
+- CDP on `http://127.0.0.1:9222`
+- Demo served: `cd examples/mcp-api-adapter/pixeldrop && python3 -m http.server 8765`
 
 ```bash
 node examples/mcp-api-adapter/pixeldrop/webmcp-cdp-smoke.mjs \
@@ -80,5 +107,6 @@ node examples/mcp-api-adapter/pixeldrop/webmcp-cdp-smoke.mjs \
 | Milestone | Status |
 | --- | --- |
 | Merge to `main` as example artifact | **Done** (PR #997) |
-| **"Fixed iPhone HEIC" headline** | **Done** — Priority 1 passed on real iPhone Safari |
+| **"Fixed iPhone HEIC" headline** | **Done** — Safari + iOS Chrome, real camera-roll HEIC |
+| Public demo video (HEIC moment) | **Recommended** — record ~30s iPhone screen capture; not blocking the claim |
 | Flagship demo (full WebMCP bolt-on story) | **Blocked** on Priority 2 only |

--- a/landing-page/demo/public/mcp-ui/pixeldrop/VERIFICATION.md
+++ b/landing-page/demo/public/mcp-ui/pixeldrop/VERIFICATION.md
@@ -2,86 +2,68 @@
 
 Use this file to decide **what you can claim publicly** vs what still needs a real test.
 
-## Verified (desktop, this thread)
+## Verified
 
 | Claim | Evidence | Date |
 | --- | --- | --- |
-| Broken demo rejects files >2MB | 18MB PNG → left pane error: "File too large (17.9MB)…" | 2026-08-28 |
-| Smart template resizes oversized images | 8000×6000 → 2048×1536 conversion note | 2026-08-28 |
+| Broken demo rejects files >2MB | 18MB PNG → left pane error: "File too large (17.9MB)…" (desktop) | 2026-08-28 |
+| Smart template resizes oversized images | 8000×6000 → 2048×1536 (desktop); 5712×4284 → 2048×1536 (iPhone Safari) | 2026-08-28 |
 | Smart template compresses under 2MB backend limit | Processed output enabled submit + upload | 2026-08-28 |
-| Same backend path as broken frontend | Upload ID `up_4yuzrboy` via `uploadToBackend()` in iframe | 2026-08-28 |
+| Same backend path as broken frontend | Upload IDs `up_4yuzrboy`, `up_p4yvp4nc`, `up_7vjocs3` via `uploadToBackend()` | 2026-08-28 |
 | Harness loads; template injects correctly | `smoke-test.mjs` + browser inspection | 2026-08-28 |
+| **HEIC from iPhone camera roll in Safari** | `IMG_6432.HEIC` → left: "Unsupported binary file: image/heic"; right: "Converted from image/heic to JPEG · Resized from 2316×3088 to 1536×2048" → `up_7vjocs3` on clawql.com harness | 2026-08-28 |
+| **Large JPEG on iPhone Safari** | `IMG_6370.jpeg` 3.7MB → left rejects 2MB limit; right resizes and uploads `up_p4yvp4nc` | 2026-08-28 |
 
-**Safe public lead:** "We wrapped a broken upload with a /mcp-ui template that resizes and compresses large images client-side, then calls the site's own backend capability — without changing their code."
+**Safe public lead:** "We wrapped a broken upload with a /mcp-ui template that converts HEIC, resizes oversized photos, and calls the site's own backend — tested on real iPhone Safari, no changes to their code."
 
-## Unverified — do not imply these are proven
+**Also safe:** "Same HEIC the broken UI rejects (`image/heic`) uploads successfully after client-side conversion to JPEG."
+
+## Still unverified
 
 | Claim | Why unproven | Blocks flagship demo? |
 | --- | --- | --- |
-| **HEIC from iPhone camera roll decodes in Safari** | `createImageBitmap` on real `.heic` never tested on physical iPhone | **Yes** — this is the tweet's exact pain point |
 | **WebMCP discovery → execute path** | Harness bypasses WebMCP; calls `uploadToBackend()` directly | **Yes** — bolt-on pitch depends on this mechanism |
 | Drag-and-drop on mobile | N/A by platform (no drag gesture) | No — desktop-only feature |
-| HEIC on desktop Chrome | Browser-dependent; no real HEIC file tested here | Partial — secondary to iPhone story |
+| HEIC on desktop Chrome | Browser-dependent; not tested with real `.heic` on desktop | No — iPhone story is the primary claim |
 
-**Unsafe framing:** "We fixed the iPhone HEIC problem" or "WebMCP bolt-on works end-to-end" until the two tests below pass.
-
-**Acceptable interim framing:** "Resize/compression verified on desktop; HEIC expected to work on Safari where `createImageBitmap` decodes HEIC — **pending device verification**."
+**Do not claim yet:** "WebMCP bolt-on works end-to-end" until Priority 2 below passes.
 
 ---
 
-## Priority 1: iPhone Safari HEIC test (~5 minutes)
+## Priority 1: iPhone Safari HEIC test — **PASSED**
 
-**Goal:** Confirm `createImageBitmap` decodes a real camera-roll HEIC and the smart template uploads successfully.
+**Result (2026-08-28):** Real device test on clawql.com harness in iPhone Safari.
 
-**Prerequisites**
+| Pane | File | Outcome |
+| --- | --- | --- |
+| Left (broken) | `IMG_6432.HEIC` | `Unsupported binary file: "image/heic"` |
+| Right (smart-upload) | same HEIC | `Converted from image/heic to JPEG · Resized from 2316×3088 to 1536×2048` → Upload ID `up_7vjocs3` |
 
-- iPhone with at least one HEIC photo in Photos (default on modern iPhones)
-- Mac or LAN access to serve the demo (or deploy to HTTPS host)
-- Same Wi‑Fi if using local IP (Safari requires secure context for some APIs; `http://127.0.0.1` works on-device only when served on the phone itself — use `python3 -m http.server 8765 --bind 0.0.0.0` and open `http://<your-lan-ip>:8765/smart-upload-test-harness.html`, or use ngrok/cloudflare tunnel for HTTPS)
+**Also verified same session:** `IMG_6370.jpeg` (3.7MB) — left rejects size; right resizes 5712×4284 → 2048×1536 → `up_p4yvp4nc`.
 
-**Steps**
-
-1. Serve the demo folder over HTTP(S) reachable from the iPhone.
-2. Open `smart-upload-test-harness.html` in **Safari** on the iPhone.
-3. On the **left (broken)** pane: select a camera-roll HEIC.  
-   **Expected:** "Unsupported binary file" (or similar) — confirms the bug reproduces.
-4. On the **right (smart-upload)** pane: select the **same** HEIC via "Or click to choose a file".  
-   **Expected (pass):** preview appears, conversion note mentions JPEG, Upload enables, success with `up_…` ID.  
-   **Expected (fail):** "Could not read … as an image" — HEIC decode not available; need polyfill (e.g. heic2any).
-5. Record: iOS version, Safari version, filename, conversion note text, upload ID or error message.
-6. Update the **Verified** table in this file with results.
-
-**Pass criteria:** Right pane uploads a real camera-roll HEIC that left pane rejects.
+No heic2any polyfill required on iPhone Safari — native `createImageBitmap` decoded the camera-roll HEIC.
 
 ---
 
-## Priority 2: WebMCP CDP test (Chrome preview)
+## Priority 2: WebMCP CDP test (Chrome preview) — **OPEN**
 
 **Goal:** Exercise the real discovery → execute path that production `clawql sources add --kind webmcp` uses — not the harness iframe bypass.
 
 **Prerequisites**
 
 - Chrome **preview** (or build) with WebMCP enabled and `document.modelContext` available
-- CDP endpoint, e.g. `http://127.0.0.1:9222`  
-  Launch example:  
-  `google-chrome --remote-debugging-port=9222 --enable-features=...` (see current WebMCP preview docs)
+- CDP endpoint, e.g. `http://127.0.0.1:9222`
 - Demo served over HTTP:  
   `cd examples/mcp-api-adapter/pixeldrop && python3 -m http.server 8765`
 
 **Option A — ClawQL source registration (full stack)**
 
 ```bash
-# Terminal 1: serve PixelDrop
-cd examples/mcp-api-adapter/pixeldrop && python3 -m http.server 8765
-
-# Terminal 2: register WebMCP source (from repo root, ClawQL built)
 clawql sources add http://127.0.0.1:8765/pixeldrop-broken-demo.html \
   --kind webmcp --name pixeldrop --webmcp-cdp-url http://127.0.0.1:9222
-
-# Discover and execute upload_photo via ClawQL search/execute or /mcp-ui catalog
 ```
 
-**Option B — CDP smoke script (this folder)**
+**Option B — CDP smoke script**
 
 ```bash
 node examples/mcp-api-adapter/pixeldrop/webmcp-cdp-smoke.mjs \
@@ -89,20 +71,14 @@ node examples/mcp-api-adapter/pixeldrop/webmcp-cdp-smoke.mjs \
   --cdp-url http://127.0.0.1:9222
 ```
 
-**Pass criteria**
-
-1. `upload_photo` discovered via `document.modelContext.getTools()`
-2. Execute with a small base64 JPEG returns `{ uploadId, timestamp }`
-3. Gallery on the page updates (same as broken frontend success path)
-
-**On failure:** Script prints CDP/WebMCP availability errors; do not claim bolt-on works until green.
+**Pass criteria:** `upload_photo` discovered + execute returns `{ uploadId, timestamp }`.
 
 ---
 
-## Merge vs demo-ready
+## Demo-ready status
 
-| Milestone | Requirement |
+| Milestone | Status |
 | --- | --- |
-| **Merge to `main` as example artifact** | Desktop resize test + harness — **done** (PR #997) |
-| **Flagship "we fixed your upload" demo (Act 2/3)** | Priority 1 **and** Priority 2 above |
-| **"Fixed iPhone HEIC" headline** | Priority 1 pass only |
+| Merge to `main` as example artifact | **Done** (PR #997) |
+| **"Fixed iPhone HEIC" headline** | **Done** — Priority 1 passed on real iPhone Safari |
+| Flagship demo (full WebMCP bolt-on story) | **Blocked** on Priority 2 only |

--- a/landing-page/demo/public/mcp-ui/pixeldrop/VERIFICATION.md
+++ b/landing-page/demo/public/mcp-ui/pixeldrop/VERIFICATION.md
@@ -82,17 +82,31 @@ No `heic2any` polyfill required on either iPhone browser.
 
 ---
 
-## Priority 2: WebMCP CDP test (Chrome preview) — **OPEN**
+## Priority 2: WebMCP CDP / judge-environment test — **OPEN** (API surface fixed; runtime gate pending)
 
-**Goal:** Exercise the real discovery → execute path that production `clawql sources add --kind webmcp` uses — not the harness iframe bypass. Unrelated to mobile; isolated remaining task.
+**Goal:** Exercise real discovery → execute on Chrome 149+ (or ChatGPT desktop browser) — not the harness iframe bypass.
 
-**Prerequisites**
+### API surface (fixed 2026-08-28, before runtime gate)
 
-- Chrome **preview** with WebMCP + `document.modelContext`
-- CDP on `http://127.0.0.1:9222`
-- Demo served: `cd examples/mcp-api-adapter/pixeldrop && python3 -m http.server 8765`
+| Item | Status |
+| --- | --- |
+| Register via `document.modelContext ?? navigator.modelContext` | **Fixed** in PixelDrop + landing `WebMcpRegister` |
+| `execute` returns `JSON.stringify(...)` (DOMString) | **Fixed** — Chrome Imperative API returns string from `executeTool` |
+| CDP `executeTool(tool, jsonString)` | **Fixed** in `webmcp-browser.ts` |
+| Runtime verify on Chrome 149+ | **Blocked in cloud VM** — environment has Chrome **148.0.7778.96**; WebMCP flag/OT needs **149+** |
+
+### Console probe (run on your Mac — the actual gate)
+
+1. Chrome **149+** → `chrome://flags/#enable-webmcp-testing` → Enabled → **relaunch**
+2. Open https://clawql.com/mcp-ui/pixeldrop/pixeldrop-broken-demo.html (hard-refresh after deploy)
+3. Paste contents of `webmcp-console-probe.js` into DevTools console
+
+**Pass:** `documentMC: true`, `tools` includes `upload_photo`, `executeParsed.uploadId` like `up_…`, `galleryGrew: true`, `executeRawType: "string"`.
+
+**Fail modes to fear:** tools empty with no error (dead registration path); execute throws; result is object ChatGPT cannot parse as text.
 
 ```bash
+# Optional local serve + CDP (still needs Chrome 149+ with flag + CDP port)
 node examples/mcp-api-adapter/pixeldrop/webmcp-cdp-smoke.mjs \
   --page-url http://127.0.0.1:8765/pixeldrop-broken-demo.html \
   --cdp-url http://127.0.0.1:9222

--- a/landing-page/demo/public/mcp-ui/pixeldrop/pixeldrop-broken-demo.html
+++ b/landing-page/demo/public/mcp-ui/pixeldrop/pixeldrop-broken-demo.html
@@ -186,13 +186,14 @@
     // this tool directly bypasses BUG 3 and BUG 4 entirely, because those
     // bugs live in handleFileSelect(), not in uploadToBackend() itself.
     //
-    // NOTE: navigator.modelContext is the current (early 2026) WebMCP
-    // API surface. Per ongoing spec discussion this entry point may
-    // migrate to document.modelContext — check current spec status
-    // before wiring a production integration against this.
+    // WebMCP — Chrome 149+ / ChatGPT browser expect document.modelContext.
+    // navigator.modelContext is a deprecated alias (Chrome 150+); prefer document
+    // first so a dead navigator stub cannot swallow registration silently.
+    // execute must return a DOMString (Chrome Imperative API); agents/ChatGPT
+    // parse text — JSON.stringify keeps structured fields readable.
     // ---------------------------------------------------------------------
 
-    const modelContext = navigator.modelContext ?? document.modelContext
+    const modelContext = document.modelContext ?? navigator.modelContext
     if (modelContext?.registerTool) {
       modelContext.registerTool({
         name: 'upload_photo',
@@ -226,19 +227,20 @@
           // like a normal one would — proving it's the same code path.
           addToGallery(`data:image/jpeg;base64,${file}`)
           logUpload(result, 'webmcp')
-          return {
+          return JSON.stringify({
             uploadId: result.uploadId,
             timestamp: result.timestamp,
             caption: caption ?? null,
-          }
+          })
         },
       })
-      console.log('[PixelDrop] WebMCP tool "upload_photo" registered.')
+      console.log('[PixelDrop] WebMCP tool "upload_photo" registered via',
+        document.modelContext ? 'document.modelContext' : 'navigator.modelContext')
     } else {
       console.warn(
         '[PixelDrop] modelContext not available in this browser. ' +
-        'WebMCP tool was not registered. Requires a browser with the ' +
-        'WebMCP preview enabled (e.g. Chrome behind a flag as of early 2026).'
+        'WebMCP tool was not registered. Requires Chrome 149+ with ' +
+        'chrome://flags/#enable-webmcp-testing (or ChatGPT desktop browser).'
       )
     }
   </script>

--- a/landing-page/demo/public/mcp-ui/pixeldrop/smart-upload-test-harness.html
+++ b/landing-page/demo/public/mcp-ui/pixeldrop/smart-upload-test-harness.html
@@ -180,15 +180,25 @@
     function ensureFixedGallery() {
       const pane = document.getElementById('fixed-pane');
       if (!document.getElementById('fixed-gallery')) {
-        pane.insertAdjacentHTML('beforeend',
-          '<div class="fixed-gallery" id="fixed-gallery"></div>' +
-          '<div class="fixed-upload-log" id="fixed-upload-log"></div>');
+        const gallery = document.createElement('div');
+        gallery.className = 'fixed-gallery';
+        gallery.id = 'fixed-gallery';
+        const log = document.createElement('div');
+        log.className = 'fixed-upload-log';
+        log.id = 'fixed-upload-log';
+        pane.append(gallery, log);
       }
     }
 
-    function addToFixedGallery(dataUrl) {
+    function addToFixedGallery(fileBase64) {
+      if (!/^[A-Za-z0-9+/=]+$/.test(fileBase64)) {
+        console.error('Invalid base64 payload for gallery preview');
+        return;
+      }
       const img = document.createElement('img');
-      img.src = dataUrl;
+      const bytes = Uint8Array.from(atob(fileBase64), (c) => c.charCodeAt(0));
+      const blob = new Blob([bytes], { type: 'image/jpeg' });
+      img.src = URL.createObjectURL(blob);
       img.alt = 'Uploaded photo';
       document.getElementById('fixed-gallery').appendChild(img);
     }
@@ -235,7 +245,7 @@
         // broken iframe's DOM (that would imply the broken UI succeeded).
         try {
           const result = await targetWindow.uploadToBackend(fileBase64, filename);
-          addToFixedGallery(`data:image/jpeg;base64,${fileBase64}`);
+          addToFixedGallery(fileBase64);
           logFixedUpload(result, 'smart-upload-harness');
 
           renderResultMessage(

--- a/landing-page/demo/public/mcp-ui/pixeldrop/smart-upload-test-harness.html
+++ b/landing-page/demo/public/mcp-ui/pixeldrop/smart-upload-test-harness.html
@@ -81,8 +81,8 @@
   <h1>ClawQL Smart Upload — Left/Right Comparison</h1>
   <div class="instructions">
     Drop or select <strong>the same image</strong> on both sides.
-    Try a large image over 2MB or a camera-roll HEIC to see the difference.
-    HEIC + resize verified on iPhone Safari (see VERIFICATION.md).
+    Try a camera-roll HEIC or a large image over 2MB on both sides.
+    HEIC verified on iPhone Safari and iOS Chrome (2026-08-28) — see VERIFICATION.md.
     <br><br>
     <strong>Mobile:</strong> drag-and-drop is desktop-only; use the file picker on both sides.
     HEIC decode on iPhone Safari needs a real device test before demo claims.

--- a/landing-page/demo/public/mcp-ui/pixeldrop/smart-upload-test-harness.html
+++ b/landing-page/demo/public/mcp-ui/pixeldrop/smart-upload-test-harness.html
@@ -122,6 +122,25 @@
   </div>
 
   <script>
+    function renderResultMessage(containerId, variant, message) {
+      const host = document.getElementById(containerId);
+      if (!host) return;
+      host.replaceChildren();
+      const div = document.createElement('div');
+      div.style.cssText =
+        variant === 'error'
+          ? 'background:#fee2e2;color:#991b1b;padding:10px 14px;border-radius:6px;margin-top:12px;'
+          : 'background:#dcfce7;color:#166534;padding:10px 14px;border-radius:6px;margin-top:12px;';
+      div.textContent = message;
+      host.appendChild(div);
+    }
+
+    function mountTemplateHtml(container, html) {
+      container.replaceChildren();
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+      container.append(...doc.body.childNodes);
+    }
+
     // -------------------------------------------------------------------
     // Inject the smart-upload template into the right pane, with its
     // {{toolName}} placeholder resolved and its hx-post form replaced
@@ -133,14 +152,16 @@
     async function loadSmartUploadTemplate() {
       const res = await fetch('file-upload-smart.htmx.html');
       if (!res.ok) {
-        document.getElementById('fixed-pane').innerHTML =
-          `<p style="color:#991b1b">Failed to load template: ${res.status}. ` +
-          `Serve this folder over HTTP (python3 -m http.server), not file://.</p>`;
+        renderResultMessage(
+          'fixed-pane',
+          'error',
+          `Failed to load template: ${res.status}. Serve this folder over HTTP (python3 -m http.server), not file://.`
+        );
         return;
       }
       let html = await res.text();
       html = html.replaceAll('{{toolName}}', 'upload_photo');
-      document.getElementById('fixed-pane').innerHTML = html;
+      mountTemplateHtml(document.getElementById('fixed-pane'), html);
 
       // Re-run any <script> tags injected via innerHTML (browsers don't
       // execute these automatically when set via innerHTML).
@@ -217,18 +238,19 @@
           addToFixedGallery(`data:image/jpeg;base64,${fileBase64}`);
           logFixedUpload(result, 'smart-upload-harness');
 
-          document.getElementById('result-upload_photo').innerHTML =
-            `<div style="background:#dcfce7;color:#166534;padding:10px 14px;` +
-            `border-radius:6px;margin-top:12px;">` +
+          renderResultMessage(
+            'result-upload_photo',
+            'success',
             `Uploaded via smart-upload template. Upload ID: ${result.uploadId}` +
-            (caption ? ` · Caption: ${caption}` : '') +
-            `</div>`;
+              (caption ? ` · Caption: ${caption}` : '')
+          );
         } catch (err) {
           console.error('Direct backend call failed:', err);
-          document.getElementById('result-upload_photo').innerHTML =
-            `<div style="background:#fee2e2;color:#991b1b;padding:10px 14px;` +
-            `border-radius:6px;margin-top:12px;">` +
-            `Upload failed: ${err.message}</div>`;
+          renderResultMessage(
+            'result-upload_photo',
+            'error',
+            `Upload failed: ${err instanceof Error ? err.message : String(err)}`
+          );
         }
       });
     }

--- a/landing-page/demo/public/mcp-ui/pixeldrop/smart-upload-test-harness.html
+++ b/landing-page/demo/public/mcp-ui/pixeldrop/smart-upload-test-harness.html
@@ -72,6 +72,24 @@
       display: block;
     }
     .fixed-pane-content { padding: 16px; min-height: 500px; }
+    .fixed-gallery {
+      display: flex;
+      gap: 8px;
+      margin-top: 16px;
+      flex-wrap: wrap;
+    }
+    .fixed-gallery img {
+      width: 100px;
+      height: 100px;
+      object-fit: cover;
+      border-radius: 4px;
+      border: 1px solid #d1d5db;
+    }
+    .fixed-upload-log {
+      font-size: 12px;
+      color: #6b7280;
+      margin-top: 8px;
+    }
     @media (max-width: 800px) {
       .panes { flex-direction: column; }
     }
@@ -85,7 +103,6 @@
     HEIC verified on iPhone Safari and iOS Chrome (2026-08-28) — see VERIFICATION.md.
     <br><br>
     <strong>Mobile:</strong> drag-and-drop is desktop-only; use the file picker on both sides.
-    HEIC decode on iPhone Safari needs a real device test before demo claims.
   </div>
 
   <div class="panes">
@@ -136,6 +153,28 @@
         });
 
       wireFormToIframe();
+      ensureFixedGallery();
+    }
+
+    function ensureFixedGallery() {
+      const pane = document.getElementById('fixed-pane');
+      if (!document.getElementById('fixed-gallery')) {
+        pane.insertAdjacentHTML('beforeend',
+          '<div class="fixed-gallery" id="fixed-gallery"></div>' +
+          '<div class="fixed-upload-log" id="fixed-upload-log"></div>');
+      }
+    }
+
+    function addToFixedGallery(dataUrl) {
+      const img = document.createElement('img');
+      img.src = dataUrl;
+      img.alt = 'Uploaded photo';
+      document.getElementById('fixed-gallery').appendChild(img);
+    }
+
+    function logFixedUpload(result, source) {
+      document.getElementById('fixed-upload-log').textContent =
+        `Last upload: ${result.uploadId} · ${result.timestamp} · via ${source}`;
     }
 
     function wireFormToIframe() {
@@ -170,10 +209,13 @@
         // registered tool invocation, not a direct function reference -
         // this is a stand-in specifically for testing conversion logic
         // without requiring a WebMCP-preview browser.
+        // Backend only — same uploadToBackend() the broken UI would call if it
+        // worked. Gallery + log stay on the fixed pane; do not mutate the
+        // broken iframe's DOM (that would imply the broken UI succeeded).
         try {
           const result = await targetWindow.uploadToBackend(fileBase64, filename);
-          targetWindow.addToGallery(`data:image/jpeg;base64,${fileBase64}`);
-          targetWindow.logUpload(result, 'smart-upload-harness');
+          addToFixedGallery(`data:image/jpeg;base64,${fileBase64}`);
+          logFixedUpload(result, 'smart-upload-harness');
 
           document.getElementById('result-upload_photo').innerHTML =
             `<div style="background:#dcfce7;color:#166534;padding:10px 14px;` +

--- a/landing-page/demo/public/mcp-ui/pixeldrop/smart-upload-test-harness.html
+++ b/landing-page/demo/public/mcp-ui/pixeldrop/smart-upload-test-harness.html
@@ -81,8 +81,8 @@
   <h1>ClawQL Smart Upload — Left/Right Comparison</h1>
   <div class="instructions">
     Drop or select <strong>the same image</strong> on both sides.
-    Try a large image over 2MB to see the verified resize path (left rejects, right succeeds).
-    HEIC from iPhone is the target use case but is <strong>not yet verified</strong> — see VERIFICATION.md.
+    Try a large image over 2MB or a camera-roll HEIC to see the difference.
+    HEIC + resize verified on iPhone Safari (see VERIFICATION.md).
     <br><br>
     <strong>Mobile:</strong> drag-and-drop is desktop-only; use the file picker on both sides.
     HEIC decode on iPhone Safari needs a real device test before demo claims.

--- a/landing-page/demo/public/mcp-ui/pixeldrop/webmcp-console-probe.js
+++ b/landing-page/demo/public/mcp-ui/pixeldrop/webmcp-console-probe.js
@@ -1,0 +1,72 @@
+/**
+ * Paste into DevTools console on:
+ *   https://clawql.com/mcp-ui/pixeldrop/pixeldrop-broken-demo.html
+ * (or local http://127.0.0.1:8765/pixeldrop-broken-demo.html)
+ *
+ * Prerequisites:
+ *   - Chrome 149+ (not 148)
+ *   - chrome://flags/#enable-webmcp-testing → Enabled → full relaunch
+ *   - Hard-refresh the page after deploy of document-first registration
+ *
+ * This is the judge-environment gate: discovery + execute + return shape.
+ */
+;(async () => {
+  const out = {
+    chromeHint: navigator.userAgent,
+    documentMC: !!document.modelContext,
+    navigatorMC: !!navigator.modelContext,
+    sameRef: document.modelContext === navigator.modelContext,
+    tools: /** @type {string[]|null} */ (null),
+    executeRaw: /** @type {unknown} */ (null),
+    executeRawType: /** @type {string|null} */ (null),
+    executeParsed: /** @type {unknown} */ (null),
+    galleryGrew: /** @type {boolean|null} */ (null),
+    error: /** @type {string|null} */ (null),
+  }
+
+  try {
+    const mc = document.modelContext ?? navigator.modelContext
+    if (!mc?.getTools || !mc?.executeTool) {
+      throw new Error('modelContext missing getTools/executeTool — flag off or Chrome < 149?')
+    }
+
+    const tools = await mc.getTools()
+    out.tools = tools.map((t) => t.name)
+    const tool = tools.find((t) => t.name === 'upload_photo')
+    if (!tool) {
+      throw new Error(
+        'upload_photo not in getTools(): [' + out.tools.join(', ') + '] — registration failed or wrong API surface'
+      )
+    }
+
+    // 1×1 red JPEG (base64 payload only)
+    const tiny =
+      '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAX/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AJ/4AD//2Q=='
+
+    const before = document.querySelectorAll('#gallery img').length
+
+    // Chrome Imperative API: second arg is a JSON *string*
+    const raw = await mc.executeTool(
+      tool,
+      JSON.stringify({
+        file: tiny,
+        filename: 'probe.jpg',
+        caption: 'webmcp-console-probe',
+      })
+    )
+    out.executeRaw = raw
+    out.executeRawType = typeof raw
+    try {
+      out.executeParsed = typeof raw === 'string' ? JSON.parse(raw) : raw
+    } catch {
+      out.executeParsed = { unparsed: raw }
+    }
+
+    out.galleryGrew = document.querySelectorAll('#gallery img').length > before
+  } catch (e) {
+    out.error = e instanceof Error ? e.message : String(e)
+  }
+
+  console.log('[PixelDrop WebMCP probe]', out)
+  return out
+})()

--- a/landing-page/demo/src/components/WebMcpRegister.tsx
+++ b/landing-page/demo/src/components/WebMcpRegister.tsx
@@ -15,7 +15,9 @@ export function WebMcpRegister() {
 
   useEffect(() => {
     if (typeof window === 'undefined') return
-    const mc = navigator.modelContext
+    // Chrome 149+ / ChatGPT browser: document.modelContext is canonical.
+    // Prefer it so a deprecated navigator stub cannot swallow registration.
+    const mc = document.modelContext ?? navigator.modelContext
     if (!mc || typeof mc.registerTool !== 'function') return
 
     const ac = new AbortController()
@@ -44,10 +46,10 @@ export function WebMcpRegister() {
           const raw = input as { path?: string }
           const path = String(raw.path ?? '')
           if (!path.startsWith('/') || path.startsWith('//')) {
-            return { ok: false, error: 'Path must be a same-origin path starting with /' }
+            return JSON.stringify({ ok: false, error: 'Path must be a same-origin path starting with /' })
           }
           router.push(path)
-          return { ok: true, path }
+          return JSON.stringify({ ok: true, path })
         },
       },
       {
@@ -62,11 +64,11 @@ export function WebMcpRegister() {
         },
         annotations: { readOnlyHint: true },
         async execute(_input: object) {
-          return {
+          return JSON.stringify({
             pathname: pathnameRef.current,
             title: document.title,
             href: window.location.href,
-          }
+          })
         },
       },
       {
@@ -91,21 +93,21 @@ export function WebMcpRegister() {
           let id = String(raw.id ?? '').trim()
           if (id.startsWith('#')) id = id.slice(1)
           if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
-            return { ok: false, error: 'Invalid id' }
+            return JSON.stringify({ ok: false, error: 'Invalid id' })
           }
           const el = document.getElementById(id)
           if (!el) {
-            return { ok: false, error: 'No element with that id' }
+            return JSON.stringify({ ok: false, error: 'No element with that id' })
           }
           el.scrollIntoView({ behavior: 'smooth', block: 'start' })
-          return { ok: true, id }
+          return JSON.stringify({ ok: true, id })
         },
       },
     ]
 
     for (const tool of tools) {
       try {
-        mc.registerTool(tool, { signal })
+        void mc.registerTool(tool, { signal })
       } catch (err) {
         console.warn('[WebMCP] registerTool failed:', tool.name, err)
       }

--- a/landing-page/demo/src/types/webmcp.d.ts
+++ b/landing-page/demo/src/types/webmcp.d.ts
@@ -1,10 +1,15 @@
 /**
  * WebMCP (Model Context) — https://webmachinelearning.github.io/webmcp/
+ * Chrome 149+: document.modelContext is canonical; navigator is deprecated alias.
  */
 export {}
 
 declare global {
+  interface Document {
+    readonly modelContext?: ModelContext
+  }
   interface Navigator {
+    /** @deprecated Prefer document.modelContext (Chrome 150+) */
     readonly modelContext?: ModelContext
   }
 }
@@ -13,7 +18,22 @@ interface ModelContext {
   registerTool(
     tool: ModelContextTool,
     options?: ModelContextRegisterToolOptions,
-  ): void
+  ): void | Promise<void>
+  getTools?(options?: { fromOrigins?: string[] }): Promise<RegisteredTool[]>
+  executeTool?(
+    tool: RegisteredTool,
+    inputJson: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<string | null>
+  addEventListener?(type: 'toolchange', listener: (ev: Event) => void): void
+}
+
+interface RegisteredTool {
+  name: string
+  title?: string
+  description?: string
+  inputSchema?: object
+  origin?: string
 }
 
 interface ModelContextTool {
@@ -21,18 +41,22 @@ interface ModelContextTool {
   title?: string
   description: string
   inputSchema?: object
+  /** Chrome Imperative API expects a DOMString return (often JSON text). */
   execute: (input: object, client?: ModelContextClient) => Promise<unknown>
   annotations?: ToolAnnotations
 }
 
 interface ToolAnnotations {
   readOnlyHint?: boolean
+  untrustedContentHint?: boolean
 }
 
 interface ModelContextRegisterToolOptions {
   signal?: AbortSignal
+  exposedTo?: string[]
 }
 
 interface ModelContextClient {
+  signal?: AbortSignal
   requestUserInteraction?: (callback: () => Promise<unknown>) => Promise<unknown>
 }

--- a/packages/clawql-api/src/webmcp/webmcp-browser.ts
+++ b/packages/clawql-api/src/webmcp/webmcp-browser.ts
@@ -275,15 +275,16 @@ export function executeWebmcpToolEffect(
       const mc = document.modelContext;
       if (!mc?.getTools || !mc?.executeTool) throw new Error("WebMCP not available");
       const toolName = ${toolNameJson};
-      const input = ${inputJson};
+      // Chrome Imperative API: executeTool(tool, inputJsonString)
+      const inputJson = ${JSON.stringify(inputJson)};
       const tools = await mc.getTools();
       const tool = tools.find((t) => t.name === toolName);
       if (!tool) throw new Error("Tool not found: " + toolName);
-      const result = await mc.executeTool(tool, input);
+      const result = await mc.executeTool(tool, inputJson);
       try {
-        return { ok: true, data: JSON.parse(result) };
+        return { ok: true, data: typeof result === "string" ? JSON.parse(result) : result, rawType: typeof result };
       } catch {
-        return { ok: true, data: result };
+        return { ok: true, data: result, rawType: typeof result };
       }
     })()`;
 

--- a/website/src/types/webmcp.d.ts
+++ b/website/src/types/webmcp.d.ts
@@ -1,10 +1,15 @@
 /**
  * WebMCP (Model Context) — https://webmachinelearning.github.io/webmcp/
+ * Chrome 149+: document.modelContext is canonical; navigator is deprecated alias.
  */
 export {}
 
 declare global {
+  interface Document {
+    readonly modelContext?: ModelContext
+  }
   interface Navigator {
+    /** @deprecated Prefer document.modelContext (Chrome 150+) */
     readonly modelContext?: ModelContext
   }
 }
@@ -13,7 +18,21 @@ interface ModelContext {
   registerTool(
     tool: ModelContextTool,
     options?: ModelContextRegisterToolOptions,
-  ): void
+  ): void | Promise<void>
+  getTools?(options?: { fromOrigins?: string[] }): Promise<RegisteredTool[]>
+  executeTool?(
+    tool: RegisteredTool,
+    inputJson: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<string | null>
+}
+
+interface RegisteredTool {
+  name: string
+  title?: string
+  description?: string
+  inputSchema?: object
+  origin?: string
 }
 
 /** @see https://webmachinelearning.github.io/webmcp/ §4.2.1 */
@@ -22,19 +41,23 @@ interface ModelContextTool {
   title?: string
   description: string
   inputSchema?: object
+  /** Chrome Imperative API expects a DOMString return (often JSON text). */
   execute: (input: object, client: ModelContextClient) => Promise<unknown>
   annotations?: ToolAnnotations
 }
 
 interface ToolAnnotations {
   readOnlyHint?: boolean
+  untrustedContentHint?: boolean
 }
 
 interface ModelContextRegisterToolOptions {
   signal?: AbortSignal
+  exposedTo?: string[]
 }
 
 interface ModelContextClient {
+  signal?: AbortSignal
   requestUserInteraction?: (
     callback: () => Promise<unknown>,
   ) => Promise<unknown>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Records real iPhone device verification + WebMCP API surface fix for Chrome 149 judges.

## Mobile (done)

| Environment | HEIC | Result |
| --- | --- | --- |
| iPhone Safari | Native | `IMG_6432.HEIC` → `up_7vjocs3` |
| iOS Chrome | Native | Same device, same pass |

## WebMCP API surface (this PR)

- Prefer `document.modelContext ?? navigator.modelContext` (was reversed / navigator-only)
- `execute` returns `JSON.stringify(...)` (Chrome Imperative DOMString)
- CDP `executeTool(tool, jsonString)`
- Console probe: `webmcp-console-probe.js` — discovery + execute + shape

**Runtime gate still needs your Mac:** this cloud VM has Chrome **148**; WebMCP needs **149+** with the testing flag. Paste the probe on clawql.com after deploy.

Also: harness gallery renders on fixed pane only (not broken iframe).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03b41-a8f7-766e-b8b6-1e0170a7356a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03b41-a8f7-766e-b8b6-1e0170a7356a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

