### PR TITLE
fix(extractbench): v8 MCP startup, docling execute args, ontology repo root

### DIFF
--- a/docs/benchmarks/extractbench-clawql-results.md
+++ b/docs/benchmarks/extractbench-clawql-results.md
@@ -66,17 +66,18 @@ The internal comparison that proves pipeline value: **ClawQL IDP + Qwen** vs **r
 
 ## Run diary
 
-| Date | Split | Pipeline | Notes                      |
-| ---- | ----- | -------- | -------------------------- |
-| —    | —     | —        | Overlay landed; scores TBD |
+| Date       | Split        | Pipeline                   | Notes                                                                                        |
+| ---------- | ------------ | -------------------------- | -------------------------------------------------------------------------------------------- |
+| 2026-09-01 | test (6 doc) | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args                      |
+| 2026-09-01 | short (252)  | clawql_idp_docling_extract | In progress — `CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC=1`, log `/tmp/extractbench-short-split.log` |
 
 ## Implementation notes
 
 - Provider: `inspect_pdf` → Docling when needed → schema map (LLM or structural)
 - Long-list completeness: chunked text mapping with array merge (no page-image VLM oneshot)
 - Missing fields must stay `null` (no invention) — T3 dense-doc failure mode
-- Env: `CLAWQL_MCP_URL`, `QWEN35_SERVER_URL` (Arm A), `DOCLING_BASE_URL`
-- Startup: `integrations/extractbench/scripts/start-clawql-for-extractbench.sh`
+- Env: `CLAWQL_MCP_URL`, `QWEN35_SERVER_URL` (Arm A), `DOCLING_BASE_URL`, `CLAWQL_REPO_ROOT`, `CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC=1`
+- Startup: `integrations/extractbench/scripts/start-clawql-for-extractbench.sh` (ClawQL 8.x tier + docling provider)
 
 ## Related
 

--- a/docs/benchmarks/extractbench-clawql-results.md
+++ b/docs/benchmarks/extractbench-clawql-results.md
@@ -42,27 +42,27 @@ The internal comparison that proves pipeline value: **ClawQL IDP + Qwen** vs **r
 
 ## Arm B — ClawQL IDP Docling-only (structural)
 
-| Split   |  Value F1 | Precision | Recall | Page F1 | Cost/page | Latency (P50) | Notes |
-| ------- | --------: | --------: | -----: | ------: | --------: | ------------: | ----- |
+| Split   |  Value F1 | Precision | Recall | Page F1 | Cost/page | Latency (P50) | Notes                                                      |
+| ------- | --------: | --------: | -----: | ------: | --------: | ------------: | ---------------------------------------------------------- |
 | Short   | **39.18** |     43.54 |  37.89 |    0.00 |    $0.000 |         19.1s | **Partial** — 44/252 docs (17%); ontology 44/44 `recallOk` |
-| Overall | _pending_ |         — |      — |       — |         — |             — | No LLM schema map |
-| Long    | _pending_ |         — |      — |       — |         — |             — | Ablation vs Arm A |
+| Overall | _pending_ |         — |      — |       — |         — |             — | No LLM schema map                                          |
+| Long    | _pending_ |         — |      — |       — |         — |             — | Ablation vs Arm A                                          |
 
 Partial short-split details (2026-09-01, `clawql_idp_docling_extract`, structural schema map):
 
