### PR TITLE
fix(website): restore mobile docs horizontal padding

### DIFF
--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -133,7 +133,7 @@ export const Header = forwardRef<
       ref={ref}
       className={clsx(
         className,
-        'fixed inset-x-0 top-0 z-50 flex h-14 items-center justify-between gap-12 px-4 transition sm:px-6 lg:left-72 lg:z-30 lg:px-8 xl:left-80',
+        'fixed inset-x-0 top-0 z-50 flex h-14 items-center justify-between gap-12 px-6 transition lg:left-72 lg:z-30 lg:px-8 xl:left-80',
         !isInsideMobileNavigation &&
           'backdrop-blur-xs lg:left-72 xl:left-80 dark:backdrop-blur-sm',
         isInsideMobileNavigation

--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -41,7 +41,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
               <Navigation className="docs-desktop-nav hidden lg:mt-10 lg:block" />
             </div>
           </header>
-          <div className="relative flex h-full flex-col px-4 pt-14 sm:px-6 lg:px-8">
+          <div className="relative flex h-full flex-col px-6 pt-14 lg:px-8">
             <main id="main-content" className="flex-auto" tabIndex={-1}>
               {children}
             </main>

--- a/website/src/components/MobileNavigation.tsx
+++ b/website/src/components/MobileNavigation.tsx
@@ -67,7 +67,7 @@ function MobileNavigationDialog({
         </TransitionChild>
 
         <TransitionChild>
-          <div className="fixed top-14 bottom-0 left-0 w-full overflow-y-auto bg-claw-warm-white px-4 pt-6 pb-4 shadow-lg ring-1 shadow-zinc-900/10 ring-zinc-900/7.5 transition duration-500 ease-in-out data-closed:-translate-x-full min-[416px]:max-w-sm sm:px-6 sm:pb-10 dark:bg-claw-bg dark:ring-claw-graph/50">
+          <div className="fixed top-14 bottom-0 left-0 w-full overflow-y-auto bg-claw-warm-white px-6 pt-6 pb-4 shadow-lg ring-1 shadow-zinc-900/10 ring-zinc-900/7.5 transition duration-500 ease-in-out data-closed:-translate-x-full min-[416px]:max-w-sm sm:pb-10 dark:bg-claw-bg dark:ring-claw-graph/50">
             <Navigation />
           </div>
         </TransitionChild>

--- a/website/src/styles/tailwind.css
+++ b/website/src/styles/tailwind.css
@@ -83,10 +83,6 @@
 
   @media (width < 40rem) {
     .docs-table-scroll {
-      margin-left: -1rem;
-      margin-right: -1rem;
-      padding-left: 1rem;
-      padding-right: 1rem;
       scrollbar-width: thin;
     }
   }
@@ -183,12 +179,4 @@
     -webkit-overflow-scrolling: touch;
   }
 
-  @media (width < 40rem) {
-    .prose
-      :where(pre):not(:where([class~='not-prose'], [class~='not-prose'] *)) {
-      margin-left: -1rem;
-      margin-right: -1rem;
-      border-radius: 0;
-    }
-  }
 }

--- a/website/tests/mobile-content-padding.spec.ts
+++ b/website/tests/mobile-content-padding.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test'
+
+const MOBILE_VIEWPORT = { width: 390, height: 844 }
+
+/** Minimum inset from the viewport edge for readable docs content on mobile. */
+const MIN_CONTENT_INSET_PX = 20
+
+test.describe('mobile content padding', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize(MOBILE_VIEWPORT)
+  })
+
+  const routes = [
+    { path: '/agent-setup', heading: 'Local vs cluster secrets' },
+    { path: '/deployment/operations-guide', heading: 'Before you start' },
+    { path: '/quickstart', heading: '1. Start the MCP server' },
+  ]
+
+  for (const { path, heading } of routes) {
+    test(`${path} keeps prose inset on mobile`, async ({ page }) => {
+      await page.goto(path)
+
+      const headingEl = page.locator('h2, h3').filter({ hasText: heading }).first()
+      await expect(headingEl).toBeVisible()
+      const headingBox = await headingEl.boundingBox()
+      expect(headingBox?.x ?? 0).toBeGreaterThanOrEqual(MIN_CONTENT_INSET_PX)
+
+      const pre = page.locator('.prose pre').first()
+      await expect(pre).toBeVisible()
+      const preBox = await pre.boundingBox()
+      expect(preBox?.x ?? 0).toBeGreaterThanOrEqual(MIN_CONTENT_INSET_PX)
+
+      const table = page.locator('.docs-table-scroll').first()
+      if ((await table.count()) > 0) {
+        await expect(table).toBeVisible()
+        const tableBox = await table.boundingBox()
+        expect(tableBox?.x ?? 0).toBeGreaterThanOrEqual(MIN_CONTENT_INSET_PX)
+      }
+    })
+  }
+})

--- a/website/typography.ts
+++ b/website/typography.ts
@@ -138,12 +138,8 @@ export default {
             marginTop: theme('spacing.16'),
             marginBottom: theme('spacing.16'),
             maxWidth: 'none',
-            marginLeft: `calc(-1 * ${theme('spacing.4')})`,
-            marginRight: `calc(-1 * ${theme('spacing.4')})`,
-            [`@media (width >= ${theme('screens.sm')})`]: {
-              marginLeft: `calc(-1 * ${theme('spacing.6')})`,
-              marginRight: `calc(-1 * ${theme('spacing.6')})`,
-            },
+            marginLeft: `calc(-1 * ${theme('spacing.6')})`,
+            marginRight: `calc(-1 * ${theme('spacing.6')})`,
             [`@media (width >= ${theme('screens.lg')})`]: {
               marginLeft: `calc(-1 * ${theme('spacing.8')})`,
               marginRight: `calc(-1 * ${theme('spacing.8')})`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On mobile, docs pages looked like they had no left padding — headings, lists, tables, and code blocks appeared flush against the screen edge (see screenshot from `/agent-setup`).

## Root cause

Two issues combined:

1. **Edge bleed CSS** — Mobile styles applied `-1rem` negative horizontal margins to `.prose pre` and `.docs-table-scroll`, exactly cancelling the layout's `px-4` gutter.
2. **Tight base padding** — `px-4` (16px) was minimal on narrow viewports.

## Fix

- Remove mobile negative-margin bleed on code blocks and tables (keep horizontal scroll).
- Increase base horizontal padding to `px-6` (24px) on main content shell, header, and mobile nav.
- Align HR bleed margins with the new padding tier.
- Add Playwright regression tests asserting minimum prose inset on mobile.

## Testing

- `npx playwright test tests/mobile-content-padding.spec.ts` — 3/3 passed
- Manual iPhone 12 Pro viewport check on `/agent-setup` — headings, lists, tables, and code blocks all show visible left inset

[Mobile padding fixed on agent-setup](https://cursor.com/agents/bc-019f9b5e-4d74-72e6-90bb-d0c2100f09d7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_padding_agent_setup_fixed.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9b5e-4d74-72e6-90bb-d0c2100f09d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9b5e-4d74-72e6-90bb-d0c2100f09d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

