### PR TITLE
fix(ci): bootstrap Cloudflare Pages project for landing deploy

### DIFF
--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -176,6 +176,13 @@ jobs:
           name: landing-page-out
           path: landing-page/demo/out
 
+      - name: Ensure Cloudflare Pages project exists
+        if: steps.cf.outputs.enabled == 'true'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bash scripts/deploy/ensure-cloudflare-pages-project.sh
+
       - name: Deploy to Cloudflare Pages
         if: steps.cf.outputs.enabled == 'true'
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0

--- a/landing-page/README.md
+++ b/landing-page/README.md
@@ -92,7 +92,7 @@ Workflow [`.github/workflows/deploy-landing-page.yml`](../.github/workflows/depl
 
 ### Cloudflare Pages (for full agent score)
 
-When `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` are set, the same workflow also deploys to **Cloudflare Pages** (`clawql-website`). Opt out with repo variable **`LANDING_PAGE_CLOUDFLARE_DEPLOY=false`**. Wrangler runs from `landing-page/demo/` so sibling `functions/` (Link headers + markdown negotiation) is bundled with `out/`.
+When `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` are set, the same workflow also deploys to **Cloudflare Pages** (`clawql-website`). CI runs [`scripts/deploy/ensure-cloudflare-pages-project.sh`](../../scripts/deploy/ensure-cloudflare-pages-project.sh) before the first deploy so the project is created when missing. Opt out with repo variable **`LANDING_PAGE_CLOUDFLARE_DEPLOY=false`**. Wrangler runs from `landing-page/demo/` so sibling `functions/` (Link headers + markdown negotiation) is bundled with `out/`.
 
 **DNS (one-time, when switching):** Attach custom domain `clawql.com` to the Pages project in the Cloudflare dashboard (preferred path to level 5 on [isitagentready.com](https://isitagentready.com/clawql.com)).
 

--- a/scripts/deploy/ensure-cloudflare-pages-project.sh
+++ b/scripts/deploy/ensure-cloudflare-pages-project.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Ensure a Cloudflare Pages project exists before wrangler pages deploy.
+#
+# Auth (same as deploy-docs / landing-page workflow):
+#   CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID
+#
+# Optional:
+#   CLAWQL_LANDING_PAGES_PROJECT   (default: clawql-website)
+#   CLAWQL_LANDING_PAGES_BRANCH    (default: main)
+set -euo pipefail
+
+PROJECT_NAME="${CLAWQL_LANDING_PAGES_PROJECT:-clawql-website}"
+PRODUCTION_BRANCH="${CLAWQL_LANDING_PAGES_BRANCH:-main}"
+TOKEN="${CLOUDFLARE_API_TOKEN:-}"
+ACCOUNT_ID="${CLOUDFLARE_ACCOUNT_ID:-}"
+
+if [[ -z "${TOKEN// }" || -z "${ACCOUNT_ID// }" ]]; then
+  echo "ERROR: CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID are required."
+  exit 1
+fi
+
+export CLOUDFLARE_API_TOKEN="$TOKEN"
+export CLOUDFLARE_ACCOUNT_ID="$ACCOUNT_ID"
+
+WRANGLER="${WRANGLER_CMD:-npx --yes wrangler@4}"
+
+project_exists() {
+  local json
+  json="$($WRANGLER pages project list --json 2>/dev/null || true)"
+  if [[ -z "${json// }" ]]; then
+    return 1
+  fi
+  if command -v jq >/dev/null 2>&1; then
+    if echo "$json" | jq -e --arg n "$PROJECT_NAME" '
+      if type == "array" then .[]
+      elif (.result? | type) == "array" then .result[]
+      else empty end | select(.name == $n)
+    ' >/dev/null 2>&1; then
+      return 0
+    fi
+  fi
+  echo "$json" | grep -Fq "\"name\":\"${PROJECT_NAME}\"" || echo "$json" | grep -Fq "\"name\": \"${PROJECT_NAME}\""
+}
+
+if project_exists; then
+  echo "Cloudflare Pages project already exists: ${PROJECT_NAME}"
+  exit 0
+fi
+
+echo "Creating Cloudflare Pages project: ${PROJECT_NAME} (production branch: ${PRODUCTION_BRANCH})"
+if $WRANGLER pages project create "$PROJECT_NAME" --production-branch "$PRODUCTION_BRANCH"; then
+  echo "Created Cloudflare Pages project: ${PROJECT_NAME}"
+  exit 0
+fi
+
+if project_exists; then
+  echo "Create reported an error but project ${PROJECT_NAME} is present — continuing."
+  exit 0
+fi
+
+echo "ERROR: Failed to create Cloudflare Pages project ${PROJECT_NAME}."
+exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes recurring **Deploy landing page** workflow failures on the Cloudflare Pages job when `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` are set but the **`clawql-website`** Pages project has not been created yet.

GitHub Pages deploy was already succeeding; only `wrangler pages deploy` failed with:

> The Pages project "clawql-website" does not exist.

## Changes

- Add `scripts/deploy/ensure-cloudflare-pages-project.sh` — lists projects via Wrangler; creates `clawql-website` with production branch `main` when missing.
- Run the ensure script in `.github/workflows/deploy-landing-page.yml` before the Wrangler deploy step.
- Document auto-bootstrap in `landing-page/README.md`.

## Test plan

- [x] `bash -n` on ensure script
- [ ] CI ShellCheck & actionlint on workflow change
- [ ] After merge: trigger `Deploy landing page` workflow_dispatch or push to `landing-page/**` and confirm Cloudflare job passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9b5e-4d74-72e6-90bb-d0c2100f09d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9b5e-4d74-72e6-90bb-d0c2100f09d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