-| Metric | Value |
-| ------ | ----: |
-| Docs evaluated | 44 / 252 (17%) |
-| Value F1 (macro avg) | 39.18 |
-| Value precision | 43.54 |
-| Value recall | 37.89 |
-| Array record F1 | 35.97 |
-| Accuracy | 31.26 |
-| Median per-doc Value F1 | 51.9 |
-| Best doc Value F1 | 64.9 (`2A-9-160294_109927`) |
-| Worst doc Value F1 | 0.0 (`real_wyo_Goshen_2024`) |
-| Latency P50 / P95 | 19.1s / 80.1s per doc |
-| Latency max (outlier) | 10.1h (`3N1AB7AP8FY283932_professional_valuation`) |
+| Metric                  |                                              Value |
+| ----------------------- | -------------------------------------------------: |
+| Docs evaluated          |                                     44 / 252 (17%) |
+| Value F1 (macro avg)    |                                              39.18 |
+| Value precision         |                                              43.54 |
+| Value recall            |                                              37.89 |
+| Array record F1         |                                              35.97 |
+| Accuracy                |                                              31.26 |
+| Median per-doc Value F1 |                                               51.9 |
+| Best doc Value F1       |                        64.9 (`2A-9-160294_109927`) |
+| Worst doc Value F1      |                       0.0 (`real_wyo_Goshen_2024`) |
+| Latency P50 / P95       |                              19.1s / 80.1s per doc |
+| Latency max (outlier)   | 10.1h (`3N1AB7AP8FY283932_professional_valuation`) |
 
 Re-evaluate as more docs complete:
 
@@ -90,11 +90,11 @@ uv run extract-bench run clawql_idp_docling_extract --group short --skip_inferen
 
 ## Run diary
 
-| Date       | Split          | Pipeline                   | Notes                                                                                                                                 |
-| ---------- | -------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| 2026-09-01 | test (6 doc)   | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args                                                               |
-| 2026-09-01 | short (252)    | clawql_idp_docling_extract | **In progress** (44/252) — partial eval Value F1 **39.18**; ontology 44/44 `recallOk`; tmux `eb-short-split`                          |
-| 2026-09-01 | short (44/252) | clawql_idp_docling_extract | Partial re-eval (`--skip_inference`); reports at `vendor/ExtractBench/output/clawql_idp_docling_extract/_evaluation_report.*`         |
+| Date       | Split          | Pipeline                   | Notes                                                                                                                         |
+| ---------- | -------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| 2026-09-01 | test (6 doc)   | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args                                                       |
+| 2026-09-01 | short (252)    | clawql_idp_docling_extract | **In progress** (44/252) — partial eval Value F1 **39.18**; ontology 44/44 `recallOk`; tmux `eb-short-split`                  |
+| 2026-09-01 | short (44/252) | clawql_idp_docling_extract | Partial re-eval (`--skip_inference`); reports at `vendor/ExtractBench/output/clawql_idp_docling_extract/_evaluation_report.*` |
 
 ## Implementation notes
 

--- a/docs/benchmarks/extractbench-clawql-results.md
+++ b/docs/benchmarks/extractbench-clawql-results.md
@@ -69,7 +69,7 @@ The internal comparison that proves pipeline value: **ClawQL IDP + Qwen** vs **r
 | Date       | Split        | Pipeline                   | Notes                                                                                        |
 | ---------- | ------------ | -------------------------- | -------------------------------------------------------------------------------------------- |
 | 2026-09-01 | test (6 doc) | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args                      |
-| 2026-09-01 | short (252)  | clawql_idp_docling_extract | In progress — `CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC=1`, log `/tmp/extractbench-short-split.log` |
+| 2026-09-01 | short (252)  | clawql_idp_docling_extract | **In progress** (~1 doc/min) — `CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC=1`; first 10/10 `raw_output.ontology.t1.recallOk`; log `/tmp/extractbench-short-split.log`, tmux `eb-short-split` |
 
 ## Implementation notes
 

--- a/docs/benchmarks/extractbench-clawql-results.md
+++ b/docs/benchmarks/extractbench-clawql-results.md
@@ -7,12 +7,12 @@ Overlay: [`integrations/extractbench/`](../../integrations/extractbench/)
 
 ## Status
 
-**Scaffolding ready; live scores pending.**
+**Arm B short split in progress; partial evaluation available (44/252 docs, 2026-09-01).**
 
 Run order (cost discipline):
 
-1. `--test` (6 docs)
-2. `--group short`
+1. `--test` (6 docs) ✓
+2. `--group short` — **in progress** (44/252); partial eval below
 3. Full run only if short F1 is competitive
 4. Second full run for reproducibility
 
