### PR TITLE
feat(streams): fetch mcp-api-adapter REST from celld AgentSessionDO

### DIFF
--- a/charts/clawql-mcp/templates/_helpers.tpl
+++ b/charts/clawql-mcp/templates/_helpers.tpl
@@ -446,6 +446,15 @@ app.kubernetes.io/component: streams-celld
 {{- end -}}
 {{- end }}
 
+{{/* Optional mcp-api-adapter REST origin for celld Workers (CLAWQL_MCP_ADAPTER_URL). */}}
+{{- define "clawql-mcp.celldAdapterUrl" -}}
+{{- if .Values.streams.celld.adapterUrl -}}
+{{- .Values.streams.celld.adapterUrl -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end }}
+
 {{/* Optional Managed Edge Gateway nginx (one hostname for /mcp + /v1). */}}
 {{- define "clawql-mcp.managedGatewayName" -}}
 {{- printf "%s-managed-gateway" (include "clawql-mcp.fullname" .) | trunc 63 | trimSuffix "-" }}

--- a/charts/clawql-mcp/templates/celld-stack.yaml
+++ b/charts/clawql-mcp/templates/celld-stack.yaml
@@ -106,6 +106,11 @@ spec:
             - name: CLAWQL_MCP_URL
               value: {{ $mcpUrl | quote }}
             {{- end }}
