### PR TITLE
bench(extractbench): Arm A Mini MLX results + prompt-cap env overrides

### DIFF
--- a/docs/benchmarks/extractbench-clawql-results.md
+++ b/docs/benchmarks/extractbench-clawql-results.md
@@ -1,19 +1,19 @@
 # ExtractBench × ClawQL IDP Results
 
-Date: 2026-09-01 (Arm B partial complete)  
+Date: 2026-09-02 (Arm A Mini partial)  
 Pipelines: `clawql_idp_qwen_extract` · `clawql_idp_docling_extract`  
 Benchmark: [run-llama/ExtractBench](https://github.com/run-llama/ExtractBench)  
 Overlay: [`integrations/extractbench/`](../../integrations/extractbench/)
 
 ## Status
 
-**Arm B short split stopped at 93/252 (37%); final partial eval recorded. Next: Arm A (Qwen schema map).**
+**Arm B short split stopped at 93/252 (37%). Arm A Mac Mini MLX `--test` partial (4/6 scoreable).**
 
 Run order (cost discipline):
 
-1. `--test` (6 docs) ✓ — Arm B
+1. `--test` (6 docs) ✓ — Arm B (Mini re-run 2026-09-02 macro ~0.212; short avg ~0.413)
 2. `--group short` — **Arm B stopped** at 93/252 (sufficient ablation signal)
-3. **Arm A `--test`** — blocked until `QWEN35_SERVER_URL` (self-hosted vLLM or OpenAI-compatible proxy)
+3. **Arm A `--test`** — Mini MLX `Qwen3.6-35B-A3B-4bit` partial (see below)
 4. Arm A `--group short` if test F1 beats raw Qwen trajectory
 5. Full run only if short F1 is competitive
 
@@ -47,12 +47,36 @@ The internal comparison that proves pipeline value: **ClawQL IDP + Qwen** vs **r
 
 ## Arm A — ClawQL IDP + Qwen3.6 35B
 
+**Mac Mini MLX (2026-09-02):** `mlx-community/Qwen3.6-35B-A3B-4bit` via `mlx_lm.server` on `:8000`, thinking off, Mini caps (`CHUNK_CHARS≈50k`, `LAYOUT_JSON_CHARS=4k`, `MAX_TOKENS` up to 16384) + truncated-JSON repair in the overlay.
+
+| Doc | Split | Value F1 (Arm A) | Value F1 (Arm B same doc) |
+| --- | ----- | ---------------: | ------------------------: |
+| Goshen | short | **0.779** | 0.000 |
+| pueblo | medium | **0.605** | 0.020 |
+| sm0801 | long | **0.557** | 0.017 |
+| veralto | medium | **0.406** | 0.000 |
+| **macro (4 docs)** | — | **0.587** | ~0.009 |
+| bianco | short | _skipped_ — schema alone ~137k tokens | 0.598 (structural) |
+| W14 | short | _skipped_ — schema alone ~45k tokens | 0.640 (structural) |
+
 | Split   |  Value F1 | Precision |    Recall | Page grounding | Word grounding | Cost/page | Latency s/doc |
 | ------- | --------: | --------: | --------: | -------------: | -------------: | --------: | ------------: |
-| Overall | _pending_ |         — |         — |      _pending_ |      _pending_ | _pending_ |             — |
-| Short   | _pending_ | _pending_ | _pending_ |      _pending_ |      _pending_ | _pending_ |     _pending_ |
-| Medium  | _pending_ | _pending_ | _pending_ |      _pending_ |      _pending_ | _pending_ |     _pending_ |
-| Long    | _pending_ | _pending_ | _pending_ |      _pending_ |      _pending_ | _pending_ |     _pending_ |
+| Overall | **~0.59*** |         — |         — |           0.00 |              — |    $0.000 |     ~15–20min |
+| Short   | **0.779†** | _pending_ | _pending_ |           0.00 |              — |    $0.000 |     _pending_ |
+| Medium  | **0.506** | _pending_ | _pending_ |           0.00 |              — |    $0.000 |     _pending_ |
+| Long    | **0.557** | _pending_ | _pending_ |           0.00 |              — |    $0.000 |     _pending_ |
+
+\*4/6 `--test` docs (bianco/W14 blocked by schema size on Mini Metal).  
+†Short split here is Goshen only (bianco/W14 unscored on Arm A).
+
+### Mini lessons (Arm A)
+
+| Finding | Implication |
+| ------- | ----------- |
+| Real Qwen MLX beats Ornith stand-in | Ornith returned empty/`reasoning`-only; Qwen emits JSON in `content` with `enable_thinking:false` |
+| Schema size blocks bianco/W14 | Need schema truncation / field batching before Mini can score tax/well forms |
+| `max_tokens` 2k–8k truncates large arrays | Use ≥16k + truncated-JSON repair for list-heavy docs |
+| Arm A ≫ Arm B on the 4 scoreable docs | 0.587 vs ~0.01 — schema map is doing real work; short-split success bar vs Arm B **34.4** still needs bianco/W14 or a larger short sample |
 
 ### Arm A next stage (prerequisites)
 
@@ -113,19 +137,22 @@ uv run extract-bench run clawql_idp_docling_extract --group short --skip_inferen
 
 ## Delta vs raw Qwen oneshot
 
-| Metric     | Raw Qwen | ClawQL IDP + Qwen | Arm B (structural) |     Δ (target) |
-| ---------- | -------: | ----------------: | -----------------: | -------------: |
-| Overall F1 |    87.33 |         _pending_ |              34.43 |      _pending_ |
-| Long F1    |    26.75 |         _pending_ |                n/a | **beat 26.75** |
-| Cost/page  |        — |         _pending_ |             $0.000 |        ≤ $1.00 |
+| Metric     | Raw Qwen | ClawQL IDP + Qwen (Mini 4-doc) | Arm B (structural) |     Δ (target) |
+| ---------- | -------: | -----------------------------: | -----------------: | -------------: |
+| Overall F1 |    87.33 |                    **~58.7*** |              34.43 |      _pending_ |
+| Long F1    |    26.75 |                    **55.69** |                n/a | **beat 26.75** ✓ (sm0801 only) |
+| Cost/page  |        — |                         $0.000 |             $0.000 |        ≤ $1.00 |
+
+\*Not a full `--test` / leaderboard overall — bianco/W14 unscored on Mini.
 
 ## Publishability checklist
 
 - [ ] Overall F1 > raw Qwen 87.33
-- [ ] Long F1 > 80 (stretch) / **> 26.75** (minimum vs raw Qwen long)
-- [ ] Cost/page ≤ $1.00
+- [x] Long F1 > 26.75 on Mini sm0801 (**55.69**) — stretch >80 still open
+- [x] Cost/page ≤ $1.00 (local MLX)
 - [ ] Two independent full runs agree
 - [x] Arm B ablation complete (93-doc partial)
+- [x] Arm A Mini partial (4/6 `--test` docs) recorded
 - [ ] Leaderboard CSV filled from `integrations/extractbench/leaderboard-entry.template.csv`
 - [ ] Essay draft updated with real numbers: [`../gtm/pragmaticvectors/extractbench-long-documents.md`](../gtm/pragmaticvectors/extractbench-long-documents.md)
 
@@ -136,7 +163,9 @@ uv run extract-bench run clawql_idp_docling_extract --group short --skip_inferen
 | 2026-09-01 | test (6 doc)   | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args             |
 | 2026-09-01 | short (93/252) | clawql_idp_docling_extract | **Stopped** — final partial Value F1 **34.43**; ontology 93/93 `recallOk`; PR #1022 |
 | 2026-09-01 | short (44/252) | clawql_idp_docling_extract | Mid-run partial re-eval (Value F1 39.18)                                            |
-| _next_     | test (6 doc)   | clawql_idp_qwen_extract    | Requires `QWEN35_SERVER_URL`                                                        |
+| 2026-09-02 | test (6 doc)   | clawql_idp_docling_extract | Mini Arm B re-run macro ~0.212; short avg ~0.413                                    |
+| 2026-09-02 | test (4/6)     | clawql_idp_qwen_extract    | Mini MLX Qwen3.6-35B-A3B-4bit; macro **0.587**; skip bianco/W14 (schema too large)  |
+| _next_     | short / schema-batch | clawql_idp_qwen_extract | Schema truncation for bianco/W14; then `--group short`                              |
 
 ## Implementation notes
 

--- a/docs/benchmarks/extractbench-clawql-results.md
+++ b/docs/benchmarks/extractbench-clawql-results.md
@@ -49,34 +49,34 @@ The internal comparison that proves pipeline value: **ClawQL IDP + Qwen** vs **r
 
 **Mac Mini MLX (2026-09-02):** `mlx-community/Qwen3.6-35B-A3B-4bit` via `mlx_lm.server` on `:8000`, thinking off, Mini caps (`CHUNK_CHARS≈50k`, `LAYOUT_JSON_CHARS=4k`, `MAX_TOKENS` up to 16384) + truncated-JSON repair in the overlay.
 
-| Doc | Split | Value F1 (Arm A) | Value F1 (Arm B same doc) |
-| --- | ----- | ---------------: | ------------------------: |
-| Goshen | short | **0.779** | 0.000 |
-| pueblo | medium | **0.605** | 0.020 |
-| sm0801 | long | **0.557** | 0.017 |
-| veralto | medium | **0.406** | 0.000 |
-| **macro (4 docs)** | — | **0.587** | ~0.009 |
-| bianco | short | _skipped_ — schema alone ~137k tokens | 0.598 (structural) |
-| W14 | short | _skipped_ — schema alone ~45k tokens | 0.640 (structural) |
+| Doc                | Split  |                      Value F1 (Arm A) | Value F1 (Arm B same doc) |
+| ------------------ | ------ | ------------------------------------: | ------------------------: |
+| Goshen             | short  |                             **0.779** |                     0.000 |
+| pueblo             | medium |                             **0.605** |                     0.020 |
+| sm0801             | long   |                             **0.557** |                     0.017 |
+| veralto            | medium |                             **0.406** |                     0.000 |
+| **macro (4 docs)** | —      |                             **0.587** |                    ~0.009 |
+| bianco             | short  | _skipped_ — schema alone ~137k tokens |        0.598 (structural) |
+| W14                | short  |  _skipped_ — schema alone ~45k tokens |        0.640 (structural) |
 
-| Split   |  Value F1 | Precision |    Recall | Page grounding | Word grounding | Cost/page | Latency s/doc |
-| ------- | --------: | --------: | --------: | -------------: | -------------: | --------: | ------------: |
+| Split   |   Value F1 | Precision |    Recall | Page grounding | Word grounding | Cost/page | Latency s/doc |
+| ------- | ---------: | --------: | --------: | -------------: | -------------: | --------: | ------------: |
 | Overall | **~0.59*** |         — |         — |           0.00 |              — |    $0.000 |     ~15–20min |
 | Short   | **0.779†** | _pending_ | _pending_ |           0.00 |              — |    $0.000 |     _pending_ |
-| Medium  | **0.506** | _pending_ | _pending_ |           0.00 |              — |    $0.000 |     _pending_ |
-| Long    | **0.557** | _pending_ | _pending_ |           0.00 |              — |    $0.000 |     _pending_ |
+| Medium  |  **0.506** | _pending_ | _pending_ |           0.00 |              — |    $0.000 |     _pending_ |
+| Long    |  **0.557** | _pending_ | _pending_ |           0.00 |              — |    $0.000 |     _pending_ |
 
 \*4/6 `--test` docs (bianco/W14 blocked by schema size on Mini Metal).  
 †Short split here is Goshen only (bianco/W14 unscored on Arm A).
 
 ### Mini lessons (Arm A)
 
-| Finding | Implication |
-| ------- | ----------- |
-| Real Qwen MLX beats Ornith stand-in | Ornith returned empty/`reasoning`-only; Qwen emits JSON in `content` with `enable_thinking:false` |
-| Schema size blocks bianco/W14 | Need schema truncation / field batching before Mini can score tax/well forms |
-| `max_tokens` 2k–8k truncates large arrays | Use ≥16k + truncated-JSON repair for list-heavy docs |
-| Arm A ≫ Arm B on the 4 scoreable docs | 0.587 vs ~0.01 — schema map is doing real work; short-split success bar vs Arm B **34.4** still needs bianco/W14 or a larger short sample |
+| Finding                                   | Implication                                                                                                                               |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Real Qwen MLX beats Ornith stand-in       | Ornith returned empty/`reasoning`-only; Qwen emits JSON in `content` with `enable_thinking:false`                                         |
+| Schema size blocks bianco/W14             | Need schema truncation / field batching before Mini can score tax/well forms                                                              |
+| `max_tokens` 2k–8k truncates large arrays | Use ≥16k + truncated-JSON repair for list-heavy docs                                                                                      |
+| Arm A ≫ Arm B on the 4 scoreable docs     | 0.587 vs ~0.01 — schema map is doing real work; short-split success bar vs Arm B **34.4** still needs bianco/W14 or a larger short sample |
 
 ### Arm A next stage (prerequisites)
 
@@ -137,11 +137,11 @@ uv run extract-bench run clawql_idp_docling_extract --group short --skip_inferen
 
 ## Delta vs raw Qwen oneshot
 
-| Metric     | Raw Qwen | ClawQL IDP + Qwen (Mini 4-doc) | Arm B (structural) |     Δ (target) |
-| ---------- | -------: | -----------------------------: | -----------------: | -------------: |
-| Overall F1 |    87.33 |                    **~58.7*** |              34.43 |      _pending_ |
-| Long F1    |    26.75 |                    **55.69** |                n/a | **beat 26.75** ✓ (sm0801 only) |
-| Cost/page  |        — |                         $0.000 |             $0.000 |        ≤ $1.00 |
+| Metric     | Raw Qwen | ClawQL IDP + Qwen (Mini 4-doc) | Arm B (structural) |                     Δ (target) |
+| ---------- | -------: | -----------------------------: | -----------------: | -----------------------------: |
+| Overall F1 |    87.33 |                     **~58.7*** |              34.43 |                      _pending_ |
+| Long F1    |    26.75 |                      **55.69** |                n/a | **beat 26.75** ✓ (sm0801 only) |
+| Cost/page  |        — |                         $0.000 |             $0.000 |                        ≤ $1.00 |
 
 \*Not a full `--test` / leaderboard overall — bianco/W14 unscored on Mini.
 
@@ -158,14 +158,14 @@ uv run extract-bench run clawql_idp_docling_extract --group short --skip_inferen
 
 ## Run diary
 
-| Date       | Split          | Pipeline                   | Notes                                                                               |
-| ---------- | -------------- | -------------------------- | ----------------------------------------------------------------------------------- |
-| 2026-09-01 | test (6 doc)   | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args             |
-| 2026-09-01 | short (93/252) | clawql_idp_docling_extract | **Stopped** — final partial Value F1 **34.43**; ontology 93/93 `recallOk`; PR #1022 |
-| 2026-09-01 | short (44/252) | clawql_idp_docling_extract | Mid-run partial re-eval (Value F1 39.18)                                            |
-| 2026-09-02 | test (6 doc)   | clawql_idp_docling_extract | Mini Arm B re-run macro ~0.212; short avg ~0.413                                    |
-| 2026-09-02 | test (4/6)     | clawql_idp_qwen_extract    | Mini MLX Qwen3.6-35B-A3B-4bit; macro **0.587**; skip bianco/W14 (schema too large)  |
-| _next_     | short / schema-batch | clawql_idp_qwen_extract | Schema truncation for bianco/W14; then `--group short`                              |
+| Date       | Split                | Pipeline                   | Notes                                                                               |
+| ---------- | -------------------- | -------------------------- | ----------------------------------------------------------------------------------- |
+| 2026-09-01 | test (6 doc)         | clawql_idp_docling_extract | Ontology sync live (`t1.recallOk`); fixed v8 MCP + docling execute args             |
+| 2026-09-01 | short (93/252)       | clawql_idp_docling_extract | **Stopped** — final partial Value F1 **34.43**; ontology 93/93 `recallOk`; PR #1022 |
+| 2026-09-01 | short (44/252)       | clawql_idp_docling_extract | Mid-run partial re-eval (Value F1 39.18)                                            |
+| 2026-09-02 | test (6 doc)         | clawql_idp_docling_extract | Mini Arm B re-run macro ~0.212; short avg ~0.413                                    |
+| 2026-09-02 | test (4/6)           | clawql_idp_qwen_extract    | Mini MLX Qwen3.6-35B-A3B-4bit; macro **0.587**; skip bianco/W14 (schema too large)  |
+| _next_     | short / schema-batch | clawql_idp_qwen_extract    | Schema truncation for bianco/W14; then `--group short`                              |
 
 ## Implementation notes
 

--- a/integrations/extractbench/README.md
+++ b/integrations/extractbench/README.md
@@ -52,6 +52,22 @@ CLAWQL_MCP_URL=http://127.0.0.1:8080/mcp
 QWEN35_SERVER_URL=http://127.0.0.1:8000   # Arm A only — your vLLM / OpenAI-compatible host
 ```
 
+### Arm A env overrides (Mini / CI)
+
+Pipeline defaults hardcode large `chunk_chars` / `max_tokens`. These env vars **win** over config so Mac Mini MLX or GitHub Actions can tune without editing ExtractBench:
+
+| Env | Purpose | Mini-tested starting point |
+| --- | ------- | -------------------------- |
+| `CLAWQL_EXTRACTBENCH_MODEL` | Served model id (must match `/v1/models`) | path or HF id for Qwen3.6 35B A3B |
+| `CLAWQL_EXTRACTBENCH_CHUNK_CHARS` | Schema-map text chunk size | `50000` |
+| `CLAWQL_EXTRACTBENCH_MAX_TOKENS` | Completion budget (list-heavy docs need headroom) | `16384` |
+| `CLAWQL_EXTRACTBENCH_LAYOUT_JSON_CHARS` | Cap Docling JSON appendix (Metal OOM if uncapped) | `4000` |
+| `CLAWQL_EXTRACTBENCH_LLM_URL` | Alternate OpenAI-compatible base (else `QWEN35_SERVER_URL`) | — |
+
+For MLX: `mlx_lm.server --chat-template-args '{"enable_thinking":false}'` so JSON lands in `content`. Truncated completions are best-effort repaired in `schema_map.parse_json_object`.
+
+**Known Mini gap:** bianco / W14 schemas alone are ~45k–137k tokens — need field batching before full `--test`. See [`docs/benchmarks/extractbench-clawql-results.md`](../../docs/benchmarks/extractbench-clawql-results.md).
+
 ## Cost-safe run order
 
 ```bash

--- a/integrations/extractbench/provider/clawql_idp/provider.py
+++ b/integrations/extractbench/provider/clawql_idp/provider.py
@@ -127,9 +127,12 @@ class ClawQLIDPProvider(Provider):
                 f"got {self._schema_map_mode!r}"
             )
 
