### PR TITLE
feat(extractbench): wire IDP provider to meta-ontology pipeline

### DIFF
--- a/integrations/extractbench/README.md
+++ b/integrations/extractbench/README.md
@@ -55,6 +55,9 @@ QWEN35_SERVER_URL=http://127.0.0.1:8000   # Arm A only — your vLLM / OpenAI-co
 ## Cost-safe run order
 
 ```bash
+# Build ontology packages when enabling CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC=1
+npm run build -w clawql-pageindex -w clawql-codegraph -w clawql-api -w clawql-memory -w clawql-ontology
+
 # 6 docs
 uv run extract-bench run clawql_idp_qwen_extract --test
 uv run extract-bench serve clawql_idp_qwen_extract
@@ -72,6 +75,17 @@ uv run extract-bench compare \
 ```
 
 **Do not use Opus for the full 4,869-page run.** Self-hosted Qwen for schema mapping; set `CLAWQL_EXTRACTBENCH_COST_PER_PAGE` (or pipeline `cost_per_page_usd`) to attribute measured infra cost when submitting.
+
+### Meta-ontology sync (optional)
+
+When `CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC=1`, each EXTRACT also runs
+[`runExtractBenchOntologyPipeline`](../../docs/specs/ontology/meta-ontology-v0.1.md)
+(scaffold → `ontology.db` → structured `memory_recall`). Results land in
+`raw_output.ontology` with T1 array completeness metrics — useful for long-document
+list truncation experiments without changing ExtractBench scoring.
+
+Requires `CLAWQL_OBSIDIAN_VAULT_PATH` (set by `start-clawql-for-extractbench.sh`) and
+built `clawql-ontology` / `clawql-memory` packages.
 
 ## Success criteria (publishable)
 