+            {{- $adapterUrl := include "clawql-mcp.celldAdapterUrl" . }}
+            {{- if $adapterUrl }}
+            - name: CLAWQL_MCP_ADAPTER_URL
+              value: {{ $adapterUrl | quote }}
+            {{- end }}
             {{- with .Values.streams.celld.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/clawql-mcp/values-streams-celld.example.yaml
+++ b/charts/clawql-mcp/values-streams-celld.example.yaml
@@ -34,8 +34,8 @@ inference:
 
 enableMemory: true
 
-# Cells call inference over HTTP and search/execute/memory_* via Streamable HTTP MCP
-# (CLAWQL_MCP_URL → in-cluster clawql-mcp /mcp, MCP 2026-07-28 preferred).
+# Cells call inference over HTTP, search/execute/memory_* via Streamable HTTP MCP,
+# and optional mcp-api-adapter REST via streams.celld.adapterUrl → CLAWQL_MCP_ADAPTER_URL.
 # Prefer CLAWQL_STREAMABLE_HTTP_JSON_RESPONSE=1 on MCP for simpler Worker parsing.
 # Host needs CLAWQL_OBSIDIAN_VAULT_PATH (writable) for real memory_ingest/recall.
 nats:

--- a/charts/clawql-mcp/values.yaml
+++ b/charts/clawql-mcp/values.yaml
@@ -1056,6 +1056,9 @@ streams:
     # Worker CLAWQL_MCP_URL for search/execute (Streamable HTTP). Empty → in-cluster MCP
     # (or mcpProxy when enabled). Set to "" only via extraEnv override if cells must not call MCP.
     mcpUrl: ""
+    # Optional mcp-api-adapter REST origin (POST /{tool}). Empty → not injected (no chart Service yet).
+    # Example: http://mcp-api-adapter.clawql.svc.cluster.local:8090
+    adapterUrl: ""
     service:
       type: ClusterIP
       workerPort: 8080

--- a/docs/streams/clawql-celld.md
+++ b/docs/streams/clawql-celld.md
@@ -210,17 +210,17 @@ celld deploy (esbuild)
   └─ Worker + DO classes
         ├─ clawql-streams (router, filter, stream_* MCP) — planned package
         ├─ clawql-core/streams-slim (audit, cache, hash-chain) — Workers-safe entry
-        └─ fetch(CLAWQL_MCP_URL) → clawql-mcp search/execute/memory_* (Streamable HTTP)
-             · mcp-api-adapter still host-side or deferred
+        ├─ fetch(CLAWQL_MCP_URL) → clawql-mcp search/execute/memory_* (Streamable HTTP)
+        └─ fetch(CLAWQL_MCP_ADAPTER_URL) → mcp-api-adapter REST POST /{tool}
   env / vars ≤ 1 MiB
   code ≤ 64 MiB
 ```
 
 **In-process today:** `AgentSessionDO` imports [`clawql-core/streams-slim`](../../packages/clawql-core/README.md) for hash-chained `audit` + session `cache`. Example: [`examples/streams-celld`](../../examples/streams-celld/).
 
-**Out-of-process today:** `search` / `execute` / `memory_ingest` / `memory_recall` via thin `fetch` to Streamable HTTP MCP (`CLAWQL_MCP_URL`, prefer protocol **2026-07-28** / JSON responses). Inference via `fetch(INFERENCE_URL)`. Do **not** embed full `clawql-api`, `clawql-memory`, or the full `clawql-core` barrel (`webmcp-draft` / `node:fs`).
+**Out-of-process today:** `search` / `execute` / `memory_*` via Streamable HTTP MCP (`CLAWQL_MCP_URL`). Optional protocol-fabric REST via `CLAWQL_MCP_ADAPTER_URL` (`POST /{tool}` on mcp-api-adapter). Inference via `fetch(INFERENCE_URL)`. Do **not** embed full `clawql-api`, `clawql-memory`, `mcp-api-adapter`, or the full `clawql-core` barrel (`webmcp-draft` / `node:fs`).
 
-**Still deferred:** protocol fan-out (`mcp-api-adapter`).
+**Still deferred:** offline Workers-safe `clawql-api` slim; durable isolate audit ring → DO LTX (WORM rows already use `storage.put`).
 
 **Provider specs:** ship a **slim default set** in the bundle; load additional OpenAPI/GraphQL specs via `fetch` into SQLite on first use or at subscription create — do not embed full enterprise catalogs in env.
 

--- a/examples/streams-celld/README.md
+++ b/examples/streams-celld/README.md
@@ -1,12 +1,12 @@
-# ClawQL Streams — celld skeleton + clawql-core + MCP fetch (Lab 5b)
+# ClawQL Streams — celld skeleton + clawql-core + MCP/adapter fetch (Lab 5b)
 
-Minimal **Workers / Durable Objects** bundle for [ClawQL Streams](https://docs.clawql.com/streams/clawql-streams) on **[celld v0.4.0](https://github.com/denoland/celld/releases/tag/v0.4.0)**, with in-process **`clawql-core/streams-slim`** and optional **`fetch(CLAWQL_MCP_URL)`** for `search` / `execute`.
+Minimal **Workers / Durable Objects** bundle for [ClawQL Streams](https://docs.clawql.com/streams/clawql-streams) on **[celld v0.4.0](https://github.com/denoland/celld/releases/tag/v0.4.0)**, with in-process **`clawql-core/streams-slim`**, optional **`fetch(CLAWQL_MCP_URL)`**, and optional **`fetch(CLAWQL_MCP_ADAPTER_URL)`**.
 
 | DO class | Role |
 | -------- | ---- |
 | `GatewayDO` | Webhook ingress (`POST /webhook/{subscriptionId}`), spawn sessions |
 | `SubscriptionDO` | Significance filter stub (`sub:{id}` naming) |
-| `AgentSessionDO` | Session + WORM row + **audit/cache** via streams-slim + optional `fetch(INFERENCE_URL)` + optional `fetch(CLAWQL_MCP_URL)` |
+| `AgentSessionDO` | Session + WORM + audit/cache + optional MCP / adapter / inference fetches |
 
 **Learn walkthrough:** [Streams getting started — Lab 5b](https://docs.clawql.com/learn/streams-getting-started#lab-5b--clawql-streams-wrangler-skeleton--bundle-check-30-min)
 
@@ -18,13 +18,16 @@ Minimal **Workers / Durable Objects** bundle for [ClawQL Streams](https://docs.c
 | `cache` (session scratch) | **In-process** — `clawql-core/streams-slim` |
 | Hash-chain verify | **In-process** — via clawql-merkle (needs `nodejs_compat`) |
 | Inference | **Out-of-process** — `fetch(INFERENCE_URL)` |
-| `search` / `execute` | **Out-of-process** — `fetch(CLAWQL_MCP_URL)` Streamable HTTP (`tools/call`, MCP **2026-07-28** preferred) |
-| `memory_ingest` / `memory_recall` | **Out-of-process** — same MCP fetch path (vault stays on the host) |
-| `mcp-api-adapter` | **Deferred** — Node Express/gRPC host |
+| `search` / `execute` / `memory_*` | **Out-of-process** — `fetch(CLAWQL_MCP_URL)` Streamable HTTP |
+| `mcp-api-adapter` | **Out-of-process** — `fetch(CLAWQL_MCP_ADAPTER_URL)` REST `POST /{tool}` |
 
-`streams-slim` **excludes** `webmcp-draft` (`node:fs`), cuckoo, Loki, and plugin dynamic loaders. Full **`clawql-api` / `clawql-memory` are not embedded** — cells call the MCP host instead.
+Do **not** embed `clawql-api`, `clawql-memory`, or `mcp-api-adapter` (Express/gRPC/`node:fs`).
 
-Set `CLAWQL_MCP_URL` (and optional `CLAWQL_MCP_BEARER_TOKEN`) in Wrangler `vars` / fleet env. When unset, MCP tools return `{ deferred: true, … }`. Prefer `CLAWQL_STREAMABLE_HTTP_JSON_RESPONSE=1` on clawql-mcp so POSTs return JSON (Workers still parse SSE `data:` lines).
+| Env | Meaning |
+| --- | ------- |
+| `CLAWQL_MCP_URL` | Streamable HTTP MCP endpoint (usually `…/mcp`) |
+| `CLAWQL_MCP_ADAPTER_URL` | Adapter **origin** only (e.g. `http://127.0.0.1:8090`) |
+| `CLAWQL_MCP_BEARER_TOKEN` / `CLAWQL_MCP_ADAPTER_BEARER_TOKEN` | Optional Bearer |
 
 ## Prerequisites
 
@@ -32,49 +35,28 @@ Set `CLAWQL_MCP_URL` (and optional `CLAWQL_MCP_BEARER_TOKEN`) in Wrangler `vars`
 - [esbuild](https://esbuild.github.io/) on `PATH`
 - Workspace packages built: `npm run build -w clawql-merkle -w clawql-core`
 
-## Local dev (`celld dev`)
+## Local dev / smoke
 
 ```bash
 cd examples/streams-celld
 celld dev --port 9876
+# smoke (mock MCP + mock adapter):
+bash scripts/smoke.sh
 ```
-
-Another terminal:
-
-```bash
-curl -s http://127.0.0.1:9876/health | jq .
-curl -s -X POST http://127.0.0.1:9876/webhook/demo-lab \
-  -H 'content-type: application/json' \
-  -H 'x-clawql-event-id: lab-event-1' \
-  -d '{"hello":"streams"}' | jq '.session.audit, .session.core, .session.tools'
-```
-
-Expect `audit.clawqlCore.ok: true`, a hash-chain `verify.ok: true`, and `core.package: "clawql-core/streams-slim"`. With `CLAWQL_MCP_URL` set, `tools.search` / `tools.execute` / `tools.memory_ingest` / `tools.memory_recall` should succeed via Streamable HTTP.
 
 ## Bundle size gate (64 MiB Workers limit)
 
 ```bash
 node scripts/bundle-check.mjs
-# or: clawql streams celld bundle-check --project examples/streams-celld
 ```
 
-Typical size with Effect + streams-slim ≈ **0.4 MiB** (~0.6% of limit). The MCP client is a few KB of `fetch` — no SDK.
-
-## Smoke (mock MCP)
-
-```bash
-npm run smoke -w @clawql/example-streams-celld
-# or: bash examples/streams-celld/scripts/smoke.sh
-```
-
-Starts a mock Streamable HTTP MCP, runs `celld dev` with `CLAWQL_MCP_URL` pointed at it, and asserts search/execute payloads.
+Typical size ≈ **0.4 MiB**. MCP + adapter clients are thin `fetch` helpers.
 
 ## Fleet deploy / Helm
 
-Helm injects `CLAWQL_MCP_URL` (in-cluster `/mcp`) and `INFERENCE_URL` when the streams-celld overlay is enabled. See [`deployment/samples/streams-celld/`](../../deployment/samples/streams-celld/README.md) and `clawql streams celld deploy`.
+Helm injects `CLAWQL_MCP_URL` + `INFERENCE_URL`. Set `streams.celld.adapterUrl` when an adapter Service is available (not charted by default). See [`deployment/samples/streams-celld/`](../../deployment/samples/streams-celld/README.md).
 
 ## Next steps
 
-- Optional Workers-safe slim `clawql-api` for offline/in-cell search without network
-- Persist isolate audit ring beyond process memory (LTX WORM on fleet bucket already covers DO `storage.put` rows)
-- Optional `mcp-api-adapter` protocol fan-out still host-side
+- Persist isolate audit ring beyond process memory into DO LTX storage
+- Optional Workers-safe slim `clawql-api` for offline/in-cell search

--- a/examples/streams-celld/package.json
+++ b/examples/streams-celld/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "bundle-check": "node scripts/bundle-check.mjs",
     "test:mcp-fetch": "node scripts/mcp-fetch.test.mjs",
+    "test:adapter-fetch": "node scripts/adapter-fetch.test.mjs",
     "dev": "celld dev --port 9876",
     "smoke": "bash scripts/smoke.sh"
   },

--- a/examples/streams-celld/scripts/adapter-fetch.test.mjs
+++ b/examples/streams-celld/scripts/adapter-fetch.test.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Unit checks for adapter-fetch (no celld required).
+ */
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { callAdapterTool } from "../src/adapter-fetch.js";
+
+async function testDeferredWhenUnset() {
+  const out = await callAdapterTool({ url: "" }, "search", { query: "x" });
+  assert.equal(out.deferred, true);
+  assert.equal(out.ok, false);
+}
+
+async function testCallAdapterTool() {
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (c) => (body += c));
+    req.on("end", () => {
+      assert.equal(req.method, "POST");
+      assert.equal(req.url, "/search");
+      const parsed = JSON.parse(body);
+      assert.equal(parsed.query, "hello");
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, source: "unit", query: parsed.query }));
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = /** @type {import('node:net').AddressInfo} */ (server.address());
+  const out = await callAdapterTool(
+    { url: `http://127.0.0.1:${port}` },
+    "search",
+    { query: "hello", limit: 1 }
+  );
+  assert.equal(out.ok, true);
+  assert.equal(out.transport, "mcp-api-adapter-rest");
+  assert.equal(out.parsed?.query, "hello");
+  server.close();
+  await once(server, "close");
+}
+
+await testDeferredWhenUnset();
+await testCallAdapterTool();
+console.log("adapter-fetch.test: PASS");