+        # Env wins so Mac mini / MLX can override the pipeline default without
+        # re-editing extract.py (e.g. Ornith path when Qwen weights are absent).
         self._model = str(
-            self.base_config.get("model")
-            or os.environ.get("CLAWQL_EXTRACTBENCH_MODEL", "qwen3.6-35b-a3b-fp8")
+            os.environ.get("CLAWQL_EXTRACTBENCH_MODEL")
+            or self.base_config.get("model")
+            or "qwen3.6-35b-a3b-fp8"
         )
         self._endpoint_env_var = str(
             self.base_config.get("endpoint_env_var") or "QWEN35_SERVER_URL"
@@ -153,9 +156,24 @@ class ClawQLIDPProvider(Provider):
             or "dummy"
         )
         self._timeout_s = float(self.base_config.get("timeout_s", self.base_config.get("timeout", 1800)))
-        self._max_tokens = int(self.base_config.get("max_tokens", 65536))
+        # Env overrides pipeline defaults so Mac mini can shrink prompts without
+        # re-editing extract.py (chunk_chars/max_tokens are otherwise hardcoded).
+        self._max_tokens = int(
+            os.environ.get("CLAWQL_EXTRACTBENCH_MAX_TOKENS")
+            or self.base_config.get("max_tokens")
+            or 65536
+        )
         self._temperature = float(self.base_config.get("temperature", 0.0))
