### PR TITLE
feat(streams): fetch memory_ingest/recall via MCP from celld

### DIFF
--- a/charts/clawql-mcp/values-streams-celld.example.yaml
+++ b/charts/clawql-mcp/values-streams-celld.example.yaml
@@ -34,8 +34,9 @@ inference:
 
 enableMemory: true
 
-# Cells call inference over HTTP and search/execute via Streamable HTTP MCP
+# Cells call inference over HTTP and search/execute/memory_* via Streamable HTTP MCP
 # (CLAWQL_MCP_URL → in-cluster clawql-mcp /mcp, MCP 2026-07-28 preferred).
 # Prefer CLAWQL_STREAMABLE_HTTP_JSON_RESPONSE=1 on MCP for simpler Worker parsing.
+# Host needs CLAWQL_OBSIDIAN_VAULT_PATH (writable) for real memory_ingest/recall.
 nats:
   enabled: false

--- a/docs/streams/clawql-celld.md
+++ b/docs/streams/clawql-celld.md
@@ -210,17 +210,17 @@ celld deploy (esbuild)
   └─ Worker + DO classes
         ├─ clawql-streams (router, filter, stream_* MCP) — planned package
         ├─ clawql-core/streams-slim (audit, cache, hash-chain) — Workers-safe entry
-        └─ fetch(CLAWQL_MCP_URL) → clawql-mcp search/execute (Streamable HTTP)
-             · memory_* / mcp-api-adapter still host-side or deferred
+        └─ fetch(CLAWQL_MCP_URL) → clawql-mcp search/execute/memory_* (Streamable HTTP)
+             · mcp-api-adapter still host-side or deferred
   env / vars ≤ 1 MiB
   code ≤ 64 MiB
 ```
 
 **In-process today:** `AgentSessionDO` imports [`clawql-core/streams-slim`](../../packages/clawql-core/README.md) for hash-chained `audit` + session `cache`. Example: [`examples/streams-celld`](../../examples/streams-celld/).
 
-**Out-of-process today:** `search` / `execute` via thin `fetch` to Streamable HTTP MCP (`CLAWQL_MCP_URL`, prefer protocol **2026-07-28** / JSON responses). Inference via `fetch(INFERENCE_URL)`. Do **not** embed full `clawql-api` or the full `clawql-core` barrel (`webmcp-draft` / `node:fs`).
+**Out-of-process today:** `search` / `execute` / `memory_ingest` / `memory_recall` via thin `fetch` to Streamable HTTP MCP (`CLAWQL_MCP_URL`, prefer protocol **2026-07-28** / JSON responses). Inference via `fetch(INFERENCE_URL)`. Do **not** embed full `clawql-api`, `clawql-memory`, or the full `clawql-core` barrel (`webmcp-draft` / `node:fs`).
 
-**Still deferred:** durable `memory_*` vault IO unless exposed on the MCP host; protocol fan-out (`mcp-api-adapter`).
+**Still deferred:** protocol fan-out (`mcp-api-adapter`).
 
 **Provider specs:** ship a **slim default set** in the bundle; load additional OpenAPI/GraphQL specs via `fetch` into SQLite on first use or at subscription create — do not embed full enterprise catalogs in env.
 

--- a/examples/streams-celld/README.md
+++ b/examples/streams-celld/README.md
@@ -19,12 +19,12 @@ Minimal **Workers / Durable Objects** bundle for [ClawQL Streams](https://docs.c
 | Hash-chain verify | **In-process** — via clawql-merkle (needs `nodejs_compat`) |
 | Inference | **Out-of-process** — `fetch(INFERENCE_URL)` |
 | `search` / `execute` | **Out-of-process** — `fetch(CLAWQL_MCP_URL)` Streamable HTTP (`tools/call`, MCP **2026-07-28** preferred) |
-| `memory_*` | **Deferred** — clawql-memory + vault (or MCP when enabled) |
+| `memory_ingest` / `memory_recall` | **Out-of-process** — same MCP fetch path (vault stays on the host) |
 | `mcp-api-adapter` | **Deferred** — Node Express/gRPC host |
 
-`streams-slim` **excludes** `webmcp-draft` (`node:fs`), cuckoo, Loki, and plugin dynamic loaders. Full **`clawql-api` is not embedded** (disk-backed specs + gRPC) — cells call the MCP host instead.
+`streams-slim` **excludes** `webmcp-draft` (`node:fs`), cuckoo, Loki, and plugin dynamic loaders. Full **`clawql-api` / `clawql-memory` are not embedded** — cells call the MCP host instead.
 
-Set `CLAWQL_MCP_URL` (and optional `CLAWQL_MCP_BEARER_TOKEN`) in Wrangler `vars` / fleet env. When unset, `tools.search` / `tools.execute` return `{ deferred: true, … }`. Prefer `CLAWQL_STREAMABLE_HTTP_JSON_RESPONSE=1` on clawql-mcp so POSTs return JSON (Workers still parse SSE `data:` lines).
+Set `CLAWQL_MCP_URL` (and optional `CLAWQL_MCP_BEARER_TOKEN`) in Wrangler `vars` / fleet env. When unset, MCP tools return `{ deferred: true, … }`. Prefer `CLAWQL_STREAMABLE_HTTP_JSON_RESPONSE=1` on clawql-mcp so POSTs return JSON (Workers still parse SSE `data:` lines).
 
 ## Prerequisites
 
@@ -49,7 +49,7 @@ curl -s -X POST http://127.0.0.1:9876/webhook/demo-lab \
   -d '{"hello":"streams"}' | jq '.session.audit, .session.core, .session.tools'
 ```
 
