### PR TITLE
test: relax stdio Ready timing bound for CI load flakes

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -148,7 +148,8 @@ describe("server (stdio)", () => {
     const t0 = Date.now();
     let readyMs = -1;
     const waitReady = new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error("Ready not seen in time")), 5_000);
+      // CI runners occasionally take >5s to spawn + print Ready under load.
+      const timer = setTimeout(() => reject(new Error("Ready not seen in time")), 10_000);
       const poll = setInterval(() => {
         if (serverLogs.join("").includes("Server running on stdio")) {
           readyMs = Date.now() - t0;
@@ -165,7 +166,9 @@ describe("server (stdio)", () => {
       const { tools } = await client.listTools();
       expect(tools.some((t) => t.name === "memory_recall")).toBe(true);
       expect(readyMs).toBeGreaterThanOrEqual(0);
-      expect(readyMs).toBeLessThan(4_000);
+      // Soft bound: must stay well under cold-catalog timescales, but CI load
+      // sometimes crosses 4s (observed ~4.1–4.2s flakes on Node 22).
+      expect(readyMs).toBeLessThan(8_000);
     } finally {
       await client.close();
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Lands the follow-up that was pushed to `#1008` after that PR merged: CI runners occasionally take ~4.1–4.2s for stdio Ready under load on Node 22, which fails `readyMs < 4_000`.

## Changes

- Wait timeout: 5s → 10s
- Soft bound: 4s → 8s (still well under cold-catalog timescales)

## Why

`#1008` merged CodeQL 4.37.9 but Node 22 still failed this flake after merge. Without this on `main`, subsequent PRs (`#1007`, observability, etc.) can fail the same way.

## Test plan

- [x] Cherry-pick of proven commit `7aa6a450`
- [ ] CI green on Node 22/24/25
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03b41-a8f7-766e-b8b6-1e0170a7356a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03b41-a8f7-766e-b8b6-1e0170a7356a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