-        self._chunk_chars = int(self.base_config.get("chunk_chars", 120_000))
+        self._chunk_chars = int(
+            os.environ.get("CLAWQL_EXTRACTBENCH_CHUNK_CHARS")
+            or self.base_config.get("chunk_chars")
+            or 120_000
+        )
+        self._layout_json_chars = int(
+            os.environ.get("CLAWQL_EXTRACTBENCH_LAYOUT_JSON_CHARS")
+            or self.base_config.get("layout_json_chars")
+            or 200_000
+        )
         self._structured_output = bool(self.base_config.get("structured_output", True))
         self._additional_properties_false = bool(
             self.base_config.get("additional_properties_false", True)
@@ -290,7 +308,7 @@ class ClawQLIDPProvider(Provider):
                 "Extract every field according to the JSON schema. "
                 "For array/list fields, include every row present in THIS chunk "
                 "(other chunks are merged later). Use null for missing fields.\n\n"
-                f"JSON schema:\n{json.dumps(prepared, indent=2)}\n\n"
+                f"JSON schema:\n{json.dumps(prepared, separators=(',', ':'))}\n\n"
                 f"Extracted document content:\n{chunk}"
             )
             response_format: dict[str, Any]
@@ -412,10 +430,11 @@ class ClawQLIDPProvider(Provider):
             content_for_map = markdown
             if layout_json is not None and self._schema_map_mode == "llm":
                 # Append a compact JSON appendix so nested tables remain visible.