-Expect `audit.clawqlCore.ok: true`, a hash-chain `verify.ok: true`, and `core.package: "clawql-core/streams-slim"`. With `CLAWQL_MCP_URL` set, `tools.search.ok` / `tools.execute.ok` should be true.
+Expect `audit.clawqlCore.ok: true`, a hash-chain `verify.ok: true`, and `core.package: "clawql-core/streams-slim"`. With `CLAWQL_MCP_URL` set, `tools.search` / `tools.execute` / `tools.memory_ingest` / `tools.memory_recall` should succeed via Streamable HTTP.
 
 ## Bundle size gate (64 MiB Workers limit)
 
@@ -77,4 +77,4 @@ Helm injects `CLAWQL_MCP_URL` (in-cluster `/mcp`) and `INFERENCE_URL` when the s
 
 - Optional Workers-safe slim `clawql-api` for offline/in-cell search without network
 - Persist isolate audit ring beyond process memory (LTX WORM on fleet bucket already covers DO `storage.put` rows)
-- Wire `memory_*` via the same MCP fetch path when vault is available on the host
+- Optional `mcp-api-adapter` protocol fan-out still host-side

--- a/examples/streams-celld/scripts/mock-mcp-server.mjs
+++ b/examples/streams-celld/scripts/mock-mcp-server.mjs
@@ -1,12 +1,16 @@
 #!/usr/bin/env node
 /**
- * Minimal Streamable HTTP MCP stub for Lab 5b smoke (search + execute).
+ * Minimal Streamable HTTP MCP stub for Lab 5b smoke
+ * (search + execute + memory_ingest + memory_recall).
  * Speaks MCP 2026-07-28-style JSON JSON-RPC tools/call — no SDK.
  */
 import { createServer } from "node:http";
 
 const port = Number(process.env.MOCK_MCP_PORT || process.argv[2] || 9891);
 const path = "/mcp";
