### PR TITLE
feat(streams): embed clawql-core/streams-slim in celld AgentSessionDO

### DIFF
--- a/docs/streams/clawql-celld.md
+++ b/docs/streams/clawql-celld.md
@@ -208,12 +208,16 @@ Gateway still allocates `doInstanceId` / `virtualKeyId` before first spawn and w
 ```text
 celld deploy (esbuild)
   └─ Worker + DO classes
-        ├─ clawql-streams (router, filter, stream_* MCP)
-        ├─ clawql-core (search / execute / memory_*)
-        └─ mcp-api-adapter (protocol surfaces)
+        ├─ clawql-streams (router, filter, stream_* MCP) — planned package
+        ├─ clawql-core/streams-slim (audit, cache, hash-chain) — Workers-safe entry
+        └─ (deferred) clawql-api search/execute · mcp-api-adapter · clawql-memory
   env / vars ≤ 1 MiB
   code ≤ 64 MiB
 ```
+
+**In-process today:** `AgentSessionDO` imports [`clawql-core/streams-slim`](../../packages/clawql-core/README.md) for hash-chained `audit` + session `cache`. Example: [`examples/streams-celld`](../../examples/streams-celld/).
+
+**Still out-of-process / deferred:** `search` / `execute` (`clawql-api`), `memory_*` (`clawql-memory`), protocol fan-out (`mcp-api-adapter`), inference (`fetch` to clawql-inference). Do **not** embed the full `clawql-core` barrel — it pulls `webmcp-draft` (`node:fs`).
 
 **Provider specs:** ship a **slim default set** in the bundle; load additional OpenAPI/GraphQL specs via `fetch` into SQLite on first use or at subscription create — do not embed full enterprise catalogs in env.
 
@@ -221,16 +225,17 @@ celld deploy (esbuild)
 
 ```bash
 # clawql streams celld bundle-check
-celld deploy . --bucket "$CELLD_BUCKET" --dry-run   # or esbuild metafile
+clawql streams celld bundle-check --project examples/streams-celld
 # Fail the job if Worker/DO artifact size > 67108864 bytes
 ```
 
 CI must fail closed on oversize bundles. Prefer:
 
 - Externalize `clawql-inference` (always)
+- Import **`clawql-core/streams-slim`**, not `clawql-core` (full barrel)
 - Tree-shake unused providers
-- Avoid Node polyfills that pull `fs` / `http`
-- Optional Streams-slim build profile if full Core exceeds budget (open question in Streams §15)
+- Avoid Node polyfills that pull `fs` / `http` (keep `nodejs_compat` for `crypto` / `Buffer` only)
+- Optional further Streams-slim cuts if Effect + api ever approach budget (open question in Streams §15)
 
 ---
 

--- a/docs/streams/clawql-streams.md
+++ b/docs/streams/clawql-streams.md
@@ -765,7 +765,7 @@ Streams + Core + mcp-api-adapter is the **Protocol Fabric with an event loop**: 
 
 ## 15. Open questions
 
-1. **Bundle size.** Can `clawql-core` + `mcp-api-adapter` + Streams fit under **64 MiB** with aggressive tree-shaking, or do we need a Streams-slim core profile?
+1. **Bundle size.** **Resolved for core:** `clawql-core/streams-slim` + Effect ≈ **0.4 MiB** in [`examples/streams-celld`](../../examples/streams-celld/) (well under 64 MiB). Remaining question: can a future Workers-safe `clawql-api` slim + Streams router still fit with aggressive tree-shaking?
 2. **celld alpha vs cellrt.** When is celld production-stable enough to prefer over K8s HPA? When does Helm default self-hosted Streams to **`cellrt`** instead of (or alongside) celld?
 3. **Replay and idempotency.** On buffer replay, significance may re-fire. Idempotency keys: `eventId + subscriptionId` (and stable DO/cell names — see celld / cellrt naming).
 4. **Kafka / Kinesis.** First-class `StreamSourceType` in v0.2 or defer to enterprise add-on?