@@ -42,10 +42,34 @@ The internal comparison that proves pipeline value: **ClawQL IDP + Qwen** vs **r
 
 ## Arm B — ClawQL IDP Docling-only (structural)
 
-| Split   |  Value F1 | Notes             |
-| ------- | --------: | ----------------- |
-| Overall | _pending_ | No LLM schema map |
-| Long    | _pending_ | Ablation vs Arm A |
+| Split   |  Value F1 | Precision | Recall | Page F1 | Cost/page | Latency (P50) | Notes |
+| ------- | --------: | --------: | -----: | ------: | --------: | ------------: | ----- |
+| Short   | **39.18** |     43.54 |  37.89 |    0.00 |    $0.000 |         19.1s | **Partial** — 44/252 docs (17%); ontology 44/44 `recallOk` |
+| Overall | _pending_ |         — |      — |       — |         — |             — | No LLM schema map |
+| Long    | _pending_ |         — |      — |       — |         — |             — | Ablation vs Arm A |
+
+Partial short-split details (2026-09-01, `clawql_idp_docling_extract`, structural schema map):
+
+| Metric | Value |
+| ------ | ----: |
+| Docs evaluated | 44 / 252 (17%) |
+| Value F1 (macro avg) | 39.18 |
+| Value precision | 43.54 |
+| Value recall | 37.89 |
+| Array record F1 | 35.97 |
+| Accuracy | 31.26 |
+| Median per-doc Value F1 | 51.9 |
+| Best doc Value F1 | 64.9 (`2A-9-160294_109927`) |
+| Worst doc Value F1 | 0.0 (`real_wyo_Goshen_2024`) |
+| Latency P50 / P95 | 19.1s / 80.1s per doc |
+| Latency max (outlier) | 10.1h (`3N1AB7AP8FY283932_professional_valuation`) |
+
+Re-evaluate as more docs complete:
+
+```bash
+cd vendor/ExtractBench
+uv run extract-bench run clawql_idp_docling_extract --group short --skip_inference --force --open_report=False
+```
 
 ## Delta vs raw Qwen oneshot
 
@@ -66,10 +90,11 @@ The internal comparison that proves pipeline value: **ClawQL IDP + Qwen** vs **r
 
 ## Run diary
 
-| Date       | Split        | Pipeline                   | Notes                                                                                                                                                                               |
-| ---------- | ------------ | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 2026-09-01 | test (6 doc) | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args                                                                                                             |
-| 2026-09-01 | short (252)  | clawql_idp_docling_extract | **In progress** (~1 doc/min) — `CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC=1`; first 10/10 `raw_output.ontology.t1.recallOk`; log `/tmp/extractbench-short-split.log`, tmux `eb-short-split` |
+| Date       | Split          | Pipeline                   | Notes                                                                                                                                 |
+| ---------- | -------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-09-01 | test (6 doc)   | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args                                                               |
+| 2026-09-01 | short (252)    | clawql_idp_docling_extract | **In progress** (44/252) — partial eval Value F1 **39.18**; ontology 44/44 `recallOk`; tmux `eb-short-split`                          |
+| 2026-09-01 | short (44/252) | clawql_idp_docling_extract | Partial re-eval (`--skip_inference`); reports at `vendor/ExtractBench/output/clawql_idp_docling_extract/_evaluation_report.*`         |
 
 ## Implementation notes
 

--- a/docs/benchmarks/extractbench-clawql-results.md
+++ b/docs/benchmarks/extractbench-clawql-results.md
@@ -66,9 +66,9 @@ The internal comparison that proves pipeline value: **ClawQL IDP + Qwen** vs **r
 
 ## Run diary
 
-| Date       | Split        | Pipeline                   | Notes                                                                                        |
-| ---------- | ------------ | -------------------------- | -------------------------------------------------------------------------------------------- |
-| 2026-09-01 | test (6 doc) | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args                      |
+| Date       | Split        | Pipeline                   | Notes                                                                                                                                                                               |
+| ---------- | ------------ | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-09-01 | test (6 doc) | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args                                                                                                             |
 | 2026-09-01 | short (252)  | clawql_idp_docling_extract | **In progress** (~1 doc/min) — `CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC=1`; first 10/10 `raw_output.ontology.t1.recallOk`; log `/tmp/extractbench-short-split.log`, tmux `eb-short-split` |
 
 ## Implementation notes