+
+/** @type {Map<string, { title: string, insights: string }>} */
+const vault = new Map();
 
 const server = createServer(async (req, res) => {
   const url = new URL(req.url || "/", `http://127.0.0.1:${port}`);
@@ -74,6 +78,44 @@ const server = createServer(async (req, res) => {
         operationId: args.operationId,
         args: args.args ?? {},
         result: { status: "noop" },
+      };
+    } else if (name === "memory_ingest") {
+      const title = String(args.title || "untitled");
+      const insights = String(args.insights || "");
+      vault.set(title, { title, insights });
+      payload = {
+        ok: true,
+        source: "mock-mcp",
+        path: `Memory/${title.replace(/\s+/g, "-").toLowerCase()}.md`,
+        title,
+      };
+    } else if (name === "memory_recall") {
+      const query = String(args.query || "").toLowerCase();
+      const results = [...vault.values()]
+        .filter(
+          (n) =>
+            n.title.toLowerCase().includes(query) ||
+            n.insights.toLowerCase().includes(query) ||
+            query.includes("streams")
+        )
+        .slice(0, Number(args.limit) || 5)
+        .map((n) => ({
+          path: `Memory/${n.title.replace(/\s+/g, "-").toLowerCase()}.md`,
+          score: 1,
+          snippet: n.insights.slice(0, 120),
+        }));
+      if (results.length === 0) {
+        results.push({
+          path: "Memory/streams-celld-session.md",
+          score: 0.5,
+          snippet: "mock recall hit for streams-celld",
+        });
+      }
+      payload = {
+        ok: true,
+        source: "mock-mcp",
+        query: args.query,
+        results,
       };
     } else {
       res.writeHead(200, { "content-type": "application/json" });

--- a/examples/streams-celld/scripts/smoke.sh
+++ b/examples/streams-celld/scripts/smoke.sh
@@ -17,7 +17,7 @@ fi
 node "$ROOT/scripts/bundle-check.mjs"
 node "$ROOT/scripts/mcp-fetch.test.mjs"
 
-# Mock MCP for search/execute (stateless JSON tools/call).
+# Mock MCP for search/execute/memory_* (stateless JSON tools/call).
 node "$ROOT/scripts/mock-mcp-server.mjs" "$MCP_PORT" &
 MCP_PID=$!
 
@@ -54,9 +54,10 @@ done
 
 curl -sf "$BASE/health" | grep -q clawql-streams-celld-skeleton
 
+EVENT_ID="smoke-mcp-$(date +%s)-$$"
 RESP=$(curl -sf -X POST "$BASE/webhook/smoke" \
   -H 'content-type: application/json' \
-  -H 'x-clawql-event-id: smoke-mcp-1' \
+  -H "x-clawql-event-id: ${EVENT_ID}" \
   -d '{"probe":true}')
 
 fail() {
@@ -72,5 +73,8 @@ echo "$RESP" | grep -q 'streams:session:' || fail "expected cache session key"
 echo "$RESP" | grep -q 'streamable-http' || fail "expected MCP streamable-http transport"
 echo "$RESP" | grep -q '"source":"mock-mcp"' || fail "expected mock-mcp search/execute payload"
 echo "$RESP" | grep -q '"mcpUrlConfigured":true' || fail "expected mcpUrlConfigured true"
+echo "$RESP" | grep -q 'memory_ingest' || fail "expected memory_ingest tool result"
+echo "$RESP" | grep -q 'memory_recall' || fail "expected memory_recall tool result"
+echo "$RESP" | grep -q 'memory_\*' || fail "expected memory_* in core surface list"
 
 echo "smoke: PASS"

--- a/examples/streams-celld/src/agent-session-do.js
+++ b/examples/streams-celld/src/agent-session-do.js
@@ -1,12 +1,14 @@
 /**
  * AgentSessionDO — ephemeral session with in-cell clawql-core (streams-slim)
- * plus optional fetch(CLAWQL_MCP_URL) for search/execute.
+ * plus optional fetch(CLAWQL_MCP_URL) for search/execute/memory_*.
  * Model calls use fetch(INFERENCE_URL) — never child_process.
  */
 import {
   appendSessionCreatedAudit,
   cacheSessionMeta,
   executeViaMcp,
+  memoryIngestViaMcp,
+  memoryRecallViaMcp,
   searchViaMcp,
   verifyAuditChain,
 } from "./streams-core-facade.js";
@@ -110,15 +112,30 @@ export class AgentSessionDO {
       }
 
       const mcp = resolveMcpConfig(this.env);
+      const memoryTitle = `streams-celld session ${eventId.slice(0, 8)}`;
       const tools = {
         search: await searchViaMcp(mcp, `subscription:${subscriptionId}`, {
           limit: 3,
         }),
         execute: await executeViaMcp(mcp, "streams.session.noop", { eventId }),
+        memory_ingest: await memoryIngestViaMcp(mcp, {
+          title: memoryTitle,
+          insights: `AgentSessionDO spawned subscription=${subscriptionId} event=${eventId}`,
+          sessionId: eventId,
+          type: "context",
+          tags: ["streams", "celld"],
+        }),
+        memory_recall: await memoryRecallViaMcp(
+          mcp,
+          `streams-celld ${subscriptionId}`,
+          { limit: 3 }
+        ),
       };
       await this.state.storage.put(`tool_calls:${startedAt}`, {
         searchOk: tools.search?.ok === true,
         executeOk: tools.execute?.ok === true,
+        memoryIngestOk: tools.memory_ingest?.ok === true,
+        memoryRecallOk: tools.memory_recall?.ok === true,
         deferred: !mcp.url,
       });
 
@@ -137,10 +154,10 @@ export class AgentSessionDO {
           package: "clawql-core/streams-slim",
           inProcess: ["audit", "cache", "hash-chain"],
           outOfProcess: mcp.url
-            ? ["search", "execute", "inference"]
+            ? ["search", "execute", "memory_*", "inference"]
             : ["inference"],
           deferred: mcp.url
-            ? ["memory_*", "mcp-api-adapter"]
+            ? ["mcp-api-adapter"]
             : ["search", "execute", "memory_*", "mcp-api-adapter"],
           mcpUrlConfigured: Boolean(mcp.url),
         },

--- a/examples/streams-celld/src/streams-core-facade.js
+++ b/examples/streams-celld/src/streams-core-facade.js
@@ -7,9 +7,9 @@
  *
  * Out-of-process via fetch(CLAWQL_MCP_URL) Streamable HTTP:
  * - search / execute → clawql-mcp (clawql-api on the host)
+ * - memory_ingest / memory_recall → clawql-mcp (clawql-memory + vault on host)
  *
  * Still deferred:
- * - memory_ingest / memory_recall → clawql-memory + vault (or MCP when enabled)
  * - inference completions → fetch(INFERENCE_URL)
  * - mcp-api-adapter protocol surfaces → Node Express/gRPC host
  */
@@ -72,6 +72,39 @@ export async function executeViaMcp(mcp, operationId, args = {}) {
     { url: mcp.url ?? "", bearer: mcp.bearer },
     "execute",
     { operationId, args }
+  );
+}
+
+/**
+ * Persist a short vault note via host memory_ingest (MCP).
+ * @param {{ url?: string, bearer?: string }} mcp
+ * @param {{ title: string, insights: string, sessionId?: string, type?: string, tags?: string[] }} input
+ */
+export async function memoryIngestViaMcp(mcp, input) {
+  return callMcpTool(
+    { url: mcp.url ?? "", bearer: mcp.bearer },
+    "memory_ingest",
+    {
+      title: input.title,
+      insights: input.insights,
+      ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+      ...(input.type ? { type: input.type } : {}),
+      ...(input.tags ? { tags: input.tags } : {}),
+    }
+  );
+}
+
+/**
+ * Recall vault context via host memory_recall (MCP).
+ * @param {{ url?: string, bearer?: string }} mcp
+ * @param {string} query
+ * @param {{ limit?: number }} [opts]
+ */
+export async function memoryRecallViaMcp(mcp, query, opts = {}) {
+  return callMcpTool(
+    { url: mcp.url ?? "", bearer: mcp.bearer },
+    "memory_recall",
+    { query, limit: opts.limit ?? 5 }
   );
 }
 

--- a/packages/clawql-core/README.md
+++ b/packages/clawql-core/README.md
@@ -35,6 +35,6 @@ Workers-safe subset for Durable Object cells (no `webmcp-draft` / `node:fs`, no 
 import { runAuditOperation, runCacheOperation } from "clawql-core/streams-slim";
 ```
 
-Requires celld / Workers **`nodejs_compat`** for `node:crypto` + `Buffer` (hash-chain). Search / execute stay on the MCP host via cell `fetch(CLAWQL_MCP_URL)` (Streamable HTTP) — they are not in this package. Example: [`examples/streams-celld`](../../examples/streams-celld/).
+Requires celld / Workers **`nodejs_compat`** for `node:crypto` + `Buffer` (hash-chain). Search / execute / memory stay on the MCP host via cell `fetch(CLAWQL_MCP_URL)` (Streamable HTTP) — they are not in this package. Example: [`examples/streams-celld`](../../examples/streams-celld/).
 
 **8.0 hard break:** Phase-2 `Plugin` / `beforeCallTool` and any compatibility bridge are removed — rewrite against `ProviderPlugin`.

--- a/website/src/app/learn/streams-getting-started/page.mdx
+++ b/website/src/app/learn/streams-getting-started/page.mdx
@@ -423,7 +423,7 @@ clawql streams celld bundle-check
 
 Expect ≈ **0.4 MiB** (~0.6% of the **64 MiB** Workers limit). The full `clawql-core` barrel is **not** used — it would pull `webmcp-draft` (`node:fs`).
 
-Webhook responses include `session.audit.clawqlCore` (hash-chained append) and `session.core.inProcess: ["audit","cache","hash-chain"]`. With **`CLAWQL_MCP_URL`** set, `session.tools.search` / `session.tools.execute` call Streamable HTTP MCP (`tools/call`, prefer protocol **2026-07-28**). When unset, those tools return `{ deferred: true }`. Full `clawql-api` stays on the MCP host — not in the Worker bundle.
+Webhook responses include `session.audit.clawqlCore` (hash-chained append) and `session.core.inProcess: ["audit","cache","hash-chain"]`. With **`CLAWQL_MCP_URL`** set, `session.tools.search` / `execute` / `memory_ingest` / `memory_recall` call Streamable HTTP MCP (`tools/call`, prefer protocol **2026-07-28**). When unset, those tools return `{ deferred: true }`. Full `clawql-api` / vault IO stay on the MCP host — not in the Worker bundle.
 
 Smoke with a mock MCP: `bash examples/streams-celld/scripts/smoke.sh`.
 

--- a/website/src/generated/clawql-celld-body.mdx
+++ b/website/src/generated/clawql-celld-body.mdx
@@ -210,17 +210,17 @@ celld deploy (esbuild)
   └─ Worker + DO classes
         ├─ clawql-streams (router, filter, stream_* MCP) — planned package
         ├─ clawql-core/streams-slim (audit, cache, hash-chain) — Workers-safe entry
-        └─ fetch(CLAWQL_MCP_URL) → clawql-mcp search/execute (Streamable HTTP)
-             · memory_* / mcp-api-adapter still host-side or deferred
+        └─ fetch(CLAWQL_MCP_URL) → clawql-mcp search/execute/memory_* (Streamable HTTP)
+             · mcp-api-adapter still host-side or deferred
   env / vars ≤ 1 MiB
   code ≤ 64 MiB
 ```
 
 **In-process today:** `AgentSessionDO` imports [`clawql-core/streams-slim`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/packages/clawql-core/README.md) for hash-chained `audit` + session `cache`. Example: [`examples/streams-celld`](../../examples/streams-celld/).
 
-**Out-of-process today:** `search` / `execute` via thin `fetch` to Streamable HTTP MCP (`CLAWQL_MCP_URL`, prefer protocol **2026-07-28** / JSON responses). Inference via `fetch(INFERENCE_URL)`. Do **not** embed full `clawql-api` or the full `clawql-core` barrel (`webmcp-draft` / `node:fs`).
+**Out-of-process today:** `search` / `execute` / `memory_ingest` / `memory_recall` via thin `fetch` to Streamable HTTP MCP (`CLAWQL_MCP_URL`, prefer protocol **2026-07-28** / JSON responses). Inference via `fetch(INFERENCE_URL)`. Do **not** embed full `clawql-api`, `clawql-memory`, or the full `clawql-core` barrel (`webmcp-draft` / `node:fs`).
 
-**Still deferred:** durable `memory_*` vault IO unless exposed on the MCP host; protocol fan-out (`mcp-api-adapter`).
+**Still deferred:** protocol fan-out (`mcp-api-adapter`).
 
 **Provider specs:** ship a **slim default set** in the bundle; load additional OpenAPI/GraphQL specs via `fetch` into SQLite on first use or at subscription create — do not embed full enterprise catalogs in env.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After [#1044](https://github.com/danielsmithdevelopment/ClawQL/pull/1044), cells also call **`memory_ingest` / `memory_recall`** via the same thin `fetch(CLAWQL_MCP_URL)` Streamable HTTP path. Vault IO stays on the MCP host (`CLAWQL_OBSIDIAN_VAULT_PATH`).

## Changes

- `memoryIngestViaMcp` / `memoryRecallViaMcp` in `streams-core-facade.js`
- `AgentSessionDO` records memory tool calls on spawn; `core.outOfProcess` includes `memory_*`
- Mock MCP + smoke assert ingest/recall
- Docs / Lab 5b / Helm example comments

## Evidence

Smoke PASS; bundle still ~0.41 MiB.

[streams_celld_memory_mcp_webhook.json](https://cursor.com/agents/bc-019f8f57-601a-7ec1-bff0-d35011fef4ec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstreams_celld_memory_mcp_webhook.json)

## Test plan

- [x] `bash examples/streams-celld/scripts/smoke.sh`
- [ ] CI green then merge-after-green

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8f57-601a-7ec1-bff0-d35011fef4ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8f57-601a-7ec1-bff0-d35011fef4ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

