### PR TITLE
feat(streams): persist isolate audit ring to DO LTX storage

### DIFF
--- a/docs/streams/clawql-celld.md
+++ b/docs/streams/clawql-celld.md
@@ -200,6 +200,8 @@ Gateway still allocates `doInstanceId` / `virtualKeyId` before first spawn and w
 | `tool_calls`      | tool name, args hash, ATR result                                              |
 | `export_status`   | pending / flushed / failed                                                    |
 | `worm:*`          | append-only forensic trail                                                    |
+| `audit:ring`      | latest isolate hash-chain snapshot (flushed on spawn)                         |
+| `audit:seq:{n}`   | per-seq WORM rows from the clawql-core audit ring                             |
 
 ---
 
@@ -220,7 +222,9 @@ celld deploy (esbuild)
 
 **Out-of-process today:** `search` / `execute` / `memory_*` via Streamable HTTP MCP (`CLAWQL_MCP_URL`). Optional protocol-fabric REST via `CLAWQL_MCP_ADAPTER_URL` (`POST /{tool}` on mcp-api-adapter). Inference via `fetch(INFERENCE_URL)`. Do **not** embed full `clawql-api`, `clawql-memory`, `mcp-api-adapter`, or the full `clawql-core` barrel (`webmcp-draft` / `node:fs`).
 
-**Still deferred:** offline Workers-safe `clawql-api` slim; durable isolate audit ring → DO LTX (WORM rows already use `storage.put`).
+**Durable audit:** after each spawn, the isolate hash-chain is flushed to DO storage (`audit:ring` snapshot + `audit:seq:{n}` WORM rows) so LTX survives isolate restarts (alongside existing `worm:*` DO_CREATED rows).
+
+**Still deferred:** offline Workers-safe `clawql-api` slim.
 
 **Provider specs:** ship a **slim default set** in the bundle; load additional OpenAPI/GraphQL specs via `fetch` into SQLite on first use or at subscription create — do not embed full enterprise catalogs in env.
 