--- a/examples/streams-celld/scripts/mock-adapter-server.mjs
+++ b/examples/streams-celld/scripts/mock-adapter-server.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Minimal mcp-api-adapter REST stub for Lab 5b smoke (POST /{tool}).
+ */
+import { createServer } from "node:http";
+
+const port = Number(process.env.MOCK_ADAPTER_PORT || process.argv[2] || 9892);
+const tools = new Set(["search", "execute", "memory_ingest", "memory_recall"]);
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url || "/", `http://127.0.0.1:${port}`);
+  if (req.method === "GET" && url.pathname === "/healthz") {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ok: true, transport: "mock-adapter", toolCount: tools.size }));
+    return;
+  }
+  if (req.method !== "POST") {
+    res.writeHead(404).end("not found");
+    return;
+  }
+
+  const name = url.pathname.replace(/^\//, "");
+  if (!tools.has(name)) {
+    res.writeHead(404, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: `unknown tool: ${name}` }));
+    return;
+  }
+
+  const chunks = [];
+  for await (const c of req) chunks.push(c);
+  let args = {};
+  try {
+    args = JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+  } catch {
+    res.writeHead(400).end("bad json");
+    return;
+  }
+
+  let payload;
+  if (name === "search") {
+    payload = {
+      ok: true,
+      source: "mock-adapter",
+      query: args.query,
+      results: [{ operationId: "streams.session.noop", score: 1 }],
+    };
+  } else if (name === "execute") {
+    payload = {
+      ok: true,
+      source: "mock-adapter",
+      operationId: args.operationId,
+      result: { status: "noop" },
+    };
+  } else if (name === "memory_ingest") {
+    payload = {
+      ok: true,
+      source: "mock-adapter",
+      path: `Memory/${String(args.title || "note").replace(/\s+/g, "-").toLowerCase()}.md`,
+      title: args.title,
+    };
+  } else {
+    payload = {
+      ok: true,
+      source: "mock-adapter",
+      query: args.query,
+      results: [{ path: "Memory/streams-celld-session.md", score: 1, snippet: "adapter recall" }],
+    };
+  }
+
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify(payload));
+});
+
+server.listen(port, "127.0.0.1", () => {
+  console.log(`mock-adapter: http://127.0.0.1:${port}`);
+});

