### PR TITLE
docs(extractbench): Arm B final partial (93 docs) + Arm A runbook

### DIFF
--- a/docs/benchmarks/extractbench-clawql-results.md
+++ b/docs/benchmarks/extractbench-clawql-results.md
@@ -1,22 +1,36 @@
 # ExtractBench × ClawQL IDP Results
 
-Date: _pending_  
+Date: 2026-09-01 (Arm B partial complete)  
 Pipelines: `clawql_idp_qwen_extract` · `clawql_idp_docling_extract`  
 Benchmark: [run-llama/ExtractBench](https://github.com/run-llama/ExtractBench)  
 Overlay: [`integrations/extractbench/`](../../integrations/extractbench/)
 
 ## Status
 
-**Arm B short split in progress; partial evaluation available (44/252 docs, 2026-09-01).**
+**Arm B short split stopped at 93/252 (37%); final partial eval recorded. Next: Arm A (Qwen schema map).**
 
 Run order (cost discipline):
 
-1. `--test` (6 docs) ✓
-2. `--group short` — **in progress** (44/252); partial eval below
-3. Full run only if short F1 is competitive
-4. Second full run for reproducibility
+1. `--test` (6 docs) ✓ — Arm B
+2. `--group short` — **Arm B stopped** at 93/252 (sufficient ablation signal)
+3. **Arm A `--test`** — blocked until `QWEN35_SERVER_URL` (self-hosted vLLM or OpenAI-compatible proxy)
+4. Arm A `--group short` if test F1 beats raw Qwen trajectory
+5. Full run only if short F1 is competitive
 
 Do **not** use Opus for the full ExtractBench corpus. Prefer self-hosted Qwen3.6 35B for schema mapping (Arm A) or structural Docling-only (Arm B).
+
+## Lessons learned (Arm B)
+
+| Finding | Implication |
+| ------- | ----------- |
+| Value F1 **34.4** at 93 docs (macro avg) | Structural-only is a **floor**, not a product — validates layered design |
+| Median doc F1 **39.6** vs macro **34.4** | Hard doc types (13F filings) drag averages; **routing by doc class** matters |
+| Page/bbox grounding **0%** | Evidence spans must come from layout pipeline or LLM map — needed for leaderboard grounding metrics |
+| Ontology sync **93/93** `recallOk` | Layer 2/3 meta-ontology bridge works; keep enabled for Arm A runs |
+| Docling outliers (**10h** on one valuation PDF) | Need async convert + per-doc timeouts before batch runs |
+| Architecture end-to-end ✓ | MCP → Docling → schema map → ontology recall — ready for Arm A swap-in |
+
+**Verdict:** Good for ClawQL **orchestration + ontology** thesis; bad if misread as extraction quality. Arm A is the decisive test.
 
 ## Baselines (upstream leaderboard, August 2026)
 
@@ -40,31 +54,57 @@ The internal comparison that proves pipeline value: **ClawQL IDP + Qwen** vs **r
 | Medium  | _pending_ | _pending_ | _pending_ |      _pending_ |      _pending_ | _pending_ |     _pending_ |
 | Long    | _pending_ | _pending_ | _pending_ |      _pending_ |      _pending_ | _pending_ |     _pending_ |
 
-## Arm B — ClawQL IDP Docling-only (structural)
+### Arm A next stage (prerequisites)
+
+Cloud agent VM has **no GPU** — Qwen3.6 35B must be external:
+
+```bash
+# Required
+export QWEN35_SERVER_URL=https://your-vllm-host:8000   # OpenAI-compatible /v1
+export CLAWQL_MCP_URL=http://127.0.0.1:8080/mcp
+export DOCLING_BASE_URL=http://127.0.0.1:5001
+export CLAWQL_REPO_ROOT=/path/to/ClawQL
+export CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC=1   # optional telemetry
+
+# Start services (see integrations/extractbench/README.md)
+integrations/extractbench/scripts/start-clawql-for-extractbench.sh 8080
+
+cd vendor/ExtractBench
+uv run extract-bench run clawql_idp_qwen_extract --test
+uv run extract-bench run clawql_idp_qwen_extract --group short --max_concurrent 4
+
+# Compare vs raw Qwen baseline
+uv run extract-bench compare \
+  clawql_idp_qwen_extract \
+  qwen3_6_35b_a3b_fp8_vllm_extract_oneshot_structured_output_file
+```
+
+**Success bar for short split:** Value F1 materially above Arm B (**34.4**) and trending toward raw Qwen oneshot (**87.3** overall; long split **26.75** is the key gap to beat).
+
+## Arm B — ClawQL IDP Docling-only (structural) — FINAL PARTIAL
 
 | Split   |  Value F1 | Precision | Recall | Page F1 | Cost/page | Latency (P50) | Notes |
 | ------- | --------: | --------: | -----: | ------: | --------: | ------------: | ----- |
-| Short   | **39.18** |     43.54 |  37.89 |    0.00 |    $0.000 |         19.1s | **Partial** — 44/252 docs (17%); ontology 44/44 `recallOk` |
-| Overall | _pending_ |         — |      — |       — |         — |             — | No LLM schema map |
-| Long    | _pending_ |         — |      — |       — |         — |             — | Ablation vs Arm A |
+| Short   | **34.43** |     39.38 |  33.28 |    0.00 |    $0.000 |         19.4s | **Stopped** at 93/252 (37%); ontology 93/93 `recallOk` |
+| Overall | _n/a_     |         — |      — |       — |         — |             — | Ablation only |
+| Long    | _n/a_     |         — |      — |       — |         — |             — | Not run separately |
 
-Partial short-split details (2026-09-01, `clawql_idp_docling_extract`, structural schema map):
+Partial short-split details (2026-09-01, `clawql_idp_docling_extract`, structural schema map, **93 docs**):
 
 | Metric | Value |
 | ------ | ----: |
-| Docs evaluated | 44 / 252 (17%) |
-| Value F1 (macro avg) | 39.18 |
-| Value precision | 43.54 |
-| Value recall | 37.89 |
-| Array record F1 | 35.97 |
-| Accuracy | 31.26 |
-| Median per-doc Value F1 | 51.9 |
-| Best doc Value F1 | 64.9 (`2A-9-160294_109927`) |
-| Worst doc Value F1 | 0.0 (`real_wyo_Goshen_2024`) |
-| Latency P50 / P95 | 19.1s / 80.1s per doc |
+| Docs evaluated | 93 / 252 (37%) — run **stopped** |
+| Value F1 (macro avg) | 34.43 |
+| Value precision | 39.38 |
+| Value recall | 33.28 |
+| Array record F1 | 22.45 |
+| Accuracy | 22.91 |
+| Median per-doc Value F1 | 39.6 |
+| Ontology `recallOk` | 93 / 93 |
+| Latency P50 / P95 | 19.4s / 89.5s per doc |
 | Latency max (outlier) | 10.1h (`3N1AB7AP8FY283932_professional_valuation`) |
 
-Re-evaluate as more docs complete:
+Re-evaluate partial results:
 
 ```bash
 cd vendor/ExtractBench
@@ -73,34 +113,36 @@ uv run extract-bench run clawql_idp_docling_extract --group short --skip_inferen
 
 ## Delta vs raw Qwen oneshot
 
-| Metric     | Raw Qwen | ClawQL IDP + Qwen |         Δ |
-| ---------- | -------: | ----------------: | --------: |
-| Overall F1 |    87.33 |         _pending_ | _pending_ |
-| Long F1    |    26.75 |         _pending_ | _pending_ |
-| Cost/page  |        — |         _pending_ |         — |
+| Metric     | Raw Qwen | ClawQL IDP + Qwen | Arm B (structural) |         Δ (target) |
+| ---------- | -------: | ----------------: | -----------------: | -----------------: |
+| Overall F1 |    87.33 |         _pending_ |              34.43 | _pending_ |
+| Long F1    |    26.75 |         _pending_ |                n/a | **beat 26.75** |
+| Cost/page  |        — |         _pending_ |             $0.000 | ≤ $1.00 |
 
 ## Publishability checklist
 
 - [ ] Overall F1 > raw Qwen 87.33
-- [ ] Long F1 > 80
+- [ ] Long F1 > 80 (stretch) / **> 26.75** (minimum vs raw Qwen long)
 - [ ] Cost/page ≤ $1.00
 - [ ] Two independent full runs agree
+- [x] Arm B ablation complete (93-doc partial)
 - [ ] Leaderboard CSV filled from `integrations/extractbench/leaderboard-entry.template.csv`
 - [ ] Essay draft updated with real numbers: [`../gtm/pragmaticvectors/extractbench-long-documents.md`](../gtm/pragmaticvectors/extractbench-long-documents.md)
 
 ## Run diary
 
-| Date       | Split          | Pipeline                   | Notes                                                                                                                                 |
-| ---------- | -------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| 2026-09-01 | test (6 doc)   | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args                                                               |
-| 2026-09-01 | short (252)    | clawql_idp_docling_extract | **In progress** (44/252) — partial eval Value F1 **39.18**; ontology 44/44 `recallOk`; tmux `eb-short-split`                          |
-| 2026-09-01 | short (44/252) | clawql_idp_docling_extract | Partial re-eval (`--skip_inference`); reports at `vendor/ExtractBench/output/clawql_idp_docling_extract/_evaluation_report.*`         |
+| Date       | Split           | Pipeline                   | Notes                                                                                                                                 |
+| ---------- | --------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-09-01 | test (6 doc)    | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args                                                               |
+| 2026-09-01 | short (93/252)  | clawql_idp_docling_extract | **Stopped** — final partial Value F1 **34.43**; ontology 93/93 `recallOk`; PR #1022                                                   |
+| 2026-09-01 | short (44/252)  | clawql_idp_docling_extract | Mid-run partial re-eval (Value F1 39.18)                                                                                                |
+| _next_     | test (6 doc)    | clawql_idp_qwen_extract    | Requires `QWEN35_SERVER_URL`                                                                                                          |
 
 ## Implementation notes
 
 - Provider: `inspect_pdf` → Docling when needed → schema map (LLM or structural)
 - Long-list completeness: chunked text mapping with array merge (no page-image VLM oneshot)
-- Missing fields must stay `null` (no invention) — T3 dense-doc failure mode
+- Missing fields must stay `null` (no invention) — T3 dense-doc failure mode (13F ~0% F1 on Arm B)
 - Env: `CLAWQL_MCP_URL`, `QWEN35_SERVER_URL` (Arm A), `DOCLING_BASE_URL`, `CLAWQL_REPO_ROOT`, `CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC=1`
 - Startup: `integrations/extractbench/scripts/start-clawql-for-extractbench.sh` (ClawQL 8.x tier + docling provider)
 
@@ -108,3 +150,4 @@ uv run extract-bench run clawql_idp_docling_extract --group short --skip_inferen
 
 - Harvey LAB (parallel): [`harvey-lab-clawql-results.md`](harvey-lab-clawql-results.md)
 - IDP hub: [`../providers/idp-pipeline.md`](../providers/idp-pipeline.md)
+- Essay draft: [`../gtm/pragmaticvectors/extractbench-long-documents.md`](../gtm/pragmaticvectors/extractbench-long-documents.md)

--- a/docs/benchmarks/extractbench-clawql-results.md
+++ b/docs/benchmarks/extractbench-clawql-results.md
@@ -21,14 +21,14 @@ Do **not** use Opus for the full ExtractBench corpus. Prefer self-hosted Qwen3.6
 
 ## Lessons learned (Arm B)
 
-| Finding | Implication |
-| ------- | ----------- |
-| Value F1 **34.4** at 93 docs (macro avg) | Structural-only is a **floor**, not a product — validates layered design |
-| Median doc F1 **39.6** vs macro **34.4** | Hard doc types (13F filings) drag averages; **routing by doc class** matters |
-| Page/bbox grounding **0%** | Evidence spans must come from layout pipeline or LLM map — needed for leaderboard grounding metrics |
-| Ontology sync **93/93** `recallOk` | Layer 2/3 meta-ontology bridge works; keep enabled for Arm A runs |
-| Docling outliers (**10h** on one valuation PDF) | Need async convert + per-doc timeouts before batch runs |
-| Architecture end-to-end ✓ | MCP → Docling → schema map → ontology recall — ready for Arm A swap-in |
+| Finding                                         | Implication                                                                                         |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Value F1 **34.4** at 93 docs (macro avg)        | Structural-only is a **floor**, not a product — validates layered design                            |
+| Median doc F1 **39.6** vs macro **34.4**        | Hard doc types (13F filings) drag averages; **routing by doc class** matters                        |
+| Page/bbox grounding **0%**                      | Evidence spans must come from layout pipeline or LLM map — needed for leaderboard grounding metrics |
+| Ontology sync **93/93** `recallOk`              | Layer 2/3 meta-ontology bridge works; keep enabled for Arm A runs                                   |
+| Docling outliers (**10h** on one valuation PDF) | Need async convert + per-doc timeouts before batch runs                                             |
+| Architecture end-to-end ✓                       | MCP → Docling → schema map → ontology recall — ready for Arm A swap-in                              |
 
 **Verdict:** Good for ClawQL **orchestration + ontology** thesis; bad if misread as extraction quality. Arm A is the decisive test.
 
@@ -56,11 +56,11 @@ The internal comparison that proves pipeline value: **ClawQL IDP + Qwen** vs **r
 
 ### Arm A next stage (prerequisites)
 
-Cloud agent VM has **no GPU** — Qwen3.6 35B must be external:
+Cloud agent VM has **no GPU** — Qwen3.6 35B must be external. **Mac mini (MLX):** serve an OpenAI-compatible `/v1` endpoint locally (e.g. `mlx-lm.server` on port 8000) and point `QWEN35_SERVER_URL` at it:
 
 ```bash
 # Required
-export QWEN35_SERVER_URL=https://your-vllm-host:8000   # OpenAI-compatible /v1
+export QWEN35_SERVER_URL=http://127.0.0.1:8000   # MLX OpenAI-compatible /v1 on Mac mini
 export CLAWQL_MCP_URL=http://127.0.0.1:8080/mcp
 export DOCLING_BASE_URL=http://127.0.0.1:5001
 export CLAWQL_REPO_ROOT=/path/to/ClawQL
@@ -83,26 +83,26 @@ uv run extract-bench compare \
 
 ## Arm B — ClawQL IDP Docling-only (structural) — FINAL PARTIAL
 
-| Split   |  Value F1 | Precision | Recall | Page F1 | Cost/page | Latency (P50) | Notes |
-| ------- | --------: | --------: | -----: | ------: | --------: | ------------: | ----- |
+| Split   |  Value F1 | Precision | Recall | Page F1 | Cost/page | Latency (P50) | Notes                                                  |
+| ------- | --------: | --------: | -----: | ------: | --------: | ------------: | ------------------------------------------------------ |
 | Short   | **34.43** |     39.38 |  33.28 |    0.00 |    $0.000 |         19.4s | **Stopped** at 93/252 (37%); ontology 93/93 `recallOk` |
-| Overall | _n/a_     |         — |      — |       — |         — |             — | Ablation only |
-| Long    | _n/a_     |         — |      — |       — |         — |             — | Not run separately |
+| Overall |     _n/a_ |         — |      — |       — |         — |             — | Ablation only                                          |
+| Long    |     _n/a_ |         — |      — |       — |         — |             — | Not run separately                                     |
 
 Partial short-split details (2026-09-01, `clawql_idp_docling_extract`, structural schema map, **93 docs**):
 
-| Metric | Value |
-| ------ | ----: |
-| Docs evaluated | 93 / 252 (37%) — run **stopped** |
-| Value F1 (macro avg) | 34.43 |
-| Value precision | 39.38 |
-| Value recall | 33.28 |
-| Array record F1 | 22.45 |
-| Accuracy | 22.91 |
-| Median per-doc Value F1 | 39.6 |
-| Ontology `recallOk` | 93 / 93 |
-| Latency P50 / P95 | 19.4s / 89.5s per doc |
-| Latency max (outlier) | 10.1h (`3N1AB7AP8FY283932_professional_valuation`) |
+| Metric                  |                                              Value |
+| ----------------------- | -------------------------------------------------: |
+| Docs evaluated          |                   93 / 252 (37%) — run **stopped** |
+| Value F1 (macro avg)    |                                              34.43 |
+| Value precision         |                                              39.38 |
+| Value recall            |                                              33.28 |
+| Array record F1         |                                              22.45 |
+| Accuracy                |                                              22.91 |
+| Median per-doc Value F1 |                                               39.6 |
+| Ontology `recallOk`     |                                            93 / 93 |
+| Latency P50 / P95       |                              19.4s / 89.5s per doc |
+| Latency max (outlier)   | 10.1h (`3N1AB7AP8FY283932_professional_valuation`) |
 
 Re-evaluate partial results:
 
@@ -113,11 +113,11 @@ uv run extract-bench run clawql_idp_docling_extract --group short --skip_inferen
 
 ## Delta vs raw Qwen oneshot
 
-| Metric     | Raw Qwen | ClawQL IDP + Qwen | Arm B (structural) |         Δ (target) |
-| ---------- | -------: | ----------------: | -----------------: | -----------------: |
-| Overall F1 |    87.33 |         _pending_ |              34.43 | _pending_ |
+| Metric     | Raw Qwen | ClawQL IDP + Qwen | Arm B (structural) |     Δ (target) |
+| ---------- | -------: | ----------------: | -----------------: | -------------: |
+| Overall F1 |    87.33 |         _pending_ |              34.43 |      _pending_ |
 | Long F1    |    26.75 |         _pending_ |                n/a | **beat 26.75** |
-| Cost/page  |        — |         _pending_ |             $0.000 | ≤ $1.00 |
+| Cost/page  |        — |         _pending_ |             $0.000 |        ≤ $1.00 |
 
 ## Publishability checklist
 
@@ -131,12 +131,12 @@ uv run extract-bench run clawql_idp_docling_extract --group short --skip_inferen
 
 ## Run diary
 
-| Date       | Split           | Pipeline                   | Notes                                                                                                                                 |
-| ---------- | --------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| 2026-09-01 | test (6 doc)    | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args                                                               |
-| 2026-09-01 | short (93/252)  | clawql_idp_docling_extract | **Stopped** — final partial Value F1 **34.43**; ontology 93/93 `recallOk`; PR #1022                                                   |
-| 2026-09-01 | short (44/252)  | clawql_idp_docling_extract | Mid-run partial re-eval (Value F1 39.18)                                                                                                |
-| _next_     | test (6 doc)    | clawql_idp_qwen_extract    | Requires `QWEN35_SERVER_URL`                                                                                                          |
+| Date       | Split          | Pipeline                   | Notes                                                                               |
+| ---------- | -------------- | -------------------------- | ----------------------------------------------------------------------------------- |
+| 2026-09-01 | test (6 doc)   | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args             |
+| 2026-09-01 | short (93/252) | clawql_idp_docling_extract | **Stopped** — final partial Value F1 **34.43**; ontology 93/93 `recallOk`; PR #1022 |
+| 2026-09-01 | short (44/252) | clawql_idp_docling_extract | Mid-run partial re-eval (Value F1 39.18)                                            |
+| _next_     | test (6 doc)   | clawql_idp_qwen_extract    | Requires `QWEN35_SERVER_URL`                                                        |
 
 ## Implementation notes
 

--- a/docs/benchmarks/extractbench-clawql-results.md
+++ b/docs/benchmarks/extractbench-clawql-results.md
@@ -66,17 +66,18 @@ The internal comparison that proves pipeline value: **ClawQL IDP + Qwen** vs **r
 
 ## Run diary
 
-| Date | Split | Pipeline | Notes                      |
-| ---- | ----- | -------- | -------------------------- |
-| —    | —     | —        | Overlay landed; scores TBD |
+| Date       | Split        | Pipeline                   | Notes                                                                                        |
+| ---------- | ------------ | -------------------------- | -------------------------------------------------------------------------------------------- |
+| 2026-09-01 | test (6 doc) | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args                      |
+| 2026-09-01 | short (252)  | clawql_idp_docling_extract | In progress — `CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC=1`, log `/tmp/extractbench-short-split.log` |
 
 ## Implementation notes
 
 - Provider: `inspect_pdf` → Docling when needed → schema map (LLM or structural)
 - Long-list completeness: chunked text mapping with array merge (no page-image VLM oneshot)
 - Missing fields must stay `null` (no invention) — T3 dense-doc failure mode
-- Env: `CLAWQL_MCP_URL`, `QWEN35_SERVER_URL` (Arm A), `DOCLING_BASE_URL`
-- Startup: `integrations/extractbench/scripts/start-clawql-for-extractbench.sh`
+- Env: `CLAWQL_MCP_URL`, `QWEN35_SERVER_URL` (Arm A), `DOCLING_BASE_URL`, `CLAWQL_REPO_ROOT`, `CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC=1`
+- Startup: `integrations/extractbench/scripts/start-clawql-for-extractbench.sh` (ClawQL 8.x tier + docling provider)
 
 ## Related
 

--- a/docs/benchmarks/extractbench-clawql-results.md
+++ b/docs/benchmarks/extractbench-clawql-results.md
@@ -69,7 +69,7 @@ The internal comparison that proves pipeline value: **ClawQL IDP + Qwen** vs **r
 | Date       | Split        | Pipeline                   | Notes                                                                                        |
 | ---------- | ------------ | -------------------------- | -------------------------------------------------------------------------------------------- |
 | 2026-09-01 | test (6 doc) | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args                      |
-| 2026-09-01 | short (252)  | clawql_idp_docling_extract | In progress — `CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC=1`, log `/tmp/extractbench-short-split.log` |
+| 2026-09-01 | short (252)  | clawql_idp_docling_extract | **In progress** (~1 doc/min) — `CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC=1`; first 10/10 `raw_output.ontology.t1.recallOk`; log `/tmp/extractbench-short-split.log`, tmux `eb-short-split` |
 
 ## Implementation notes
 

--- a/docs/benchmarks/extractbench-clawql-results.md
+++ b/docs/benchmarks/extractbench-clawql-results.md
@@ -7,12 +7,12 @@ Overlay: [`integrations/extractbench/`](../../integrations/extractbench/)
 
 ## Status
 
-**Scaffolding ready; live scores pending.**
+**Arm B short split in progress; partial evaluation available (44/252 docs, 2026-09-01).**
 
 Run order (cost discipline):
 
-1. `--test` (6 docs)
-2. `--group short`
+1. `--test` (6 docs) ✓
+2. `--group short` — **in progress** (44/252); partial eval below
 3. Full run only if short F1 is competitive
 4. Second full run for reproducibility
 
@@ -42,10 +42,34 @@ The internal comparison that proves pipeline value: **ClawQL IDP + Qwen** vs **r
 
 ## Arm B — ClawQL IDP Docling-only (structural)
 
-| Split   |  Value F1 | Notes             |
-| ------- | --------: | ----------------- |
-| Overall | _pending_ | No LLM schema map |
-| Long    | _pending_ | Ablation vs Arm A |
+| Split   |  Value F1 | Precision | Recall | Page F1 | Cost/page | Latency (P50) | Notes |
+| ------- | --------: | --------: | -----: | ------: | --------: | ------------: | ----- |
+| Short   | **39.18** |     43.54 |  37.89 |    0.00 |    $0.000 |         19.1s | **Partial** — 44/252 docs (17%); ontology 44/44 `recallOk` |
+| Overall | _pending_ |         — |      — |       — |         — |             — | No LLM schema map |
+| Long    | _pending_ |         — |      — |       — |         — |             — | Ablation vs Arm A |
+
+Partial short-split details (2026-09-01, `clawql_idp_docling_extract`, structural schema map):
+
+| Metric | Value |
+| ------ | ----: |
+| Docs evaluated | 44 / 252 (17%) |
+| Value F1 (macro avg) | 39.18 |
+| Value precision | 43.54 |
+| Value recall | 37.89 |
+| Array record F1 | 35.97 |
+| Accuracy | 31.26 |
+| Median per-doc Value F1 | 51.9 |
+| Best doc Value F1 | 64.9 (`2A-9-160294_109927`) |
+| Worst doc Value F1 | 0.0 (`real_wyo_Goshen_2024`) |
+| Latency P50 / P95 | 19.1s / 80.1s per doc |
+| Latency max (outlier) | 10.1h (`3N1AB7AP8FY283932_professional_valuation`) |
+
+Re-evaluate as more docs complete:
+
+```bash
+cd vendor/ExtractBench
+uv run extract-bench run clawql_idp_docling_extract --group short --skip_inference --force --open_report=False
+```
 
 ## Delta vs raw Qwen oneshot
 
@@ -66,10 +90,11 @@ The internal comparison that proves pipeline value: **ClawQL IDP + Qwen** vs **r
 
 ## Run diary
 
-| Date       | Split        | Pipeline                   | Notes                                                                                                                                                                               |
-| ---------- | ------------ | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 2026-09-01 | test (6 doc) | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args                                                                                                             |
-| 2026-09-01 | short (252)  | clawql_idp_docling_extract | **In progress** (~1 doc/min) — `CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC=1`; first 10/10 `raw_output.ontology.t1.recallOk`; log `/tmp/extractbench-short-split.log`, tmux `eb-short-split` |
+| Date       | Split          | Pipeline                   | Notes                                                                                                                                 |
+| ---------- | -------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-09-01 | test (6 doc)   | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args                                                               |
+| 2026-09-01 | short (252)    | clawql_idp_docling_extract | **In progress** (44/252) — partial eval Value F1 **39.18**; ontology 44/44 `recallOk`; tmux `eb-short-split`                          |
+| 2026-09-01 | short (44/252) | clawql_idp_docling_extract | Partial re-eval (`--skip_inference`); reports at `vendor/ExtractBench/output/clawql_idp_docling_extract/_evaluation_report.*`         |
 
 ## Implementation notes
 

--- a/docs/benchmarks/extractbench-clawql-results.md
+++ b/docs/benchmarks/extractbench-clawql-results.md
@@ -66,9 +66,9 @@ The internal comparison that proves pipeline value: **ClawQL IDP + Qwen** vs **r
 
 ## Run diary
 
-| Date       | Split        | Pipeline                   | Notes                                                                                        |
-| ---------- | ------------ | -------------------------- | -------------------------------------------------------------------------------------------- |
-| 2026-09-01 | test (6 doc) | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args                      |
+| Date       | Split        | Pipeline                   | Notes                                                                                                                                                                               |
+| ---------- | ------------ | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-09-01 | test (6 doc) | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args                                                                                                             |
 | 2026-09-01 | short (252)  | clawql_idp_docling_extract | **In progress** (~1 doc/min) — `CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC=1`; first 10/10 `raw_output.ontology.t1.recallOk`; log `/tmp/extractbench-short-split.log`, tmux `eb-short-split` |
 
 ## Implementation notes

--- a/integrations/extractbench/README.md
+++ b/integrations/extractbench/README.md
@@ -10,25 +10,25 @@ ExtractBench's headline finding: on documents longer than ~50 pages, commercial 
 
 ClawQL IDP routes with **pdf-inspector**, extracts with **Docling** (page/table structural, no VLM attention window), then maps to the JSON Schema with either:
 
-| Arm | Pipeline name | Schema map |
-| --- | --- | --- |
-| A | `clawql_idp_qwen_extract` | Self-hosted Qwen3.6 35B (OpenAI-compatible) over extracted text |
-| B | `clawql_idp_docling_extract` | Deterministic table/label mapping (no LLM) |
+| Arm | Pipeline name                | Schema map                                                      |
+| --- | ---------------------------- | --------------------------------------------------------------- |
+| A   | `clawql_idp_qwen_extract`    | Self-hosted Qwen3.6 35B (OpenAI-compatible) over extracted text |
+| B   | `clawql_idp_docling_extract` | Deterministic table/label mapping (no LLM)                      |
 
 Arm A is the primary leaderboard candidate. Arm B is the cost-floor / ablation.
 
 ## Layout
 
-| Path | Purpose |
-| --- | --- |
-| `provider/clawql_idp/` | Provider package copied into ExtractBench |
-| `scripts/apply_clawql_provider.py` | Copy + register pipelines / docs / env |
-| `scripts/start-clawql-for-extractbench.sh` | MCP HTTP with IDP flags |
-| `scripts/run-extractbench.sh` | Apply + `extract-bench run` |
-| `tests/test_schema_map.py` | Offline unit tests |
-| `leaderboard-entry.template.csv` | Submission row template |
-| `../../docs/benchmarks/extractbench-clawql-results.md` | Results ledger |
-| `../../docs/gtm/pragmaticvectors/extractbench-long-documents.md` | Essay draft |
+| Path                                                             | Purpose                                   |
+| ---------------------------------------------------------------- | ----------------------------------------- |
+| `provider/clawql_idp/`                                           | Provider package copied into ExtractBench |
+| `scripts/apply_clawql_provider.py`                               | Copy + register pipelines / docs / env    |
+| `scripts/start-clawql-for-extractbench.sh`                       | MCP HTTP with IDP flags                   |
+| `scripts/run-extractbench.sh`                                    | Apply + `extract-bench run`               |
+| `tests/test_schema_map.py`                                       | Offline unit tests                        |
+| `leaderboard-entry.template.csv`                                 | Submission row template                   |
+| `../../docs/benchmarks/extractbench-clawql-results.md`           | Results ledger                            |
+| `../../docs/gtm/pragmaticvectors/extractbench-long-documents.md` | Essay draft                               |
 
 ## Setup
 
@@ -86,6 +86,10 @@ list truncation experiments without changing ExtractBench scoring.
 
 Requires `CLAWQL_OBSIDIAN_VAULT_PATH` (set by `start-clawql-for-extractbench.sh`) and
 built `clawql-ontology` / `clawql-memory` packages.
+
+**ClawQL 8.x:** use `start-clawql-for-extractbench.sh` (sets `CLAWQL_TIER=enterprise`,
+`CLAWQL_PROVIDER=default`, `CLAWQL_BUNDLED_PROVIDERS=docling`, `CLAWQL_REPO_ROOT`) —
+bare `CLAWQL_ENABLE_*` flags are ignored without instance/tier composition.
 
 ## Success criteria (publishable)
 

--- a/integrations/extractbench/provider/clawql_idp/ontology_sync.py
+++ b/integrations/extractbench/provider/clawql_idp/ontology_sync.py
@@ -35,7 +35,15 @@ def clawql_repo_root() -> Path:
     env = os.environ.get("CLAWQL_REPO_ROOT", "").strip()
     if env:
         return Path(env).resolve()
-    # integrations/extractbench/provider/clawql_idp/ontology_sync.py → repo root
+    cur = Path(__file__).resolve().parent
+    for _ in range(10):
+        script = cur / "integrations/extractbench/scripts/run-ontology-pipeline.mjs"
+        if script.is_file():
+            return cur
+        if cur.parent == cur:
+            break
+        cur = cur.parent
+    # Fallback when provider is copied into ExtractBench (integrations/ not under cwd).
     return Path(__file__).resolve().parents[4]
 
 

--- a/integrations/extractbench/provider/clawql_idp/provider.py
+++ b/integrations/extractbench/provider/clawql_idp/provider.py
@@ -195,22 +195,20 @@ class ClawQLIDPProvider(Provider):
             return self._mcp.call_tool(
                 "execute",
                 {
-                    "operationId": "docling::docling_convert_source",
+                    "operationId": "docling_convert_source",
                     "args": {
-                        "body": {
-                            "sources": [
-                                {
-                                    "kind": "file",
-                                    "base64_string": b64,
-                                    "filename": file_path.name,
-                                }
-                            ],
-                            "options": {
-                                "to_formats": ["md", "json"],
-                                "do_ocr": True,
-                                "do_table_structure": True,
-                            },
-                        }
+                        "sources": [
+                            {
+                                "kind": "file",
+                                "base64_string": b64,
+                                "filename": file_path.name,
+                            }
+                        ],
+                        "options": {
+                            "to_formats": ["md", "json"],
+                            "do_ocr": True,
+                            "do_table_structure": True,
+                        },
                     },
                 },
             )

--- a/integrations/extractbench/scripts/run-extractbench.sh
+++ b/integrations/extractbench/scripts/run-extractbench.sh
@@ -11,6 +11,7 @@ EB_ROOT="${1:?ExtractBench checkout path required}"
 shift || true
 
 PIPELINE="${CLAWQL_EXTRACTBENCH_PIPELINE:-clawql_idp_qwen_extract}"
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 
 python3 "$SCRIPT_DIR/apply_clawql_provider.py" --extractbench "$EB_ROOT"
 
@@ -20,6 +21,7 @@ if [[ ! -f .env ]] && [[ -f .env.example ]]; then
   echo "Created .env from .env.example — set CLAWQL_MCP_URL and QWEN35_SERVER_URL"
 fi
 
+export CLAWQL_REPO_ROOT="$ROOT"
 if [[ -z "${CLAWQL_MCP_URL:-}" ]]; then
   export CLAWQL_MCP_URL="http://127.0.0.1:8080/mcp"
 fi

--- a/integrations/extractbench/scripts/start-clawql-for-extractbench.sh
+++ b/integrations/extractbench/scripts/start-clawql-for-extractbench.sh
@@ -8,11 +8,15 @@ ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 VAULT="${CLAWQL_OBSIDIAN_VAULT_PATH:-/tmp/clawql-extractbench-vault}"
 mkdir -p "$VAULT/Memory"
 
-export CLAWQL_ENABLE_DOCUMENTS="${CLAWQL_ENABLE_DOCUMENTS:-1}"
-export CLAWQL_ENABLE_PDF_INSPECTOR="${CLAWQL_ENABLE_PDF_INSPECTOR:-1}"
-export CLAWQL_ENABLE_IDP_PIPELINE="${CLAWQL_ENABLE_IDP_PIPELINE:-1}"
-# LangExtract optional — ExtractBench schema map uses Qwen/vLLM by default.
-export CLAWQL_ENABLE_LANGEXTRACT="${CLAWQL_ENABLE_LANGEXTRACT:-0}"
+# ClawQL 8.x: bare CLAWQL_ENABLE_* is ignored — use tier + provider pack + optional instance overrides.
+export CLAWQL_REPO_ROOT="$ROOT"
+export CLAWQL_ALLOW_NO_ENFORCEMENT="${CLAWQL_ALLOW_NO_ENFORCEMENT:-1}"
+export CLAWQL_TIER="${CLAWQL_TIER:-enterprise}"
+export CLAWQL_PROVIDER="${CLAWQL_PROVIDER:-default}"
+export CLAWQL_BUNDLED_PROVIDERS="${CLAWQL_BUNDLED_PROVIDERS:-docling}"
+# Enterprise tier enables idpPipeline; turn on pdf-inspector explicitly for inspect_pdf routing.
+export CLAWQL_INSTANCE_SPEC="${CLAWQL_INSTANCE_SPEC:-{\"tier\":\"enterprise\",\"documents\":{\"pdfInspector\":{\"enabled\":true}}}}"
+
 export CLAWQL_OBSIDIAN_VAULT_PATH="$VAULT"
 # Optional: scaffold → ontology.db → memory_recall after each EXTRACT (T1 completeness telemetry)
 export CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC="${CLAWQL_EXTRACTBENCH_ONTOLOGY_SYNC:-0}"
@@ -25,6 +29,7 @@ export DOCLING_BASE_URL="${DOCLING_BASE_URL:-http://127.0.0.1:5001}"
 
 echo "Starting ClawQL MCP for ExtractBench on :$PORT"
 echo "  vault=$VAULT"
+echo "  CLAWQL_REPO_ROOT=$CLAWQL_REPO_ROOT"
 echo "  DOCLING_BASE_URL=$DOCLING_BASE_URL"
 echo "  CLAWQL_MCP_URL=http://127.0.0.1:${PORT}/mcp"
 

--- a/integrations/extractbench/tests/test_ontology_sync.py
+++ b/integrations/extractbench/tests/test_ontology_sync.py
@@ -12,6 +12,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "provider"))
 
 from clawql_idp.ontology_sync import (  # noqa: E402
+    clawql_repo_root,
     derive_document_type,
     ontology_sync_enabled,
     run_ontology_pipeline,
@@ -29,6 +30,11 @@ class OntologySyncTests(unittest.TestCase):
             self.assertTrue(ontology_sync_enabled())
         with patch.dict("os.environ", {}, clear=True):
             self.assertFalse(ontology_sync_enabled())
+
+    def test_clawql_repo_root_walks_up_to_integrations(self) -> None:
+        root = clawql_repo_root()
+        script = root / "integrations/extractbench/scripts/run-ontology-pipeline.mjs"
+        self.assertTrue(script.is_file(), f"expected script at {script}")
 
     def test_run_ontology_pipeline_parses_stdout(self) -> None:
         summary = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes out **Arm B** ExtractBench short split at 93/252 docs and documents the **Arm A** next stage.

## Arm B final partial (stopped)

| Metric | Value |
|--------|------:|
| Docs | 93 / 252 (37%) |
| Value F1 | **34.43** |
| Ontology recallOk | 93 / 93 |
| Cost/page | $0 |

Run stopped intentionally — structural ablation signal sufficient; pivot to Arm A (Qwen schema map).

## Lessons captured

- Structural-only = floor (~34% F1), validates layered design
- 13F / dense tables = failure mode for Arm B; LLM chunked map is the fix under test
- Ontology sync bridge works end-to-end
- Arm A requires external `QWEN35_SERVER_URL` (no GPU on cloud VM)

## Next stage

Arm A runbook added to `docs/benchmarks/extractbench-clawql-results.md`:
1. `--test` with `clawql_idp_qwen_extract`
2. Short split if test looks good
3. Compare vs raw Qwen oneshot baseline

Depends on PR #1022 extractbench integration fixes (merged or stacked).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03676-50aa-7ef6-b5ff-fff45a324c7e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03676-50aa-7ef6-b5ff-fff45a324c7e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

