### PR TITLE
fix(supply-chain): browserslist OSV + docs Deploy/Platform nav

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -38,20 +38,22 @@
       }
     },
     "../packages/clawql-api": {
-      "version": "7.2.0",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
-        "@graphql-mesh/utils": "^0.104.36",
+        "@graphql-mesh/utils": "^0.107.0",
         "@grpc/grpc-js": "^1.14.4",
         "@grpc/proto-loader": "^0.8.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@omnigraph/openapi": "^0.109.51",
+        "@omnigraph/openapi": "^0.110.2",
         "@smithy/protocol-http": "^5.5.16",
         "@smithy/signature-v4": "^5.6.9",
-        "clawql-auth": "7.2.0",
-        "clawql-core": "7.2.0",
+        "clawql-audit": "0.1.0",
+        "clawql-auth": "0.1.0",
+        "clawql-core": "0.1.0",
         "effect": "^3.21.4",
+        "express-rate-limit": "^8.5.2",
         "graphql": "^16.14.0",
         "node-fetch": "^3.3.2",
         "prom-client": "^15.1.3",
@@ -3859,9 +3861,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.27",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
-      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -3932,9 +3934,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "funding": [
         {
           "type": "opencollective",
@@ -3951,10 +3953,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -4046,9 +4048,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4675,9 +4677,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.351",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.351.tgz",
-      "integrity": "sha512-9D7Iqx8RImSvCnOsj86rCH6eQjZFQoM04Jn6HnZVM0Nu/G58/gmKYQ1d12MZTbjQbQSTGI8nwEy07ErsA2slLA==",
+      "version": "1.5.420",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -7622,10 +7624,13 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
-      "license": "MIT"
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "6.0.0",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -54,6 +54,7 @@
     "@types/react-dom": "19.2.3",
     "@hono/node-server": "2.0.11",
     "brace-expansion": "5.0.9",
+    "browserslist": "4.28.7",
     "fast-uri": "3.1.5",
     "hono": "4.12.34",
     "ip-address": "10.3.1",

--- a/landing-page/demo/package-lock.json
+++ b/landing-page/demo/package-lock.json
@@ -2600,9 +2600,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.41",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.41.tgz",
-      "integrity": "sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -2638,9 +2638,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -2658,10 +2658,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -2732,9 +2732,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001800",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
-      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "funding": [
         {
           "type": "opencollective",
@@ -2993,9 +2993,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.385",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.385.tgz",
-      "integrity": "sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==",
+      "version": "1.5.420",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5254,9 +5254,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/landing-page/demo/package.json
+++ b/landing-page/demo/package.json
@@ -44,6 +44,7 @@
   "overrides": {
     "@hono/node-server": "2.0.11",
     "brace-expansion": "5.0.9",
+    "browserslist": "4.28.7",
     "fast-uri": "3.1.5",
     "hono": "4.12.34",
     "js-yaml": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -232,6 +232,7 @@
     "@opentelemetry/propagator-jaeger": "2.9.0",
     "sharp": "0.35.3",
     "brace-expansion": "5.0.9",
+    "browserslist": "4.28.7",
     "effect": "3.22.1",
     "@aws-sdk/credential-provider-login": "3.972.73"
   }

--- a/website/scripts/generate-docs-archive.mjs
+++ b/website/scripts/generate-docs-archive.mjs
@@ -128,6 +128,14 @@ function parseSidebarHrefs(source) {
     const href = match[1].split('#')[0]
     hrefs.add(href)
   }
+
+  const learnBlock = source.match(/LEARN_MODULE_HREFS\s*=\s*\[([\s\S]*?)\]\s*as const/)
+  if (learnBlock) {
+    for (const match of learnBlock[1].matchAll(/'(\/learn\/[^']+)'/g)) {
+      hrefs.add(match[1])
+    }
+  }
+
   // Security training modules come from the generated registry (not string literals).
   if (hrefs.has('/security') || hrefs.has('/security/best-practices')) {
     hrefs.add('/security/defense-in-depth')
@@ -137,6 +145,16 @@ function parseSidebarHrefs(source) {
       hrefs.add(p)
     }
   }
+
+  // Plugin detail pages are spread from pluginsHubCards (dynamic hrefs).
+  if (hrefs.has('/plugins')) {
+    for (const p of loadJsonArray(
+      'src/generated/clawql-plugins/sitemap-paths.json',
+    )) {
+      hrefs.add(p)
+    }
+  }
+
   return hrefs
 }
 

--- a/website/src/generated/docs-archive.json
+++ b/website/src/generated/docs-archive.json
@@ -1,7 +1,7 @@
 {
-  "generatedAt": "2026-09-01T20:33:20.808Z",
-  "sidebarHrefCount": 87,
-  "entryCount": 64,
+  "generatedAt": "2026-09-02T00:31:09.798Z",
+  "sidebarHrefCount": 118,
+  "entryCount": 31,
   "groups": [
     {
       "name": "Platform",
@@ -16,12 +16,6 @@
           "href": "/dashboard-kubernetes",
           "title": "Dashboard on Kubernetes",
           "description": "Bundled dashboard UI, Vault sync, and Helm wiring.",
-          "group": "Platform"
-        },
-        {
-          "href": "/design/operator-target-architecture",
-          "title": "Operator target architecture",
-          "description": "",
           "group": "Platform"
         },
         {
@@ -49,205 +43,10 @@
           "group": "Platform"
         },
         {
-          "href": "/nats-jetstream",
-          "title": "NATS JetStream",
-          "description": "Optional event-driven backbone for Ouroboros, agents, and edge sync: Helm values, JetStream retention controls, persistence, and health checks.",
-          "group": "Platform"
-        },
-        {
           "href": "/onyx-knowledge",
           "title": "Onyx knowledge (legacy path)",
           "description": "",
           "group": "Platform"
-        }
-      ]
-    },
-    {
-      "name": "Plugins",
-      "entries": [
-        {
-          "href": "/plugins/automation",
-          "title": "Automation",
-          "description": "schedule, notify, workflow, argocd — each opt-in via env.",
-          "group": "Plugins"
-        },
-        {
-          "href": "/plugins/bundled-providers",
-          "title": "Bundled providers",
-          "description": "Default stack: Cloudflare, GitHub, Slack, Linear, Notion, Onyx.",
-          "group": "Plugins"
-        },
-        {
-          "href": "/plugins/codegraph",
-          "title": "Code graph",
-          "description": "codegraph_* — structural AST indexing, Graphify import, hybrid recall.",
-          "group": "Plugins"
-        },
-        {
-          "href": "/plugins/core",
-          "title": "Gateway core",
-          "description": "search, execute, audit, cache — always composed, no opt-out.",
-          "group": "Plugins"
-        },
-        {
-          "href": "/plugins/data",
-          "title": "Data",
-          "description": "",
-          "group": "Plugins"
-        },
-        {
-          "href": "/plugins/documents",
-          "title": "Documents & IDP",
-          "description": "ingest_external_knowledge, Onyx search, optional IDP tools.",
-          "group": "Plugins"
-        },
-        {
-          "href": "/plugins/hitl-label-studio",
-          "title": "HITL (Label Studio)",
-          "description": "Human-in-the-loop review — planned full plugin wiring.",
-          "group": "Plugins"
-        },
-        {
-          "href": "/plugins/inference-providers",
-          "title": "Inference providers",
-          "description": "OpenAI, Anthropic, Ollama builtins and third-party clawql-inference plugins.",
-          "group": "Plugins"
-        },
-        {
-          "href": "/plugins/memory",
-          "title": "Memory (vault)",
-          "description": "memory_ingest / memory_recall — default on, Obsidian vault.",
-          "group": "Plugins"
-        },
-        {
-          "href": "/plugins/ouroboros",
-          "title": "Ouroboros",
-          "description": "Evolutionary loop MCP tools and optional Postgres lineage.",
-          "group": "Plugins"
-        },
-        {
-          "href": "/plugins/panguard-proxy",
-          "title": "Panguard MCP proxy",
-          "description": "Blocking pre-execute hooks for enterprise MCP defense.",
-          "group": "Plugins"
-        },
-        {
-          "href": "/plugins/payments",
-          "title": "Payments",
-          "description": "Stripe, x402, MPP, Adyen — see also the clawql-payments platform guide.",
-          "group": "Plugins"
-        },
-        {
-          "href": "/plugins/sandbox",
-          "title": "Sandbox",
-          "description": "sandbox_exec MCP + clawql sandbox CLI — Kata, Seatbelt, fail-closed harnesses.",
-          "group": "Plugins"
-        },
-        {
-          "href": "/plugins/third-party",
-          "title": "Third-party plugins",
-          "description": "Roadmap and checklist for external clawql-* npm plugins.",
-          "group": "Plugins"
-        },
-        {
-          "href": "/plugins/web",
-          "title": "Web",
-          "description": "",
-          "group": "Plugins"
-        }
-      ]
-    },
-    {
-      "name": "Learn",
-      "entries": [
-        {
-          "href": "/learn/audit-tool-and-observability",
-          "title": "Audit tool & observability",
-          "description": "Core `audit` ring buffer plus Prometheus, Grafana, and Loki — breadcrumbs without vault writes.",
-          "group": "Learn"
-        },
-        {
-          "href": "/learn/cache-handoff-between-chats",
-          "title": "Cache handoff between chats",
-          "description": "Core `cache` tool: scratch state, TTL, namespacing, and carrying context into a new chat session.",
-          "group": "Learn"
-        },
-        {
-          "href": "/learn/document-pipeline",
-          "title": "Document pipeline",
-          "description": "Seven-vendor IDP path: Nextcloud → Tika → Gotenberg → Stirling → archive → Onyx → Coneshare.",
-          "group": "Learn"
-        },
-        {
-          "href": "/learn/effect-ts",
-          "title": "Effect-TS in ClawQL",
-          "description": "Why Effect-TS enforces the 7-layer architecture: Layers, Gateway composition, fail-closed errors, and optional plugins.",
-          "group": "Learn"
-        },
-        {
-          "href": "/learn/external-ingest-knowledge",
-          "title": "External ingest & knowledge lake",
-          "description": "Import Markdown or a single URL into the vault with `ingest_external_knowledge`, dry runs, and vault pairing.",
-          "group": "Learn"
-        },
-        {
-          "href": "/learn/knowledge-search-onyx",
-          "title": "Onyx enterprise search",
-          "description": "Optional `knowledge_search_onyx`: ACL-aware semantic search over your enterprise Onyx index.",
-          "group": "Learn"
-        },
-        {
-          "href": "/learn/memory",
-          "title": "clawql-memory (Memory 2.0)",
-          "description": "Vault ingest/recall, wikilink graph, hybrid vectors, PageIndex, team sync, and the inference flywheel.",
-          "group": "Learn"
-        },
-        {
-          "href": "/learn/ouroboros-tools",
-          "title": "Ouroboros tools",
-          "description": "`ouroboros_*`: seed from documents, evolutionary loop, Postgres lineage, and route hints vs raw infra.",
-          "group": "Learn"
-        },
-        {
-          "href": "/learn/sandbox-exec",
-          "title": "Sandbox exec",
-          "description": "Optional sandbox_exec MCP tool; pair with Local agent sandbox for full harness containment.",
-          "group": "Learn"
-        },
-        {
-          "href": "/learn/schedule-notify-workflows",
-          "title": "Schedule & notify workflows",
-          "description": "`schedule` synthetics plus `notify` to Slack — threads, HITL hooks, and Label Studio handoff patterns.",
-          "group": "Learn"
-        },
-        {
-          "href": "/learn/search-and-execute-mcp",
-          "title": "Using search & execute",
-          "description": "`search` / `execute` inputs, args, response fields, and common pitfalls when calling loaded OpenAPI specs.",
-          "group": "Learn"
-        }
-      ]
-    },
-    {
-      "name": "Deploy",
-      "entries": [
-        {
-          "href": "/deployment/platforms",
-          "title": "Deployment platforms",
-          "description": "",
-          "group": "Deploy"
-        },
-        {
-          "href": "/helm",
-          "title": "Helm",
-          "description": "Chart at charts/clawql-mcp: values, GHCR image, optional Ingress, PVC, and upgrade notes.",
-          "group": "Deploy"
-        },
-        {
-          "href": "/tailscale",
-          "title": "Tailscale & Headscale",
-          "description": "Beginner guide: private tailnets for MCP and execute—MagicDNS, Serve, CLAWQL_MCP_URL, Headscale, ACLs, Kubernetes vs mesh DNS.",
-          "group": "Deploy"
         }
       ]
     },
@@ -289,12 +88,6 @@
     {
       "name": "Vision",
       "entries": [
-        {
-          "href": "/vision/idp-platform",
-          "title": "IDP platform",
-          "description": "Document pipeline product story — self-hosted vs hosted IDP, archive, VDR.",
-          "group": "Vision"
-        },
         {
           "href": "/vision/slide-deck",
           "title": "Slide deck",
@@ -362,12 +155,6 @@
         {
           "href": "/ouroboros/build-plan",
           "title": "DAOS build plan",
-          "description": "",
-          "group": "Ouroboros"
-        },
-        {
-          "href": "/ouroboros/daos",
-          "title": "DAOS unified architecture",
           "description": "",
           "group": "Ouroboros"
         },

--- a/website/src/lib/docs-nav-data.ts
+++ b/website/src/lib/docs-nav-data.ts
@@ -109,8 +109,12 @@ export const docsNavigation: Array<NavGroup> = [
         title: 'Operations guide',
         href: '/deployment/operations-guide',
       },
+      { title: 'Platforms', href: '/deployment/platforms' },
       { title: 'Kubernetes & Helm', href: '/deployment/kubernetes' },
+      { title: 'Helm charts', href: '/helm' },
+      { title: 'NATS JetStream', href: '/nats-jetstream' },
       { title: 'OpenClaw', href: '/openclaw' },
+      { title: 'Tailscale', href: '/tailscale' },
     ],
   },
   {
@@ -147,6 +151,11 @@ export const docsNavigation: Array<NavGroup> = [
       {
         title: 'Enterprise Ontology',
         href: '/architecture/enterprise-ontology',
+      },
+      { title: 'IDP platform', href: '/vision/idp-platform' },
+      {
+        title: 'Operator target architecture',
+        href: '/design/operator-target-architecture',
       },
       {
         title: 'memory_recall structured filters',
@@ -211,6 +220,7 @@ export const docsNavigation: Array<NavGroup> = [
         tag: 'Draft',
       },
       { title: 'Ouroboros', href: '/ouroboros' },
+      { title: 'DAOS architecture', href: '/ouroboros/daos' },
     ],
   },
   {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

### Supply chain (OSV)
- Bump **browserslist** to **4.28.7** via npm overrides in root, `dashboard/`, and `landing-page/demo/`
- Fixes 4 High OSV findings (`GHSA-73wf-gq98-2v4g`, `GHSA-c83g-rgw3-j3cx`) that were failing CI Supply chain job

### Docs (remainder)
- **Deploy** sidebar: platforms, helm charts, NATS JetStream, tailscale
- **Platform** sidebar: IDP platform, operator target architecture, DAOS architecture
- **Archive generator**: correctly excludes Learn module hrefs and plugin sitemap paths (catalog drops from ~64 to **31** true orphans)

## Testing
- `/tmp/osv-scanner scan --recursive --config osv-scanner.toml .` → **No issues found**
- `website npm run format:check` → pass
- `node website/scripts/generate-docs-archive.mjs` → 31 off-sidebar routes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8f57-601a-7ec1-bff0-d35011fef4ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8f57-601a-7ec1-bff0-d35011fef4ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

