### PR TITLE
feat(streams): celld skeleton Lab 5b and Helm celld v0.4.0 backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deploy-cloud-run deploy-k8s deploy-docs local-k8s-up operator-install operator-status desktop-dev desktop-dist-mac desktop-dist-win desktop-dist-linux bootstrap-vault-eso local-k8s-mcp-delete local-docker-up helm-lint helm-ui-template-tests helm-workflow-template-tests helm-argocd-template-tests helm-nats-keda-template-tests helm-vault-secrets-template-tests helm-team-sync-template-tests helm-docling-template-tests helm-idp-template-tests helm-operator-template-tests helm-managed-gateway-template-tests compose-lending-config-test compose-vertical-config-test compose-tier1-config-test distribution-npm-pack-test mcp-docker-workspace-test kustomize-local-lint lint-k8s-manifests smoke-grpcurl-istio-gateway-mcp smoke-mcp-http-istio-gateway smoke-localhost-uis smoke-nats-idp-webhooks verify-vault-policy verify-mcp-core-tools-local
+.PHONY: deploy-cloud-run deploy-k8s deploy-docs local-k8s-up operator-install operator-status desktop-dev desktop-dist-mac desktop-dist-win desktop-dist-linux bootstrap-vault-eso local-k8s-mcp-delete local-docker-up helm-lint helm-ui-template-tests helm-workflow-template-tests helm-argocd-template-tests helm-nats-keda-template-tests helm-celld-template-tests helm-vault-secrets-template-tests helm-team-sync-template-tests helm-docling-template-tests helm-idp-template-tests helm-operator-template-tests helm-managed-gateway-template-tests compose-lending-config-test compose-vertical-config-test compose-tier1-config-test distribution-npm-pack-test mcp-docker-workspace-test kustomize-local-lint lint-k8s-manifests smoke-grpcurl-istio-gateway-mcp smoke-mcp-http-istio-gateway smoke-localhost-uis smoke-nats-idp-webhooks verify-vault-policy verify-mcp-core-tools-local
 
 # Validate charts/clawql-mcp (requires helm on PATH)
 helm-lint:
@@ -67,6 +67,9 @@ helm-argocd-template-tests:
 helm-nats-keda-template-tests:
 	@bash scripts/kubernetes/test-helm-nats-keda-templates.sh
 
+helm-celld-template-tests:
+	@bash scripts/kubernetes/test-helm-celld-templates.sh
+
 # Helm-only by default; set CLAWQL_HTTP_BASE + webhook tokens for live HTTP checks.
 smoke-nats-idp-webhooks:
 	@SMOKE_HELM_ONLY=$${SMOKE_HELM_ONLY:-1} bash scripts/dev/smoke-nats-idp-webhooks.sh
@@ -104,7 +107,7 @@ distribution-npm-pack-test:
 mcp-docker-workspace-test:
 	@bash scripts/dev/test-docker-mcp-workspace-deps.sh
 
-lint-k8s-manifests: helm-lint helm-ui-template-tests helm-workflow-template-tests helm-argocd-template-tests helm-nats-keda-template-tests helm-vault-secrets-template-tests helm-team-sync-template-tests helm-docling-template-tests helm-idp-template-tests helm-operator-template-tests helm-managed-gateway-template-tests compose-lending-config-test compose-vertical-config-test compose-tier1-config-test kustomize-local-lint packer-golden-host-tests pulumi-provision-tests
+lint-k8s-manifests: helm-lint helm-ui-template-tests helm-workflow-template-tests helm-argocd-template-tests helm-nats-keda-template-tests helm-celld-template-tests helm-vault-secrets-template-tests helm-team-sync-template-tests helm-docling-template-tests helm-idp-template-tests helm-operator-template-tests helm-managed-gateway-template-tests compose-lending-config-test compose-vertical-config-test compose-tier1-config-test kustomize-local-lint packer-golden-host-tests pulumi-provision-tests
 
 packer-golden-host-tests:
 	@bash scripts/packer/test-golden-host-scripts.sh