--- a/integrations/extractbench/provider/clawql_idp/ontology_sync.py
+++ b/integrations/extractbench/provider/clawql_idp/ontology_sync.py
@@ -1,0 +1,155 @@
+"""Bridge ExtractBench schema-map output into ClawQL meta-ontology (Layer 2/3).
+
+Calls ``integrations/extractbench/scripts/run-ontology-pipeline.mjs`` which
+wraps ``runExtractBenchOntologyPipeline`` (scaffold → populate → ontology.db → recall).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "_", value.strip().lower()).strip("_")
+    return slug or "document"
+
+
+def derive_document_type(schema: dict[str, Any], example_id: str | None = None) -> str:
+    """Stable document type id for ontology scaffold."""
+    for key in ("title", "name", "$id"):
+        raw = schema.get(key)
+        if isinstance(raw, str) and raw.strip():
+            return _slugify(raw)
+    if example_id and example_id.strip():
+        return _slugify(example_id.split("/")[-1])
+    return "extractbench_document"
+
+
+def clawql_repo_root() -> Path:
+    env = os.environ.get("CLAWQL_REPO_ROOT", "").strip()
+    if env:
+        return Path(env).resolve()
+    # integrations/extractbench/provider/clawql_idp/ontology_sync.py → repo root
+    return Path(__file__).resolve().parents[4]
+
+
+def ontology_pipeline_script() -> Path:
+    return clawql_repo_root() / "integrations/extractbench/scripts/run-ontology-pipeline.mjs"
+
+
+def ontology_sync_enabled(config: dict[str, Any] | None = None) -> bool:
+    if config and "ontology_sync" in config:
+        return bool(config.get("ontology_sync"))
+    return os.environ.get("CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def run_ontology_pipeline(
+    *,
+    json_schema: dict[str, Any],
+    extracted: dict[str, Any],
+    document_type: str | None = None,
+    document_id: str,
+    vault_root: str | None = None,
+    limit: int = 10_000,
+    node_bin: str | None = None,
+    timeout_s: float = 300.0,
+) -> dict[str, Any]:
+    """Run meta-ontology pipeline; return summary JSON (recall + row counts)."""
+    script = ontology_pipeline_script()
+    if not script.is_file():
+        raise FileNotFoundError(f"ontology pipeline script not found: {script}")
+
+    vault = (vault_root or os.environ.get("CLAWQL_OBSIDIAN_VAULT_PATH") or "").strip()
+    if not vault:
+        raise ValueError(
+            "CLAWQL_OBSIDIAN_VAULT_PATH or vault_root is required for ontology sync"
+        )
+
+    doc_type = document_type or derive_document_type(json_schema, document_id)
+    payload = {
+        "jsonSchema": json_schema,
+        "documentType": doc_type,
+        "documentId": document_id,
+        "extracted": extracted,
+        "vaultRoot": vault,
+        "limit": limit,
+    }
+
+    node = node_bin or os.environ.get("CLAWQL_NODE_BIN", "node")
+    env = os.environ.copy()
+    env["CLAWQL_OBSIDIAN_VAULT_PATH"] = vault
+    proc = subprocess.run(
+        [node, str(script)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=timeout_s,
+        check=False,
+        cwd=str(clawql_repo_root()),
+        env=env,
+    )
+    if proc.returncode != 0:
+        stderr = (proc.stderr or proc.stdout or "").strip()
+        raise RuntimeError(
+            f"ontology pipeline failed (exit {proc.returncode}): {stderr[:2000]}"
+        )
+    line = (proc.stdout or "").strip().splitlines()[-1] if proc.stdout else ""
+    if not line:
+        raise RuntimeError("ontology pipeline returned empty stdout")
+    result = json.loads(line)
+    if not isinstance(result, dict):
+        raise RuntimeError("ontology pipeline returned non-object JSON")
+    result["documentType"] = doc_type
+    result["documentId"] = document_id
+    return result
+
+
+def t1_completeness_metrics(
+    result: dict[str, Any],
+    schema: dict[str, Any],
+) -> dict[str, Any]:
+    """Compare recalled row counts vs extracted array lengths (T1 completeness)."""
+    rows_populated: dict[str, int] = dict(result.get("rowsPopulated") or {})
+    repeated = schema.get("repeated_structure")
+    array_fields: list[str] = []
+    if isinstance(repeated, dict):
+        array_fields = [k for k, v in repeated.items() if isinstance(v, dict)]
+    props = schema.get("properties")
+    if isinstance(props, dict):
+        for key, spec in props.items():
+            if isinstance(spec, dict) and spec.get("type") == "array":
+                if key not in array_fields:
+                    array_fields.append(key)
+
+    metrics: dict[str, Any] = {"arrays": {}, "complete": True}
+    recall = result.get("recall") or {}
+    hits = recall.get("hits") if isinstance(recall, dict) else None
+    first_hit = hits[0] if isinstance(hits, list) and hits else None
+    fields = (first_hit or {}).get("fields") if isinstance(first_hit, dict) else None
+
+    for field in array_fields:
+        expected = rows_populated.get(field)
+        recalled_len: int | None = None
+        if isinstance(fields, dict) and isinstance(fields.get(field), list):
+            recalled_len = len(fields[field])
+        metrics["arrays"][field] = {
+            "rowsPopulated": expected,
+            "recalled": recalled_len,
+            "match": expected is not None and recalled_len == expected,
+        }
+        if expected is not None and recalled_len != expected:
+            metrics["complete"] = False
+
+    metrics["recallOk"] = bool(recall.get("ok")) if isinstance(recall, dict) else False
+    return metrics

--- a/integrations/extractbench/provider/clawql_idp/provider.py
+++ b/integrations/extractbench/provider/clawql_idp/provider.py
@@ -41,6 +41,11 @@ from extract_bench.schemas.pipeline_io import (
 from extract_bench.schemas.product import ProductType
 
 from .mcp_client import ClawQLMcpClient
+from .ontology_sync import (
+    ontology_sync_enabled,
+    run_ontology_pipeline,
+    t1_completeness_metrics,
+)
 from .schema_map import (
     SCHEMA_MAP_SYSTEM_PROMPT,
     chunk_text_for_mapping,
@@ -164,6 +169,8 @@ class ClawQLIDPProvider(Provider):
             or 0.0
         )
         self._force_docling = bool(self.base_config.get("force_docling", False))
+        self._ontology_sync = ontology_sync_enabled(self.base_config)
+        self._ontology_limit = int(self.base_config.get("ontology_recall_limit", 10_000))
         self._mcp = ClawQLMcpClient(self._mcp_url, timeout_s=self._timeout_s)
 
     def _inspect_pdf(self, file_path: Path) -> dict[str, Any]:
@@ -432,6 +439,22 @@ class ClawQLIDPProvider(Provider):
             if not isinstance(extracted, dict) or extracted == {}:
                 raise ProviderPermanentError("schema mapping produced empty extraction")
 
+            ontology_meta: dict[str, Any] | None = None
+            if self._ontology_sync and isinstance(extracted, dict):
+                try:
+                    ontology_result = run_ontology_pipeline(
+                        json_schema=request.schema_override,
+                        extracted=extracted,
+                        document_id=str(request.example_id or file_path.stem),
+                        limit=self._ontology_limit,
+                    )
+                    ontology_meta = {
+                        "pipeline": ontology_result,
+                        "t1": t1_completeness_metrics(ontology_result, request.schema_override),
+                    }
+                except Exception as exc:  # noqa: BLE001 — optional enrichment; do not fail EXTRACT
+                    ontology_meta = {"error": str(exc)}
+
             cost_usd = self._cost_per_page_usd * pages if pages > 0 else self._cost_per_page_usd
             raw_output: dict[str, Any] = {
                 "extracted_data": extracted,
@@ -440,6 +463,7 @@ class ClawQLIDPProvider(Provider):
                 "inspect_pdf": inspect,
                 "docling": inspect_docling if used_docling else None,
                 "schema_map": map_meta,
+                "ontology": ontology_meta,
                 "num_pages": pages or None,
                 "cost_usd": cost_usd,
                 "cost_per_page_usd": self._cost_per_page_usd if pages else None,
@@ -448,6 +472,7 @@ class ClawQLIDPProvider(Provider):
                     "model": self._model if self._schema_map_mode == "llm" else None,
                     "mcp_url": self._mcp_url,
                     "force_docling": self._force_docling,
+                    "ontology_sync": self._ontology_sync,
                 },
             }
 

--- a/integrations/extractbench/scripts/apply_clawql_provider.py
+++ b/integrations/extractbench/scripts/apply_clawql_provider.py
@@ -76,6 +76,9 @@ CLAWQL_MCP_URL=http://127.0.0.1:8080/mcp
 QWEN35_SERVER_URL=
 # Optional measured infra cost attribution (USD / page)
 # CLAWQL_EXTRACTBENCH_COST_PER_PAGE=0.10
+# Optional meta-ontology sync after schema map (requires built clawql-ontology)
+# CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC=1
+# CLAWQL_OBSIDIAN_VAULT_PATH=/tmp/clawql-extractbench-vault
 """
 
 