--- a/examples/streams-celld/README.md
+++ b/examples/streams-celld/README.md
@@ -14,7 +14,7 @@ Minimal **Workers / Durable Objects** bundle for [ClawQL Streams](https://docs.c
 
 | Surface | Status |
 | ------- | ------ |
-| `audit` (hash-chained ring) | **In-process** — `clawql-core/streams-slim` |
+| `audit` (hash-chained ring) | **In-process** + **LTX flush** — streams-slim ring; snapshot `audit:ring` + `audit:seq:*` |
 | `cache` (session scratch) | **In-process** — `clawql-core/streams-slim` |
 | Hash-chain verify | **In-process** — via clawql-merkle (needs `nodejs_compat`) |
 | Inference | **Out-of-process** — `fetch(INFERENCE_URL)` |
@@ -58,5 +58,5 @@ Helm injects `CLAWQL_MCP_URL` + `INFERENCE_URL`. Set `streams.celld.adapterUrl` 
 
 ## Next steps
 
-- Persist isolate audit ring beyond process memory into DO LTX storage
 - Optional Workers-safe slim `clawql-api` for offline/in-cell search
+- Optional Helm chart Service for mcp-api-adapter (cells already accept `adapterUrl`)

--- a/examples/streams-celld/scripts/smoke.sh
+++ b/examples/streams-celld/scripts/smoke.sh
@@ -86,5 +86,8 @@ echo "$RESP" | grep -q 'memory_\*' || fail "expected memory_* in core surface li
 echo "$RESP" | grep -q 'mcp-api-adapter-rest' || fail "expected adapter REST transport"
 echo "$RESP" | grep -q '"source":"mock-adapter"' || fail "expected mock-adapter search payload"
 echo "$RESP" | grep -q '"adapterUrlConfigured":true' || fail "expected adapterUrlConfigured true"
+echo "$RESP" | grep -q '"snapshotKey":"audit:ring"' || fail "expected audit LTX snapshotKey"
+echo "$RESP" | grep -q 'audit:seq:' || fail "expected audit:seq WORM keys"
+echo "$RESP" | grep -q '"durable"' || fail "expected core.durable surfaces"
 
 echo "smoke: PASS"

--- a/examples/streams-celld/src/agent-session-do.js
+++ b/examples/streams-celld/src/agent-session-do.js
@@ -7,6 +7,7 @@ import {
   appendSessionCreatedAudit,
   cacheSessionMeta,
   executeViaMcp,
+  listAuditEntries,
   memoryIngestViaMcp,
   memoryRecallViaMcp,
   searchViaMcp,
@@ -34,6 +35,47 @@ function resolveInferenceUrl(env) {
     (env.INFERENCE_URL || env.CLAWQL_STREAMS_INFERENCE_URL || "").trim() ||
     undefined
   );
+}
+
+/**
+ * Flush the isolate-local clawql-core audit ring into DO durable storage (LTX).
+ * Snapshot at audit:ring; per-seq WORM rows at audit:seq:{n}.
+ * @param {{ storage: { put: (k: string, v: unknown) => Promise<void> } }} state
+ * @param {{ verify?: unknown, eventId: string, startedAt: number }} ctx
+ */
+async function persistAuditRingToLtx(state, ctx) {
+  const listed = await listAuditEntries(50);
+  const entries = Array.isArray(listed?.entries) ? listed.entries : [];
+  const snapshot = {
+    ok: listed?.ok === true,
+    total: listed?.total ?? entries.length,
+    maxEntries: listed?.maxEntries,
+    verify: ctx.verify ?? null,
+    eventId: ctx.eventId,
+    flushedAt: Date.now(),
+    startedAt: ctx.startedAt,
+    entries,
+  };
+  await state.storage.put("audit:ring", snapshot);
+  const seqKeys = [];
+  for (const entry of entries) {
+    const seq = entry?.seq;
+    if (typeof seq !== "number") continue;
+    const key = `audit:seq:${seq}`;
+    await state.storage.put(key, {
+      ...entry,
+      eventId: ctx.eventId,
+      flushedAt: snapshot.flushedAt,
+    });
+    seqKeys.push(key);
+  }
+  return {
+    ok: true,
+    snapshotKey: "audit:ring",
+    seqKeys,
+    entryCount: entries.length,
+    headHash: entries.length ? entries[entries.length - 1]?.hash : null,
+  };
 }
 
 export class AgentSessionDO {
@@ -81,6 +123,7 @@ export class AgentSessionDO {
       let audit = { ok: false };
       let cache = { ok: false };
       let auditVerify = { ok: false };
+      let auditPersisted = { ok: false };
       try {
         audit = await appendSessionCreatedAudit({
           subscriptionId,
@@ -90,6 +133,11 @@ export class AgentSessionDO {
         });
         cache = await cacheSessionMeta(eventId, meta);
         auditVerify = await verifyAuditChain();
+        auditPersisted = await persistAuditRingToLtx(this.state, {
+          verify: auditVerify,
+          eventId,
+          startedAt,
+        });
       } catch (err) {
         audit = {
           ok: false,
@@ -172,12 +220,14 @@ export class AgentSessionDO {
           wormKey: `worm:${startedAt}`,
           clawqlCore: audit,
           verify: auditVerify,
+          ltx: auditPersisted,
         },
         cache,
         tools,
         core: {
           package: "clawql-core/streams-slim",
           inProcess: ["audit", "cache", "hash-chain"],
+          durable: ["audit:ring", "audit:seq:*", "worm:*"],
           outOfProcess,
           deferred,
           mcpUrlConfigured: Boolean(mcp.url),
@@ -187,6 +237,11 @@ export class AgentSessionDO {
     }
 
     const meta = await this.state.storage.get("session_meta");
-    return Response.json({ do: "AgentSessionDO", session: meta ?? null });
+    const auditRing = await this.state.storage.get("audit:ring");
+    return Response.json({
+      do: "AgentSessionDO",
+      session: meta ?? null,
+      auditRing: auditRing ?? null,
+    });
   }
 }

--- a/examples/streams-celld/src/streams-core-facade.js
+++ b/examples/streams-celld/src/streams-core-facade.js
@@ -129,3 +129,13 @@ export async function verifyAuditChain() {
   const text = result.content?.[0]?.text;
   return text ? JSON.parse(text) : { ok: false };
 }
+
+/**
+ * Snapshot the in-process hash-chained audit ring (for DO LTX flush).
+ * @param {number} [limit]
+ */
+export async function listAuditEntries(limit = 50) {
+  const result = await runAuditOperation({ operation: "list", limit });
+  const text = result.content?.[0]?.text;
+  return text ? JSON.parse(text) : { ok: false, entries: [] };
+}

--- a/website/src/app/learn/streams-getting-started/page.mdx
+++ b/website/src/app/learn/streams-getting-started/page.mdx
@@ -423,7 +423,7 @@ clawql streams celld bundle-check
 
 Expect ≈ **0.4 MiB** (~0.6% of the **64 MiB** Workers limit). The full `clawql-core` barrel is **not** used — it would pull `webmcp-draft` (`node:fs`).
 
-Webhook responses include `session.audit.clawqlCore` (hash-chained append) and `session.core.inProcess: ["audit","cache","hash-chain"]`. With **`CLAWQL_MCP_URL`** set, `session.tools.search` / `execute` / `memory_ingest` / `memory_recall` call Streamable HTTP MCP. With **`CLAWQL_MCP_ADAPTER_URL`** set, `session.tools.adapter_search` probes mcp-api-adapter REST (`POST /search`). When unset, those tools return `{ deferred: true }`.
+Webhook responses include `session.audit.clawqlCore` (hash-chained append), `session.audit.ltx.snapshotKey: "audit:ring"`, and `session.core.inProcess: ["audit","cache","hash-chain"]`. With **`CLAWQL_MCP_URL`** set, MCP tools call Streamable HTTP. With **`CLAWQL_MCP_ADAPTER_URL`** set, `adapter_search` probes mcp-api-adapter REST.
 
 Smoke with a mock MCP: `bash examples/streams-celld/scripts/smoke.sh`.
 

--- a/website/src/generated/clawql-celld-body.mdx
+++ b/website/src/generated/clawql-celld-body.mdx
@@ -200,6 +200,8 @@ Gateway still allocates `doInstanceId` / `virtualKeyId` before first spawn and w
 | `tool_calls`      | tool name, args hash, ATR result                                              |
 | `export_status`   | pending / flushed / failed                                                    |
 | `worm:*`          | append-only forensic trail                                                    |
+| `audit:ring`      | latest isolate hash-chain snapshot (flushed on spawn)                         |
+| `audit:seq:\{n\}` | per-seq WORM rows from the clawql-core audit ring                             |
 
 ---
 
@@ -220,7 +222,9 @@ celld deploy (esbuild)
 
 **Out-of-process today:** `search` / `execute` / `memory_*` via Streamable HTTP MCP (`CLAWQL_MCP_URL`). Optional protocol-fabric REST via `CLAWQL_MCP_ADAPTER_URL` (`POST /\{tool\}` on mcp-api-adapter). Inference via `fetch(INFERENCE_URL)`. Do **not** embed full `clawql-api`, `clawql-memory`, `mcp-api-adapter`, or the full `clawql-core` barrel (`webmcp-draft` / `node:fs`).
 
-**Still deferred:** offline Workers-safe `clawql-api` slim; durable isolate audit ring → DO LTX (WORM rows already use `storage.put`).
+**Durable audit:** after each spawn, the isolate hash-chain is flushed to DO storage (`audit:ring` snapshot + `audit:seq:\{n\}` WORM rows) so LTX survives isolate restarts (alongside existing `worm:*` DO_CREATED rows).
+
+**Still deferred:** offline Workers-safe `clawql-api` slim.
 
 **Provider specs:** ship a **slim default set** in the bundle; load additional OpenAPI/GraphQL specs via `fetch` into SQLite on first use or at subscription create — do not embed full enterprise catalogs in env.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After mcp-api-adapter REST fetch (#1046), flush the in-process `clawql-core/streams-slim` audit hash-chain into Durable Object storage so LTX survives isolate restarts.

## Changes

- `listAuditEntries()` on `streams-core-facade`
- `persistAuditRingToLtx()` on spawn → `audit:ring` snapshot + `audit:seq:{n}` WORM rows
- Spawn response includes `audit.ltx` and `core.durable`
- `GET` session returns `auditRing`
- Smoke asserts LTX keys; docs/README/Lab sync updated

## Local verification

- `bash examples/streams-celld/scripts/smoke.sh` → **PASS**
- `adapter-fetch.test` / `mcp-fetch.test` / bundle-check → **PASS**
- Spawn evidence: `audit.ltx.snapshotKey = "audit:ring"`, `seqKeys: ["audit:seq:1"]`, `core.durable` includes audit + worm keys

## Test plan

- [x] Local smoke + unit tests
- [ ] CI green → merge-after-green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8f57-601a-7ec1-bff0-d35011fef4ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8f57-601a-7ec1-bff0-d35011fef4ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