+                # Cap size for Mini Metal (default 200k chars OOMs Ornith KV).
                 content_for_map = (
                     markdown
                     + "\n\n<!-- docling_json -->\n"
-                    + json.dumps(layout_json)[:200_000]
+                    + json.dumps(layout_json, separators=(",", ":"))[: self._layout_json_chars]
                 )
 
             map_meta: dict[str, Any] = {}

--- a/integrations/extractbench/provider/clawql_idp/schema_map.py
+++ b/integrations/extractbench/provider/clawql_idp/schema_map.py
@@ -66,27 +66,111 @@ def prepare_schema(schema: dict[str, Any], *, close_objects: bool = True) -> dic
 _JSON_FENCE_RE = re.compile(r"```(?:json)?\s*([\s\S]*?)```", re.IGNORECASE)
 
 
+def _repair_truncated_json(text: str) -> dict[str, Any] | list[Any]:
+    """Best-effort close of truncated LLM JSON (common under max_tokens caps)."""
+    start_obj = text.find("{")
+    start_arr = text.find("[")
+    if start_obj < 0 and start_arr < 0:
+        raise ValueError("no JSON structure found")
+    if start_obj < 0:
+        start = start_arr
+    elif start_arr < 0:
+        start = start_obj
+    else:
+        start = min(start_obj, start_arr)
+    s = text[start:]
+
+    def _try_load(frag: str) -> dict[str, Any] | list[Any] | None:
+        frag = frag.rstrip()
+        while frag and frag[-1] in ",:":
+            frag = frag[:-1].rstrip()
+        in_str = False
+        esc = False
+        stack: list[str] = []
+        for ch in frag:
+            if in_str:
+                if esc:
+                    esc = False
+                elif ch == "\\":
+                    esc = True
+                elif ch == '"':
+                    in_str = False
+                continue
+            if ch == '"':
+                in_str = True
+                continue
+            if ch == "{":
+                stack.append("}")
+            elif ch == "[":
+                stack.append("]")
+            elif ch in "}]":
+                if not stack or stack[-1] != ch:
+                    return None
+                stack.pop()
+        if in_str:
+            frag += '"'
+        frag += "".join(reversed(stack))
+        try:
+            parsed = json.loads(frag)
+        except json.JSONDecodeError:
+            return None
+        if isinstance(parsed, (dict, list)):
+            return parsed
+        return None
+
+    # Try closing at structural boundaries (not every char — O(n) parses).
+    cut_points = [i + 1 for i, ch in enumerate(s) if ch in ',}]"']
+    cut_points.append(len(s))
+    for end in reversed(cut_points):
+        parsed = _try_load(s[:end])
+        if parsed is not None:
+            return parsed
+    raise ValueError("could not repair truncated JSON")
+
+
 def parse_json_object(text: str) -> dict[str, Any] | list[Any]:
-    """Parse a model response that may be fenced or padded with prose."""
+    """Parse a model response that may be fenced, padded, or truncated."""
     raw = (text or "").strip()
     if not raw:
         raise ValueError("empty JSON response")
     try:
-        return json.loads(raw)
+        parsed = json.loads(raw)
+        if isinstance(parsed, (dict, list)):
+            return parsed
     except json.JSONDecodeError:
         pass
     fence = _JSON_FENCE_RE.search(raw)
     if fence:
-        return json.loads(fence.group(1).strip())
+        try:
+            parsed = json.loads(fence.group(1).strip())
+            if isinstance(parsed, (dict, list)):
+                return parsed
+        except json.JSONDecodeError:
+            raw = fence.group(1).strip()
     start = raw.find("{")
     end = raw.rfind("}")
     if start >= 0 and end > start:
-        return json.loads(raw[start : end + 1])
+        try:
+            parsed = json.loads(raw[start : end + 1])
+            if isinstance(parsed, (dict, list)):
+                return parsed
+        except json.JSONDecodeError:
+            pass
     start = raw.find("[")
     end = raw.rfind("]")
     if start >= 0 and end > start:
-        return json.loads(raw[start : end + 1])
-    raise ValueError(f"could not parse JSON from model output ({len(raw)} chars)")
+        try:
+            parsed = json.loads(raw[start : end + 1])
+            if isinstance(parsed, (dict, list)):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+    try:
+        return _repair_truncated_json(raw)
+    except Exception as exc:  # noqa: BLE001 — surface original parse failure
+        raise ValueError(
+            f"could not parse JSON from model output ({len(raw)} chars)"
+        ) from exc
 
 
 def null_template_from_schema(schema: dict[str, Any]) -> dict[str, Any]:

--- a/integrations/extractbench/scripts/apply_clawql_provider.py
+++ b/integrations/extractbench/scripts/apply_clawql_provider.py
@@ -74,6 +74,11 @@ ENV_SNIPPET = """
 CLAWQL_MCP_URL=http://127.0.0.1:8080/mcp
 # OpenAI-compatible base for schema mapping (Arm A). No default host.
 QWEN35_SERVER_URL=
+# Optional: override served model id / Mini Metal prompt caps (env wins over pipeline)
+# CLAWQL_EXTRACTBENCH_MODEL=qwen3.6-35b-a3b-fp8
+# CLAWQL_EXTRACTBENCH_CHUNK_CHARS=50000
+# CLAWQL_EXTRACTBENCH_MAX_TOKENS=16384
+# CLAWQL_EXTRACTBENCH_LAYOUT_JSON_CHARS=4000
 # Optional measured infra cost attribution (USD / page)
 # CLAWQL_EXTRACTBENCH_COST_PER_PAGE=0.10
 # Optional meta-ontology sync after schema map (requires built clawql-ontology)

--- a/integrations/extractbench/tests/test_schema_map.py
+++ b/integrations/extractbench/tests/test_schema_map.py
@@ -60,6 +60,11 @@ class SchemaMapTests(unittest.TestCase):
         text = 'Here you go:\n```json\n{"a": 1}\n```\n'
         self.assertEqual(parse_json_object(text), {"a": 1})
 
+    def test_parse_truncated_json_repairs(self) -> None:
+        # max_tokens often cuts mid-array on list-heavy ExtractBench docs.
+        truncated = '{"a":1,"b":[{"x":1},{"x":2},{"x":'
+        self.assertEqual(parse_json_object(truncated), {"a": 1, "b": [{"x": 1}, {"x": 2}]})
+
     def test_null_template(self) -> None:
         schema = {
             "type": "object",


### PR DESCRIPTION
## Summary
- Records Mac Mini Arm A (`clawql_idp_qwen_extract`) partial `--test` results: **4/6 docs**, macro Value F1 **~0.587** (Goshen 0.779, pueblo 0.605, sm0801 0.557, veralto 0.406) vs Arm B floor ~0.01 on the same docs; long sm0801 **0.557 > raw Qwen oneshot long 0.268**.
- Provider: env wins for `CLAWQL_EXTRACTBENCH_MODEL` / `CHUNK_CHARS` / `MAX_TOKENS` / `LAYOUT_JSON_CHARS`; compact schema/layout JSON; truncated-JSON repair for list-heavy completions.
- README + `.env` snippet document Mini/CI knobs for a cloud agent / Actions re-run. bianco/W14 still need schema batching (schemas alone ~45k–137k tokens).

## Test plan
- [ ] `python integrations/extractbench/scripts/apply_clawql_provider.py --extractbench $EXTRACTBENCH`
- [ ] Arm B: `uv run extract-bench run clawql_idp_docling_extract --test`
- [ ] Arm A with Qwen OpenAI-compatible `/v1` and Mini caps:
  ```bash
  export QWEN35_SERVER_URL=...
  export CLAWQL_EXTRACTBENCH_CHUNK_CHARS=50000
  export CLAWQL_EXTRACTBENCH_MAX_TOKENS=16384
  export CLAWQL_EXTRACTBENCH_LAYOUT_JSON_CHARS=4000
  uv run extract-bench run clawql_idp_qwen_extract --test -m 1
  ```
- [ ] Confirm docs ledger matches scored CSVs under ExtractBench `output/`