--- a/integrations/extractbench/README.md
+++ b/integrations/extractbench/README.md
@@ -10,25 +10,25 @@ ExtractBench's headline finding: on documents longer than ~50 pages, commercial 
 
 ClawQL IDP routes with **pdf-inspector**, extracts with **Docling** (page/table structural, no VLM attention window), then maps to the JSON Schema with either:
 
-| Arm | Pipeline name | Schema map |
-| --- | --- | --- |
-| A | `clawql_idp_qwen_extract` | Self-hosted Qwen3.6 35B (OpenAI-compatible) over extracted text |
-| B | `clawql_idp_docling_extract` | Deterministic table/label mapping (no LLM) |
+| Arm | Pipeline name                | Schema map                                                      |
+| --- | ---------------------------- | --------------------------------------------------------------- |
+| A   | `clawql_idp_qwen_extract`    | Self-hosted Qwen3.6 35B (OpenAI-compatible) over extracted text |
+| B   | `clawql_idp_docling_extract` | Deterministic table/label mapping (no LLM)                      |
 
 Arm A is the primary leaderboard candidate. Arm B is the cost-floor / ablation.
 
 ## Layout
 
-| Path | Purpose |
-| --- | --- |
-| `provider/clawql_idp/` | Provider package copied into ExtractBench |
-| `scripts/apply_clawql_provider.py` | Copy + register pipelines / docs / env |
-| `scripts/start-clawql-for-extractbench.sh` | MCP HTTP with IDP flags |
-| `scripts/run-extractbench.sh` | Apply + `extract-bench run` |
-| `tests/test_schema_map.py` | Offline unit tests |
-| `leaderboard-entry.template.csv` | Submission row template |
-| `../../docs/benchmarks/extractbench-clawql-results.md` | Results ledger |
-| `../../docs/gtm/pragmaticvectors/extractbench-long-documents.md` | Essay draft |
+| Path                                                             | Purpose                                   |
+| ---------------------------------------------------------------- | ----------------------------------------- |
+| `provider/clawql_idp/`                                           | Provider package copied into ExtractBench |
+| `scripts/apply_clawql_provider.py`                               | Copy + register pipelines / docs / env    |
+| `scripts/start-clawql-for-extractbench.sh`                       | MCP HTTP with IDP flags                   |
+| `scripts/run-extractbench.sh`                                    | Apply + `extract-bench run`               |
+| `tests/test_schema_map.py`                                       | Offline unit tests                        |
+| `leaderboard-entry.template.csv`                                 | Submission row template                   |
+| `../../docs/benchmarks/extractbench-clawql-results.md`           | Results ledger                            |
+| `../../docs/gtm/pragmaticvectors/extractbench-long-documents.md` | Essay draft                               |
 
 ## Setup
 
@@ -86,6 +86,10 @@ list truncation experiments without changing ExtractBench scoring.
 
 Requires `CLAWQL_OBSIDIAN_VAULT_PATH` (set by `start-clawql-for-extractbench.sh`) and
 built `clawql-ontology` / `clawql-memory` packages.
+
+**ClawQL 8.x:** use `start-clawql-for-extractbench.sh` (sets `CLAWQL_TIER=enterprise`,
+`CLAWQL_PROVIDER=default`, `CLAWQL_BUNDLED_PROVIDERS=docling`, `CLAWQL_REPO_ROOT`) —
+bare `CLAWQL_ENABLE_*` flags are ignored without instance/tier composition.
 
 ## Success criteria (publishable)
 

--- a/integrations/extractbench/provider/clawql_idp/ontology_sync.py
+++ b/integrations/extractbench/provider/clawql_idp/ontology_sync.py
@@ -35,7 +35,15 @@ def clawql_repo_root() -> Path:
     env = os.environ.get("CLAWQL_REPO_ROOT", "").strip()
     if env:
         return Path(env).resolve()
