### PR TITLE
chore(clawql-harness): version 0.1.0 and CHANGELOG for first npm publish

### DIFF
--- a/docs/design/modularization-implementation-status.md
+++ b/docs/design/modularization-implementation-status.md
@@ -339,7 +339,7 @@ These vision items are **not** done by package extraction alone:
 | `packages/clawql-documents`  | `clawql-documents`  | 8.0.0       |
 | `packages/clawql-web`        | `clawql-web`        | 8.0.0       |
 | `packages/clawql-data`       | `clawql-data`       | 8.0.0       |
-| `packages/clawql-harness`    | `clawql-harness`    | 8.0.0       |
+| `packages/clawql-harness`    | `clawql-harness`    | 0.1.0       |
 | `packages/clawql-tee`        | `clawql-tee`        | 8.0.0       |
 | `packages/clawql-automation` | `clawql-automation` | 8.0.0       |
 | `packages/clawql-sandbox`    | `clawql-sandbox`    | 8.0.0       |

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "clawql-core": "8.0.0",
         "clawql-data": "8.0.0",
         "clawql-documents": "8.0.0",
-        "clawql-harness": "8.0.0",
+        "clawql-harness": "0.1.0",
         "clawql-inference": "8.0.0",
         "clawql-memory": "8.0.0",
         "clawql-merkle": "8.0.0",
@@ -14465,7 +14465,7 @@
       }
     },
     "packages/clawql-harness": {
-      "version": "8.0.0",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "clawql-api": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "clawql-core": "8.0.0",
     "clawql-data": "8.0.0",
     "clawql-documents": "8.0.0",
-    "clawql-harness": "8.0.0",
+    "clawql-harness": "0.1.0",
     "clawql-inference": "8.0.0",
     "clawql-memory": "8.0.0",
     "clawql-merkle": "8.0.0",

--- a/packages/clawql-harness/CHANGELOG.md
+++ b/packages/clawql-harness/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+## Unreleased
+
+## 0.1.0
+
+First public npm release. `clawql-harness` is the model-agnostic execution-loop harness for ClawQL — plugin registry, tool/WORM bridges, and bundled Ouroboros and OpenCode2 plugins.
+
+### Core harness
+
+- **`ClawQLHarness`:** Effect-based execution loop with plugin registry, tool invocation (`invokeHarnessTool`), and WORM event bridges.
+- **`clawql-harness/plugin`:** `makeHarnessLayer` and `createOuroborosHarnessPlugin` for bridging harness tools into MCP hosts.
+- **`clawql-harness/bench`:** `compareHarnesses` and scenario-synthesis bridge for harness benchmarking.
+
+### Ouroboros plugin (`clawql-harness/plugins/ouroboros`)
+
+- Registers `clawql_think` and the full `ouroboros_*` tool set (shared with `clawql-ouroboros`).
+- Stagnation detection and persona hooks for long-running agent loops.
+
+### OpenCode2 plugin (`clawql-harness/plugins/opencode2`)
+
+- Optional embed bridge for `@opencode-ai/sdk` v2 + `opencode-ai` CLI.
+- Harness tool `opencode2_session`: lazy `createOpencode` on first call, `session.create` + `session.prompt` with flat v2 params (`sessionID`, `parts`, `model`, `directory`).
+- Defaults to free OpenCode model `opencode/big-pickle` (no API keys required for demos).
+- Prepends `opencode-ai/bin` to `PATH`; ephemeral port when `CLAWQL_OPENCODE_PORT` is unset.
+- `CLAWQL_OPENCODE_DISABLE_EMBED=1` for unit tests / force CLI fallback.
+- Structured error when peers are missing (use `clawql opencode` CLI instead).
+
+### Install
+
+```bash
+npm install clawql-harness
+# optional OpenCode2 peers
+npm install @opencode-ai/sdk opencode-ai
+```
+
+### Quick start
+
+```typescript
+import { Effect } from "effect";
+import { ClawQLHarness } from "clawql-harness";
+import { createOuroborosHarnessPlugin } from "clawql-harness/plugins/ouroboros";
+
+const harness = await Effect.runPromise(
+  ClawQLHarness.create({
+    plugins: [createOuroborosHarnessPlugin()],
+    model: { provider: "stub", name: "bench-model" },
+  })
+);
+```
+
+See `packages/clawql-harness/README.md` and `packages/clawql-harness/plugins/opencode2/README.md` for full docs.

--- a/packages/clawql-harness/package.json
+++ b/packages/clawql-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawql-harness",
-  "version": "8.0.0",
+  "version": "0.1.0",
   "description": "ClawQL execution-loop harness \u2014 plugin registry, tool/WORM bridges, Ouroboros and OpenCode2 plugins",
   "license": "Apache-2.0",
   "type": "module",
@@ -80,7 +80,8 @@
   "files": [
     "dist",
     "plugins",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Prepares `clawql-harness` for its first public npm release at **0.1.0** (unpublished packages start at 0.1.0 per semver policy).

## Changes

- Add `packages/clawql-harness/CHANGELOG.md` with 0.1.0 first-publish notes (core harness, Ouroboros plugin, OpenCode2 embed plugin, install/quick start)
- Bump `packages/clawql-harness/package.json` version `8.0.0` → `0.1.0`
- Include `CHANGELOG.md` in npm `files` array
- Update root `package.json` workspace reference and `package-lock.json`
- Update `docs/design/modularization-implementation-status.md` version table

## Testing

- `npm run test -w clawql-harness` — 8 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0366b-043e-76b0-88fc-250a1ecca70c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0366b-043e-76b0-88fc-250a1ecca70c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

