### PR TITLE
fix(deps): web-tree-sitter 0.26 via @vscode/tree-sitter-wasm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6572,6 +6572,12 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
+        "node_modules/@vscode/tree-sitter-wasm": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@vscode/tree-sitter-wasm/-/tree-sitter-wasm-0.3.1.tgz",
+            "integrity": "sha512-RJFoomET6FajjG511fmQxeBQfU6M24a0aFZPqpid+ttIxanWf1VGytBG0UmsGjt07qmIPJS8U31D+aecuCucsQ==",
+            "license": "MIT"
+        },
         "node_modules/@whatwg-node/disposablestack": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/@whatwg-node/disposablestack/-/disposablestack-0.0.6.tgz",
@@ -13977,12 +13983,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/web-tree-sitter": {
-            "version": "0.25.6",
-            "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.6.tgz",
-            "integrity": "sha512-WG+/YGbxw8r+rLlzzhV+OvgiOJCWdIpOucG3qBf3RCBFMkGDb1CanUi2BxCxjnkpzU3/hLWPT8VO5EKsMk9Fxg==",
-            "license": "MIT"
-        },
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -14372,13 +14372,14 @@
             "version": "8.0.0",
             "license": "MIT",
             "dependencies": {
+                "@vscode/tree-sitter-wasm": "^0.3.1",
                 "effect": "^3.21.4",
                 "graphology": "^0.26.0",
                 "graphology-communities-louvain": "^2.0.2",
                 "graphology-types": "^0.24.8",
                 "tree-sitter-wasms": "^0.1.13",
                 "typescript": "^6.0.3",
-                "web-tree-sitter": "^0.25.6",
+                "web-tree-sitter": "^0.26.12",
                 "zod": "4.3.6"
             },
             "devDependencies": {
@@ -14389,6 +14390,12 @@
             "engines": {
                 "node": ">=22"
             }
+        },
+        "packages/clawql-codegraph/node_modules/web-tree-sitter": {
+            "version": "0.26.13",
+            "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.13.tgz",
+            "integrity": "sha512-5bUZ7vbQ1kcondet96wzP974+JfCZDeQ7bTpacICm2nnvHpa5cO0ByRsoMcAhUP+743vpkb4m0BFlVSm+Ye9VA==",
+            "license": "MIT"
         },
         "packages/clawql-core": {
             "version": "8.0.0",

--- a/packages/clawql-codegraph/package.json
+++ b/packages/clawql-codegraph/package.json
@@ -35,8 +35,9 @@
     "graphology-types": "^0.24.8",
     "tree-sitter-wasms": "^0.1.13",
     "typescript": "^6.0.3",
-    "web-tree-sitter": "^0.25.6",
-    "zod": "4.3.6"
+    "web-tree-sitter": "^0.26.12",
+    "zod": "4.3.6",
+    "@vscode/tree-sitter-wasm": "^0.3.1"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/packages/clawql-codegraph/src/indexer/extract-tree-sitter.ts
+++ b/packages/clawql-codegraph/src/indexer/extract-tree-sitter.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { Parser, Language, type Node } from "web-tree-sitter";
@@ -12,8 +13,11 @@ export type TreeSitterExtractResult = {
 };
 
 /**
- * Languages with a `tree-sitter-wasms` grammar. TS/JS still prefer the compiler API;
+ * Languages with a tree-sitter WASM grammar. TS/JS still prefer the compiler API;
  * these ids are used for everything else (and as a TS/JS fallback).
+ *
+ * Grammar WASMs: prefer `@vscode/tree-sitter-wasm` (ABI-matched to web-tree-sitter
+ * ≥0.26); fall back to `tree-sitter-wasms` for languages VS Code does not ship.
  */
 export type TreeSitterLanguageId =
   | "python"
@@ -496,9 +500,30 @@ async function ensureParser(): Promise<void> {
   await parserInit;
 }
 
-function wasmPath(profile: LangProfile): string {
+function vscodeWasmPath(profile: LangProfile): string | null {
+  try {
+    const pkgRoot = path.dirname(require.resolve("@vscode/tree-sitter-wasm/package.json"));
+    // VS Code package uses kebab-case for C# (`c-sharp`); profiles use `c_sharp`.
+    const file =
+      profile.wasm === "tree-sitter-c_sharp.wasm"
+        ? "tree-sitter-c-sharp.wasm"
+        : profile.wasm;
+    const candidate = path.join(pkgRoot, "wasm", file);
+    return existsSync(candidate) ? candidate : null;
+  } catch {
+    return null;
+  }
+}
+
+function legacyWasmPath(profile: LangProfile): string {
   const pkgRoot = path.dirname(require.resolve("tree-sitter-wasms/package.json"));
   return path.join(pkgRoot, "out", profile.wasm);
+}
+
+function wasmPath(profile: LangProfile): string {
+  // Prefer @vscode/tree-sitter-wasm (ABI-compatible with web-tree-sitter ≥0.26).
+  // Fall back to tree-sitter-wasms for languages VS Code does not ship yet.
+  return vscodeWasmPath(profile) ?? legacyWasmPath(profile);
 }
 
 async function getLanguage(id: TreeSitterLanguageId): Promise<Language> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Supersedes Dependabot #948.

`web-tree-sitter` **0.26** changed the WASM ABI; grammars from `tree-sitter-wasms@0.1.x` no longer load (`getDylinkMetadata` / `failIf`).

### Fix
- Prefer `@vscode/tree-sitter-wasm` (ABI-matched to 0.26) when the grammar file exists
- Fall back to `tree-sitter-wasms` for languages VS Code does not ship
- Map `c_sharp` → `c-sharp` filename

All 7 `extract-tree-sitter` tests pass locally against 0.26.12.

Please close #948 as superseded once green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03b41-a8f7-766e-b8b6-1e0170a7356a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03b41-a8f7-766e-b8b6-1e0170a7356a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