--- a/examples/streams-celld/scripts/smoke.sh
+++ b/examples/streams-celld/scripts/smoke.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# Smoke test for examples/streams-celld (Lab 5b + clawql-core + MCP fetch).
+# Smoke test for examples/streams-celld (Lab 5b + MCP + adapter fetch).
 # Requires celld v0.4.0 + esbuild on PATH; workspace clawql-core built.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PORT="${CELLD_DEV_PORT:-9880}"
 MCP_PORT="${MOCK_MCP_PORT:-9891}"
+ADAPTER_PORT="${MOCK_ADAPTER_PORT:-9892}"
 BASE="http://127.0.0.1:${PORT}"
 SMOKE_CFG="$ROOT/wrangler.smoke.jsonc"
 
@@ -16,21 +17,25 @@ fi
 
 node "$ROOT/scripts/bundle-check.mjs"
 node "$ROOT/scripts/mcp-fetch.test.mjs"
+node "$ROOT/scripts/adapter-fetch.test.mjs"
 
-# Mock MCP for search/execute/memory_* (stateless JSON tools/call).
+# Mock MCP + mcp-api-adapter REST.
 node "$ROOT/scripts/mock-mcp-server.mjs" "$MCP_PORT" &
 MCP_PID=$!
+node "$ROOT/scripts/mock-adapter-server.mjs" "$ADAPTER_PORT" &
+ADAPTER_PID=$!
 
-# Point Worker vars at mock MCP (celld accepts a Wrangler config path).
-python3 - "$ROOT/wrangler.jsonc" "$SMOKE_CFG" "$MCP_PORT" <<'PY'
+# Point Worker vars at mocks (celld accepts a Wrangler config path).
+python3 - "$ROOT/wrangler.jsonc" "$SMOKE_CFG" "$MCP_PORT" "$ADAPTER_PORT" <<'PY'
 import json, re, sys
-src, dst, port = sys.argv[1], sys.argv[2], sys.argv[3]
+src, dst, mcp_port, adapter_port = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
 text = open(src, encoding="utf-8").read()
 text = re.sub(r"/\*[\s\S]*?\*/", "", text)
 text = re.sub(r"^\s*//.*$", "", text, flags=re.M)
 cfg = json.loads(text)
 cfg.setdefault("vars", {})
