### PR TITLE
docs(site): top-level Security sidebar with all training modules

### DIFF
--- a/website/src/lib/docs-nav-data.ts
+++ b/website/src/lib/docs-nav-data.ts
@@ -3,6 +3,8 @@
  * Hub card grids (`docs-hub-data.ts`) surface long-tail pages not listed here.
  */
 
+import { trainingModules } from '@/generated/security-training/registry'
+
 export type NavLink = {
   title: string
   href: string
@@ -15,7 +17,21 @@ export type NavGroup = {
   links: Array<NavLink>
 }
 
-/** First-run sidebar — hubs only; long-tail lives on hub pages. */
+/** Prefer the clause before `:` so long training titles fit the sidebar. */
+function shortSecurityTitle(title: string): string {
+  const beforeColon = title.split(':')[0]?.trim()
+  return beforeColon && beforeColon.length > 0 ? beforeColon : title
+}
+
+const securityBestPracticeLinks: Array<NavLink> = trainingModules.map(
+  (module) => ({
+    title: shortSecurityTitle(module.title),
+    href: `/security/best-practices/${module.slug}`,
+    tag: String(module.part),
+  }),
+)
+
+/** First-run sidebar — Security lists every /security/* page. */
 export const docsNavigation: Array<NavGroup> = [
   {
     title: 'Getting started',
@@ -35,6 +51,21 @@ export const docsNavigation: Array<NavGroup> = [
         title: 'Immutable releases',
         href: '/getting-started/immutable-releases',
       },
+    ],
+  },
+  {
+    title: 'Security',
+    links: [
+      { title: 'Overview', href: '/security' },
+      {
+        title: 'Defense in depth',
+        href: '/security/defense-in-depth',
+      },
+      {
+        title: 'Best practices',
+        href: '/security/best-practices',
+      },
+      ...securityBestPracticeLinks,
     ],
   },
   {
@@ -59,7 +90,6 @@ export const docsNavigation: Array<NavGroup> = [
         title: 'Token efficiency',
         href: '/architecture/token-efficiency',
       },
-      { title: 'Security', href: '/security' },
       { title: 'Troubleshooting', href: '/troubleshooting' },
     ],
   },
@@ -185,6 +215,7 @@ export const docsNavigation: Array<NavGroup> = [
 export const docsMobileShortcuts: Array<{ title: string; href: string }> = [
   { title: 'Home', href: '/' },
   { title: 'Quickstart', href: '/quickstart' },
+  { title: 'Security', href: '/security' },
   { title: 'Deploy', href: '/deployment' },
   { title: 'Learn', href: '/learn' },
   { title: 'Plugins', href: '/plugins' },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Security content is a major part of the docs site (overview, defense-in-depth, and 32 best-practices training modules), but it was previously reachable only via a single link under Learn.

## Changes

- Add **Security** as a top-level sidebar section (after Getting started)
- List **Overview**, **Defense in depth**, **Best practices**, and all **32 training modules** (titles shortened before `:`; part number tags from the generated registry)
- Remove the lone Security link from **Learn**
- Add **Security** to mobile drawer shortcuts

Training module links are generated from `src/generated/security-training/registry.tsx` so new modules stay in sync with the sync script.

## Test plan

- [ ] Sidebar shows Security near the top with 35 entries (3 hubs + 32 modules)
- [ ] Learn no longer contains Security
- [ ] Mobile shortcuts include Security → `/security`
- [ ] Module links resolve (e.g. `/security/best-practices/mcp-runtime-enforcement-panguard-atr`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8f57-601a-7ec1-bff0-d35011fef4ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8f57-601a-7ec1-bff0-d35011fef4ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