--- a/charts/clawql-mcp/templates/_helpers.tpl
+++ b/charts/clawql-mcp/templates/_helpers.tpl
@@ -396,6 +396,45 @@ envFrom:
 {{- printf "%s-inference" (include "clawql-mcp.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{/* ClawQL Streams celld fleet node (self-hosted DO runtime, v0.4.0 baseline). */}}
+{{- define "clawql-mcp.celldName" -}}
+{{- printf "%s-celld" (include "clawql-mcp.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "clawql-mcp.celldHeadlessName" -}}
+{{- printf "%s-celld-headless" (include "clawql-mcp.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "clawql-mcp.celldLabels" -}}
+{{ include "clawql-mcp.labels" . }}
+app.kubernetes.io/component: streams-celld
+{{- end }}
+
+{{- define "clawql-mcp.celldSelectorLabels" -}}
+{{ include "clawql-mcp.selectorLabels" . }}
+app.kubernetes.io/component: streams-celld
+{{- end }}
+
+{{- define "clawql-mcp.celldCredentialsSecret" -}}
+{{- if .Values.streams.celld.credentialsSecret -}}
+{{- .Values.streams.celld.credentialsSecret | trunc 63 | trimSuffix "-" -}}
+{{- else if .Values.envFromSecret -}}
+{{- .Values.envFromSecret | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-celld-credentials" (include "clawql-mcp.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end }}
+
+{{- define "clawql-mcp.celldInferenceUrl" -}}
+{{- if .Values.streams.celld.inferenceUrl -}}
+{{- .Values.streams.celld.inferenceUrl -}}
+{{- else if .Values.inference.enabled -}}
+{{- printf "http://%s.%s.svc.cluster.local:%v" (include "clawql-mcp.inferenceName" .) .Release.Namespace (.Values.inference.service.http.port | int) -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end }}
+
 {{/* Optional Managed Edge Gateway nginx (one hostname for /mcp + /v1). */}}
 {{- define "clawql-mcp.managedGatewayName" -}}
 {{- printf "%s-managed-gateway" (include "clawql-mcp.fullname" .) | trunc 63 | trimSuffix "-" }}

--- a/charts/clawql-mcp/templates/celld-stack.yaml
+++ b/charts/clawql-mcp/templates/celld-stack.yaml
@@ -1,0 +1,130 @@
+{{- if and .Values.streams.enabled .Values.streams.celld.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clawql-mcp.celldName" . }}
+  labels:
+    {{- include "clawql-mcp.celldLabels" . | nindent 4 }}
+spec:
+  type: {{ .Values.streams.celld.service.type }}
+  selector:
+    {{- include "clawql-mcp.celldSelectorLabels" . | nindent 4 }}
+  ports:
+    - name: worker
+      port: {{ .Values.streams.celld.service.workerPort | int }}
+      targetPort: worker
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clawql-mcp.celldHeadlessName" . }}
+  labels:
+    {{- include "clawql-mcp.celldLabels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  selector:
+    {{- include "clawql-mcp.celldSelectorLabels" . | nindent 4 }}
+  ports:
+    - name: internal
+      port: {{ .Values.streams.celld.service.internalPort | int }}
+      targetPort: internal
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "clawql-mcp.celldName" . }}
+  labels:
+    {{- include "clawql-mcp.celldLabels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "clawql-mcp.celldHeadlessName" . }}
+  replicas: {{ .Values.streams.celld.replicaCount | int }}
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      {{- include "clawql-mcp.celldSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "clawql-mcp.celldSelectorLabels" . | nindent 8 }}
+      {{- with .Values.streams.celld.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.streams.celld.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.streams.celld.terminationGracePeriodSeconds | int }}
+      containers:
+        - name: celld
+          image: "{{ .Values.streams.celld.image.repository }}:{{ .Values.streams.celld.image.tag }}"
+          imagePullPolicy: {{ .Values.streams.celld.image.pullPolicy }}
+          command:
+            - celld
+          ports:
+            - name: worker
+              containerPort: {{ .Values.streams.celld.service.workerPort | int }}
+              protocol: TCP
+            - name: internal
+              containerPort: {{ .Values.streams.celld.service.internalPort | int }}
+              protocol: TCP
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: CELLD_BUCKET
+              value: {{ required "streams.celld.bucket is required when streams.celld.enabled=true" .Values.streams.celld.bucket | quote }}
+            - name: CELLD_ADDR
+              value: "0.0.0.0:{{ .Values.streams.celld.service.workerPort | int }}"
+            - name: CELLD_INTERNAL_ADDR
+              value: "0.0.0.0:{{ .Values.streams.celld.service.internalPort | int }}"
+            - name: CELLD_ADVERTISE
+              value: "$(POD_NAME).{{ include "clawql-mcp.celldHeadlessName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.streams.celld.service.internalPort | int }}"
+            {{- if .Values.streams.celld.endpoint }}
+            - name: S3_ENDPOINT
+              value: {{ .Values.streams.celld.endpoint | quote }}
+            {{- end }}
+            - name: AWS_REGION
+              value: {{ .Values.streams.celld.region | default "auto" | quote }}
+            {{- $infUrl := include "clawql-mcp.celldInferenceUrl" . }}
+            {{- if $infUrl }}
+            - name: CLAWQL_STREAMS_INFERENCE_URL
+              value: {{ $infUrl | quote }}
+            {{- end }}
+            {{- with .Values.streams.celld.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ include "clawql-mcp.celldCredentialsSecret" . }}
+          {{- with .Values.streams.celld.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.streams.celld.healthPath | default "/.well-known/celld/health" }}
+              port: worker
+            initialDelaySeconds: {{ .Values.streams.celld.probes.readiness.initialDelaySeconds | int }}
+            periodSeconds: {{ .Values.streams.celld.probes.readiness.periodSeconds | int }}
+            timeoutSeconds: {{ .Values.streams.celld.probes.readiness.timeoutSeconds | int }}
+            failureThreshold: {{ .Values.streams.celld.probes.readiness.failureThreshold | int }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.streams.celld.healthPath | default "/.well-known/celld/health" }}
+              port: worker
+            initialDelaySeconds: {{ .Values.streams.celld.probes.liveness.initialDelaySeconds | int }}
+            periodSeconds: {{ .Values.streams.celld.probes.liveness.periodSeconds | int }}
+            timeoutSeconds: {{ .Values.streams.celld.probes.liveness.timeoutSeconds | int }}
+            failureThreshold: {{ .Values.streams.celld.probes.liveness.failureThreshold | int }}
+          resources:
+            {{- toYaml .Values.streams.celld.resources | nindent 12 }}
+{{- end }}

--- a/charts/clawql-mcp/templates/deployment.yaml
+++ b/charts/clawql-mcp/templates/deployment.yaml
@@ -128,6 +128,12 @@ spec:
             - name: ENABLE_GRPC_REFLECTION
               value: "1"
             {{- end }}
+            {{- if .Values.streams.enabled }}
+            - name: CLAWQL_ENABLE_STREAMS
+              value: "1"
+            - name: CLAWQL_STREAMS_SCALING_BACKEND
+              value: {{ .Values.streams.scalingBackend | default "kubernetes" | quote }}
+            {{- end }}
             {{/* Horizontal plugins: CLAWQL_INSTANCE_SPEC only — do not dual-write CLAWQL_ENABLE_*. */}}
             {{- if .Values.enablePrivacyFilter }}
             - name: CLAWQL_ENABLE_PRIVACY_FILTER

--- a/charts/clawql-mcp/values-streams-celld.example.yaml
+++ b/charts/clawql-mcp/values-streams-celld.example.yaml
@@ -1,0 +1,39 @@
+# Example: ClawQL Streams on celld v0.4.0 (self-hosted Durable Objects).
+#
+# Prerequisite — deploy the Worker bundle to the fleet bucket (once per app version):
+#
+#   cd examples/streams-celld
+#   export CELLD_BUCKET=s3://clawql-streams-state
+#   export S3_ENDPOINT=https://ACCOUNT.r2.cloudflarestorage.com
+#   export AWS_REGION=auto
+#   export AWS_ACCESS_KEY_ID=…
+#   export AWS_SECRET_ACCESS_KEY=…
+#   clawql streams celld deploy --bucket "$CELLD_BUCKET" --endpoint "$S3_ENDPOINT"
+#
+# Secret `clawql-provider-env` (or streams.celld.credentialsSecret) must include bucket creds.
+#
+#   helm upgrade --install clawql charts/clawql-mcp \
+#     -f charts/clawql-mcp/values-streams-celld.example.yaml \
+#     --set envFromSecret=clawql-provider-env \
+#     --set streams.celld.bucket=s3://clawql-streams-state \
+#     --set streams.celld.endpoint=https://ACCOUNT.r2.cloudflarestorage.com \
+#     -n clawql --create-namespace
+
+streams:
+  enabled: true
+  scalingBackend: celld
+  celld:
+    enabled: true
+    bucket: s3://clawql-streams-state
+    endpoint: ""
+    region: auto
+    replicaCount: 1
+
+inference:
+  enabled: true
+
+enableMemory: true
+
+# MCP HTTP remains the operator control plane; cells call inference over HTTP.
+nats:
+  enabled: false

--- a/charts/clawql-mcp/values.yaml
+++ b/charts/clawql-mcp/values.yaml
@@ -1028,6 +1028,62 @@ nats:
     # Pre-create JetStream consumer so KEDA can read lag before first worker pod.
     bootstrapConsumer: true
 
+# ClawQL Streams — event-driven agent cells (draft). See docs/streams/clawql-streams.md.
+streams:
+  enabled: false
+  # kubernetes | celld | cloudflare
+  scalingBackend: kubernetes
+  celld:
+    enabled: false
+    # Pin celld v0.4.0 — do not mix v0.3.x and v0.4.x in one fleet.
+    version: v0.4.0
+    image:
+      repository: ghcr.io/denoland/celld
+      tag: v0.4.0
+      pullPolicy: IfNotPresent
+    # Fleet bucket (required when enabled). Example: s3://clawql-streams-state
+    bucket: ""
+    endpoint: ""
+    region: auto
+    # Secret with AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY (and optional AWS_SESSION_TOKEN).
+    # Defaults to envFromSecret when empty.
+    credentialsSecret: ""
+    replicaCount: 1
+    # v0.4.0 health probe path (not /__celld/health).
+    healthPath: /.well-known/celld/health
+    # Worker INFERENCE_URL for deployed bundle — auto when inference.enabled and empty.
+    inferenceUrl: ""
+    service:
+      type: ClusterIP
+      workerPort: 8080
+      internalPort: 8081
+    terminationGracePeriodSeconds: 120
+    probes:
+      readiness:
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        timeoutSeconds: 3
+        failureThreshold: 3
+      liveness:
+        initialDelaySeconds: 15
+        periodSeconds: 20
+        timeoutSeconds: 3
+        failureThreshold: 3
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: "2"
+        memory: 2Gi
+    podAnnotations: {}
+    podSecurityContext: {}
+    securityContext: {}
+    extraEnv: []
+  ambientDelivery: true
+  auditLevel: WORM
+  subscriptionStore: postgres
+
 # Extra env (e.g. tokens from literal — prefer existing secrets for production).
 extraEnv: []
 

--- a/deployment/samples/streams-celld/README.md
+++ b/deployment/samples/streams-celld/README.md
@@ -1,0 +1,58 @@
+# Streams celld on Kubernetes — sample pack
+
+Helm overlay: [`charts/clawql-mcp/values-streams-celld.example.yaml`](../../charts/clawql-mcp/values-streams-celld.example.yaml)
+
+Worker skeleton: [`examples/streams-celld/`](../../examples/streams-celld/)
+
+Learn walkthrough: [Streams getting started — Lab 5b](https://docs.clawql.com/learn/streams-getting-started#lab-5b--clawql-streams-wrangler-skeleton--bundle-check-30-min)
+
+## Checklist
+
+1. **Bucket credentials** — Kubernetes Secret with `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`. Scope to the celld fleet bucket only.
+2. **Deploy Worker bundle** — from repo root:
+
+   ```bash
+   cd examples/streams-celld
+   clawql streams celld deploy \
+     --bucket "$CELLD_BUCKET" \
+     --endpoint "$S3_ENDPOINT" \
+     --region auto
+   ```
+
+3. **Helm install** — celld StatefulSet probes `/.well-known/celld/health` (v0.4.0+).
+
+   ```bash
+   helm upgrade --install clawql charts/clawql-mcp \
+     -f charts/clawql-mcp/values-streams-celld.example.yaml \
+     --set envFromSecret=clawql-provider-env \
+     --set streams.celld.bucket="$CELLD_BUCKET" \
+     --set streams.celld.endpoint="$S3_ENDPOINT" \
+     -n clawql --create-namespace
+   ```
+
+4. **Smoke webhook** — port-forward the celld Service worker port and POST to the skeleton:
+
+   ```bash
+   kubectl -n clawql port-forward svc/clawql-mcp-celld 8080:8080
+   curl -s -X POST http://127.0.0.1:8080/webhook/demo \
+     -H 'content-type: application/json' \
+     -H 'x-clawql-event-id: k8s-smoke-1' \
+     -d '{"source":"helm-smoke"}' | jq .
+   ```
+
+5. **Diagnose fleet** — from a pod or local CLI with the same bucket env:
+
+   ```bash
+   clawql streams celld diagnose --bucket "$CELLD_BUCKET" --endpoint "$S3_ENDPOINT"
+   kubectl -n clawql exec sts/clawql-mcp-celld-0 -- celld cell list --bucket "$CELLD_BUCKET"
+   ```
+
+## Upgrade note (v0.3 → v0.4)
+
+Stop **every** v0.3.x celld node before starting v0.4.0 — no rolling update. See [celld v0.4.0 release](https://github.com/denoland/celld/releases/tag/v0.4.0).
+
+## Related
+
+- [celld integration spec](../../docs/streams/clawql-celld.md)
+- [ClawQL Streams spec](../../docs/streams/clawql-streams.md)
+- [Kubernetes & Helm docs](https://docs.clawql.com/deployment/kubernetes)

--- a/examples/streams-celld/.gitignore
+++ b/examples/streams-celld/.gitignore
@@ -1,0 +1,2 @@
+.celld/
+node_modules/

--- a/examples/streams-celld/README.md
+++ b/examples/streams-celld/README.md
@@ -1,0 +1,72 @@
+# ClawQL Streams — celld skeleton (Lab 5b)
+
+Minimal **Workers / Durable Objects** bundle for [ClawQL Streams](https://docs.clawql.com/streams/clawql-streams) on **[celld v0.4.0](https://github.com/denoland/celld/releases/tag/v0.4.0)**.
+
+| DO class | Role |
+| -------- | ---- |
+| `GatewayDO` | Webhook ingress (`POST /webhook/{subscriptionId}`), spawn sessions |
+| `SubscriptionDO` | Significance filter stub (`sub:{id}` naming) |
+| `AgentSessionDO` | Ephemeral session + WORM row + optional `fetch(INFERENCE_URL/healthz)` |
+
+**Learn walkthrough:** [Streams getting started — Lab 5b](https://docs.clawql.com/learn/streams-getting-started#lab-5b--clawql-streams-wrangler-skeleton--bundle-check-30-min)
+
+## Prerequisites
+
+- [celld v0.4.0](https://github.com/denoland/celld/releases/tag/v0.4.0) on `PATH`
+- [esbuild](https://esbuild.github.io/) on `PATH` (required by `celld deploy` / `celld dev`)
+
+## Local dev (`celld dev`)
+
+```bash
+cd examples/streams-celld
+celld dev --port 9876
+```
+
+Another terminal:
+
+```bash
+curl -s http://127.0.0.1:9876/health | jq .
+curl -s -X POST http://127.0.0.1:9876/webhook/demo-lab \
+  -H 'content-type: application/json' \
+  -H 'x-clawql-event-id: lab-event-1' \
+  -d '{"hello":"streams"}' | jq .
+curl -s http://127.0.0.1:9876/admin/status | jq .
+```
+
+Repeat the webhook with the same `x-clawql-event-id` to observe idempotent session wake.
+
+## Bundle size gate (64 MiB Workers limit)
+
+```bash
+node scripts/bundle-check.mjs
+# or from repo root:
+clawql streams celld bundle-check --project examples/streams-celld
+```
+
+## Fleet deploy (optional)
+
+After Lab 5 bucket credentials:
+
+```bash
+export CELLD_BUCKET=s3://clawql-streams-state
+export S3_ENDPOINT=https://ACCOUNT.r2.cloudflarestorage.com
+export AWS_REGION=auto
+
+celld deploy . \
+  --bucket "$CELLD_BUCKET" \
+  --endpoint "$S3_ENDPOINT" \
+  --region "$AWS_REGION"
+
+clawql streams celld start --bucket "$CELLD_BUCKET" --listen 127.0.0.1:8080
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8080/.well-known/celld/health
+```
+
+## Kubernetes (Helm)
+
+See [`charts/clawql-mcp/values-streams-celld.example.yaml`](../../charts/clawql-mcp/values-streams-celld.example.yaml) and [`deployment/samples/streams-celld/`](../../deployment/samples/streams-celld/README.md).
+
+## Next steps
+
+- Replace stubs with `clawql-streams` + in-process `clawql-core` when the package ships
+- Wire real significance filters and `fetch()` to [`clawql-inference`](https://docs.clawql.com/inference/clawql-inference)
+- Run under Helm `streams.scalingBackend: celld` with LTX WORM on the fleet bucket

--- a/examples/streams-celld/package.json
+++ b/examples/streams-celld/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@clawql/example-streams-celld",
+  "private": true,
+  "version": "0.0.0",
+  "description": "ClawQL Streams celld DO skeleton (Lab 5b)",
+  "type": "module",
+  "scripts": {
+    "bundle-check": "node scripts/bundle-check.mjs",
+    "dev": "celld dev --port 9876"
+  }
+}

--- a/examples/streams-celld/scripts/bundle-check.mjs
+++ b/examples/streams-celld/scripts/bundle-check.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Fail if the bundled Worker artifact exceeds the Cloudflare/celld 64 MiB limit.
+ * Uses esbuild (same toolchain as celld deploy) — no fleet bucket required.
+ */
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, "..");
+const WRANGLER_LIMIT = 64 * 1024 * 1024;
+
+function parseJsonc(text) {
+  const stripped = text.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+  return JSON.parse(stripped);
+}
+
+function findEsbuild() {
+  const fromPath = spawnSync("esbuild", ["--version"], { encoding: "utf8" });
+  if (fromPath.status === 0) return "esbuild";
+  const fromNpx = spawnSync("npx", ["esbuild", "--version"], { encoding: "utf8" });
+  if (fromNpx.status === 0) return "npx esbuild";
+  console.error("bundle-check: esbuild not found on PATH");
+  process.exit(1);
+}
+
+const wranglerPath = join(projectRoot, "wrangler.jsonc");
+const wrangler = parseJsonc(readFileSync(wranglerPath, "utf8"));
+const entry = join(projectRoot, wrangler.main);
+const tmpDir = mkdtempSync(join(tmpdir(), "clawql-streams-celld-"));
+const outfile = join(tmpDir, "bundle.js");
+const metafile = join(tmpDir, "meta.json");
+
+const esbuildCmd = findEsbuild();
+const args =
+  esbuildCmd === "esbuild"
+    ? [
+        entry,
+        "--bundle",
+        "--format=esm",
+        "--platform=browser",
+        `--outfile=${outfile}`,
+        `--metafile=${metafile}`,
+        "--minify",
+      ]
+    : [
+        "esbuild",
+        entry,
+        "--bundle",
+        "--format=esm",
+        "--platform=browser",
+        `--outfile=${outfile}`,
+        `--metafile=${metafile}`,
+        "--minify",
+      ];
+
+const run = spawnSync(esbuildCmd === "esbuild" ? "esbuild" : "npx", args, {
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "pipe"],
+});
+
+if (run.status !== 0) {
+  console.error(run.stderr || run.stdout);
+  process.exit(run.status ?? 1);
+}
+
+const bundle = readFileSync(outfile);
+const size = bundle.byteLength;
+const pct = ((size / WRANGLER_LIMIT) * 100).toFixed(2);
+
+console.log(
+  `bundle-check: ${size} bytes (${pct}% of ${WRANGLER_LIMIT} byte Workers limit)`,
+);
+
+rmSync(tmpDir, { recursive: true, force: true });
+
+if (size > WRANGLER_LIMIT) {
+  console.error(`bundle-check: FAIL — exceeds 64 MiB limit by ${size - WRANGLER_LIMIT} bytes`);
+  process.exit(1);
+}
+
+console.log("bundle-check: PASS");

--- a/examples/streams-celld/scripts/smoke.sh
+++ b/examples/streams-celld/scripts/smoke.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Smoke test for examples/streams-celld (Lab 5b). Requires celld v0.4.0 + esbuild on PATH.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PORT="${CELLD_DEV_PORT:-9880}"
+BASE="http://127.0.0.1:${PORT}"
+
+if ! command -v celld >/dev/null 2>&1; then
+  echo "smoke: celld not on PATH — skip (install CELLD_VERSION=v0.4.0)" >&2
+  exit 0
+fi
+
+node "$ROOT/scripts/bundle-check.mjs"
+
+cd "$ROOT"
+celld dev --port "$PORT" &
+PID=$!
+cleanup() { kill "$PID" 2>/dev/null || true; wait "$PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+for _ in $(seq 1 30); do
+  if curl -sf "$BASE/health" >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+
+curl -sf "$BASE/health" | grep -q clawql-streams-celld-skeleton
+curl -sf -X POST "$BASE/webhook/smoke" \
+  -H 'content-type: application/json' \
+  -H 'x-clawql-event-id: smoke-1' \
+  -d '{"probe":true}' | grep -q '"action":"spawn"'
+
+echo "smoke: PASS"

--- a/examples/streams-celld/src/agent-session-do.js
+++ b/examples/streams-celld/src/agent-session-do.js
@@ -1,0 +1,80 @@
+/**
+ * AgentSessionDO — ephemeral session stub (Streams spec §4).
+ * Model calls use fetch(INFERENCE_URL) — never child_process.
+ */
+export class AgentSessionDO {
+  constructor(state, env) {
+    this.state = state;
+    this.env = env;
+  }
+
+  async fetch(request) {
+    const url = new URL(request.url);
+    if (url.pathname.endsWith("/start") && request.method === "POST") {
+      const subscriptionId = request.headers.get("x-subscription-id") ?? "unknown";
+      const eventId = request.headers.get("x-event-id") ?? crypto.randomUUID();
+      const startedAt = Date.now();
+      const doInstanceId = crypto.randomUUID();
+      const virtualKeyId = `vk_lab_${eventId.slice(0, 8)}`;
+
+      const existing = await this.state.storage.get("session_meta");
+      if (existing) {
+        return Response.json({
+          do: "AgentSessionDO",
+          idempotent: true,
+          session: existing,
+        });
+      }
+
+      const meta = {
+        doInstanceId,
+        subscriptionId,
+        eventId,
+        virtualKeyId,
+        startedAt,
+        exitReason: null,
+      };
+      await this.state.storage.put("session_meta", meta);
+      await this.state.storage.put(`worm:${startedAt}`, {
+        kind: "DO_CREATED",
+        doInstanceId,
+        virtualKeyId,
+        subscriptionId,
+        eventId,
+      });
+
+      let inference = { skipped: true, reason: "no INFERENCE_URL" };
+      const inferenceUrl = this.env.INFERENCE_URL;
+      if (inferenceUrl) {
+        try {
+          const res = await fetch(`${inferenceUrl.replace(/\/$/, "")}/healthz`, {
+            method: "GET",
+            headers: { accept: "application/json" },
+          });
+          inference = {
+            skipped: false,
+            status: res.status,
+            ok: res.ok,
+          };
+          await this.state.storage.put("inference_probe", inference);
+        } catch (err) {
+          inference = {
+            skipped: false,
+            ok: false,
+            error: err instanceof Error ? err.message : String(err),
+          };
+        }
+      }
+
+      return Response.json({
+        do: "AgentSessionDO",
+        session: meta,
+        inference,
+        audit: { wormKey: `worm:${startedAt}` },
+      });
+    }
+
+    const meta = await this.state.storage.get("session_meta");
+    return Response.json({ do: "AgentSessionDO", session: meta ?? null });
+  }
+}

--- a/examples/streams-celld/src/gateway-do.js
+++ b/examples/streams-celld/src/gateway-do.js
@@ -1,0 +1,102 @@
+/**
+ * GatewayDO — webhook ingress and session spawn (Streams spec §4).
+ */
+export class GatewayDO {
+  constructor(state, env) {
+    this.state = state;
+    this.env = env;
+  }
+
+  async fetch(request) {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/admin/status") {
+      const spawned = (await this.state.storage.get("spawn_count")) ?? 0;
+      return Response.json({
+        do: "GatewayDO",
+        spawned,
+        inferenceUrl: this.env.INFERENCE_URL ?? null,
+      });
+    }
+
+    const webhookMatch = url.pathname.match(/^\/webhook\/([^/]+)\/?$/);
+    if (webhookMatch && request.method === "POST") {
+      const subscriptionId = decodeURIComponent(webhookMatch[1]);
+      const eventId =
+        request.headers.get("x-clawql-event-id") ??
+        request.headers.get("x-request-id") ??
+        crypto.randomUUID();
+
+      const subName = `sub:${subscriptionId}`;
+      const subId = this.env.SUBSCRIPTION.idFromName(subName);
+      const subStub = this.env.SUBSCRIPTION.get(subId);
+
+      const significance = await subStub.fetch(
+        new Request("https://internal/subscription/evaluate", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-subscription-id": subscriptionId,
+            "x-event-id": eventId,
+          },
+          body: await request.text(),
+        }),
+      );
+      if (!significance.ok) {
+        return significance;
+      }
+      const evalBody = await significance.json();
+      if (!evalBody.significant) {
+        return Response.json({
+          ok: true,
+          action: "filtered",
+          subscriptionId,
+          eventId,
+          reason: evalBody.reason ?? "not_significant",
+        });
+      }
+
+      const sessionName = `sess:${subscriptionId}:${eventId}`;
+      const sessionId = this.env.AGENT_SESSION.idFromName(sessionName);
+      const sessionStub = this.env.AGENT_SESSION.get(sessionId);
+
+      const sessionRes = await sessionStub.fetch(
+        new Request("https://internal/session/start", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-subscription-id": subscriptionId,
+            "x-event-id": eventId,
+          },
+          body: JSON.stringify({
+            subscriptionId,
+            eventId,
+            payloadPreview: evalBody.preview ?? null,
+          }),
+        }),
+      );
+
+      const spawned = ((await this.state.storage.get("spawn_count")) ?? 0) + 1;
+      await this.state.storage.put("spawn_count", spawned);
+
+      const sessionBody = await sessionRes.json();
+      return Response.json({
+        ok: sessionRes.ok,
+        action: "spawn",
+        subscriptionId,
+        eventId,
+        session: sessionBody,
+        spawnCount: spawned,
+      });
+    }
+
+    return Response.json(
+      {
+        do: "GatewayDO",
+        hint: "POST /webhook/{subscriptionId} with optional x-clawql-event-id",
+        paths: ["/admin/status", "/webhook/:subscriptionId"],
+      },
+      { status: 404 },
+    );
+  }
+}

--- a/examples/streams-celld/src/subscription-do.js
+++ b/examples/streams-celld/src/subscription-do.js
@@ -1,0 +1,43 @@
+/**
+ * SubscriptionDO — significance filter stub (Streams spec §4).
+ * Production: ws_intent, config, rtpConsent, worm rows in SQLite.
+ */
+export class SubscriptionDO {
+  constructor(state, env) {
+    this.state = state;
+    this.env = env;
+  }
+
+  async fetch(request) {
+    const url = new URL(request.url);
+    if (url.pathname.endsWith("/evaluate") && request.method === "POST") {
+      const subscriptionId = request.headers.get("x-subscription-id") ?? "unknown";
+      const eventId = request.headers.get("x-event-id") ?? crypto.randomUUID();
+      const bodyText = await request.text();
+      const preview = bodyText.slice(0, 256);
+
+      await this.state.storage.put("last_event", {
+        subscriptionId,
+        eventId,
+        at: Date.now(),
+        bytes: bodyText.length,
+      });
+
+      // Lab stub: always significant when body is non-empty or header forces pass.
+      const force =
+        request.headers.get("x-clawql-significance") === "pass" ||
+        bodyText.length > 0;
+
+      return Response.json({
+        significant: force,
+        reason: force ? "lab_stub_pass" : "empty_body",
+        preview,
+        subscriptionId,
+        eventId,
+      });
+    }
+
+    const last = await this.state.storage.get("last_event");
+    return Response.json({ do: "SubscriptionDO", lastEvent: last ?? null });
+  }
+}

--- a/examples/streams-celld/src/worker.js
+++ b/examples/streams-celld/src/worker.js
@@ -1,0 +1,22 @@
+/**
+ * ClawQL Streams celld skeleton — Worker entry (Lab 5b).
+ * Routes public HTTP to GatewayDO; DO classes match clawql-celld.md §4.
+ */
+export { GatewayDO } from "./gateway-do.js";
+export { SubscriptionDO } from "./subscription-do.js";
+export { AgentSessionDO } from "./agent-session-do.js";
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    if (url.pathname === "/health") {
+      return Response.json({
+        ok: true,
+        service: "clawql-streams-celld-skeleton",
+        celldBaseline: "v0.4.0",
+      });
+    }
+    const gatewayId = env.GATEWAY.idFromName("gateway");
+    return env.GATEWAY.get(gatewayId).fetch(request);
+  },
+};

--- a/examples/streams-celld/wrangler.jsonc
+++ b/examples/streams-celld/wrangler.jsonc
@@ -1,0 +1,23 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "clawql-streams-celld-skeleton",
+  "main": "src/worker.js",
+  "compatibility_date": "2026-01-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "vars": {
+    "INFERENCE_URL": "http://127.0.0.1:8080"
+  },
+  "durable_objects": {
+    "bindings": [
+      { "name": "GATEWAY", "class_name": "GatewayDO" },
+      { "name": "SUBSCRIPTION", "class_name": "SubscriptionDO" },
+      { "name": "AGENT_SESSION", "class_name": "AgentSessionDO" }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["GatewayDO", "SubscriptionDO", "AgentSessionDO"]
+    }
+  ]
+}

--- a/scripts/kubernetes/test-helm-celld-templates.sh
+++ b/scripts/kubernetes/test-helm-celld-templates.sh
@@ -31,13 +31,14 @@ celld = open(celld_path, "r", encoding="utf-8").read()
 off = open(off_path, "r", encoding="utf-8").read()
 
 assert "kind: StatefulSet" in celld
-assert "clawql-mcp-celld" in celld
+assert "streams-celld" in celld
 assert "path: /.well-known/celld/health" in celld
 assert "CLAWQL_ENABLE_STREAMS" in celld
 assert "CELLD_ADVERTISE" in celld
 assert "ghcr.io/denoland/celld:v0.4.0" in celld
 
-assert "kind: StatefulSet" not in off or "streams-celld" not in off
+assert "streams-celld" not in off
+assert "CELLD_ADVERTISE" not in off
 assert "CLAWQL_ENABLE_STREAMS" not in off
 
 print("helm celld templates OK")

--- a/scripts/kubernetes/test-helm-celld-templates.sh
+++ b/scripts/kubernetes/test-helm-celld-templates.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT}"
+
+TMP_CELLD="$(mktemp)"
+TMP_OFF="$(mktemp)"
+trap 'rm -f "${TMP_CELLD}" "${TMP_OFF}"' EXIT
+
+_LINT_SECRET=(--set envFromSecret=clawql-lint-provider-env)
+
+helm template test charts/clawql-mcp --namespace clawql \
+  "${_LINT_SECRET[@]}" \
+  --set kyverno.imageSignaturePolicy.enabled=false \
+  -f charts/clawql-mcp/values-streams-celld.example.yaml \
+  --set streams.celld.bucket=s3://lint-clawql-streams-state \
+  --set streams.celld.endpoint=https://lint.r2.cloudflarestorage.com \
+  >"${TMP_CELLD}"
+
+helm template test charts/clawql-mcp --namespace clawql \
+  "${_LINT_SECRET[@]}" \
+  --set kyverno.imageSignaturePolicy.enabled=false \
+  >"${TMP_OFF}"
+
+python3 - "${TMP_CELLD}" "${TMP_OFF}" <<'PY'
+import sys
+
+celld_path, off_path = sys.argv[1], sys.argv[2]
+celld = open(celld_path, "r", encoding="utf-8").read()
+off = open(off_path, "r", encoding="utf-8").read()
+
+assert "kind: StatefulSet" in celld
+assert "clawql-mcp-celld" in celld
+assert "path: /.well-known/celld/health" in celld
+assert "CLAWQL_ENABLE_STREAMS" in celld
+assert "CELLD_ADVERTISE" in celld
+assert "ghcr.io/denoland/celld:v0.4.0" in celld
+
+assert "kind: StatefulSet" not in off or "streams-celld" not in off
+assert "CLAWQL_ENABLE_STREAMS" not in off
+
+print("helm celld templates OK")
+PY
+
+echo "test-helm-celld-templates: PASS"

--- a/src/onboarding/cli.ts
+++ b/src/onboarding/cli.ts
@@ -1183,13 +1183,10 @@ async function main(): Promise<void> {
       region: typeof flags.region === "string" ? flags.region : undefined,
       listen: typeof flags.listen === "string" ? flags.listen : undefined,
       advertise: typeof flags.advertise === "string" ? flags.advertise : undefined,
-      internalListen:
-        typeof flags.internalListen === "string" ? flags.internalListen : undefined,
+      internalListen: typeof flags.internalListen === "string" ? flags.internalListen : undefined,
       json: Boolean(flags.json),
       port:
-        typeof flags.port === "string" && flags.port
-          ? Number.parseInt(flags.port, 10)
-          : undefined,
+        typeof flags.port === "string" && flags.port ? Number.parseInt(flags.port, 10) : undefined,
     };
     if (subcmd === "celld") {
       const action = rest[0];
@@ -1218,7 +1215,7 @@ async function main(): Promise<void> {
         return;
       }
       console.error(
-        "Usage: clawql streams celld install | dev | deploy | start | diagnose | bundle-check",
+        "Usage: clawql streams celld install | dev | deploy | start | diagnose | bundle-check"
       );
       process.exitCode = 1;
       return;

--- a/src/onboarding/cli.ts
+++ b/src/onboarding/cli.ts
@@ -65,6 +65,14 @@ import {
 } from "./inference-cli.js";
 import { runGatewayCreate, runGatewayDestroy, runGatewayStatus } from "./gateway-cli.js";
 import {
+  runStreamsCelldBundleCheck,
+  runStreamsCelldDeploy,
+  runStreamsCelldDev,
+  runStreamsCelldDiagnose,
+  runStreamsCelldInstall,
+  runStreamsCelldStart,
+} from "./streams-cli.js";
+import {
   runPaymentsAuditCmd,
   runPaymentsAuditVerifyCmd,
   runPaymentsPlanShowCmd,
@@ -172,6 +180,7 @@ type Command =
   | "network"
   | "inference"
   | "gateway"
+  | "streams"
   | "payments"
   | "claude"
   | "codex"
@@ -237,6 +246,12 @@ function parse(argv: string[]): {
     else if (a === "--force") flags.force = true;
     else if (a === "--provider") flags.provider = argv[++i] ?? "";
     else if (a === "--bucket") flags.bucket = argv[++i] ?? "";
+    else if (a === "--project") flags.project = argv[++i] ?? "";
+    else if (a === "--endpoint") flags.endpoint = argv[++i] ?? "";
+    else if (a === "--region") flags.region = argv[++i] ?? "";
+    else if (a === "--listen") flags.listen = argv[++i] ?? "";
+    else if (a === "--advertise") flags.advertise = argv[++i] ?? "";
+    else if (a === "--internal-listen") flags.internalListen = argv[++i] ?? "";
     else if (a === "--prefix") flags.prefix = argv[++i] ?? "";
     else if (a === "--location") flags.location = argv[++i] ?? "";
     else if (a === "--path") flags.path = argv[++i] ?? "";
@@ -404,6 +419,7 @@ function parse(argv: string[]): {
     cmd === "network" ||
     cmd === "inference" ||
     cmd === "gateway" ||
+    cmd === "streams" ||
     cmd === "payments"
       ? positional[1]
       : undefined;
@@ -416,6 +432,7 @@ function parse(argv: string[]): {
     cmd === "network" ||
     cmd === "inference" ||
     cmd === "gateway" ||
+    cmd === "streams" ||
     cmd === "payments"
       ? positional.slice(2)
       : cmd === "release" || cmd === "ontology" || cmd === "memory"
@@ -607,6 +624,15 @@ gateway (Managed Edge Gateway — /mcp + /v1 + memory):
   destroy --yes   Stop processes/compose and remove ManagedGateway materials
   Flags: --profile process|local-docker --team NAME --port 8080 --no-start --json
   Docs: https://docs.clawql.com/getting-started/inference
+
+streams (ClawQL Streams — celld v0.4.0):
+  celld install [--version v0.4.0]   Pin-install celld (CELLD_VERSION)
+  celld dev [--project DIR] [--port N]   Local dev (default: examples/streams-celld)
+  celld deploy [--project DIR] --bucket s3://… [--endpoint URL] [--region auto]
+  celld start --bucket s3://… [--listen HOST:PORT] [--advertise HOST:PORT]
+  celld diagnose --bucket s3://…     Fleet lease + peer probes
+  celld bundle-check [--project DIR] Enforce Worker bundle ≤ 64 MiB
+  Docs: https://docs.clawql.com/learn/streams-getting-started
 
 Docs: https://docs.clawql.com/agent-setup
 `);
@@ -1144,6 +1170,60 @@ async function main(): Promise<void> {
       return;
     }
     console.error("Usage: clawql gateway create | status | destroy --yes");
+    process.exitCode = 1;
+    return;
+  }
+
+  if (cmd === "streams") {
+    const celldOpts = {
+      version: typeof flags.version === "string" ? flags.version : undefined,
+      project: typeof flags.project === "string" ? flags.project : undefined,
+      bucket: typeof flags.bucket === "string" ? flags.bucket : undefined,
+      endpoint: typeof flags.endpoint === "string" ? flags.endpoint : undefined,
+      region: typeof flags.region === "string" ? flags.region : undefined,
+      listen: typeof flags.listen === "string" ? flags.listen : undefined,
+      advertise: typeof flags.advertise === "string" ? flags.advertise : undefined,
+      internalListen:
+        typeof flags.internalListen === "string" ? flags.internalListen : undefined,
+      json: Boolean(flags.json),
+      port:
+        typeof flags.port === "string" && flags.port
+          ? Number.parseInt(flags.port, 10)
+          : undefined,
+    };
+    if (subcmd === "celld") {
+      const action = rest[0];
+      if (action === "install") {
+        process.exitCode = await runStreamsCelldInstall(celldOpts);
+        return;
+      }
+      if (action === "dev") {
+        process.exitCode = await runStreamsCelldDev(celldOpts);
+        return;
+      }
+      if (action === "deploy") {
+        process.exitCode = await runStreamsCelldDeploy(celldOpts);
+        return;
+      }
+      if (action === "start") {
+        process.exitCode = await runStreamsCelldStart(celldOpts);
+        return;
+      }
+      if (action === "diagnose") {
+        process.exitCode = await runStreamsCelldDiagnose(celldOpts);
+        return;
+      }
+      if (action === "bundle-check") {
+        process.exitCode = await runStreamsCelldBundleCheck(celldOpts);
+        return;
+      }
+      console.error(
+        "Usage: clawql streams celld install | dev | deploy | start | diagnose | bundle-check",
+      );
+      process.exitCode = 1;
+      return;
+    }
+    console.error("Usage: clawql streams celld <subcommand>");
     process.exitCode = 1;
     return;
   }

--- a/src/onboarding/streams-cli.ts
+++ b/src/onboarding/streams-cli.ts
@@ -54,7 +54,7 @@ function requireCelld(): string {
   const which = spawnSync("celld", ["--version"], { encoding: "utf8" });
   if (which.status !== 0) {
     console.error(
-      "celld not found. Run: clawql streams celld install (or CELLD_VERSION=v0.4.0 curl -fsSL https://celld.dev/install.sh | sh)",
+      "celld not found. Run: clawql streams celld install (or CELLD_VERSION=v0.4.0 curl -fsSL https://celld.dev/install.sh | sh)"
     );
     process.exitCode = 1;
     throw new Error("celld missing");
@@ -114,8 +114,7 @@ export async function runStreamsCelldDeploy(opts: StreamsCelldCliOptions): Promi
 export async function runStreamsCelldStart(opts: StreamsCelldCliOptions): Promise<number> {
   requireCelld();
   const listen = opts.listen ?? process.env.CELLD_ADDR ?? "0.0.0.0:8080";
-  const internal =
-    opts.internalListen ?? process.env.CELLD_INTERNAL_ADDR ?? "0.0.0.0:8081";
+  const internal = opts.internalListen ?? process.env.CELLD_INTERNAL_ADDR ?? "0.0.0.0:8081";
   const advertise = opts.advertise ?? process.env.CELLD_ADVERTISE;
   const args = [...bucketArgs(opts), "--listen", listen, "--internal-listen", internal];
   if (advertise) args.push("--advertise", advertise);
@@ -141,7 +140,9 @@ export async function runStreamsCelldBundleCheck(opts: StreamsCelldCliOptions): 
   return res.status ?? 1;
 }
 
-export async function runStreamsCelldDev(opts: StreamsCelldCliOptions & { port?: number }): Promise<number> {
+export async function runStreamsCelldDev(
+  opts: StreamsCelldCliOptions & { port?: number }
+): Promise<number> {
   requireCelld();
   const project = resolve(opts.project ?? defaultProjectDir());
   const port = opts.port ?? 9876;

--- a/src/onboarding/streams-cli.ts
+++ b/src/onboarding/streams-cli.ts
@@ -1,0 +1,149 @@
+/**
+ * `clawql streams celld` — celld v0.4.0 fleet helpers for ClawQL Streams.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const CELLD_DEFAULT_VERSION = "v0.4.0";
+export const CELLD_WORKER_LIMIT_BYTES = 64 * 1024 * 1024;
+
+export type StreamsCelldCliOptions = {
+  version?: string;
+  project?: string;
+  bucket?: string;
+  endpoint?: string;
+  region?: string;
+  listen?: string;
+  advertise?: string;
+  internalListen?: string;
+  json?: boolean;
+};
+
+function findRepoRoot(): string | null {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 12; i++) {
+    if (
+      existsSync(join(dir, "examples", "streams-celld", "wrangler.jsonc")) &&
+      existsSync(join(dir, "package.json"))
+    ) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+function defaultProjectDir(): string {
+  const fromEnv = process.env.CLAWQL_STREAMS_CELLD_PROJECT?.trim();
+  if (fromEnv && existsSync(join(fromEnv, "wrangler.jsonc"))) {
+    return resolve(fromEnv);
+  }
+  const root = findRepoRoot();
+  if (root) {
+    return join(root, "examples", "streams-celld");
+  }
+  return process.cwd();
+}
+
+function requireCelld(): string {
+  const which = spawnSync("celld", ["--version"], { encoding: "utf8" });
+  if (which.status !== 0) {
+    console.error(
+      "celld not found. Run: clawql streams celld install (or CELLD_VERSION=v0.4.0 curl -fsSL https://celld.dev/install.sh | sh)",
+    );
+    process.exitCode = 1;
+    throw new Error("celld missing");
+  }
+  return which.stdout.trim();
+}
+
+function runCelld(args: string[], opts?: { cwd?: string }): number {
+  const res = spawnSync("celld", args, {
+    cwd: opts?.cwd,
+    stdio: "inherit",
+    env: process.env,
+  });
+  return res.status ?? 1;
+}
+
+function bucketArgs(opts: StreamsCelldCliOptions): string[] {
+  const bucket = opts.bucket ?? process.env.CELLD_BUCKET?.trim();
+  if (!bucket) {
+    console.error("Missing --bucket or CELLD_BUCKET");
+    process.exitCode = 1;
+    throw new Error("bucket required");
+  }
+  const out = ["--bucket", bucket];
+  const endpoint = opts.endpoint ?? process.env.S3_ENDPOINT?.trim();
+  const region = opts.region ?? process.env.AWS_REGION?.trim() ?? "auto";
+  if (endpoint) out.push("--endpoint", endpoint);
+  if (region) out.push("--region", region);
+  return out;
+}
+
+export async function runStreamsCelldInstall(opts: StreamsCelldCliOptions): Promise<number> {
+  const version = opts.version ?? process.env.CELLD_VERSION ?? CELLD_DEFAULT_VERSION;
+  const res = spawnSync("bash", ["-lc", "curl -fsSL https://celld.dev/install.sh | sh"], {
+    stdio: "inherit",
+    env: { ...process.env, CELLD_VERSION: version },
+  });
+  if (res.status !== 0) return res.status ?? 1;
+  if (opts.json) {
+    console.log(JSON.stringify({ ok: true, version, hint: "add ~/.local/bin to PATH" }));
+  } else {
+    console.log(`Installed celld ${version}. Verify: celld --version`);
+  }
+  return 0;
+}
+
+export async function runStreamsCelldDeploy(opts: StreamsCelldCliOptions): Promise<number> {
+  requireCelld();
+  const project = resolve(opts.project ?? defaultProjectDir());
+  if (!existsSync(join(project, "wrangler.jsonc"))) {
+    console.error(`No wrangler.jsonc in ${project}`);
+    return 1;
+  }
+  return runCelld(["deploy", ".", ...bucketArgs(opts)], { cwd: project });
+}
+
+export async function runStreamsCelldStart(opts: StreamsCelldCliOptions): Promise<number> {
+  requireCelld();
+  const listen = opts.listen ?? process.env.CELLD_ADDR ?? "0.0.0.0:8080";
+  const internal =
+    opts.internalListen ?? process.env.CELLD_INTERNAL_ADDR ?? "0.0.0.0:8081";
+  const advertise = opts.advertise ?? process.env.CELLD_ADVERTISE;
+  const args = [...bucketArgs(opts), "--listen", listen, "--internal-listen", internal];
+  if (advertise) args.push("--advertise", advertise);
+  return runCelld(args);
+}
+
+export async function runStreamsCelldDiagnose(opts: StreamsCelldCliOptions): Promise<number> {
+  requireCelld();
+  return runCelld(["diagnose", ...bucketArgs(opts)]);
+}
+
+export async function runStreamsCelldBundleCheck(opts: StreamsCelldCliOptions): Promise<number> {
+  const project = resolve(opts.project ?? defaultProjectDir());
+  const script = join(project, "scripts", "bundle-check.mjs");
+  if (!existsSync(script)) {
+    console.error(`Missing ${script}`);
+    return 1;
+  }
+  const res = spawnSync(process.execPath, [script], {
+    cwd: project,
+    stdio: "inherit",
+  });
+  return res.status ?? 1;
+}
+
+export async function runStreamsCelldDev(opts: StreamsCelldCliOptions & { port?: number }): Promise<number> {
+  requireCelld();
+  const project = resolve(opts.project ?? defaultProjectDir());
+  const port = opts.port ?? 9876;
+  return runCelld(["dev", "--port", String(port)], { cwd: project });
+}

--- a/website/src/app/learn/streams-getting-started/layout.tsx
+++ b/website/src/app/learn/streams-getting-started/layout.tsx
@@ -3,7 +3,7 @@ import { docsPageMetadata } from '@/lib/seo'
 export const metadata = docsPageMetadata({
   title: 'Streams getting started (Learn)',
   description:
-    'Hands-on Streams labs (schedule, NATS JetStream, IDP overlay, agent bridge, celld v0.4.0) plus reading order through DO, celld, cellrt, TEE, and air-gap audit.',
+    'Hands-on Streams labs (schedule, NATS, IDP overlay, agent bridge, celld v0.4.0, Wrangler skeleton) plus reading order through DO, celld, cellrt, TEE, and air-gap audit.',
   path: '/learn/streams-getting-started',
 })
 

--- a/website/src/app/learn/streams-getting-started/page.mdx
+++ b/website/src/app/learn/streams-getting-started/page.mdx
@@ -382,14 +382,78 @@ celld diagnose --bucket "$CELLD_BUCKET" --endpoint "$S3_ENDPOINT" --region "$AWS
 celld cell list --bucket "$CELLD_BUCKET" --json | head
 ```
 
-**Success:** Counter increments locally; you understand `celld dev` vs fleet deploy, v0.4.0 health probes, and how DO naming maps to Streams sidecars. Next: embed `clawql-streams` + `clawql-core` in a Wrangler bundle ([celld integration §5](/streams/clawql-celld)) and run `clawql streams celld bundle-check` when that CLI ships.
+**Success:** Counter increments locally; you understand `celld dev` vs fleet deploy, v0.4.0 health probes, and how DO naming maps to Streams sidecars. Continue to **Lab 5b** for the ClawQL Wrangler skeleton and bundle gate.
+
+### Lab 5b — ClawQL Streams Wrangler skeleton + bundle-check (~30 min)
+
+**Goal:** Run the in-repo **GatewayDO / SubscriptionDO / AgentSessionDO** skeleton ([`examples/streams-celld`](https://github.com/danielsmithdevelopment/ClawQL/tree/main/examples/streams-celld)) under celld v0.4.0 and enforce the **64 MiB** Workers bundle limit.
+
+**Prerequisites:** Lab 5 celld v0.4.0 + esbuild on `PATH`.
+
+**1 — Local dev with the ClawQL skeleton**
+
+```bash
+cd examples/streams-celld
+clawql streams celld dev --port 9876
+# or: celld dev --port 9876
+```
+
+**2 — Webhook → significance → session spawn**
+
+```bash
+curl -s http://127.0.0.1:9876/health | jq .
+curl -s -X POST http://127.0.0.1:9876/webhook/demo-lab \
+  -H 'content-type: application/json' \
+  -H 'x-clawql-event-id: lab-5b-1' \
+  -d '{"hello":"streams"}' | jq .
+curl -s http://127.0.0.1:9876/admin/status | jq .
+```
+
+Repeat the POST with the same `x-clawql-event-id` — `AgentSessionDO` should report **`idempotent: true`**.
+
+**3 — Bundle size gate**
+
+```bash
+clawql streams celld bundle-check
+# equivalent: node scripts/bundle-check.mjs
+```
+
+CI and local dev should fail closed when the bundled Worker exceeds **67108864** bytes ([celld integration §5](/streams/clawql-celld)).
+
+**4 — Optional: fleet deploy + Helm celld backend**
+
+Deploy the skeleton to your fleet bucket, then enable the chart overlay:
+
+```bash
+export CELLD_BUCKET=s3://clawql-streams-state
+export S3_ENDPOINT=https://ACCOUNT_ID.r2.cloudflarestorage.com
+
+clawql streams celld deploy --project examples/streams-celld \
+  --bucket "$CELLD_BUCKET" --endpoint "$S3_ENDPOINT"
+
+helm upgrade --install clawql ./charts/clawql-mcp \
+  -f ./charts/clawql-mcp/values-streams-celld.example.yaml \
+  --set envFromSecret=clawql-provider-env \
+  --set streams.celld.bucket="$CELLD_BUCKET" \
+  --set streams.celld.endpoint="$S3_ENDPOINT" \
+  -n clawql --create-namespace
+```
+
+The celld StatefulSet probes **`/.well-known/celld/health`** (v0.4.0). Full checklist: [deployment/samples/streams-celld](https://github.com/danielsmithdevelopment/ClawQL/tree/main/deployment/samples/streams-celld).
+
+**Success:** Webhook spawns a session with a WORM row stub; bundle-check passes; you can optional deploy to K8s with `streams.scalingBackend: celld`.
 
 ## K8s operator sketch
 
 ```bash
-# Event backbone (Lab 2)
+# Event backbone (Lab 2) or celld fleet (Lab 5b)
 helm upgrade --install clawql ./charts/clawql-mcp -n clawql --create-namespace \
   --set nats.enabled=true --set nats.jetStream.enabled=true
+
+# celld Streams path (Lab 5b overlay)
+# helm upgrade --install clawql ./charts/clawql-mcp -n clawql \
+#   -f ./charts/clawql-mcp/values-streams-celld.example.yaml \
+#   --set streams.celld.bucket=s3://clawql-streams-state
 
 # MCP + inference (cells call inference over HTTP)
 export CLAWQL_ENABLE_SCHEDULE=1

--- a/website/src/lib/docs-site-card-data.ts
+++ b/website/src/lib/docs-site-card-data.ts
@@ -149,7 +149,7 @@ export const learnModuleSiteCards: Array<ReferenceCard> = [
     href: '/learn/streams-getting-started',
     name: 'Streams getting started',
     description:
-      'Hands-on labs: schedule, NATS, IDP overlay, agent bridge, celld v0.4.0 — plus DO/celld/cellrt/TEE reading order.',
+      'Hands-on labs: schedule, NATS, IDP overlay, agent bridge, celld v0.4.0 + Wrangler skeleton — plus DO/celld/cellrt/TEE reading order.',
     icon: BoltIcon,
     pattern: {
       y: 28,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Delivers **Lab 5b** (ClawQL Streams Wrangler skeleton + bundle-check) and **Helm `streams.scalingBackend: celld`** wired for **celld v0.4.0**.

### 1. `examples/streams-celld/`

- Minimal Worker + three DO classes: `GatewayDO`, `SubscriptionDO`, `AgentSessionDO`
- Webhook path: `POST /webhook/{subscriptionId}` → significance stub → session spawn + WORM row
- `scripts/bundle-check.mjs` — enforces 64 MiB Workers limit (esbuild)
- `scripts/smoke.sh` — local `celld dev` smoke

### 2. `clawql streams celld` CLI

- `install | dev | deploy | start | diagnose | bundle-check`
- Defaults project dir to `examples/streams-celld`

### 3. Helm (`charts/clawql-mcp`)

- `streams:` values block (disabled by default)
- `templates/celld-stack.yaml` — StatefulSet + Services, readiness/liveness on `/.well-known/celld/health`, pinned `ghcr.io/denoland/celld:v0.4.0`
- `values-streams-celld.example.yaml` overlay
- `CLAWQL_ENABLE_STREAMS=1` on MCP when `streams.enabled`
- `deployment/samples/streams-celld/` checklist
- `scripts/kubernetes/test-helm-celld-templates.sh` + Makefile target

### 4. Learn

- **Lab 5b** section in Streams getting started

## Verification

- `node examples/streams-celld/scripts/bundle-check.mjs` → PASS (3821 bytes)
- `CELLD_DEV_PORT=9880 bash examples/streams-celld/scripts/smoke.sh` → PASS (webhook spawn)
- `npm run build` succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8f57-601a-7ec1-bff0-d35011fef4ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8f57-601a-7ec1-bff0-d35011fef4ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