-cfg["vars"]["CLAWQL_MCP_URL"] = f"http://127.0.0.1:{port}/mcp"
+cfg["vars"]["CLAWQL_MCP_URL"] = f"http://127.0.0.1:{mcp_port}/mcp"
+cfg["vars"]["CLAWQL_MCP_ADAPTER_URL"] = f"http://127.0.0.1:{adapter_port}"
 cfg["vars"]["INFERENCE_URL"] = cfg["vars"].get("INFERENCE_URL") or "http://127.0.0.1:8080"
 open(dst, "w", encoding="utf-8").write(json.dumps(cfg, indent=2) + "\n")
 PY
@@ -41,8 +46,10 @@ PID=$!
 cleanup() {
   kill "$PID" 2>/dev/null || true
   kill "$MCP_PID" 2>/dev/null || true
+  kill "$ADAPTER_PID" 2>/dev/null || true
   wait "$PID" 2>/dev/null || true
   wait "$MCP_PID" 2>/dev/null || true
+  wait "$ADAPTER_PID" 2>/dev/null || true
   rm -f "$SMOKE_CFG"
 }
 trap cleanup EXIT
@@ -76,5 +83,8 @@ echo "$RESP" | grep -q '"mcpUrlConfigured":true' || fail "expected mcpUrlConfigu
 echo "$RESP" | grep -q 'memory_ingest' || fail "expected memory_ingest tool result"
 echo "$RESP" | grep -q 'memory_recall' || fail "expected memory_recall tool result"
 echo "$RESP" | grep -q 'memory_\*' || fail "expected memory_* in core surface list"
+echo "$RESP" | grep -q 'mcp-api-adapter-rest' || fail "expected adapter REST transport"
+echo "$RESP" | grep -q '"source":"mock-adapter"' || fail "expected mock-adapter search payload"
+echo "$RESP" | grep -q '"adapterUrlConfigured":true' || fail "expected adapterUrlConfigured true"
 
 echo "smoke: PASS"

--- a/examples/streams-celld/src/adapter-fetch.js
+++ b/examples/streams-celld/src/adapter-fetch.js
@@ -1,0 +1,105 @@
+/**
+ * Tiny mcp-api-adapter REST client for celld / Workers.
+ * POST /{toolName} with JSON args — no Express/gRPC/SDK in the DO bundle.
+ */
+
+/** @typedef {{ url: string, bearer?: string, timeoutMs?: number }} AdapterFetchConfig */
+
+/**
+ * @param {AdapterFetchConfig} config
+ * @param {string} name
+ * @param {Record<string, unknown>} [args]
+ */
+export async function callAdapterTool(config, name, args = {}) {
+  const base = String(config.url || "").replace(/\/$/, "");
+  if (!base) {
+    return {
+      ok: false,
+      deferred: true,
+      tool: name,
+      reason: "CLAWQL_MCP_ADAPTER_URL unset — adapter REST stays on host",
+    };
+  }
+
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/.test(name)) {
+    return { ok: false, tool: name, error: "invalid tool name for adapter REST" };
+  }
+
+  /** @type {Record<string, string>} */
+  const headers = {
+    "content-type": "application/json",
+    accept: "application/json",
+  };
+  if (config.bearer) {
+    headers.authorization = `Bearer ${config.bearer}`;
+  }
+
+  const url = `${base}/${encodeURIComponent(name)}`;
+  const timeoutMs = config.timeoutMs ?? 15_000;
+  let res;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(args),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      tool: name,
+      error: err instanceof Error ? err.message : String(err),
+      transport: "mcp-api-adapter-rest",
+      url: base,
+    };
+  }
+
+  const rawText = await res.text();
+  let parsed = null;
+  if (rawText.trim()) {
+    try {
+      parsed = JSON.parse(rawText);
+    } catch {
+      parsed = { text: rawText.slice(0, 500) };
+    }
+  }
+
+  if (!res.ok) {
+    return {
+      ok: false,
+      tool: name,
+      error:
+        (parsed && typeof parsed === "object" && "error" in parsed
+          ? String(/** @type {{ error?: unknown }} */ (parsed).error)
+          : null) || `HTTP ${res.status}: ${rawText.slice(0, 500)}`,
+      transport: "mcp-api-adapter-rest",
+      url: base,
+      status: res.status,
+      parsed,
+    };
+  }
+
+  const isError =
+    parsed &&
+    typeof parsed === "object" &&
+    /** @type {{ isError?: boolean }} */ (parsed).isError === true;
+
+  return {
+    ok: !isError,
+    tool: name,
+    parsed,
+    transport: "mcp-api-adapter-rest",
+    url: base,
+    ...(isError
+      ? {
+          error:
+            (parsed &&
+            typeof parsed === "object" &&
+            "text" in parsed &&
+            typeof /** @type {{ text?: unknown }} */ (parsed).text === "string"
+              ? /** @type {{ text: string }} */ (parsed).text
+              : "adapter tool returned isError"),
+        }
+      : {}),
+  };
+}