--- a/integrations/extractbench/scripts/run-ontology-pipeline.mjs
+++ b/integrations/extractbench/scripts/run-ontology-pipeline.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * stdin JSON → runExtractBenchOntologyPipeline → stdout JSON summary.
+ *
+ * Used by integrations/extractbench/provider/clawql_idp/ontology_sync.py after
+ * schema mapping. Requires `npm run build -w clawql-ontology -w clawql-memory`.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+async function main() {
+  const raw = readFileSync(0, "utf8");
+  const input = JSON.parse(raw);
+  if (input.vaultRoot?.trim()) {
+    process.env.CLAWQL_OBSIDIAN_VAULT_PATH = input.vaultRoot.trim();
+  }
+  const mod = await import(join(repoRoot, "packages/clawql-ontology/dist/index.js"));
+  const result = await mod.runExtractBenchOntologyPipelinePromise(input);
+  const summary = {
+    entityId: result.scaffold.entityId,
+    populatedFields: result.populatedFields,
+    nullFields: result.nullFields,
+    rowsPopulated: result.rowsPopulated,
+    recall: result.recall,
+  };
+  process.stdout.write(`${JSON.stringify(summary)}\n`);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack || err.message : String(err));
+  process.exit(1);
+});

--- a/integrations/extractbench/scripts/start-clawql-for-extractbench.sh
+++ b/integrations/extractbench/scripts/start-clawql-for-extractbench.sh
@@ -14,6 +14,8 @@ export CLAWQL_ENABLE_IDP_PIPELINE="${CLAWQL_ENABLE_IDP_PIPELINE:-1}"
 # LangExtract optional — ExtractBench schema map uses Qwen/vLLM by default.
 export CLAWQL_ENABLE_LANGEXTRACT="${CLAWQL_ENABLE_LANGEXTRACT:-0}"
 export CLAWQL_OBSIDIAN_VAULT_PATH="$VAULT"
+# Optional: scaffold → ontology.db → memory_recall after each EXTRACT (T1 completeness telemetry)
+export CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC="${CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC:-0}"
 # Allow inspect_pdf / anydoc to read ExtractBench dataset paths.
 export CLAWQL_PDF_INSPECTOR_FILE_ROOTS="${CLAWQL_PDF_INSPECTOR_FILE_ROOTS:-/:/tmp:$HOME:$ROOT}"
 export CLAWQL_ANYDOC_FILE_ROOTS="${CLAWQL_ANYDOC_FILE_ROOTS:-$CLAWQL_PDF_INSPECTOR_FILE_ROOTS}"