-    # integrations/extractbench/provider/clawql_idp/ontology_sync.py → repo root
+    cur = Path(__file__).resolve().parent
+    for _ in range(10):
+        script = cur / "integrations/extractbench/scripts/run-ontology-pipeline.mjs"
+        if script.is_file():
+            return cur
+        if cur.parent == cur:
+            break
+        cur = cur.parent
+    # Fallback when provider is copied into ExtractBench (integrations/ not under cwd).
     return Path(__file__).resolve().parents[4]
 
 

--- a/integrations/extractbench/provider/clawql_idp/provider.py
+++ b/integrations/extractbench/provider/clawql_idp/provider.py
@@ -195,22 +195,20 @@ class ClawQLIDPProvider(Provider):
             return self._mcp.call_tool(
                 "execute",
                 {
-                    "operationId": "docling::docling_convert_source",
+                    "operationId": "docling_convert_source",
                     "args": {
-                        "body": {
-                            "sources": [
-                                {
-                                    "kind": "file",
-                                    "base64_string": b64,
-                                    "filename": file_path.name,
-                                }
-                            ],
-                            "options": {
-                                "to_formats": ["md", "json"],
-                                "do_ocr": True,
-                                "do_table_structure": True,
-                            },
-                        }
+                        "sources": [
+                            {
+                                "kind": "file",
+                                "base64_string": b64,
+                                "filename": file_path.name,
+                            }
+                        ],
+                        "options": {
+                            "to_formats": ["md", "json"],
+                            "do_ocr": True,
+                            "do_table_structure": True,
+                        },
                     },
                 },
             )

--- a/integrations/extractbench/scripts/run-extractbench.sh
+++ b/integrations/extractbench/scripts/run-extractbench.sh
@@ -11,6 +11,7 @@ EB_ROOT="${1:?ExtractBench checkout path required}"
 shift || true
 
 PIPELINE="${CLAWQL_EXTRACTBENCH_PIPELINE:-clawql_idp_qwen_extract}"
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 
 python3 "$SCRIPT_DIR/apply_clawql_provider.py" --extractbench "$EB_ROOT"
 
@@ -20,6 +21,7 @@ if [[ ! -f .env ]] && [[ -f .env.example ]]; then
   echo "Created .env from .env.example — set CLAWQL_MCP_URL and QWEN35_SERVER_URL"
 fi
 
+export CLAWQL_REPO_ROOT="$ROOT"
 if [[ -z "${CLAWQL_MCP_URL:-}" ]]; then
   export CLAWQL_MCP_URL="http://127.0.0.1:8080/mcp"
 fi

--- a/integrations/extractbench/scripts/start-clawql-for-extractbench.sh
+++ b/integrations/extractbench/scripts/start-clawql-for-extractbench.sh
@@ -8,11 +8,15 @@ ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 VAULT="${CLAWQL_OBSIDIAN_VAULT_PATH:-/tmp/clawql-extractbench-vault}"
 mkdir -p "$VAULT/Memory"
 