--- a/examples/streams-celld/src/agent-session-do.js
+++ b/examples/streams-celld/src/agent-session-do.js
@@ -1,6 +1,6 @@
 /**
  * AgentSessionDO — ephemeral session with in-cell clawql-core (streams-slim)
- * plus optional fetch(CLAWQL_MCP_URL) for search/execute/memory_*.
+ * plus optional fetch(CLAWQL_MCP_URL) and fetch(CLAWQL_MCP_ADAPTER_URL).
  * Model calls use fetch(INFERENCE_URL) — never child_process.
  */
 import {
@@ -10,6 +10,7 @@ import {
   memoryIngestViaMcp,
   memoryRecallViaMcp,
   searchViaMcp,
+  toolViaAdapter,
   verifyAuditChain,
 } from "./streams-core-facade.js";
 
@@ -17,6 +18,14 @@ function resolveMcpConfig(env) {
   const url =
     (env.CLAWQL_MCP_URL || env.CLAWQL_MCP_HTTP_URL || "").trim() || undefined;
   const bearer = (env.CLAWQL_MCP_BEARER_TOKEN || "").trim() || undefined;
+  return { url, bearer };
+}
+
+function resolveAdapterConfig(env) {
+  const url = (env.CLAWQL_MCP_ADAPTER_URL || "").trim() || undefined;
+  const bearer =
+    (env.CLAWQL_MCP_ADAPTER_BEARER_TOKEN || env.CLAWQL_MCP_BEARER_TOKEN || "")
+      .trim() || undefined;
   return { url, bearer };
 }
 
@@ -112,6 +121,7 @@ export class AgentSessionDO {
       }
 
       const mcp = resolveMcpConfig(this.env);
+      const adapter = resolveAdapterConfig(this.env);
       const memoryTitle = `streams-celld session ${eventId.slice(0, 8)}`;
       const tools = {
         search: await searchViaMcp(mcp, `subscription:${subscriptionId}`, {
@@ -130,13 +140,28 @@ export class AgentSessionDO {
           `streams-celld ${subscriptionId}`,
           { limit: 3 }
         ),
+        adapter_search: await toolViaAdapter(adapter, "search", {
+          query: `adapter:${subscriptionId}`,
+          limit: 1,
+        }),
       };
+
+      const outOfProcess = ["inference"];
+      if (mcp.url) outOfProcess.unshift("search", "execute", "memory_*");
+      if (adapter.url) outOfProcess.push("mcp-api-adapter");
+
+      const deferred = [];
+      if (!mcp.url) deferred.push("search", "execute", "memory_*");
+      if (!adapter.url) deferred.push("mcp-api-adapter");
+
       await this.state.storage.put(`tool_calls:${startedAt}`, {
         searchOk: tools.search?.ok === true,
         executeOk: tools.execute?.ok === true,
         memoryIngestOk: tools.memory_ingest?.ok === true,
         memoryRecallOk: tools.memory_recall?.ok === true,
-        deferred: !mcp.url,
+        adapterSearchOk: tools.adapter_search?.ok === true,
+        mcpDeferred: !mcp.url,
+        adapterDeferred: !adapter.url,
       });
 
       return Response.json({
@@ -153,13 +178,10 @@ export class AgentSessionDO {
         core: {
           package: "clawql-core/streams-slim",
           inProcess: ["audit", "cache", "hash-chain"],
-          outOfProcess: mcp.url
-            ? ["search", "execute", "memory_*", "inference"]
-            : ["inference"],
-          deferred: mcp.url
-            ? ["mcp-api-adapter"]
-            : ["search", "execute", "memory_*", "mcp-api-adapter"],
+          outOfProcess,
+          deferred,
           mcpUrlConfigured: Boolean(mcp.url),
+          adapterUrlConfigured: Boolean(adapter.url),
         },
       });
     }

--- a/examples/streams-celld/src/streams-core-facade.js
+++ b/examples/streams-celld/src/streams-core-facade.js
@@ -6,18 +6,20 @@
  * - cache get / set / delete / list (session scratch)
  *
  * Out-of-process via fetch(CLAWQL_MCP_URL) Streamable HTTP:
- * - search / execute → clawql-mcp (clawql-api on the host)
- * - memory_ingest / memory_recall → clawql-mcp (clawql-memory + vault on host)
+ * - search / execute / memory_* → clawql-mcp
+ *
+ * Out-of-process via fetch(CLAWQL_MCP_ADAPTER_URL) REST:
+ * - POST /{tool} → mcp-api-adapter (protocol fan-out host; not embedded)
  *
  * Still deferred:
  * - inference completions → fetch(INFERENCE_URL)
- * - mcp-api-adapter protocol surfaces → Node Express/gRPC host
  */
 
 import {
   runAuditOperation,
   runCacheOperation,
 } from "clawql-core/streams-slim";
+import { callAdapterTool } from "./adapter-fetch.js";
 import { callMcpTool } from "./mcp-fetch.js";
 
 /**
@@ -105,6 +107,20 @@ export async function memoryRecallViaMcp(mcp, query, opts = {}) {
     { url: mcp.url ?? "", bearer: mcp.bearer },
     "memory_recall",
     { query, limit: opts.limit ?? 5 }
+  );
+}
+
+/**
+ * Protocol-fabric REST probe via mcp-api-adapter (POST /{tool}).
+ * @param {{ url?: string, bearer?: string }} adapter
+ * @param {string} name
+ * @param {Record<string, unknown>} [args]
+ */
+export async function toolViaAdapter(adapter, name, args = {}) {
+  return callAdapterTool(
+    { url: adapter.url ?? "", bearer: adapter.bearer },
+    name,
+    args
   );
 }
 

--- a/examples/streams-celld/wrangler.jsonc
+++ b/examples/streams-celld/wrangler.jsonc
@@ -6,9 +6,10 @@
   "compatibility_flags": ["nodejs_compat"],
   "vars": {
     "INFERENCE_URL": "http://127.0.0.1:8080",
-    // Out-of-process search/execute via Streamable HTTP (MCP 2026-07-28).
-    // Empty / omit → tools return deferred until CLAWQL_MCP_URL is set.
-    "CLAWQL_MCP_URL": ""
+    // Out-of-process search/execute/memory via Streamable HTTP (MCP 2026-07-28).
+    "CLAWQL_MCP_URL": "",
+    // Optional mcp-api-adapter REST origin (POST /{tool}); empty → deferred.
+    "CLAWQL_MCP_ADAPTER_URL": ""
   },
   "durable_objects": {
     "bindings": [

--- a/scripts/kubernetes/test-helm-celld-templates.sh
+++ b/scripts/kubernetes/test-helm-celld-templates.sh
@@ -6,7 +6,8 @@ cd "${ROOT}"
 
 TMP_CELLD="$(mktemp)"
 TMP_OFF="$(mktemp)"
-trap 'rm -f "${TMP_CELLD}" "${TMP_OFF}"' EXIT
+TMP_ADAPTER="$(mktemp)"
+trap 'rm -f "${TMP_CELLD}" "${TMP_OFF}" "${TMP_ADAPTER}"' EXIT
 
 _LINT_SECRET=(--set envFromSecret=clawql-lint-provider-env)
 
@@ -23,12 +24,22 @@ helm template test charts/clawql-mcp --namespace clawql \
   --set kyverno.imageSignaturePolicy.enabled=false \
   >"${TMP_OFF}"
 
-python3 - "${TMP_CELLD}" "${TMP_OFF}" <<'PY'
+helm template test charts/clawql-mcp --namespace clawql \
+  "${_LINT_SECRET[@]}" \
+  --set kyverno.imageSignaturePolicy.enabled=false \
+  -f charts/clawql-mcp/values-streams-celld.example.yaml \
+  --set streams.celld.bucket=s3://lint-clawql-streams-state \
+  --set streams.celld.endpoint=https://lint.r2.cloudflarestorage.com \
+  --set streams.celld.adapterUrl=http://mcp-api-adapter.clawql.svc.cluster.local:8090 \
+  >"${TMP_ADAPTER}"
+
+python3 - "${TMP_CELLD}" "${TMP_OFF}" "${TMP_ADAPTER}" <<'PY'
 import sys
 
-celld_path, off_path = sys.argv[1], sys.argv[2]
+celld_path, off_path, adapter_path = sys.argv[1], sys.argv[2], sys.argv[3]
 celld = open(celld_path, "r", encoding="utf-8").read()
 off = open(off_path, "r", encoding="utf-8").read()
+adapter = open(adapter_path, "r", encoding="utf-8").read()
 
 assert "kind: StatefulSet" in celld
 assert "streams-celld" in celld
@@ -39,10 +50,14 @@ assert "ghcr.io/denoland/celld:v0.4.0" in celld
 assert "CLAWQL_MCP_URL" in celld
 assert "INFERENCE_URL" in celld
 assert "/mcp" in celld
+assert "CLAWQL_MCP_ADAPTER_URL" not in celld
 
 assert "streams-celld" not in off
 assert "CELLD_ADVERTISE" not in off
 assert "CLAWQL_ENABLE_STREAMS" not in off
+
+assert "CLAWQL_MCP_ADAPTER_URL" in adapter
+assert "mcp-api-adapter.clawql.svc.cluster.local:8090" in adapter
 
 print("helm celld templates OK")
 PY

--- a/website/src/app/learn/streams-getting-started/page.mdx
+++ b/website/src/app/learn/streams-getting-started/page.mdx
@@ -423,7 +423,7 @@ clawql streams celld bundle-check
 
 Expect ≈ **0.4 MiB** (~0.6% of the **64 MiB** Workers limit). The full `clawql-core` barrel is **not** used — it would pull `webmcp-draft` (`node:fs`).
 
-Webhook responses include `session.audit.clawqlCore` (hash-chained append) and `session.core.inProcess: ["audit","cache","hash-chain"]`. With **`CLAWQL_MCP_URL`** set, `session.tools.search` / `execute` / `memory_ingest` / `memory_recall` call Streamable HTTP MCP (`tools/call`, prefer protocol **2026-07-28**). When unset, those tools return `{ deferred: true }`. Full `clawql-api` / vault IO stay on the MCP host — not in the Worker bundle.
+Webhook responses include `session.audit.clawqlCore` (hash-chained append) and `session.core.inProcess: ["audit","cache","hash-chain"]`. With **`CLAWQL_MCP_URL`** set, `session.tools.search` / `execute` / `memory_ingest` / `memory_recall` call Streamable HTTP MCP. With **`CLAWQL_MCP_ADAPTER_URL`** set, `session.tools.adapter_search` probes mcp-api-adapter REST (`POST /search`). When unset, those tools return `{ deferred: true }`.
 
 Smoke with a mock MCP: `bash examples/streams-celld/scripts/smoke.sh`.
 

--- a/website/src/generated/clawql-celld-body.mdx
+++ b/website/src/generated/clawql-celld-body.mdx
@@ -210,17 +210,17 @@ celld deploy (esbuild)
   └─ Worker + DO classes
         ├─ clawql-streams (router, filter, stream_* MCP) — planned package
         ├─ clawql-core/streams-slim (audit, cache, hash-chain) — Workers-safe entry
-        └─ fetch(CLAWQL_MCP_URL) → clawql-mcp search/execute/memory_* (Streamable HTTP)
-             · mcp-api-adapter still host-side or deferred
+        ├─ fetch(CLAWQL_MCP_URL) → clawql-mcp search/execute/memory_* (Streamable HTTP)
+        └─ fetch(CLAWQL_MCP_ADAPTER_URL) → mcp-api-adapter REST POST /{tool}
   env / vars ≤ 1 MiB
   code ≤ 64 MiB
 ```
 
 **In-process today:** `AgentSessionDO` imports [`clawql-core/streams-slim`](https://github.com/danielsmithdevelopment/ClawQL/blob/main/packages/clawql-core/README.md) for hash-chained `audit` + session `cache`. Example: [`examples/streams-celld`](../../examples/streams-celld/).
 
-**Out-of-process today:** `search` / `execute` / `memory_ingest` / `memory_recall` via thin `fetch` to Streamable HTTP MCP (`CLAWQL_MCP_URL`, prefer protocol **2026-07-28** / JSON responses). Inference via `fetch(INFERENCE_URL)`. Do **not** embed full `clawql-api`, `clawql-memory`, or the full `clawql-core` barrel (`webmcp-draft` / `node:fs`).
+**Out-of-process today:** `search` / `execute` / `memory_*` via Streamable HTTP MCP (`CLAWQL_MCP_URL`). Optional protocol-fabric REST via `CLAWQL_MCP_ADAPTER_URL` (`POST /\{tool\}` on mcp-api-adapter). Inference via `fetch(INFERENCE_URL)`. Do **not** embed full `clawql-api`, `clawql-memory`, `mcp-api-adapter`, or the full `clawql-core` barrel (`webmcp-draft` / `node:fs`).
 
-**Still deferred:** protocol fan-out (`mcp-api-adapter`).
+**Still deferred:** offline Workers-safe `clawql-api` slim; durable isolate audit ring → DO LTX (WORM rows already use `storage.put`).
 
 **Provider specs:** ship a **slim default set** in the bundle; load additional OpenAPI/GraphQL specs via `fetch` into SQLite on first use or at subscription create — do not embed full enterprise catalogs in env.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cells optionally call **mcp-api-adapter** via thin REST `fetch(CLAWQL_MCP_ADAPTER_URL)` (`POST /{tool}`) — not embedded (Express/gRPC). Streamable HTTP MCP path unchanged.

## Changes

- `adapter-fetch.js` + `toolViaAdapter` / `tools.adapter_search` probe on spawn
- Mock adapter + unit/smoke coverage
- Helm: optional `streams.celld.adapterUrl` → `CLAWQL_MCP_ADAPTER_URL`
- Docs / Lab 5b

## Evidence

Smoke PASS; bundle ~0.41 MiB.

[streams_celld_adapter_fetch_webhook.json](https://cursor.com/agents/bc-019f8f57-601a-7ec1-bff0-d35011fef4ec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstreams_celld_adapter_fetch_webhook.json)

## Test plan

- [x] `node examples/streams-celld/scripts/adapter-fetch.test.mjs`
- [x] `bash examples/streams-celld/scripts/smoke.sh`
- [ ] CI green then merge-after-green

**Follow-up (same request):** persist isolate audit ring to DO LTX after this merges.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8f57-601a-7ec1-bff0-d35011fef4ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8f57-601a-7ec1-bff0-d35011fef4ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