--- a/integrations/extractbench/tests/test_ontology_sync.py
+++ b/integrations/extractbench/tests/test_ontology_sync.py
@@ -1,0 +1,78 @@
+"""Unit tests for ExtractBench ontology sync bridge (no live Node required)."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "provider"))
+
+from clawql_idp.ontology_sync import (  # noqa: E402
+    derive_document_type,
+    ontology_sync_enabled,
+    run_ontology_pipeline,
+    t1_completeness_metrics,
+)
+
+
+class OntologySyncTests(unittest.TestCase):
+    def test_derive_document_type_from_title(self) -> None:
+        schema = {"title": "Brokerage Statement", "type": "object"}
+        self.assertEqual(derive_document_type(schema), "brokerage_statement")
+
+    def test_ontology_sync_env_flag(self) -> None:
+        with patch.dict("os.environ", {"CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC": "1"}):
+            self.assertTrue(ontology_sync_enabled())
+        with patch.dict("os.environ", {}, clear=True):
+            self.assertFalse(ontology_sync_enabled())
+
+    def test_run_ontology_pipeline_parses_stdout(self) -> None:
+        summary = {
+            "entityId": "invoice",
+            "rowsPopulated": {"lineItems": 3},
+            "recall": {"ok": True, "hits": [{"fields": {"lineItems": [1, 2, 3]}}]},
+        }
+
+        def fake_run(*_args, **_kwargs):
+            class Proc:
+                returncode = 0
+                stdout = json.dumps(summary) + "\n"
+                stderr = ""
+
+            return Proc()
+
+        with patch("clawql_idp.ontology_sync.subprocess.run", fake_run):
+            with patch.dict("os.environ", {"CLAWQL_OBSIDIAN_VAULT_PATH": "/tmp/vault"}):
+                out = run_ontology_pipeline(
+                    json_schema={"title": "Invoice", "type": "object"},
+                    extracted={"invoiceNumber": "1", "lineItems": [{}, {}, {}]},
+                    document_id="ex-1",
+                )
+        self.assertEqual(out["entityId"], "invoice")
+        self.assertEqual(out["documentType"], "invoice")
+
+    def test_t1_completeness_metrics(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {
+                "lineItems": {"type": "array", "items": {"type": "object"}},
+            },
+        }
+        result = {
+            "rowsPopulated": {"lineItems": 47},
+            "recall": {
+                "ok": True,
+                "hits": [{"fields": {"lineItems": [{}] * 47}}],
+            },
+        }
+        metrics = t1_completeness_metrics(result, schema)
+        self.assertTrue(metrics["complete"])
+        self.assertTrue(metrics["arrays"]["lineItems"]["match"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #963 (merged). Wires the ExtractBench Python IDP provider to `runExtractBenchOntologyPipeline` so each EXTRACT can optionally scaffold → populate `ontology.db` → structured `memory_recall` for T1 list-completeness telemetry.

## Changes

- **`run-ontology-pipeline.mjs`** — stdin JSON bridge to `runExtractBenchOntologyPipelinePromise` (sets `CLAWQL_OBSIDIAN_VAULT_PATH` from `vaultRoot`)
- **`ontology_sync.py`** — Python helper + `CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC` flag
- **`provider.py`** — when enabled, attaches `raw_output.ontology` with recall + T1 array completeness metrics (non-fatal on failure)
- **Tests** — `test_ontology_sync.py` (mocked subprocess)
- **Docs** — ExtractBench README section + env hints in apply/start scripts

## Usage

```bash
export CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC=1
npm run build -w clawql-pageindex -w clawql-codegraph -w clawql-api -w clawql-memory -w clawql-ontology
./integrations/extractbench/scripts/start-clawql-for-extractbench.sh 8080
```

## Test plan

- [x] `python3 integrations/extractbench/tests/test_ontology_sync.py -v`
- [x] E2E: `run-ontology-pipeline.mjs` with invoice fixture → recall ok, 2 line items
- [x] `npm run test -w clawql-ontology -- src/extractbench-pipeline.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03676-50aa-7ef6-b5ff-fff45a324c7e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03676-50aa-7ef6-b5ff-fff45a324c7e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

