### PR TITLE
docs(learn): payments & panguard end-to-end walkthroughs

### DIFF
--- a/docs/payments/clawql-payments.md
+++ b/docs/payments/clawql-payments.md
@@ -1,5 +1,7 @@
 # clawql-payments
 
+**Hands-on walkthrough:** [Payments & entitlements (Learn)](https://docs.clawql.com/learn/payments-and-entitlements) — plan limits, Stripe/x402 paths, WORM audit, and inference checklist in one sequence.
+
 **Status:** Shipped foundation (July 2026)  
 **Package:** [`packages/clawql-payments`](../../packages/clawql-payments)  
 **CLI:** `clawql payments *`

--- a/docs/plugins/panguard-proxy.md
+++ b/docs/plugins/panguard-proxy.md
@@ -11,6 +11,8 @@ next: memory
 
 # Panguard MCP proxy
 
+**Hands-on walkthrough:** [Panguard MCP enforcement (Learn)](https://docs.clawql.com/learn/panguard-mcp-enforcement) — stdio wrap, in-process hooks, Helm `mcpProxy`, and JWT bridge env.
+
 **Plugin ID:** `panguard-mcp-proxy`  
 **Shape:** hooks-only `ProviderPlugin` (does not register MCP tools)  
 **Package:** `clawql-api` — `createPanguardProxyPlugin`
@@ -41,6 +43,7 @@ The Panguard proxy plugin registers a blocking **`tool` / `pre-execute`** hook f
 
 ## Learn more
 
+- [Panguard MCP enforcement (Learn)](https://docs.clawql.com/learn/panguard-mcp-enforcement)
 - [Defense in depth (site)](/security/defense-in-depth)
 - [MCP proxy JWT ATR (repo)](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/security/mcp-proxy-jwt-atr.md)
 - [Plugin registry](/plugins)

--- a/docs/plugins/payments.md
+++ b/docs/plugins/payments.md
@@ -37,7 +37,7 @@ ClawQL’s Agentic Gateway includes native **Stripe + x402 + MPP + AP2 + ACP** s
 | **Compensation**       | Agent deposit / cash-out — `CLAWQL_COMPENSATION_ENABLED=1` (self-hosted)                                            |
 | **Accounting**         | Period subledger CSV/JSON/QB/Xero; tax profile gate; year-end evidence pack                                         |
 
-Operator guide: [clawql-payments](../payments/clawql-payments.md) → `/payments/clawql-payments` (includes [Accounting & tax](../payments/clawql-payments.md#accounting--tax)). Cloudflare prep: [cloudflare-wallets](../payments/cloudflare-wallets.md).
+Operator guide: [clawql-payments](../payments/clawql-payments.md) → `/payments/clawql-payments` (includes [Accounting & tax](../payments/clawql-payments.md#accounting--tax)). **Learn walkthrough:** [Payments & entitlements](https://docs.clawql.com/learn/payments-and-entitlements). Cloudflare prep: [cloudflare-wallets](../payments/cloudflare-wallets.md).
 
 ### Accounting & tax (operator quick start)
 

--- a/website/src/app/learn/page.mdx
+++ b/website/src/app/learn/page.mdx
@@ -31,6 +31,7 @@ Use these hubs when you care about one slice of the product:
 - **Architecture & platform** — [Architecture](/architecture), [Vision & status](/vision/roadmap), [Contributor Technical Specification](/contributing/technical-specification)
 - **Session & automation** — [clawql-memory (Memory 2.0)](/learn/memory), [Optional tools hub](/reference/optional-tools), [Schedule & notify workflows](/learn/schedule-notify-workflows), [Audit tool & observability](/learn/audit-tool-and-observability)
 - **Knowledge & documents** — [Document pipeline](/learn/document-pipeline), [External ingest](/learn/external-ingest-knowledge), [Onyx search](/learn/knowledge-search-onyx)
+- **Payments & security** — [Payments & entitlements](/learn/payments-and-entitlements), [Panguard MCP enforcement](/learn/panguard-mcp-enforcement), [Defense in depth](/security/defense-in-depth)
 - **Spec-first workflows** — [Ouroboros tools](/learn/ouroboros-tools), [Ouroboros library](/ouroboros)
 - **OpenClaw gateway** — [OpenClaw + ClawQL](/openclaw)
 

--- a/website/src/app/learn/panguard-mcp-enforcement/layout.tsx
+++ b/website/src/app/learn/panguard-mcp-enforcement/layout.tsx
@@ -1,0 +1,18 @@
+import { docsPageMetadata } from '@/lib/seo'
+
+export const metadata = docsPageMetadata({
+  title: 'Panguard MCP enforcement (Learn)',
+  description:
+    'Hands-on guide: JWT ATR chokepoints, in-process Panguard proxy hooks, Helm mcpProxy, and the clawql-panguard-mcp-bridge on Kubernetes.',
+  path: '/learn/panguard-mcp-enforcement',
+})
+
+import type { ReactNode } from 'react'
+
+export default function DocsSegmentLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return children
+}

--- a/website/src/app/learn/panguard-mcp-enforcement/page.mdx
+++ b/website/src/app/learn/panguard-mcp-enforcement/page.mdx
@@ -1,0 +1,160 @@
+import { Note } from '@/components/mdx'
+
+# Panguard MCP enforcement
+
+Enterprise ClawQL deployments need a **single chokepoint** that validates **JWT ATR** (Access–Task–Resource) claims **before** any MCP tool runs. This guide walks three enforcement paths — local stdio, in-process hooks, and Kubernetes with the **clawql-panguard-mcp-bridge** — and how they connect to [Defense in depth](/security/defense-in-depth). {{ className: 'lead' }}
+
+**Reference:** [Panguard MCP proxy plugin](/plugins/panguard-proxy) · [MCP proxy JWT ATR (repo)](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/security/mcp-proxy-jwt-atr.md) · Issue [#272](https://github.com/danielsmithdevelopment/ClawQL/issues/272)
+
+## Mental model
+
+```
+Agent → (JWT with ATR claims) → chokepoint → ClawQL MCP → search/execute → upstream APIs
+```
+
+- The agent **cannot widen** its own scopes — only the IdP / gateway issues or refreshes tokens.
+- Denials should be **structured** (WORM escalation), not silent drops — see [security ontology loop](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/security/security-ontology-knowledge-loop.md).
+- **`cache`** is scratch state between chats; it is **not** a substitute for ATR enforcement.
+
+## Before you start
+
+1. **8.0+ default:** enforcement providers are **opt-in**. A bare `clawql-mcp` boot emits a **SECURITY WARNING** when no enforcement is active (silence only with `CLAWQL_ALLOW_NO_ENFORCEMENT=1` if intentional).
+2. **Pick transport:**
+   - **stdio** — Cursor / Claude Desktop local subprocess
+   - **Streamable HTTP `/mcp`** — remote agents, K8s ingress
+   - **gRPC MCP** — high-throughput mesh clients (`50051`)
+3. **Read the curriculum** — [MCP runtime enforcement (Part 3)](/security/best-practices/mcp-runtime-enforcement-panguard-atr) pairs with this walkthrough.
+
+## Path A — Local stdio (works today)
+
+Wrap ClawQL with upstream **Panguard** on the stdio path:
+
+```bash
+npx panguard-mcp-proxy -- npx clawql-mcp
+```
+
+Or point your MCP client at that command chain. Panguard spawns ClawQL as a subprocess and enforces ATR on every tool call over stdio.
+
+**When to use:** developer laptops, air-gapped evals, CI smoke where HTTP ingress is not in play.
+
+## Path B — In-process `PanguardProxyPlugin`
+
+Run enforcement **inside** `clawql-mcp` without an external proxy process:
+
+```bash
+export CLAWQL_PANGUARD_PROXY_PLUGIN=1
+export CLAWQL_PANGUARD_IN_PROCESS=1
+npx clawql-mcp
+```
+
+| Env                            | Default | Effect                                       |
+| ------------------------------ | ------- | -------------------------------------------- |
+| `CLAWQL_PANGUARD_PROXY_PLUGIN` | off     | Register hooks-only proxy plugin             |
+| `CLAWQL_PANGUARD_IN_PROCESS`   | off     | Active blocking `tool` / `pre-execute` path  |
+| `CLAWQL_ALLOW_NO_ENFORCEMENT`  | off     | Silence boot warning when nothing is enabled |
+
+The plugin **does not add MCP tools** — it gates existing ones via `McpProxyPipeline.fireHook` (ATR never-loosen).
+
+**Verify:** call a tool your policy should deny; expect a structured block **before** `execute` reaches upstream APIs. Check [Audit Trail](/audit) / WORM for escalation events if configured.
+
+## Path C — Kubernetes (Helm `mcpProxy`)
+
+North–south order on cluster:
+
+1. **Istio Gateway** — TLS, optional JWT forwarding
+2. **`mcpProxy` Service** — Panguard bridge or nginx stand-in
+3. **`clawql-mcp-http`** — Streamable HTTP `/mcp` (+ optional gRPC `50051`)
+
+### C1 — Topology smoke (no ATR on payloads)
+
+Prove **Gateway → proxy → ClawQL** ordering and HA:
+
+```yaml
+# charts/clawql-mcp values snippet
+mcpProxy:
+  enabled: true
+  mode: nginx
+  replicaCount: 2
+```
+
+Point Istio backends at **`clawql-mcp-http-proxy`** when applying the [Docker Desktop Istio helper](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docker/istio/docker-desktop/clawql-mcp-gateway-and-virtualservice.yaml).
+
+### C2 — Production bridge image
+
+Use the reference **`clawql-panguard-mcp-bridge`** image (HTTP + Session gRPC):
+
+```yaml
+mcpProxy:
+  enabled: true
+  mode: custom
+  replicaCount: 2
+  custom:
+    image:
+      repository: ghcr.io/danielsmithdevelopment/clawql-panguard-mcp-bridge
+      tag: nightly
+    extraEnv:
+      - name: CLAWQL_BRIDGE_UPSTREAM_URL
+        value: 'http://clawql-mcp-http.clawql.svc.cluster.local:8080/mcp'
+      - name: ENABLE_GRPC
+        value: '1'
+```
+
+Copy the full overlay: [`values-mcp-proxy-panguard-bridge.example.yaml`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/charts/clawql-mcp/values-mcp-proxy-panguard-bridge.example.yaml). Details: [Panguard on Kubernetes (repo)](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/integrations/panguard-kubernetes.md).
+
+### C3 — JWT gate on the bridge (second line)
+
+When the mesh does not already validate every claim:
+
+| Variable                             | Purpose                                              |
+| ------------------------------------ | ---------------------------------------------------- |
+| `CLAWQL_MCP_JWT_ENABLED`             | `1` — verify Bearer on HTTP `/mcp` and gRPC MCP RPCs |
+| `CLAWQL_MCP_JWT_JWKS_URL`            | OIDC JWKS (RS256)                                    |
+| `CLAWQL_MCP_JWT_ATR_CLAIM`           | Claim holding ATR object/array (default `atr`)       |
+| `CLAWQL_MCP_JWT_ISSUER` / `AUDIENCE` | Optional hardening                                   |
+
+**HTTP denial:** `401` with JSON-RPC `-32001`. **gRPC denial:** `UNAUTHENTICATED`. `/healthz` and gRPC health remain exempt.
+
+Wire these via `mcpProxy.custom.extraEnv` alongside your IdP values.
+
+## Pair with payments and audit
+
+Defense-in-depth stacks usually order:
+
+1. **Ingress JWT / ATR** (this guide)
+2. **Panguard pre-execute** (tool allowlists, OWASP Agentic patterns)
+3. **x402 / plan entitlements** on inference ([Payments walkthrough](/learn/payments-and-entitlements))
+4. **WORM audit** on allow and deny ([Audit Trail](/audit))
+
+Paid or sensitive tools should fail **at the chokepoint** when scope is missing — not mid-flight inside `execute`.
+
+## Operations checklist
+
+- [ ] Scale `mcpProxy.replicaCount` ≥ 2 — losing all proxy pods **denies** MCP
+- [ ] Load-test stacked intercept layers — budget **&lt;50ms** per hop; latency **compounds**
+- [ ] Agents surface proxy errors to humans ([`AGENTS.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/AGENTS.md) behavior)
+- [ ] Enable `mcpProxy.slo.prometheusRule` when Istio metrics are available
+- [ ] Extend Kyverno `imageReferences` if you run unsigned custom gateway images
+
+## Troubleshooting
+
+| Symptom                         | Likely cause                                                                        |
+| ------------------------------- | ----------------------------------------------------------------------------------- |
+| Boot **SECURITY WARNING**       | No enforcement plugin — set Path B env or external proxy                            |
+| **401 / -32001** on HTTP MCP    | JWT missing, wrong `iss`/`aud`, or ATR claim not an object                          |
+| Tools run but should be blocked | nginx-only `mcpProxy` mode — no payload policy; switch to `custom` bridge or Path B |
+| gRPC works, HTTP fails          | Split backend hosts in Istio — align `CLAWQL_ISTIO_MCP_*` env                       |
+| High p99 latency                | Too many intercept layers — reduce hops or scale proxy                              |
+
+## What to read next
+
+- [Defense in depth](/security/defense-in-depth) — full stack narrative
+- [Security best practices](/security/best-practices) — 32-module curriculum
+- [Custom sources](/getting-started/custom-sources) — registering third-party MCP with Seatbelt / policy
+- [Payments & entitlements](/learn/payments-and-entitlements) — gate spend after authorization
+
+<Note>
+  Upstream **`@panguard-ai/panguard-mcp-proxy`** npm is **stdio ↔ stdio** only.
+  HTTP/gRPC termination requires the **ClawQL bridge** image or your own gateway
+  — see [HTTP/gRPC bridge
+  doc](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/integrations/panguard-http-grpc-bridge.md).
+</Note>

--- a/website/src/app/learn/payments-and-entitlements/layout.tsx
+++ b/website/src/app/learn/payments-and-entitlements/layout.tsx
@@ -1,0 +1,18 @@
+import { docsPageMetadata } from '@/lib/seo'
+
+export const metadata = docsPageMetadata({
+  title: 'Payments & entitlements (Learn)',
+  description:
+    'Hands-on guide: plan tiers, Stripe + x402 gates, WORM payment audit, and inference entitlement enforcement with clawql-payments.',
+  path: '/learn/payments-and-entitlements',
+})
+
+import type { ReactNode } from 'react'
+
+export default function DocsSegmentLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return children
+}

--- a/website/src/app/learn/payments-and-entitlements/page.mdx
+++ b/website/src/app/learn/payments-and-entitlements/page.mdx
@@ -1,0 +1,164 @@
+import { Note } from '@/components/mdx'
+
+# Payments & entitlements
+
+**`clawql-payments`** is how ClawQL bills managed tiers, gates inference with **plan limits**, and optionally collects **Stripe**, **x402**, or **MPP** on the Agentic Gateway. This walkthrough gets you from a dry-run local setup to a verified WORM audit trail — without conflating the three different “usage” systems. {{ className: 'lead' }}
+
+**Deep reference:** [clawql-payments](/payments/clawql-payments) · **Plugin surface:** [Payments plugin](/plugins/payments) · **Compliance:** [Hosted vs self-hosted](/payments/clawql-payments#managed-plan-tiers) (see repo `hosted-vs-self-hosted-compliance.md`)
+
+## Before you start
+
+1. **Pick your posture** — On **managed** ClawQL, Stripe platform fees and **closed-loop org credits** are in scope; cross-tenant P2P and agent compensation are **self-hosted only** ([compliance framing](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/hosted-vs-self-hosted-compliance.md)).
+2. **Know the three usage layers** — they are independent:
+
+| Layer                    | Storage                            | Purpose                                             |
+| ------------------------ | ---------------------------------- | --------------------------------------------------- |
+| **Plan entitlements**    | `$CLAWQL_HOME/Payments/usage.json` | Monthly caps (`inference_calls`, documents, memory) |
+| **Inference call store** | `$CLAWQL_HOME/Inference/`          | Token/latency flywheel — not quota enforcement      |
+| **Virtual key budgets**  | `virtual-keys.json`                | Per-team USD caps at auth time                      |
+
+3. **Have inference ready** — payments enforcement hooks into **`clawql-inference`** ([Inference setup](/getting-started/inference), [Agentic Gateway](/inference/clawql-inference)).
+
+## Path A — Local plan limits (no Stripe)
+
+Best for homelab or CI: exercise tier caps and audit without live rails.
+
+```bash
+export CLAWQL_HOME="${CLAWQL_HOME:-$HOME/.clawql}"
+mkdir -p "$CLAWQL_HOME/Payments"
+
+# Dry-run tenant on the free tier
+clawql payments plan show
+clawql payments plan upgrade --tier team   # or edit payments.json
+
+export CLAWQL_PAYMENTS_ENFORCE_INFERENCE=1
+clawql inference serve --port 8080
+```
+
+**Verify entitlement behavior:**
+
+```bash
+clawql payments usage report --month "$(date +%Y-%m)"
+```
+
+Over-limit calls return **402 `insufficient_quota`** (OpenAI-compatible shape). Tenant resolution order: request `tenantId` → virtual-key `team` header → `payments.json` → `"default"`.
+
+## Path B — Stripe subscriptions + optional Billing Meters
+
+For operators billing humans in fiat:
+
+1. Create a Stripe account and configure a **Billing Meter** in the Dashboard (event name e.g. `clawql_inference_calls`).
+2. Wire secrets (never commit):
+
+```bash
+export STRIPE_SECRET_KEY=sk_live_...
+export STRIPE_METER_EVENT_NAME=clawql_inference_calls
+export CLAWQL_PAYMENTS_REPORT_STRIPE_METER=1   # optional meter emit per inference
+clawql payments stripe setup                   # writes customer + webhook secret to payments.json
+```
+
+3. Process webhooks with signature verification:
+
+```bash
+clawql payments stripe webhook verify --body @raw-body.json --signature "t=...,v1=..."
+```
+
+Meter events and `invoice.paid` append to the **payment WORM** — see Path D.
+
+## Path C — x402 pay-per-call on MCP or HTTP
+
+**x402** gates individual inference or MCP tool calls with USDC micropayments (independent of plan `usage.json`).
+
+```bash
+clawql payments x402 wallet setup --address 0xYourWallet...
+export CLAWQL_X402_ENFORCE=1
+export CLAWQL_X402_FACILITATOR_URL=https://x402.org/facilitator
+export CLAWQL_X402_NETWORK=base-sepolia   # testnet example
+
+clawql payments x402 gate add --path "/v1/chat/completions" --price-usdc 0.001
+clawql payments x402 gate add --tool search --price-usdc 0.0001
+```
+
+**HTTP middleware order** on `clawql inference serve`:
+
+1. JSON body parser
+2. **x402 middleware** (`CLAWQL_X402_ENFORCE`)
+3. Virtual key auth
+4. OpenAI-compat router (plan entitlement check inside gateway)
+
+**MCP:** enable the [Payments plugin](/plugins/payments) (`PaymentsX402ProxyPlugin`) for tool-level x402 (+ optional AP2 mandate checks). Discovery: [`.well-known/payments.json`](https://docs.clawql.com/.well-known/payments.json) on MCP and inference HTTP.
+
+**Test a payload offline:**
+
+```bash
+clawql payments x402 verify --payload ./payment.json --resource http://localhost:8080/v1/chat/completions
+```
+
+## Path D — WORM audit (always do this in prod)
+
+Every payment rail should leave a **hash-chained** trail under `$CLAWQL_HOME/Payments/audit.jsonl`:
+
+```bash
+clawql payments audit verify
+clawql payments audit tail --limit 20
+```
+
+For multi-node fleets:
+
+```bash
+export CLAWQL_PAYMENTS_AUDIT_STORE=postgres
+```
+
+Optional SIEM push when `CLAWQL_LOKI_PUSH_URL` is set. Pair with [Audit Trail](/audit) for MCP tool events and [Observability](/observability) for LGTM dashboards.
+
+## Accounting close (operators)
+
+After you have WORM events:
+
+```bash
+clawql payments accounting export --from 2026-01-01 --to 2026-12-31 --format csv
+clawql payments accounting tax-evidence --tax-year 2026
+clawql payments tax-profile set --party-id creator-1 --tax-form 1099nec --collected
+```
+
+Subledger export ≠ full GL — see [accounting-and-tax](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/accounting-and-tax.md).
+
+## End-to-end checklist (self-hosted production)
+
+```bash
+export CLAWQL_PAYMENTS_ENFORCE_INFERENCE=1
+export CLAWQL_PAYMENTS_REPORT_STRIPE_METER=1    # if using Stripe meters
+export CLAWQL_X402_ENFORCE=1                    # if using x402
+export CLAWQL_MPP_ENABLED=1                     # optional session micropayments
+export CLAWQL_PAYMENTS_MCP_TOOLS=1              # payout / compensation tools (self-hosted)
+
+clawql payments audit verify
+clawql inference serve --port 8080
+```
+
+Smoke: one inference call → `usage.json` increments → audit line appended → (optional) Stripe meter event.
+
+## Troubleshooting
+
+| Symptom                          | First checks                                                              |
+| -------------------------------- | ------------------------------------------------------------------------- |
+| **402 `insufficient_quota`**     | `clawql payments plan show`; virtual-key `team` vs `payments.json` tenant |
+| **x402 `wallet not configured`** | `clawql payments x402 wallet setup`                                       |
+| **Facilitator verify fails**     | `CLAWQL_X402_FACILITATOR_URL` ends at host; CDP bearer env for mainnet    |
+| **Stripe meter silent**          | `CLAWQL_PAYMENTS_REPORT_STRIPE_METER=1`; customer id in `payments.json`   |
+| **Webhook signature fail**       | Verify raw body, not re-serialized JSON                                   |
+
+Full matrix: [clawql-payments troubleshooting](/payments/clawql-payments#troubleshooting).
+
+## What to read next
+
+- [Agentic Gateway](/inference/clawql-inference) — where entitlements wrap `/v1` and MCP
+- [Authentication](/auth) — virtual keys and outbound token refresh
+- [Defense in depth](/security/defense-in-depth) — payments sit in the audit / WORM layer
+- [Panguard MCP enforcement](/learn/panguard-mcp-enforcement) — block tool calls **before** they spend quota or hit paid APIs
+
+<Note>
+  **Managed vs self-hosted:** do not enable `CLAWQL_CREDITS_P2P_ENABLED` or
+  `CLAWQL_COMPENSATION_ENABLED` on `CLAWQL_MANAGED_HOSTING=1` fleets — those
+  rails are operator opt-in under their own compliance program.
+</Note>

--- a/website/src/app/payments/clawql-payments/page.tsx
+++ b/website/src/app/payments/clawql-payments/page.tsx
@@ -47,6 +47,13 @@ export default function ClawqlPaymentsPage() {
           </a>
           ,{' '}
           <a
+            href="/learn/payments-and-entitlements"
+            className="font-medium text-inherit underline underline-offset-2"
+          >
+            Learn walkthrough
+          </a>
+          ,{' '}
+          <a
             href="/inference/clawql-inference"
             className="font-medium text-inherit underline underline-offset-2"
           >

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -260,6 +260,16 @@ const ENTRIES: Array<Entry> = [
     changeFrequency: 'monthly',
     priority: 0.87,
   },
+  {
+    path: '/learn/payments-and-entitlements',
+    changeFrequency: 'monthly',
+    priority: 0.9,
+  },
+  {
+    path: '/learn/panguard-mcp-enforcement',
+    changeFrequency: 'monthly',
+    priority: 0.9,
+  },
   { path: '/mcp-clients', changeFrequency: 'monthly', priority: 0.88 },
   { path: '/openclaw', changeFrequency: 'monthly', priority: 0.87 },
   { path: '/concepts', changeFrequency: 'monthly', priority: 0.88 },

--- a/website/src/generated/clawql-payments-body.mdx
+++ b/website/src/generated/clawql-payments-body.mdx
@@ -1,54 +1,61 @@
 # clawql-payments
 
+**Hands-on walkthrough:** [Payments & entitlements (Learn)](https://docs.clawql.com/learn/payments-and-entitlements) — plan limits, Stripe/x402 paths, WORM audit, and inference checklist in one sequence.
+
 **Status:** Shipped foundation (July 2026)  
 **Package:** [`packages/clawql-payments`](../../packages/clawql-payments)  
 **CLI:** `clawql payments *`
 
 `clawql-payments` is ClawQL's unified payments layer for **human fiat** and **agent micropayments**.
 
-**Positioning:** ClawQL is the only Agentic Gateway that speaks **five agentic payment surfaces natively** — **Stripe**, **[x402](https://www.x402.org/)**, **[MPP](https://docs.stripe.com/mcp)**, **[AP2](https://ap2-protocol.org/)**, and **[ACP](https://developers.openai.com/commerce/specs/checkout)** — plus **PayPal Orders** and **Adyen Checkout** for human/enterprise fiat, all with a **WORM-audited** payment event trail. Docs-site `.well-known` discovery for UCP remains complementary; live adapters live in `clawql-payments`.
+**Positioning:** ClawQL speaks **Stripe**, **[x402](https://www.x402.org/)**, **[MPP](https://docs.stripe.com/mcp)**, **[AP2](https://ap2-protocol.org/)**, and **[ACP](https://developers.openai.com/commerce/specs/checkout)** — plus **PayPal Orders** and **Adyen Checkout** — with a **WORM-audited** payment event trail. On **managed hosting**, those rails collect **platform fees** and support **closed-loop company credits** (role budgets / within-org transfers — [org-credits](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/org-credits.md)); they are **not** a consumer P2P network. Cross-tenant peer payments and agent compensation ship for **self-hosted** operators — see [hosted vs self-hosted compliance](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/hosted-vs-self-hosted-compliance.md).
 
-It powers ClawQL's own managed tiers (Free / Pro / Team / Enterprise) and is available to self-hosted operators and ClawQL users who want to bill their own customers.
+It powers ClawQL's own managed tiers (Developer / Teams / Shared / Dedicated / Enterprise) via **Stripe** and is available to self-hosted operators who want to bill their own customers.
 
 ## What ships today
 
-| Capability                                                      | Status | Notes                                                                                                                                                                                                                                                                                  |
-| --------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Managed plan tiers + entitlements                               | ✅     | Local `usage.json` counters; limit enforcement in inference                                                                                                                                                                                                                            |
-| Stripe customers, subscriptions, invoices                       | ✅     | Live SDK when `STRIPE_SECRET_KEY` is set                                                                                                                                                                                                                                               |
-| Stripe webhook signature verification                           | ✅     | CLI verify/process; audit on `invoice.paid`                                                                                                                                                                                                                                            |
-| Stripe Billing Meters (`meterEvents.create`)                    | ✅     | API + inference hook when `CLAWQL_PAYMENTS_REPORT_STRIPE_METER=1`                                                                                                                                                                                                                      |
-| x402 gate config + facilitator HTTP verify                      | ✅     | `POST /verify` against x402.org or CDP                                                                                                                                                                                                                                                 |
-| x402 Express middleware (402 + PAYMENT-REQUIRED)                | ✅     | Wired into `clawql-inference` HTTP                                                                                                                                                                                                                                                     |
-| x402 MCP in-process enforcement                                 | ✅     | `CLAWQL_X402_ENFORCE=1` on stdio / Streamable HTTP / gRPC MCP tool calls                                                                                                                                                                                                               |
-| Payment WORM audit (hash-chained JSONL)                         | ✅     | `$CLAWQL_HOME/Payments/audit.jsonl` + `audit verify`                                                                                                                                                                                                                                   |
-| Payment WORM audit (Postgres)                                   | ✅     | `CLAWQL_PAYMENTS_AUDIT_STORE=postgres` for multi-node deployments                                                                                                                                                                                                                      |
-| Payment audit → Loki/SIEM export                                | ✅     | Fire-and-forget push on append when `CLAWQL_LOKI_PUSH_URL` is set                                                                                                                                                                                                                      |
-| `.well-known/payments.json` discovery                           | ✅     | Dynamic on MCP + inference HTTP; static route on docs site                                                                                                                                                                                                                             |
-| MPP `/openapi.json` discovery                                   | ✅     | Dynamic on MCP + inference HTTP; canonical `x-payment-info.offers[]`                                                                                                                                                                                                                   |
-| MPP HTTP 402 + MCP -32042 runtime                               | ✅     | Dual x402 + MPP challenges when `CLAWQL_MPP_ENABLED=1`                                                                                                                                                                                                                                 |
-| MPP credential verification + receipts                          | ✅     | `MppVerificationService` — x402 facilitator + Stripe SPT (`STRIPE_PROFILE_ID`)                                                                                                                                                                                                         |
-| MPP optional `mppx` adapter                                     | ✅     | `MppxAdapterService` when `CLAWQL_MPPX_ENABLED=1` + optional `mppx` dep                                                                                                                                                                                                                |
-| MCP JSON-RPC payment errors                                     | ✅     | `-32042`/`-32043` when `CLAWQL_MPP_MCP_JSONRPC=1` (default: tool-result `_meta`)                                                                                                                                                                                                       |
-| Extended finance provider **adverts** in `offers[]`             | ✅     | `CLAWQL_MPP_FINANCE_PROVIDERS` — discovery labels; PayPal live via Orders below                                                                                                                                                                                                        |
-| **AP2** Payment Mandates                                        | ✅     | `Ap2MandateService` — parse/verify VCs, optional HS256, bridge into x402 gates                                                                                                                                                                                                         |
-| **ACP** checkout sessions                                       | ✅     | `AcpCheckoutService` — create/complete + Stripe SPT (dry-run without key)                                                                                                                                                                                                              |
-| **PayPal** Orders v2                                            | ✅     | `PaypalOrdersService` — OAuth, create order, capture                                                                                                                                                                                                                                   |
-| **Adyen** Checkout                                              | ✅     | `AdyenCheckoutService` — sessions, payments, HMAC webhooks (enterprise)                                                                                                                                                                                                                |
-| **Creator payouts** (Stripe Connect + Base USDC)                | ✅     | `PayoutService` — bank transfers + live USDC with receipt confirmation                                                                                                                                                                                                                 |
-| **Ramp** agent virtual / agentic cards                          | ✅     | `RampService` — vault path + native `cards:read_agentic` when enabled                                                                                                                                                                                                                  |
-| **Consumer off-ramp** (Moonpay / Transak)                       | ✅     | Sessions + `OfframpWebhookService` completion settle                                                                                                                                                                                                                                   |
-| **Payments MCP tools** (payout / ramp / offramp / compensation) | ✅     | `CLAWQL_PAYMENTS_MCP_TOOLS=1`; optional AP2 gate; includes `agent_compensation_*`                                                                                                                                                                                                      |
-| **Prepaid credits + bank top-up**                               | ✅     | Grant ledger + Stripe FC/ACH top-up; sync [`DeductionService`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/deduction-service.md) on inference — [credits-ach.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/credits-ach.md) |
-| **Agent compensation** (credits + 2PC cash-out)                 | ✅     | `AgentCompensationService` — stage/confirm MCP + FAILED WORM; reuses `PayoutService`                                                                                                                                                                                                   |
+| Capability                                                      | Status | Notes                                                                                                                                                                                                                                                                                                                                       |
+| --------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Managed plan tiers + entitlements                               | ✅     | Local `usage.json` counters; limit enforcement in inference                                                                                                                                                                                                                                                                                 |
+| Stripe customers, subscriptions, invoices                       | ✅     | Live SDK when `STRIPE_SECRET_KEY` is set                                                                                                                                                                                                                                                                                                    |
+| Stripe webhook signature verification                           | ✅     | CLI verify/process; audit on `invoice.paid`                                                                                                                                                                                                                                                                                                 |
+| Stripe Billing Meters (`meterEvents.create`)                    | ✅     | API + inference hook when `CLAWQL_PAYMENTS_REPORT_STRIPE_METER=1`                                                                                                                                                                                                                                                                           |
+| x402 gate config + facilitator HTTP verify                      | ✅     | `POST /verify` against x402.org or CDP                                                                                                                                                                                                                                                                                                      |
+| x402 Express middleware (402 + PAYMENT-REQUIRED)                | ✅     | Wired into `clawql-inference` HTTP                                                                                                                                                                                                                                                                                                          |
+| x402 MCP in-process enforcement                                 | ✅     | `CLAWQL_X402_ENFORCE=1` on stdio / Streamable HTTP / gRPC MCP tool calls                                                                                                                                                                                                                                                                    |
+| Payment WORM audit (hash-chained JSONL)                         | ✅     | `$CLAWQL_HOME/Payments/audit.jsonl` + `audit verify`                                                                                                                                                                                                                                                                                        |
+| Payment WORM audit (Postgres)                                   | ✅     | `CLAWQL_PAYMENTS_AUDIT_STORE=postgres` for multi-node deployments                                                                                                                                                                                                                                                                           |
+| Payment audit → Loki/SIEM export                                | ✅     | Fire-and-forget push on append when `CLAWQL_LOKI_PUSH_URL` is set                                                                                                                                                                                                                                                                           |
+| `.well-known/payments.json` discovery                           | ✅     | Dynamic on MCP + inference HTTP; static route on docs site                                                                                                                                                                                                                                                                                  |
+| MPP `/openapi.json` discovery                                   | ✅     | Dynamic on MCP + inference HTTP; canonical `x-payment-info.offers[]`                                                                                                                                                                                                                                                                        |
+| MPP HTTP 402 + MCP -32042 runtime                               | ✅     | Dual x402 + MPP challenges when `CLAWQL_MPP_ENABLED=1`                                                                                                                                                                                                                                                                                      |
+| MPP credential verification + receipts                          | ✅     | `MppVerificationService` — x402 facilitator + Stripe SPT (`STRIPE_PROFILE_ID`)                                                                                                                                                                                                                                                              |
+| MPP optional `mppx` adapter                                     | ✅     | `MppxAdapterService` when `CLAWQL_MPPX_ENABLED=1` + optional `mppx` dep                                                                                                                                                                                                                                                                     |
+| MCP JSON-RPC payment errors                                     | ✅     | `-32042`/`-32043` when `CLAWQL_MPP_MCP_JSONRPC=1` (default: tool-result `_meta`)                                                                                                                                                                                                                                                            |
+| Extended finance provider **adverts** in `offers[]`             | ✅     | `CLAWQL_MPP_FINANCE_PROVIDERS` — discovery labels; PayPal live via Orders below                                                                                                                                                                                                                                                             |
+| **AP2** Payment Mandates                                        | ✅     | `Ap2MandateService` — parse/verify VCs, optional HS256, bridge into x402 gates                                                                                                                                                                                                                                                              |
+| **ACP** checkout sessions                                       | ✅     | `AcpCheckoutService` — create/complete + Stripe SPT (dry-run without key)                                                                                                                                                                                                                                                                   |
+| **PayPal** Orders v2                                            | ✅     | `PaypalOrdersService` — OAuth, create order, capture                                                                                                                                                                                                                                                                                        |
+| **Adyen** Checkout                                              | ✅     | `AdyenCheckoutService` — sessions, payments, HMAC webhooks (enterprise)                                                                                                                                                                                                                                                                     |
+| **Creator payouts** (Stripe Connect + Base USDC)                | ✅     | `PayoutService` — bank transfers + live USDC with receipt confirmation                                                                                                                                                                                                                                                                      |
+| **Ramp** agent virtual / agentic cards                          | ✅     | `RampService` — vault path + native `cards:read_agentic` when enabled                                                                                                                                                                                                                                                                       |
+| **Cloudflare Wallets** (identity + Virtual Wallets)             | 🚧     | `CloudflareWalletService` — dry-run prep; handle `clawql.cloudflare.pay` reserved — [cloudflare-wallets.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/cloudflare-wallets.md)                                                                                                                                 |
+| **Consumer off-ramp** (Moonpay / Transak)                       | ✅     | Sessions + `OfframpWebhookService` completion settle                                                                                                                                                                                                                                                                                        |
+| **Payments MCP tools** (payout / ramp / offramp / compensation) | ✅     | `CLAWQL_PAYMENTS_MCP_TOOLS=1`; optional AP2 gate; includes `agent_compensation_*`                                                                                                                                                                                                                                                           |
+| **Prepaid credits + bank top-up + P2P transfer**                | ✅\*   | Grant ledger + FC/ACH top-up; **P2P transfer self-hosted opt-in** (`CLAWQL_CREDITS_P2P_ENABLED=1`) — [credits-ach.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/credits-ach.md) / [compliance](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/hosted-vs-self-hosted-compliance.md) |
+| **Agent compensation** (credits + 2PC cash-out)                 | ✅\*   | `AgentCompensationService` — **self-hosted opt-in** (`CLAWQL_COMPENSATION_ENABLED=1`); off on managed                                                                                                                                                                                                                                       |
+| **Accounting export + tax evidence**                            | ✅     | Subledger CSV/JSON/QB/Xero; `TaxProfileService` gate; year-end pack — [accounting-and-tax.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/accounting-and-tax.md)                                                                                                                                               |
 
 ### Roadmap
 
-| Tier  | Item                  | Role                | Notes                                    |
-| ----- | --------------------- | ------------------- | ---------------------------------------- |
-| **3** | **Mollie / Razorpay** | Regional processors | Add when regional traction requires them |
+| Tier  | Item                                | Role                                        | Notes                                                                                                                                |
+| ----- | ----------------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| ~~1~~ | ~~**Accounting export**~~           | Period CSV/JSON subledger from payment WORM | ✅ Shipped — [accounting-and-tax.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/accounting-and-tax.md) |
+| ~~2~~ | ~~**Tax profile gate + year-end**~~ | Tags + export; Stripe Connect Tax for 1099s | ✅ Gate + evidence pack; no in-process IRS e-file                                                                                    |
+| **1** | **Cloudflare Wallets live**         | Identity + capped Virtual Wallet HTTP API   | Scaffold shipped; wire client when CF API is public                                                                                  |
+| **3** | **Mollie / Razorpay**               | Regional processors                         | Add when regional traction requires them                                                                                             |
 
-**Already covered (do not duplicate):** Shopify Payments (Stripe-powered), ACH Direct Debit via Stripe's APIs, card/subscription/invoice flows via Stripe, **bank ACH top-ups via Stripe Financial Connections** (Plaid-backed Link UI — no separate Plaid SDK), **Stripe Connect payouts**, **live Base USDC payouts with receipt confirmation**, **consumer off-ramp + webhooks (Moonpay/Transak)**, **Ramp vault + native agentic cards**. **Not planned:** Zelle (no merchant API), Square POS-first adapters, raw Plaid SDK unless non-payment bank data is required.
+**Already covered (do not duplicate):** Shopify Payments (Stripe-powered), ACH Direct Debit via Stripe's APIs, card/subscription/invoice flows via Stripe, **bank ACH top-ups via Stripe Financial Connections** (Plaid-backed Link UI — no separate Plaid SDK), **Stripe Connect payouts**, **live Base USDC payouts with receipt confirmation**, **consumer off-ramp + webhooks (Moonpay/Transak)**, **Ramp vault + native agentic cards**. **Not planned:** Zelle (no merchant API), Square POS-first adapters, raw Plaid SDK unless non-payment bank data is required, **full GL / tax e-file product** (subledger export + Stripe Connect Tax / CPA handoff — [accounting-and-tax.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/accounting-and-tax.md)), **full KYC product surface** (identity docs / watchlists belong in Documents + a banking vertical — see [`docs/design/clawql-banking-vertical.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/design/clawql-banking-vertical.md); payments may later expose only a thin `KycGatePort` before payouts).
 
 Docs-site **UCP** `.well-known` documents remain scanner-facing stubs. **AP2 / ACP / PayPal / Adyen** are live in self-hosted `clawql-payments` when their env flags are set.
 
@@ -65,15 +72,17 @@ clawql-payments
 ├── adyen/      Adyen Checkout sessions, payments, HMAC webhooks
 ├── payouts/    Stripe Connect bank payouts + Base USDC sends
 ├── ramp/       Ramp funds + virtual / agent cards
+├── cloudflare-wallets/  Cloudflare identity + Virtual Wallets (dry-run prep)
 ├── offramp/    Consumer USDC → fiat (Moonpay / Transak)
-├── credits/    Prepaid ledger + Stripe FC / ACH bank top-up
+├── credits/    Prepaid ledger + FC/ACH top-up + P2P tenant transfer
 ├── compensation/  Agent credits ledger + DAOS-aligned 2PC staging
+├── accounting/ Subledger export, CoA map, tax profile gate, evidence pack
 ├── plans/      Tier definitions, entitlements, usage.json counters
 ├── audit/      Hash-chained append-only JSONL + integrity verify
 └── cli/        clawql payments * implementations
 ```
 
-See also [payouts-ramp.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/payouts-ramp.md), [credits-ach.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/credits-ach.md), [agent-compensation.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/agent-compensation.md), and [sgdop-coordinator-compensation-bridge.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/sgdop-coordinator-compensation-bridge.md) (`CompensationStagingPort` shipped; Coordinator integration still roadmap).
+See also [accounting-and-tax.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/accounting-and-tax.md) (subledger export + tax ownership), [payouts-ramp.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/payouts-ramp.md), [cloudflare-wallets.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/cloudflare-wallets.md), [credits-ach.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/credits-ach.md), [agent-compensation.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/agent-compensation.md), and [sgdop-coordinator-compensation-bridge.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/sgdop-coordinator-compensation-bridge.md) (`CompensationStagingPort` shipped; Coordinator integration still roadmap).
 
 ```mermaid
 flowchart TB
@@ -128,13 +137,16 @@ Plan usage drives **quota enforcement** and optional **Stripe Billing Meters**. 
 
 All local state lives under `$CLAWQL_HOME/Payments/` (default `~/.clawql/Payments/`):
 
-| File              | Contents                                                                  |
-| ----------------- | ------------------------------------------------------------------------- |
-| `payments.json`   | Tenant id, plan tier, Stripe metadata, x402 wallet/facilitator            |
-| `x402-gates.json` | Payment-gated HTTP paths and MCP tool names                               |
-| `usage.json`      | Monthly counters per tenant (`inference_calls`, `documents`, `memory_mb`) |
-| `audit.jsonl`     | Append-only hash-chained payment audit log                                |
-| `audit.meta.json` | Chain head (`seq`, `last_hash`) for fast append                           |
+| File                   | Contents                                                                  |
+| ---------------------- | ------------------------------------------------------------------------- |
+| `payments.json`        | Tenant id, plan tier, Stripe metadata, x402 wallet/facilitator            |
+| `x402-gates.json`      | Payment-gated HTTP paths and MCP tool names                               |
+| `usage.json`           | Monthly counters per tenant (`inference_calls`, `documents`, `memory_mb`) |
+| `audit.jsonl`          | Append-only hash-chained payment audit log                                |
+| `audit.meta.json`      | Chain head (`seq`, `last_hash`) for fast append                           |
+| `accounting-map.json`  | Optional customer chart-of-accounts overrides (GL codes)                  |
+| `tax-profiles.json`    | Opaque tax readiness tags (`1099nec` / collected) — never SSNs            |
+| `tax-evidence/<year>/` | Year-end evidence packs (`evidence.json` + `evidence.md`)                 |
 
 Example `payments.json`:
 
@@ -378,6 +390,17 @@ See [agent-compensation.md](https://github.com/danielsmithdevelopment/ClawQL/blo
 | `CLAWQL_CREDITS_RETURN_URL`           | —       | Optional Financial Connections return URL                               |
 
 See [credits-ach.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/credits-ach.md) and [deduction-service.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/deduction-service.md).
+
+```bash
+export CLAWQL_CREDITS_ENABLED=1
+clawql payments credits show
+# P2P: pay @handle (stages) — confirm with code (+ optional TOTP)
+clawql payments credits directory claim --handle bob --tenant-id other-tenant
+clawql payments credits pay --to @bob --amount 10
+clawql payments credits transfer --confirm --action-id UUID --code HEX [--totp NNNNNN]
+clawql payments credits step-up enroll   # optional authenticator
+export CLAWQL_CREDITS_TRANSFER_REQUIRE_TOTP=1
+```
 
 ### Setup flow
 
@@ -640,6 +663,107 @@ if (!result.ok) {
 
 ---
 
+## Accounting & tax
+
+The payment WORM is the **subledger of record** for ClawQL-mediated money flows. ClawQL exports that trail for books and CPA handoff — it does **not** replace QuickBooks/Xero/NetSuite or file IRS forms in-process.
+
+Deep dive: [accounting-and-tax.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/accounting-and-tax.md).
+
+| Capability         | What it does                                                                                                                  |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| **Period export**  | One row per monetary WORM event → CSV / JSON / QuickBooks-style / Xero-style                                                  |
+| **Classification** | New WORM writes carry `accounting` (direction, category, tax treatment); credits top-ups = **prepaid liability**, not revenue |
+| **CoA mapping**    | Default GL codes; override with `$CLAWQL_HOME/Payments/accounting-map.json`                                                   |
+| **Integrity gate** | Export refuses to run if `audit verify` fails (unless `--skip-verify`)                                                        |
+| **Tax profiles**   | Opaque readiness tags only (no SSN/ITIN in payments storage)                                                                  |
+| **Payout gate**    | Opt-in: `CLAWQL_TAX_PROFILE_ENFORCE=1` blocks creator/agent payouts without a collected profile                               |
+| **Year-end pack**  | Markdown + JSON evidence for payouts / compensation cash-outs (not an e-file)                                                 |
+
+### Period close (operator recipe)
+
+```bash
+# 1. Integrity
+clawql payments audit verify
+
+# 2. Subledger for the books
+clawql payments accounting export \
+  --date-from 2026-01-01 --date-to 2026-03-31 \
+  --format csv \
+  --output ./books/2026-q1-subledger.csv
+
+# QuickBooks / Xero bank-style templates
+clawql payments accounting export --from 2026-01-01 --to 2026-03-31 --format qb-csv
+clawql payments accounting export --from 2026-01-01 --to 2026-03-31 --format xero-csv
+
+# 3. Year-end evidence (payouts + compensation cash-outs)
+clawql payments accounting tax-evidence --tax-year 2026
+# → $CLAWQL_HOME/Payments/tax-evidence/2026/evidence.json + evidence.md
+```
+
+Import the CSV into your GL or CPA spreadsheet. Reconcile Stripe balance / USDC wallet / ACH pending separately.
+
+### Tax profiles (payout readiness)
+
+```bash
+# Store readiness only — PII stays in vault / Stripe / KYC vendor
+clawql payments tax-profile set \
+  --party-id creator-1 \
+  --tax-form 1099nec \
+  --collected \
+  --tax-profile-ref vault:w9_abc
+
+clawql payments tax-profile show --party-id creator-1
+
+# Opt-in gate before PayoutService money-out
+export CLAWQL_TAX_PROFILE_ENFORCE=1
+```
+
+| Form / obligation                 | Owner                                                    |
+| --------------------------------- | -------------------------------------------------------- |
+| Stripe invoices / receipts        | Stripe (existing billing)                                |
+| US 1099-NEC / 1099-K on Connect   | Prefer **Stripe Connect Tax**; ClawQL exports evidence   |
+| W-9 / W-8 collection UX           | Banking / onboarding vertical; payments stores readiness |
+| VAT / GST invoices                | Stripe Tax / regional processor; invoice refs in WORM    |
+| Agent compensation classification | CPA outside ClawQL; cash-out rows in tax-evidence pack   |
+
+### Environment
+
+| Variable                     | Default | Purpose                                                                                                   |
+| ---------------------------- | ------- | --------------------------------------------------------------------------------------------------------- |
+| `CLAWQL_TAX_PROFILE_ENFORCE` | off     | When `1`, `PayoutService.createPayout` requires a collected tax profile (or `taxForm=none`) for the party |
+
+### Example `accounting-map.json`
+
+```json
+{
+  "categories": {
+    "saas_revenue": "4000",
+    "usage_revenue": "4100",
+    "micropayment_revenue": "4100",
+    "prepaid_liability": "2500",
+    "prepaid_redemption": "4100",
+    "creator_payout": "6000",
+    "agent_compensation": "6100",
+    "agent_spend": "6200"
+  }
+}
+```
+
+### Programmatic export
+
+```typescript
+import { buildAccountingExport, buildTaxEvidencePack } from 'clawql-payments'
+
+const books = await buildAccountingExport({
+  from: '2026-01-01',
+  to: '2026-12-31',
+  format: 'csv',
+})
+const evidence = await buildTaxEvidencePack({ taxYear: 2026 })
+```
+
+---
+
 ## Full CLI reference
 
 ```bash
@@ -662,6 +786,20 @@ clawql payments x402 wallet setup | gate | gate list | verify | reconcile
 clawql payments spend report --group-by provider
 clawql payments audit --correlation-id xxx
 clawql payments audit verify
+
+# Accounting & tax (subledger + evidence — not a full GL / IRS e-file)
+clawql payments accounting export --from 2026-01-01 --to 2026-12-31 --format csv
+clawql payments accounting export --date-from 2026-01-01 --date-to 2026-12-31 --format qb-csv --output ./books.csv
+clawql payments accounting tax-evidence --tax-year 2026
+clawql payments tax-profile set --party-id creator-1 --tax-form 1099nec --collected
+clawql payments tax-profile show [--party-id creator-1]
+
+# Prepaid credits (top-up + P2P @handle pay with stage/confirm step-up)
+clawql payments credits show | bank-link | topup --customer cus_xxx --amount 25
+clawql payments credits directory claim --handle bob --tenant-id other-tenant
+clawql payments credits pay --to @bob --amount 10
+clawql payments credits transfer --confirm --action-id UUID --code HEX [--totp NNNNNN]
+clawql payments credits step-up enroll|show
 ```
 
 ---
@@ -741,6 +879,7 @@ See also: [`packages/clawql-inference/README.md`](https://github.com/danielsmith
 
 ## Related
 
+- Accounting & tax: [`docs/payments/accounting-and-tax.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/payments/accounting-and-tax.md)
 - Package README: [`packages/clawql-payments/README.md`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/packages/clawql-payments/README.md)
 - Inference doc: [`docs/inference/clawql-inference.md`](/inference/clawql-inference)
 - x402 protocol: [x402.org](https://www.x402.org/)

--- a/website/src/generated/clawql-plugins/bodies/panguard-proxy.mdx
+++ b/website/src/generated/clawql-plugins/bodies/panguard-proxy.mdx
@@ -1,23 +1,28 @@
 # Panguard MCP proxy
 
-**Plugin ID:** `panguard-mcp-proxy`  
-**Kind:** `mcp-proxy` (does not register MCP tools)  
-**Package:** `clawql-api` — `PanguardProxyPlugin`
+**Hands-on walkthrough:** [Panguard MCP enforcement (Learn)](https://docs.clawql.com/learn/panguard-mcp-enforcement) — stdio wrap, in-process hooks, Helm `mcpProxy`, and JWT bridge env.
 
-The Panguard proxy plugin is the synchronous **`beforeCallTool`** chokepoint for policy enforcement when ClawQL runs behind an enterprise MCP proxy or with in-process ATR rules ([#272](https://github.com/danielsmithdevelopment/ClawQL/issues/272)).
+**Plugin ID:** `panguard-mcp-proxy`  
+**Shape:** hooks-only `ProviderPlugin` (does not register MCP tools)  
+**Package:** `clawql-api` — `createPanguardProxyPlugin`
+
+The Panguard proxy plugin registers a blocking **`tool` / `pre-execute`** hook for policy enforcement when ClawQL runs behind an enterprise MCP proxy or with in-process ATR rules ([#272](https://github.com/danielsmithdevelopment/ClawQL/issues/272)). `McpProxyPipeline` fires hooks via `fireHook` (ATR never-loosen).
+
+**8.0+:** enforcement providers are **default-off**. A bare install has no tool-scope enforcement until you opt in. Boot emits a **SECURITY WARNING** when none is active (silence with `CLAWQL_ALLOW_NO_ENFORCEMENT=1` only if intentional).
 
 ## What it does
 
-- Intercepts every MCP tool call before execution
+- Intercepts every MCP tool call before execution (blocking `pre-execute`)
 - Applies JWT ATR / policy decisions (allow, deny, scope checks)
 - Does **not** add tools to the MCP surface — it only gates existing ones
 
 ## Enable / disable
 
-| Env                                  | Default | Effect                                          |
-| ------------------------------------ | ------- | ----------------------------------------------- |
-| **`CLAWQL_PANGUARD_PROXY_PLUGIN=0`** | on      | Omit the proxy plugin from composition          |
-| **`CLAWQL_PANGUARD_IN_PROCESS=1`**   | off     | Use in-process policy path (active development) |
+| Env                                  | Default | Effect                                             |
+| ------------------------------------ | ------- | -------------------------------------------------- |
+| **`CLAWQL_PANGUARD_PROXY_PLUGIN=1`** | off     | Register the proxy plugin in composition           |
+| **`CLAWQL_PANGUARD_IN_PROCESS=1`**   | off     | Active in-process policy path (blocking hooks)     |
+| **`CLAWQL_ALLOW_NO_ENFORCEMENT=1`**  | off     | Silence boot warning when no enforcement is active |
 
 ## When to use
 
@@ -27,9 +32,11 @@ The Panguard proxy plugin is the synchronous **`beforeCallTool`** chokepoint for
 
 ## Learn more
 
+- [Panguard MCP enforcement (Learn)](https://docs.clawql.com/learn/panguard-mcp-enforcement)
 - [Defense in depth (site)](/security/defense-in-depth)
 - [MCP proxy JWT ATR (repo)](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/security/mcp-proxy-jwt-atr.md)
 - [Plugin registry](/plugins)
+- [Migrate to 8.0](/getting-started/migrate-to-8.0)
 
 export function wrapper({ children }) {
   return children

--- a/website/src/generated/clawql-plugins/bodies/payments.mdx
+++ b/website/src/generated/clawql-plugins/bodies/payments.mdx
@@ -1,37 +1,54 @@
 # Payments (`clawql-payments`)
 
-**Status:** Shipped (foundation + Tier 1 protocols + Adyen + Connect payouts / Ramp / off-ramp + prepaid credits + agent compensation)  
+**Status:** Shipped (foundation + Tier 1 protocols + Adyen + Connect payouts / Ramp / off-ramp + prepaid credits + agent compensation + accounting export / tax evidence)  
 **Package:** [`packages/clawql-payments`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/plugins/../packages/clawql-payments)  
-**Toggle:** Always available as a library; gate rails via `CLAWQL_X402_ENFORCE`, `CLAWQL_MPP_ENABLED`, `CLAWQL_AP2_ENABLED`, `CLAWQL_ACP_ENABLED`, `CLAWQL_PAYPAL_ENABLED`, `CLAWQL_ADYEN_ENABLED`, `CLAWQL_CREDITS_ENABLED`, `CLAWQL_COMPENSATION_ENABLED`, `CLAWQL_PAYMENTS_MCP_TOOLS`, plan entitlements  
+**Toggle:** Always available as a library; gate rails via `CLAWQL_X402_ENFORCE`, `CLAWQL_MPP_ENABLED`, `CLAWQL_AP2_ENABLED`, `CLAWQL_ACP_ENABLED`, `CLAWQL_PAYPAL_ENABLED`, `CLAWQL_ADYEN_ENABLED`, `CLAWQL_CREDITS_ENABLED`, `CLAWQL_CREDITS_P2P_ENABLED` (default off), `CLAWQL_COMPENSATION_ENABLED` (default off), `CLAWQL_MANAGED_HOSTING`, `CLAWQL_PAYMENTS_MCP_TOOLS`, `CLAWQL_TAX_PROFILE_ENFORCE`, plan entitlements  
 **Plugin:** `PaymentsX402ProxyPlugin` (`payments-x402-mcp-proxy`) for MCP tool-level x402 enforcement (+ optional AP2 mandate checks); optional payout / compensation tools via `CLAWQL_PAYMENTS_MCP_TOOLS=1`
 
 ## Positioning
 
-ClawQL is the only Agentic Gateway with native **Stripe + x402 + MPP + AP2 + ACP** payment surfaces, **PayPal Orders**, **Adyen Checkout** (enterprise), **Connect payouts / Ramp / consumer off-ramp**, **prepaid credits**, **agent compensation**, and a **WORM-audited** payment event trail:
+**Read first:** [hosted vs self-hosted compliance](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/plugins/payments/hosted-vs-self-hosted-compliance.md). Managed hosting uses Stripe for **platform fees** and optional **closed-loop company credits** ([org-credits](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/plugins/payments/org-credits.md)). **Cross-tenant P2P** and **agent compensation** are self-hosted opt-in and forced off when `CLAWQL_MANAGED_HOSTING=1`.
 
-| Rail               | Role                                                                                   |
-| ------------------ | -------------------------------------------------------------------------------------- |
-| **Stripe**         | Human fiat — subscriptions, invoices, Billing Meters, Shared Payment Tokens            |
-| **x402**           | Per-request USDC micropayments (one chain settlement per paid call)                    |
-| **MPP**            | Session-based streaming micropayments (pre-authorize once; high-frequency agent spend) |
-| **AP2**            | Cryptographic Payment Mandates (authorization / non-repudiation under MCP)             |
-| **ACP**            | Merchant-side agentic checkout sessions (ChatGPT Instant Checkout–style)               |
-| **PayPal**         | Human wallet Orders v2 create/capture                                                  |
-| **Adyen**          | Enterprise Checkout sessions, payments, HMAC-verified webhooks                         |
-| **Payouts / Ramp** | Creator bank + Base USDC; Ramp agent cards; Moonpay/Transak off-ramp                   |
-| **Credits**        | Prepaid ledger + ACH/FC top-up; sync `DeductionService` on inference                   |
-| **Compensation**   | Agent deposit / cash-out with DAOS-aligned 2PC staging                                 |
+ClawQL’s Agentic Gateway includes native **Stripe + x402 + MPP + AP2 + ACP** surfaces, **PayPal**, **Adyen**, **Connect payouts / Ramp / off-ramp**, **Cloudflare Wallets** (dry-run prep), **closed-loop prepaid credits**, optional **self-hosted P2P / agent compensation**, a **WORM-audited** payment trail, and an **accounting subledger export**:
 
-Operator guide: [clawql-payments](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/plugins/payments/clawql-payments.md) → `/payments/clawql-payments`.
+| Rail                   | Role                                                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Stripe**             | Human fiat — subscriptions, invoices, Billing Meters, Shared Payment Tokens                                         |
+| **x402**               | Per-request USDC micropayments (one chain settlement per paid call)                                                 |
+| **MPP**                | Session-based streaming micropayments (pre-authorize once; high-frequency agent spend)                              |
+| **AP2**                | Cryptographic Payment Mandates (authorization / non-repudiation under MCP)                                          |
+| **ACP**                | Merchant-side agentic checkout sessions (ChatGPT Instant Checkout–style)                                            |
+| **PayPal**             | Human wallet Orders v2 create/capture                                                                               |
+| **Adyen**              | Enterprise Checkout sessions, payments, HMAC-verified webhooks                                                      |
+| **Payouts / Ramp**     | Creator bank + Base USDC; Ramp agent cards; Moonpay/Transak off-ramp                                                |
+| **Cloudflare Wallets** | `clawql.cloudflare.pay` identity + capped Virtual Wallets (dry-run prep)                                            |
+| **Credits**            | Prepaid ledger + ACH/FC; **org closed-loop** budgets; **cross-tenant P2P** only with `CLAWQL_CREDITS_P2P_ENABLED=1` |
+| **Compensation**       | Agent deposit / cash-out — `CLAWQL_COMPENSATION_ENABLED=1` (self-hosted)                                            |
+| **Accounting**         | Period subledger CSV/JSON/QB/Xero; tax profile gate; year-end evidence pack                                         |
+
+Operator guide: [clawql-payments](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/plugins/payments/clawql-payments.md) → `/payments/clawql-payments` (includes [Accounting & tax](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/plugins/payments/clawql-payments.md#accounting--tax)). **Learn walkthrough:** [Payments & entitlements](https://docs.clawql.com/learn/payments-and-entitlements). Cloudflare prep: [cloudflare-wallets](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/plugins/payments/cloudflare-wallets.md).
+
+### Accounting & tax (operator quick start)
+
+```bash
+clawql payments audit verify
+clawql payments accounting export --from 2026-01-01 --to 2026-12-31 --format csv
+clawql payments accounting tax-evidence --tax-year 2026
+clawql payments tax-profile set --party-id creator-1 --tax-form 1099nec --collected
+```
+
+Full ownership model (subledger vs GL, 1099 / W-9, no in-process e-file): [accounting-and-tax.md](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/plugins/payments/accounting-and-tax.md).
 
 ## Roadmap
 
-1. **Mollie / Razorpay** — Tier 3 regional processors when regional traction requires them
+1. **Cloudflare Wallets live API** — swap dry-run store for Virtual Wallet HTTP client when public
+2. **Mollie / Razorpay** — Tier 3 regional processors when regional traction requires them
 
 Docs-site UCP discovery remains a stub. Adyen/AP2/ACP/PayPal live when env flags are set on self-hosted `clawql-payments`.
 
 ## Related
 
+- [Accounting & tax](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/plugins/payments/accounting-and-tax.md)
 - [Inference payments integration](https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/plugins/inference/clawql-inference.md#plan-entitlements-and-payments-clawql-payments)
 - [Plugin registry](/plugins#registry)
 

--- a/website/src/lib/docs-nav-data.ts
+++ b/website/src/lib/docs-nav-data.ts
@@ -41,12 +41,14 @@ const LEARN_MODULE_HREFS = [
   '/learn/external-ingest-knowledge',
   '/learn/knowledge-search-onyx',
   '/learn/document-pipeline',
+  '/learn/payments-and-entitlements',
   '/learn/sandbox-exec',
   '/learn/effect-ts',
   '/learn/ouroboros-tools',
   '/learn/schedule-notify-workflows',
   '/learn/cache-handoff-between-chats',
   '/learn/audit-tool-and-observability',
+  '/learn/panguard-mcp-enforcement',
 ] as const
 
 const learnModuleByHref = new Map(

--- a/website/src/lib/docs-site-card-data.ts
+++ b/website/src/lib/docs-site-card-data.ts
@@ -75,6 +75,20 @@ export const learnModuleSiteCards: Array<ReferenceCard> = [
     },
   },
   {
+    href: '/learn/payments-and-entitlements',
+    name: 'Payments & entitlements',
+    description:
+      'Plan tiers, Stripe + x402 gates, WORM payment audit, and inference quota enforcement end-to-end.',
+    icon: TagIcon,
+    pattern: {
+      y: 24,
+      squares: [
+        [0, 0],
+        [1, 1],
+      ],
+    },
+  },
+  {
     href: '/learn/sandbox-exec',
     name: 'Sandbox exec',
     description:
@@ -182,6 +196,20 @@ export const learnModuleSiteCards: Array<ReferenceCard> = [
       squares: [
         [0, 0],
         [1, 2],
+      ],
+    },
+  },
+  {
+    href: '/learn/panguard-mcp-enforcement',
+    name: 'Panguard MCP enforcement',
+    description:
+      'JWT ATR chokepoints: stdio wrap, in-process proxy plugin, Helm mcpProxy, and the MCP bridge image.',
+    icon: ShapesIcon,
+    pattern: {
+      y: 26,
+      squares: [
+        [0, 2],
+        [2, 0],
       ],
     },
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds hands-on **Learn** walkthroughs for the two platform areas called out in the discoverability roadmap:

### [Payments & entitlements](/learn/payments-and-entitlements)
- Three usage systems (plan / inference store / virtual keys)
- Paths: local plan limits, Stripe + meters, x402 gates, WORM audit, accounting close
- Production checklist + troubleshooting table
- Cross-links: platform guide, plugin, inference, audit, panguard

### [Panguard MCP enforcement](/learn/panguard-mcp-enforcement)
- JWT ATR mental model and 8.0+ opt-in defaults
- Paths: stdio wrap, in-process `PanguardProxyPlugin`, Helm `mcpProxy` (nginx + bridge), JWT bridge env
- Operations checklist + pairing with payments/audit
- Cross-links: security curriculum, defense-in-depth, K8s integration docs

Also updates repo `docs/payments/clawql-payments.md`, `docs/plugins/payments.md`, and `docs/plugins/panguard-proxy.md` with Learn links; syncs generated MDX bodies.

## Testing
- `website npm run format:check` — pass
- `website npm run build` — `/learn/payments-and-entitlements` and `/learn/panguard-mcp-enforcement` prerendered
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8f57-601a-7ec1-bff0-d35011fef4ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8f57-601a-7ec1-bff0-d35011fef4ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