--- a/examples/streams-celld/README.md
+++ b/examples/streams-celld/README.md
@@ -1,19 +1,34 @@
-# ClawQL Streams — celld skeleton (Lab 5b)
+# ClawQL Streams — celld skeleton + clawql-core (Lab 5b)
 
-Minimal **Workers / Durable Objects** bundle for [ClawQL Streams](https://docs.clawql.com/streams/clawql-streams) on **[celld v0.4.0](https://github.com/denoland/celld/releases/tag/v0.4.0)**.
+Minimal **Workers / Durable Objects** bundle for [ClawQL Streams](https://docs.clawql.com/streams/clawql-streams) on **[celld v0.4.0](https://github.com/denoland/celld/releases/tag/v0.4.0)**, with in-process **`clawql-core/streams-slim`**.
 
 | DO class | Role |
 | -------- | ---- |
 | `GatewayDO` | Webhook ingress (`POST /webhook/{subscriptionId}`), spawn sessions |
 | `SubscriptionDO` | Significance filter stub (`sub:{id}` naming) |
-| `AgentSessionDO` | Ephemeral session + WORM row + optional `fetch(INFERENCE_URL/healthz)` |
+| `AgentSessionDO` | Session + WORM row + **audit/cache** via streams-slim + optional `fetch(INFERENCE_URL)` |
 
 **Learn walkthrough:** [Streams getting started — Lab 5b](https://docs.clawql.com/learn/streams-getting-started#lab-5b--clawql-streams-wrangler-skeleton--bundle-check-30-min)
+
+## In-process vs deferred
+
+| Surface | Status |
+| ------- | ------ |
+| `audit` (hash-chained ring) | **In-process** — `clawql-core/streams-slim` |
+| `cache` (session scratch) | **In-process** — `clawql-core/streams-slim` |
+| Hash-chain verify | **In-process** — via clawql-merkle (needs `nodejs_compat`) |
+| Inference | **Out-of-process** — `fetch(INFERENCE_URL)` |
+| `search` / `execute` | **Deferred** — clawql-api stays on MCP host |
+| `memory_*` | **Deferred** — clawql-memory + vault |
+| `mcp-api-adapter` | **Deferred** — Node Express/gRPC host |
+
+`streams-slim` **excludes** `webmcp-draft` (`node:fs`), cuckoo, Loki, and plugin dynamic loaders.
 
 ## Prerequisites
 
 - [celld v0.4.0](https://github.com/denoland/celld/releases/tag/v0.4.0) on `PATH`
-- [esbuild](https://esbuild.github.io/) on `PATH` (required by `celld deploy` / `celld dev`)
+- [esbuild](https://esbuild.github.io/) on `PATH`
+- Workspace packages built: `npm run build -w clawql-merkle -w clawql-core`
 
 ## Local dev (`celld dev`)
 
@@ -29,44 +44,25 @@ curl -s http://127.0.0.1:9876/health | jq .
 curl -s -X POST http://127.0.0.1:9876/webhook/demo-lab \
   -H 'content-type: application/json' \
   -H 'x-clawql-event-id: lab-event-1' \
-  -d '{"hello":"streams"}' | jq .
-curl -s http://127.0.0.1:9876/admin/status | jq .
+  -d '{"hello":"streams"}' | jq '.session.audit, .session.core'
 ```
 
-Repeat the webhook with the same `x-clawql-event-id` to observe idempotent session wake.
+Expect `audit.clawqlCore.ok: true`, a hash-chain `verify.ok: true`, and `core.package: "clawql-core/streams-slim"`.
 
 ## Bundle size gate (64 MiB Workers limit)
 
 ```bash
 node scripts/bundle-check.mjs
-# or from repo root:
-clawql streams celld bundle-check --project examples/streams-celld
+# or: clawql streams celld bundle-check --project examples/streams-celld
 ```
 
-## Fleet deploy (optional)
+Typical size with Effect + streams-slim ≈ **0.4 MiB** (~0.6% of limit).
 
-After Lab 5 bucket credentials:
+## Fleet deploy / Helm
 
-```bash
-export CELLD_BUCKET=s3://clawql-streams-state
-export S3_ENDPOINT=https://ACCOUNT.r2.cloudflarestorage.com
-export AWS_REGION=auto
-
-celld deploy . \
-  --bucket "$CELLD_BUCKET" \
-  --endpoint "$S3_ENDPOINT" \
-  --region "$AWS_REGION"
-
-clawql streams celld start --bucket "$CELLD_BUCKET" --listen 127.0.0.1:8080
-curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8080/.well-known/celld/health
-```
-
-## Kubernetes (Helm)
-
-See [`charts/clawql-mcp/values-streams-celld.example.yaml`](../../charts/clawql-mcp/values-streams-celld.example.yaml) and [`deployment/samples/streams-celld/`](../../deployment/samples/streams-celld/README.md).
+Same as before — see [`deployment/samples/streams-celld/`](../../deployment/samples/streams-celld/README.md) and `clawql streams celld deploy`.
 
 ## Next steps
 
-- Replace stubs with `clawql-streams` + in-process `clawql-core` when the package ships
-- Wire real significance filters and `fetch()` to [`clawql-inference`](https://docs.clawql.com/inference/clawql-inference)
-- Run under Helm `streams.scalingBackend: celld` with LTX WORM on the fleet bucket
+- Slim `clawql-api` Workers surface for true in-cell `search`/`execute`, or `fetch` to in-cluster MCP
+- Persist audit beyond isolate memory (LTX WORM on fleet bucket already covers DO `storage.put` rows)

--- a/examples/streams-celld/package.json
+++ b/examples/streams-celld/package.json
@@ -2,10 +2,16 @@
   "name": "@clawql/example-streams-celld",
   "private": true,
   "version": "0.0.0",
-  "description": "ClawQL Streams celld DO skeleton (Lab 5b)",
+  "description": "ClawQL Streams celld DO skeleton with clawql-core/streams-slim (Lab 5b)",
   "type": "module",
   "scripts": {
     "bundle-check": "node scripts/bundle-check.mjs",
-    "dev": "celld dev --port 9876"
+    "dev": "celld dev --port 9876",
+    "smoke": "bash scripts/smoke.sh"
+  },
+  "dependencies": {
+    "clawql-core": "0.1.0",
+    "clawql-merkle": "0.1.0",
+    "effect": "^3.21.4"
   }
 }

--- a/examples/streams-celld/scripts/bundle-check.mjs
+++ b/examples/streams-celld/scripts/bundle-check.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 /**
  * Fail if the bundled Worker artifact exceeds the Cloudflare/celld 64 MiB limit.
- * Uses esbuild (same toolchain as celld deploy) — no fleet bucket required.
+ * Bundles with nodejs_compat-friendly settings (node:crypto / Buffer via runtime).
  */
 import { spawnSync } from "node:child_process";
-import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { tmpdir } from "node:os";
@@ -12,6 +13,7 @@ import { tmpdir } from "node:os";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(__dirname, "..");
 const WRANGLER_LIMIT = 64 * 1024 * 1024;
+const require = createRequire(import.meta.url);
 
 function parseJsonc(text) {
   const stripped = text.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
@@ -20,9 +22,15 @@ function parseJsonc(text) {
 
 function findEsbuild() {
   const fromPath = spawnSync("esbuild", ["--version"], { encoding: "utf8" });
-  if (fromPath.status === 0) return "esbuild";
+  if (fromPath.status === 0) return { bin: "esbuild", prefix: [] };
+  try {
+    const esbuildBin = join(dirname(require.resolve("esbuild/package.json")), "bin", "esbuild");
+    if (existsSync(esbuildBin)) return { bin: esbuildBin, prefix: [] };
+  } catch {
+    // fall through
+  }
   const fromNpx = spawnSync("npx", ["esbuild", "--version"], { encoding: "utf8" });
-  if (fromNpx.status === 0) return "npx esbuild";
+  if (fromNpx.status === 0) return { bin: "npx", prefix: ["esbuild"] };
   console.error("bundle-check: esbuild not found on PATH");
   process.exit(1);
 }
@@ -34,32 +42,28 @@ const tmpDir = mkdtempSync(join(tmpdir(), "clawql-streams-celld-"));
 const outfile = join(tmpDir, "bundle.js");
 const metafile = join(tmpDir, "meta.json");
 
-const esbuildCmd = findEsbuild();
-const args =
-  esbuildCmd === "esbuild"
-    ? [
-        entry,
-        "--bundle",
-        "--format=esm",
-        "--platform=browser",
-        `--outfile=${outfile}`,
-        `--metafile=${metafile}`,
-        "--minify",
-      ]
-    : [
-        "esbuild",
-        entry,
-        "--bundle",
-        "--format=esm",
-        "--platform=browser",
-        `--outfile=${outfile}`,
-        `--metafile=${metafile}`,
-        "--minify",
-      ];
+const { bin, prefix } = findEsbuild();
+const args = [
+  ...prefix,
+  entry,
+  "--bundle",
+  "--format=esm",
+  // celld Workers use nodejs_compat — leave Node builtins for the runtime.
+  "--platform=node",
+  "--target=es2022",
+  "--conditions=worker,workerd,import",
+  "--main-fields=module,main",
+  "--packages=bundle",
+  `--outfile=${outfile}`,
+  `--metafile=${metafile}`,
+  "--minify",
+];
 
-const run = spawnSync(esbuildCmd === "esbuild" ? "esbuild" : "npx", args, {
+const run = spawnSync(bin, args, {
   encoding: "utf8",
   stdio: ["ignore", "pipe", "pipe"],
+  cwd: projectRoot,
+  env: process.env,
 });
 
 if (run.status !== 0) {

--- a/examples/streams-celld/scripts/smoke.sh
+++ b/examples/streams-celld/scripts/smoke.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Smoke test for examples/streams-celld (Lab 5b). Requires celld v0.4.0 + esbuild on PATH.
+# Smoke test for examples/streams-celld (Lab 5b + clawql-core embed).
+# Requires celld v0.4.0 + esbuild on PATH; workspace clawql-core built.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -19,15 +20,27 @@ PID=$!
 cleanup() { kill "$PID" 2>/dev/null || true; wait "$PID" 2>/dev/null || true; }
 trap cleanup EXIT
 
-for _ in $(seq 1 30); do
+for _ in $(seq 1 40); do
   if curl -sf "$BASE/health" >/dev/null 2>&1; then break; fi
   sleep 1
 done
 
 curl -sf "$BASE/health" | grep -q clawql-streams-celld-skeleton
-curl -sf -X POST "$BASE/webhook/smoke" \
+
+RESP=$(curl -sf -X POST "$BASE/webhook/smoke" \
   -H 'content-type: application/json' \
-  -H 'x-clawql-event-id: smoke-1' \
-  -d '{"probe":true}' | grep -q '"action":"spawn"'
+  -H 'x-clawql-event-id: smoke-core-1' \
+  -d '{"probe":true}')
+
+fail() {
+  echo "smoke: FAIL - $1" >&2
+  echo "$RESP" >&2
+  exit 1
+}
+
+echo "$RESP" | grep -q '"action":"spawn"' || fail "expected action spawn"
+echo "$RESP" | grep -q 'clawql-core/streams-slim' || fail "expected clawql-core/streams-slim"
+echo "$RESP" | grep -q '"hash":' || fail "expected hash-chained audit append"
+echo "$RESP" | grep -q 'streams:session:' || fail "expected cache session key"
 
 echo "smoke: PASS"

--- a/examples/streams-celld/src/agent-session-do.js
+++ b/examples/streams-celld/src/agent-session-do.js
@@ -1,7 +1,16 @@
 /**
- * AgentSessionDO — ephemeral session stub (Streams spec §4).
+ * AgentSessionDO — ephemeral session with in-cell clawql-core (streams-slim).
  * Model calls use fetch(INFERENCE_URL) — never child_process.
+ * Audit/cache run in-process; search/execute remain deferred (see streams-core-facade).
  */
+import {
+  appendSessionCreatedAudit,
+  cacheSessionMeta,
+  executeDeferred,
+  searchDeferred,
+  verifyAuditChain,
+} from "./streams-core-facade.js";
+
 export class AgentSessionDO {
   constructor(state, env) {
     this.state = state;
@@ -23,6 +32,7 @@ export class AgentSessionDO {
           do: "AgentSessionDO",
           idempotent: true,
           session: existing,
+          core: { clawqlCore: "streams-slim", note: "idempotent wake — no re-audit" },
         });
       }
 
@@ -42,6 +52,25 @@ export class AgentSessionDO {
         subscriptionId,
         eventId,
       });
+
+      let audit = { ok: false };
+      let cache = { ok: false };
+      let auditVerify = { ok: false };
+      try {
+        audit = await appendSessionCreatedAudit({
+          subscriptionId,
+          eventId,
+          doInstanceId,
+          virtualKeyId,
+        });
+        cache = await cacheSessionMeta(eventId, meta);
+        auditVerify = await verifyAuditChain();
+      } catch (err) {
+        audit = {
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
 
       let inference = { skipped: true, reason: "no INFERENCE_URL" };
       const inferenceUrl = this.env.INFERENCE_URL;
@@ -66,11 +95,27 @@ export class AgentSessionDO {
         }
       }
 
+      const tools = {
+        search: await searchDeferred(`subscription:${subscriptionId}`),
+        execute: await executeDeferred("streams.session.noop", { eventId }),
+      };
+
       return Response.json({
         do: "AgentSessionDO",
         session: meta,
         inference,
-        audit: { wormKey: `worm:${startedAt}` },
+        audit: {
+          wormKey: `worm:${startedAt}`,
+          clawqlCore: audit,
+          verify: auditVerify,
+        },
+        cache,
+        tools,
+        core: {
+          package: "clawql-core/streams-slim",
+          inProcess: ["audit", "cache", "hash-chain"],
+          deferred: ["search", "execute", "memory_*", "mcp-api-adapter"],
+        },
       });
     }
 

--- a/examples/streams-celld/src/streams-core-facade.js
+++ b/examples/streams-celld/src/streams-core-facade.js
@@ -1,0 +1,80 @@
+/**
+ * In-cell ClawQL core façade for Streams AgentSessionDO.
+ *
+ * In-process today (via clawql-core/streams-slim):
+ * - audit append / list / verify (hash-chained ring buffer, isolate-local)
+ * - cache get / set / delete / list (session scratch)
+ *
+ * Deferred / out-of-process (not in clawql-core):
+ * - search / execute → clawql-api + MCP host (or fetch to clawql-mcp)
+ * - memory_ingest / memory_recall → clawql-memory + vault
+ * - inference completions → fetch(INFERENCE_URL) (already out-of-process)
+ * - mcp-api-adapter protocol surfaces → Node Express/gRPC host
+ */
+
+import {
+  runAuditOperation,
+  runCacheOperation,
+} from "clawql-core/streams-slim";
+
+/**
+ * @param {{ subscriptionId: string, eventId: string, doInstanceId: string, virtualKeyId: string }} ctx
+ */
+export async function appendSessionCreatedAudit(ctx) {
+  const result = await runAuditOperation({
+    operation: "append",
+    category: "streams",
+    action: "session_created",
+    summary: `AgentSessionDO spawned for ${ctx.subscriptionId}`,
+    correlationId: ctx.eventId,
+  });
+  const text = result.content?.[0]?.text;
+  return text ? JSON.parse(text) : { ok: false };
+}
+
+/**
+ * @param {string} eventId
+ * @param {unknown} meta
+ */
+export async function cacheSessionMeta(eventId, meta) {
+  const key = `streams:session:${eventId}`;
+  const result = await runCacheOperation({
+    operation: "set",
+    key,
+    value: JSON.stringify(meta),
+  });
+  return { key, ...result };
+}
+
+/**
+ * @param {string} query
+ */
+export async function searchDeferred(query) {
+  return {
+    deferred: true,
+    tool: "search",
+    reason:
+      "clawql-api is Node-hosted; call via fetch→MCP or wait for streams-slim API",
+    query,
+  };
+}
+
+/**
+ * @param {string} operationId
+ * @param {unknown} args
+ */
+export async function executeDeferred(operationId, args) {
+  return {
+    deferred: true,
+    tool: "execute",
+    reason: "clawql-api execute stays out-of-process on celld path",
+    operationId,
+    args,
+  };
+}
+
+export async function verifyAuditChain() {
+  const result = await runAuditOperation({ operation: "verify" });
+  const text = result.content?.[0]?.text;
+  return text ? JSON.parse(text) : { ok: false };
+}

--- a/packages/clawql-core/README.md
+++ b/packages/clawql-core/README.md
@@ -27,4 +27,14 @@ Canonical spec: [`docs/design/clawql-core-plugin-architecture.md`](../../docs/de
 
 **Internal modules:** `merkle/`, `hash-chain/`, `cuckoo/`, `loki/`, `plugin/`, `audit/`, `providers/webmcp-draft/`.
 
+### Streams / celld entry (`clawql-core/streams-slim`)
+
+Workers-safe subset for Durable Object cells (no `webmcp-draft` / `node:fs`, no cuckoo, no Loki, no plugin dynamic loader):
+
+```ts
+import { runAuditOperation, runCacheOperation } from "clawql-core/streams-slim";
+```
+
+Requires celld / Workers **`nodejs_compat`** for `node:crypto` + `Buffer` (hash-chain). Search / execute / memory stay on the MCP host or via `fetch` — they are not in this package. Example: [`examples/streams-celld`](../../examples/streams-celld/).
+
 **8.0 hard break:** Phase-2 `Plugin` / `beforeCallTool` and any compatibility bridge are removed — rewrite against `ProviderPlugin`.

--- a/packages/clawql-core/package.json
+++ b/packages/clawql-core/package.json
@@ -13,6 +13,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./streams-slim": {
+      "types": "./dist/streams-slim.d.ts",
+      "import": "./dist/streams-slim.js",
+      "require": "./dist/streams-slim.cjs"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/clawql-core/src/streams-slim.test.ts
+++ b/packages/clawql-core/src/streams-slim.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { runAuditOperation, runCacheOperation } from "./streams-slim.js";
+
+describe("streams-slim entry", () => {
+  it("exports audit append + verify without webmcp", async () => {
+    const appended = await runAuditOperation({
+      operation: "append",
+      category: "streams",
+      action: "test",
+      summary: "streams-slim unit",
+      correlationId: "slim-1",
+    });
+    const body = JSON.parse(appended.content[0]!.text);
+    expect(body.ok).toBe(true);
+    expect(body.hash).toMatch(/^[a-f0-9]{64}$/);
+
+    const verified = await runAuditOperation({ operation: "verify" });
+    const v = JSON.parse(verified.content[0]!.text);
+    expect(v.ok).toBe(true);
+  });
+
+  it("exports cache set/get", async () => {
+    const set = await runCacheOperation({
+      operation: "set",
+      key: "streams:slim:test",
+      value: "ok",
+    });
+    expect(set.ok).toBe(true);
+    const get = await runCacheOperation({ operation: "get", key: "streams:slim:test" });
+    expect(get.ok).toBe(true);
+    if (get.ok && "hit" in get) {
+      expect(get.hit).toBe(true);
+      expect(get.value).toBe("ok");
+    }
+  });
+});

--- a/packages/clawql-core/src/streams-slim.ts
+++ b/packages/clawql-core/src/streams-slim.ts
@@ -1,0 +1,26 @@
+/**
+ * Streams / celld Workers-safe surface of clawql-core.
+ *
+ * Includes: audit ring buffer, session cache, hash-chain (via clawql-merkle),
+ * config helpers, errors.
+ *
+ * Excludes (Node / disk / dynamic loaders):
+ * - providers/webmcp-draft (node:fs draft store)
+ * - cuckoo (Buffer-heavy; vault chunk index — use on MCP host)
+ * - plugin dynamic-loader / SkillRegistry install path
+ * - Loki push helpers (optional host observability)
+ *
+ * Requires celld / Workers `nodejs_compat` for `node:crypto` + `Buffer`
+ * (hash-chain seal uses createHash from clawql-merkle).
+ *
+ * Search / execute / memory_* stay out-of-process or deferred — they live in
+ * clawql-api / clawql-memory / MCP host, not this package.
+ */
+
+export * from "./audit/index.js";
+export * from "./hash-chain/index.js";
+export * from "./cache/index.js";
+export * from "./config/index.js";
+export * from "./errors/index.js";
+export * from "./merkle/index.js";
+export * from "./utils/index.js";

--- a/packages/clawql-core/tsup.config.ts
+++ b/packages/clawql-core/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/streams-slim.ts"],
   format: ["esm", "cjs"],
   dts: true,
   sourcemap: true,

--- a/website/src/app/learn/streams-getting-started/page.mdx
+++ b/website/src/app/learn/streams-getting-started/page.mdx
@@ -411,12 +411,19 @@ curl -s http://127.0.0.1:9876/admin/status | jq .
 
 Repeat the POST with the same `x-clawql-event-id` — `AgentSessionDO` should report **`idempotent: true`**.
 
-**3 — Bundle size gate**
+**3 — Bundle size gate + clawql-core**
+
+The skeleton embeds **`clawql-core/streams-slim`** (audit + cache + hash-chain). Build workspace packages first:
 
 ```bash
+npm run build -w clawql-merkle -w clawql-core
 clawql streams celld bundle-check
-# equivalent: node scripts/bundle-check.mjs
+# equivalent: node examples/streams-celld/scripts/bundle-check.mjs
 ```
+
+Expect ≈ **0.4 MiB** (~0.6% of the **64 MiB** Workers limit). The full `clawql-core` barrel is **not** used — it would pull `webmcp-draft` (`node:fs`).
+
+Webhook responses include `session.audit.clawqlCore` (hash-chained append) and `session.core.inProcess: ["audit","cache","hash-chain"]`. `search` / `execute` remain **deferred** to the MCP host.
 
 CI and local dev should fail closed when the bundled Worker exceeds **67108864** bytes ([celld integration §5](/streams/clawql-celld)).
 
@@ -441,7 +448,7 @@ helm upgrade --install clawql ./charts/clawql-mcp \
 
 The celld StatefulSet probes **`/.well-known/celld/health`** (v0.4.0). Full checklist: [deployment/samples/streams-celld](https://github.com/danielsmithdevelopment/ClawQL/tree/main/deployment/samples/streams-celld).
 
-**Success:** Webhook spawns a session with a WORM row stub; bundle-check passes; you can optional deploy to K8s with `streams.scalingBackend: celld`.
+**Success:** Webhook spawns a session with in-process **clawql-core** audit/cache; bundle-check stays under 64 MiB; optional Helm deploy with `streams.scalingBackend: celld`.
 
 ## K8s operator sketch
 

--- a/website/src/generated/clawql-celld-body.mdx
+++ b/website/src/generated/clawql-celld-body.mdx
@@ -208,12 +208,16 @@ Gateway still allocates `doInstanceId` / `virtualKeyId` before first spawn and w
 ```text
 celld deploy (esbuild)
   └─ Worker + DO classes
-        ├─ clawql-streams (router, filter, stream_* MCP)
-        ├─ clawql-core (search / execute / memory_*)
-        └─ mcp-api-adapter (protocol surfaces)
+        ├─ clawql-streams (router, filter, stream_* MCP) — planned package
+        ├─ clawql-core/streams-slim (audit, cache, hash-chain) — Workers-safe entry
+        └─ (deferred) clawql-api search/execute · mcp-api-adapter · clawql-memory
   env / vars ≤ 1 MiB
   code ≤ 64 MiB
 ```
+
+**In-process today:** `AgentSessionDO` imports [`clawql-core/streams-slim`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/packages/clawql-core/README.md) for hash-chained `audit` + session `cache`. Example: [`examples/streams-celld`](../../examples/streams-celld/).
+
+**Still out-of-process / deferred:** `search` / `execute` (`clawql-api`), `memory_*` (`clawql-memory`), protocol fan-out (`mcp-api-adapter`), inference (`fetch` to clawql-inference). Do **not** embed the full `clawql-core` barrel — it pulls `webmcp-draft` (`node:fs`).
 
 **Provider specs:** ship a **slim default set** in the bundle; load additional OpenAPI/GraphQL specs via `fetch` into SQLite on first use or at subscription create — do not embed full enterprise catalogs in env.
 
@@ -221,16 +225,17 @@ celld deploy (esbuild)
 
 ```bash
 # clawql streams celld bundle-check
-celld deploy . --bucket "$CELLD_BUCKET" --dry-run   # or esbuild metafile
+clawql streams celld bundle-check --project examples/streams-celld
 # Fail the job if Worker/DO artifact size > 67108864 bytes
 ```
 
 CI must fail closed on oversize bundles. Prefer:
 
 - Externalize `clawql-inference` (always)
+- Import **`clawql-core/streams-slim`**, not `clawql-core` (full barrel)
 - Tree-shake unused providers
-- Avoid Node polyfills that pull `fs` / `http`
-- Optional Streams-slim build profile if full Core exceeds budget (open question in Streams §15)
+- Avoid Node polyfills that pull `fs` / `http` (keep `nodejs_compat` for `crypto` / `Buffer` only)
+- Optional further Streams-slim cuts if Effect + api ever approach budget (open question in Streams §15)
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Embeds real **`clawql-core`** into the celld Streams skeleton via a Workers-safe **`streams-slim`** entry.

### `clawql-core/streams-slim`

New package export (and tsup entry) with:

- **Included:** audit, cache, hash-chain, merkle, config, errors
- **Excluded:** `webmcp-draft` (`node:fs`), cuckoo, Loki, plugin dynamic loader

Unit tests cover audit append/verify and cache set/get.

### `examples/streams-celld`

- `AgentSessionDO` calls in-process `runAuditOperation` + `runCacheOperation` on spawn
- `streams-core-facade.js` documents deferred `search` / `execute` / `memory_*`
- Bundle-check uses `--platform=node` (celld `nodejs_compat` for `crypto`/`Buffer`)
- Smoke asserts hash-chained audit + streams-slim marker

### Docs

- celld §5 bundle architecture corrected (core ≠ search/execute)
- Streams §15 open question updated — core size resolved (~0.4 MiB)
- Lab 5b Learn steps for core build + bundle-check

## Verification

```text
bundle-check: 408631 bytes (0.61% of 64 MiB) PASS
smoke: PASS (audit hash + clawql-core/streams-slim)
vitest streams-slim.test.ts: 2 passed
```

Webhook spawn returns `audit.clawqlCore.ok: true` with genesis-linked hash and `core.inProcess: ["audit","cache","hash-chain"]`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8f57-601a-7ec1-bff0-d35011fef4ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8f57-601a-7ec1-bff0-d35011fef4ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