-export CLAWQL_ENABLE_DOCUMENTS="${CLAWQL_ENABLE_DOCUMENTS:-1}"
-export CLAWQL_ENABLE_PDF_INSPECTOR="${CLAWQL_ENABLE_PDF_INSPECTOR:-1}"
-export CLAWQL_ENABLE_IDP_PIPELINE="${CLAWQL_ENABLE_IDP_PIPELINE:-1}"
-# LangExtract optional — ExtractBench schema map uses Qwen/vLLM by default.
-export CLAWQL_ENABLE_LANGEXTRACT="${CLAWQL_ENABLE_LANGEXTRACT:-0}"
+# ClawQL 8.x: bare CLAWQL_ENABLE_* is ignored — use tier + provider pack + optional instance overrides.
+export CLAWQL_REPO_ROOT="$ROOT"
+export CLAWQL_ALLOW_NO_ENFORCEMENT="${CLAWQL_ALLOW_NO_ENFORCEMENT:-1}"
+export CLAWQL_TIER="${CLAWQL_TIER:-enterprise}"
+export CLAWQL_PROVIDER="${CLAWQL_PROVIDER:-default}"
+export CLAWQL_BUNDLED_PROVIDERS="${CLAWQL_BUNDLED_PROVIDERS:-docling}"
+# Enterprise tier enables idpPipeline; turn on pdf-inspector explicitly for inspect_pdf routing.
+export CLAWQL_INSTANCE_SPEC="${CLAWQL_INSTANCE_SPEC:-{\"tier\":\"enterprise\",\"documents\":{\"pdfInspector\":{\"enabled\":true}}}}"
+
 export CLAWQL_OBSIDIAN_VAULT_PATH="$VAULT"
 # Optional: scaffold → ontology.db → memory_recall after each EXTRACT (T1 completeness telemetry)
 export CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC="${CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC:-0}"
@@ -25,6 +29,7 @@ export DOCLING_BASE_URL="${DOCLING_BASE_URL:-http://127.0.0.1:5001}"
 
 echo "Starting ClawQL MCP for ExtractBench on :$PORT"
 echo "  vault=$VAULT"
+echo "  CLAWQL_REPO_ROOT=$CLAWQL_REPO_ROOT"
 echo "  DOCLING_BASE_URL=$DOCLING_BASE_URL"
 echo "  CLAWQL_MCP_URL=http://127.0.0.1:${PORT}/mcp"
 

--- a/integrations/extractbench/tests/test_ontology_sync.py
+++ b/integrations/extractbench/tests/test_ontology_sync.py
@@ -12,6 +12,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "provider"))
 
 from clawql_idp.ontology_sync import (  # noqa: E402
+    clawql_repo_root,
     derive_document_type,
     ontology_sync_enabled,
     run_ontology_pipeline,
@@ -29,6 +30,11 @@ class OntologySyncTests(unittest.TestCase):
             self.assertTrue(ontology_sync_enabled())
         with patch.dict("os.environ", {}, clear=True):
             self.assertFalse(ontology_sync_enabled())
+
+    def test_clawql_repo_root_walks_up_to_integrations(self) -> None:
+        root = clawql_repo_root()
+        script = root / "integrations/extractbench/scripts/run-ontology-pipeline.mjs"
+        self.assertTrue(script.is_file(), f"expected script at {script}")
 
     def test_run_ontology_pipeline_parses_stdout(self) -> None:
         summary = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes required to run ExtractBench **Arm B** (`clawql_idp_docling_extract`) against ClawQL 8.x with optional meta-ontology sync enabled.

## Changes

- **`start-clawql-for-extractbench.sh`**: ClawQL 8.x tier/provider config (`CLAWQL_TIER=enterprise`, bundled docling provider, `CLAWQL_REPO_ROOT`, instance spec for pdfInspector)
- **`provider.py`**: Correct docling `operationId` (`docling_convert_source`) and flat execute `args` (`sources`/`options`, not nested `body`)
- **`ontology_sync.py`**: Walk up from provider install path to find ClawQL repo root; honor `CLAWQL_REPO_ROOT`
- **`run-extractbench.sh`**: Export `CLAWQL_REPO_ROOT`
- **Tests/docs**: Repo-root walk-up test; README v8 startup notes; run diary + **partial eval results**

## Validation

- ExtractBench overlay unit tests pass (13/13)
- Live `--test` (6 docs): inference OK; ontology sync `t1.recallOk` on completed docs
- **Short split (252 docs) running** — Arm B structural Docling-only
- **Partial eval (44/252 docs):** Value F1 **39.18**, precision 43.54, recall 37.89; ontology **44/44** `recallOk`

## Related

- Live run diary: `docs/benchmarks/extractbench-clawql-results.md`
- Legal entity Layer 1 recall merged in #1020 (separate from this PR)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03676-50aa-7ef6-b5ff-fff45a324c7e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03676-50aa-7ef6-b5ff-fff45a324c7e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

