### PR TITLE
fix security status publish + backfill docs scan history

### DIFF
--- a/docs/design/security-status-page-spec.md
+++ b/docs/design/security-status-page-spec.md
@@ -36,13 +36,14 @@ Latest release: v8.0.0
 Published: 2026-08-28
 Commit: a518ef32
 
-SBOM (Syft):        [Download SBOM — SPDX JSON]
+SBOM (Syft):        [Download SBOM — CycloneDX JSON]
 Signed image digest: sha256:4f8a2b...
-Verify signature:    cosign verify --key cosign.pub \
-                        ghcr.io/danielsmithdevelopment/clawql:8.0.0
+Verify signature:    cosign verify ghcr.io/danielsmithdevelopment/clawql-mcp@sha256:<digest> \
+                        --certificate-identity-regexp 'https://github\.com/danielsmithdevelopment/ClawQL/.*' \
+                        --certificate-oidc-issuer-regexp 'https://token\.actions\.githubusercontent\.com.*'
 ```
 
-Every field here is either a direct download link to the real artifact or a copy-pasteable command a reader can run themselves against the actual published image — nothing on this page is a description of the SBOM or the signature, it is the SBOM and a way to check the signature directly.
+Every field here is either a direct download link to the real artifact or a copy-pasteable command a reader can run themselves against the actual published image — nothing on this page is a description of the SBOM or the signature, it is the SBOM and a way to check the signature directly. (Implementation note: CI emits **CycloneDX** via Syft, and images are signed **keyless** with Cosign OIDC — not a static `cosign.pub`.)
 
 ### 3.2 Scan History
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5981,9 +5981,9 @@
       }
     },
     "node_modules/@toon-format/toon": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@toon-format/toon/-/toon-2.3.0.tgz",
-      "integrity": "sha512-/Ew9etdRQKVMnm9fDaCG0JjyAOK/O7T0M97oum1aW4W+UR8ZhVVPBanIV7oWgHBiGlnVxV9M55PWQCHofDV07w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@toon-format/toon/-/toon-2.3.1.tgz",
+      "integrity": "sha512-sWqEMeAJGMda9qRrfPKrX3C4c33CO9SJuvJzzrcBEn5sbDB+k6pSLkDsfN0rVnLQwR97MV3sDgVbcxQNsq8xVw==",
       "license": "MIT",
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "clawql-inference": "0.1.0",
     "clawql-memory": "0.1.0",
     "clawql-merkle": "0.1.0",
+    "clawql-network": "0.1.0",
     "clawql-observability": "0.1.0",
     "clawql-ontology": "0.1.0",
     "clawql-operator": "0.1.0",
@@ -167,7 +168,6 @@
     "clawql-payments": "0.1.0",
     "clawql-release": "0.1.0",
     "clawql-sandbox": "0.1.0",
-    "clawql-network": "0.1.0",
     "clawql-tee": "0.1.0",
     "clawql-web": "0.1.0",
     "dotenv": "^17.4.2",
@@ -239,6 +239,7 @@
     "brace-expansion": "5.0.9",
     "browserslist": "4.28.7",
     "effect": "3.22.1",
-    "@aws-sdk/credential-provider-login": "3.972.73"
+    "@aws-sdk/credential-provider-login": "3.972.73",
+    "@toon-format/toon": "2.3.1"
   }
 }

--- a/scripts/ci/publish-security-scan-history.mjs
+++ b/scripts/ci/publish-security-scan-history.mjs
@@ -2,6 +2,9 @@
 /**
  * Append new SecurityScanRunRecord artifacts from CI into website/public/security-scan-history.json.
  * Invoked by .github/workflows/security-status-publish.yml (scheduled, separate from scan job).
+ *
+ * API calls must use api.github.com (or GITHUB_API_URL). GITHUB_SERVER_URL is github.com and is
+ * only for human-facing HTML links — using it for /repos/... API paths 404s (see failed cron runs).
  */
 import { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
@@ -14,16 +17,23 @@ const historyPath = resolve(root, 'website/public/security-scan-history.json')
 const repo = process.env.GITHUB_REPOSITORY ?? 'danielsmithdevelopment/ClawQL'
 const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN
 const maxRuns = Number(process.env.SECURITY_STATUS_MAX_RUNS ?? '30')
-const serverUrl = process.env.GITHUB_SERVER_URL ?? 'https://github.com'
+const htmlServerUrl = (process.env.GITHUB_SERVER_URL ?? 'https://github.com').replace(/\/$/, '')
+const apiBase = (process.env.GITHUB_API_URL ?? 'https://api.github.com').replace(/\/$/, '')
 
 if (!token) {
-  console.error('GITHUB_TOKEN required')
+  console.error('GITHUB_TOKEN (or GH_TOKEN) required')
   process.exit(1)
+}
+
+/** @param {string} pathOrUrl */
+function apiUrl(pathOrUrl) {
+  if (pathOrUrl.startsWith('http://') || pathOrUrl.startsWith('https://')) return pathOrUrl
+  return `${apiBase}${pathOrUrl.startsWith('/') ? '' : '/'}${pathOrUrl}`
 }
 
 /** @param {string} url */
 async function ghJson(url) {
-  const res = await fetch(url, {
+  const res = await fetch(apiUrl(url), {
     headers: {
       Authorization: `Bearer ${token}`,
       Accept: 'application/vnd.github+json',
@@ -39,30 +49,47 @@ async function ghJson(url) {
 
 /** @param {string} url */
 async function ghBuffer(url) {
-  const res = await fetch(url, {
+  const res = await fetch(apiUrl(url), {
     headers: {
       Authorization: `Bearer ${token}`,
       Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
     },
   })
   if (!res.ok) throw new Error(`GitHub API ${res.status} download ${url}`)
   return Buffer.from(await res.arrayBuffer())
 }
 
-/** @returns {import('./security-scan-history.types.js').SecurityStatusHistory} */
+/**
+ * @typedef {{
+ *   schemaVersion: 1
+ *   updatedAt: string
+ *   latestRelease: ReturnType<typeof buildLatestRelease>
+ *   runs: Array<{
+ *     runId: string
+ *     timestamp: string
+ *     commit: string
+ *     sbom?: { artifactUrl?: string; artifactName?: string; format?: string }
+ *     signing?: { signed?: boolean; imageDigest?: string | null }
+ *   }>
+ * }} SecurityStatusHistory
+ */
+
+/** @returns {SecurityStatusHistory} */
 function loadHistory() {
   if (!existsSync(historyPath)) {
     return {
       schemaVersion: 1,
       updatedAt: new Date().toISOString(),
-      latestRelease: buildLatestRelease(),
+      latestRelease: buildLatestRelease(null),
       runs: [],
     }
   }
   return JSON.parse(readFileSync(historyPath, 'utf8'))
 }
 
-function buildLatestRelease() {
+/** @param {SecurityStatusHistory['runs'][number] | null} newest */
+function buildLatestRelease(newest) {
   let version = '8.0.0'
   try {
     const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'))
@@ -70,16 +97,28 @@ function buildLatestRelease() {
   } catch {
     /* default */
   }
+
+  const digest = newest?.signing?.imageDigest ?? null
+  const repository = 'ghcr.io/danielsmithdevelopment/clawql-mcp'
+  const cosignTarget = digest
+    ? `${repository}@${digest.startsWith('sha256:') ? digest : `sha256:${digest}`}`
+    : `${repository}@sha256:<digest>`
+
   return {
     version,
-    published: null,
-    commit: null,
-    sbomFormat: 'cyclonedx-json',
-    sbomArtifactName: 'sbom-cyclonedx-repository',
+    published: newest?.timestamp ? newest.timestamp.slice(0, 10) : null,
+    commit: newest?.commit ?? null,
+    sbomFormat: newest?.sbom?.format ?? 'cyclonedx-json',
+    sbomArtifactName: newest?.sbom?.artifactName ?? 'sbom-cyclonedx-repository',
+    sbomArtifactUrl:
+      newest?.sbom?.artifactUrl ??
+      (newest?.runId
+        ? `${htmlServerUrl}/${repo}/actions/runs/${newest.runId}#artifacts`
+        : null),
     image: {
-      repository: 'ghcr.io/danielsmithdevelopment/clawql-mcp',
-      digest: null,
-      cosignVerifyCommand: `cosign verify ghcr.io/danielsmithdevelopment/clawql-mcp@sha256:<digest> \\
+      repository,
+      digest,
+      cosignVerifyCommand: `cosign verify ${cosignTarget} \\
   --certificate-identity-regexp 'https://github\\.com/danielsmithdevelopment/ClawQL/.*' \\
   --certificate-oidc-issuer-regexp 'https://token\\.actions\\.githubusercontent\\.com.*'`,
     },
@@ -89,7 +128,7 @@ function buildLatestRelease() {
 /** @param {number} workflowRunId @param {string} destDir */
 async function downloadSecurityRecord(workflowRunId, destDir) {
   const artifacts = await ghJson(
-    `${serverUrl}/repos/${repo}/actions/runs/${workflowRunId}/artifacts?per_page=100`,
+    `/repos/${repo}/actions/runs/${workflowRunId}/artifacts?per_page=100`,
   )
   const list = /** @type {{ artifacts?: Array<{ id: number; name: string; expired: boolean }> }} */ (
     artifacts
@@ -97,7 +136,7 @@ async function downloadSecurityRecord(workflowRunId, destDir) {
   const hit = list?.find((a) => a.name === 'security-scan-run-record' && !a.expired)
   if (!hit) return null
 
-  const zip = await ghBuffer(`${serverUrl}/repos/${repo}/actions/artifacts/${hit.id}/zip`)
+  const zip = await ghBuffer(`/repos/${repo}/actions/artifacts/${hit.id}/zip`)
   const zipPath = join(destDir, 'artifact.zip')
   writeFileSync(zipPath, zip)
   execFileSync('unzip', ['-o', '-q', zipPath, '-d', destDir])
@@ -108,10 +147,9 @@ async function downloadSecurityRecord(workflowRunId, destDir) {
 
 async function main() {
   const history = loadHistory()
-  history.latestRelease = buildLatestRelease()
   const known = new Set(history.runs.map((r) => r.runId))
 
-  const workflows = await ghJson(`${serverUrl}/repos/${repo}/actions/workflows?per_page=100`)
+  const workflows = await ghJson(`/repos/${repo}/actions/workflows?per_page=100`)
   const ci = /** @type {{ workflows?: Array<{ id: number; path: string }> }} */ (workflows).workflows?.find(
     (w) => w.path === '.github/workflows/ci.yml',
   )
@@ -121,7 +159,7 @@ async function main() {
   }
 
   const runsResp = await ghJson(
-    `${serverUrl}/repos/${repo}/actions/workflows/${ci.id}/runs?branch=main&status=completed&per_page=50`,
+    `/repos/${repo}/actions/workflows/${ci.id}/runs?branch=main&status=completed&per_page=50`,
   )
   const runs = /** @type {{ workflow_runs?: Array<{ id: number; head_branch: string }> }} */ (
     runsResp
@@ -129,6 +167,7 @@ async function main() {
 
   if (!runs?.length) {
     console.log('No completed main CI runs found')
+    history.latestRelease = buildLatestRelease(history.runs[0] ?? null)
     writeFileSync(historyPath, `${JSON.stringify(history, null, 2)}\n`)
     return
   }
@@ -153,6 +192,7 @@ async function main() {
 
   history.runs.sort((a, b) => Number(b.runId) - Number(a.runId))
   history.runs = history.runs.slice(0, maxRuns)
+  history.latestRelease = buildLatestRelease(history.runs[0] ?? null)
   history.updatedAt = new Date().toISOString()
 
   mkdirSync(resolve(historyPath, '..'), { recursive: true })

--- a/website/public/AGENTS.md
+++ b/website/public/AGENTS.md
@@ -2,6 +2,10 @@
 
 Use this file when an **MCP client** (Cursor, IDE agents, or automation) talks to ClawQL **through** an intercepting proxy that enforces **JWT ATR** or similar policy (see [#272](https://github.com/danielsmithdevelopment/ClawQL/issues/272) and [`docs/security/mcp-proxy-jwt-atr.md`](docs/security/mcp-proxy-jwt-atr.md)).
 
+## Effect-TS (hard rule)
+
+Production code that **can** be Effect-based **must** be — there is no "pure sync is fine" carve-out. Never ship domain IO, orchestration, policy, or even sync helpers (URL/HTML builders, sync crypto, env flag readers) as bare `async`/`Promise`/plain-value APIs when an Effect `Context.Tag` + `Layer` or `Effect.sync` is possible. Forced Promise edges (Express / MCP SDK) stay thin façades over `run*Effect`; run `Effect.runSync` only at those absolute host boundaries. Only types-only modules are exempt. Every `packages/*` workspace must declare `effect` and ship a Tag + Layer (see `npm run check:effect-every-package`). Details: [`.cursor/rules/effect-ts-everywhere.mdc`](.cursor/rules/effect-ts-everywhere.mdc).
+
 ## Blocked or denied tool calls
 
 - **Stop and report.** If the proxy or server returns an error (including HTTP **403**, JSON-RPC error, or an explicit “blocked by policy” body), **tell the human operator** what failed and why, using the response payload when available.

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -32,8 +32,7 @@ This file helps AI agents and crawlers find canonical documentation. For full-te
 
 ## Deployment & security
 - [Deployment](https://docs.clawql.com/deployment): Docker, Kubernetes, and operations
-- [Authentication](https://docs.clawql.com/auth): Inbound vs outbound auth — OAuth refresh, EMA / ID-JAG, signing
-- [Audit Trail](https://docs.clawql.com/audit): Append-only WORM trail — hash chain, Merkle roots, dual-ack replication
+- [Security status](https://docs.clawql.com/security/status): Append-only Trivy/OSV scan history, SBOM, Cosign verify
 - [Defense in depth](https://docs.clawql.com/security/defense-in-depth): Layered MCP security model
 - [Security best practices](https://docs.clawql.com/security/best-practices): 32-module agentic AI security series
 

--- a/website/public/security-scan-history.json
+++ b/website/public/security-scan-history.json
@@ -1,17 +1,305 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-07T02:42:29.964Z",
   "latestRelease": {
     "version": "8.0.0",
-    "published": null,
-    "commit": null,
+    "published": "2026-09-02",
+    "commit": "6015ab413f53413a5bb8bb61480e323c06194296",
     "sbomFormat": "cyclonedx-json",
     "sbomArtifactName": "sbom-cyclonedx-repository",
+    "sbomArtifactUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33663508801#artifacts",
     "image": {
       "repository": "ghcr.io/danielsmithdevelopment/clawql-mcp",
       "digest": null,
       "cosignVerifyCommand": "cosign verify ghcr.io/danielsmithdevelopment/clawql-mcp@sha256:<digest> \\\n  --certificate-identity-regexp 'https://github\\.com/danielsmithdevelopment/ClawQL/.*' \\\n  --certificate-oidc-issuer-regexp 'https://token\\.actions\\.githubusercontent\\.com.*'"
     }
   },
-  "runs": []
+  "runs": [
+    {
+      "runId": "33663508801",
+      "timestamp": "2026-09-02T17:52:05.428Z",
+      "commit": "6015ab413f53413a5bb8bb61480e323c06194296",
+      "branch": "main",
+      "scanners": {
+        "trivy": {
+          "result": "pass"
+        },
+        "osv": {
+          "result": "pass"
+        }
+      },
+      "sbom": {
+        "generated": true,
+        "format": "cyclonedx-json",
+        "artifactUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33663508801#artifacts",
+        "artifactName": "sbom-cyclonedx-repository"
+      },
+      "signing": {
+        "signed": false,
+        "imageDigest": null
+      },
+      "overallResult": "merged",
+      "ciRunUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33663508801"
+    },
+    {
+      "runId": "33661023840",
+      "timestamp": "2026-09-02T17:28:13.520Z",
+      "commit": "c75497f647661a0a8d1302d58e0eb77ae1842c3b",
+      "branch": "main",
+      "scanners": {
+        "trivy": {
+          "result": "pass"
+        },
+        "osv": {
+          "result": "pass"
+        }
+      },
+      "sbom": {
+        "generated": true,
+        "format": "cyclonedx-json",
+        "artifactUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33661023840#artifacts",
+        "artifactName": "sbom-cyclonedx-repository"
+      },
+      "signing": {
+        "signed": false,
+        "imageDigest": null
+      },
+      "overallResult": "merged",
+      "ciRunUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33661023840"
+    },
+    {
+      "runId": "33657504430",
+      "timestamp": "2026-09-02T16:53:48.212Z",
+      "commit": "abea2864910e5e91bff5f14942c07c6e1ff6e301",
+      "branch": "main",
+      "scanners": {
+        "trivy": {
+          "result": "pass"
+        },
+        "osv": {
+          "result": "pass"
+        }
+      },
+      "sbom": {
+        "generated": true,
+        "format": "cyclonedx-json",
+        "artifactUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33657504430#artifacts",
+        "artifactName": "sbom-cyclonedx-repository"
+      },
+      "signing": {
+        "signed": false,
+        "imageDigest": null
+      },
+      "overallResult": "merged",
+      "ciRunUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33657504430"
+    },
+    {
+      "runId": "33655075542",
+      "timestamp": "2026-09-02T16:30:15.380Z",
+      "commit": "ee9e5905b6191731d2bd5b80162236a34a146e37",
+      "branch": "main",
+      "scanners": {
+        "trivy": {
+          "result": "pass"
+        },
+        "osv": {
+          "result": "pass"
+        }
+      },
+      "sbom": {
+        "generated": true,
+        "format": "cyclonedx-json",
+        "artifactUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33655075542#artifacts",
+        "artifactName": "sbom-cyclonedx-repository"
+      },
+      "signing": {
+        "signed": false,
+        "imageDigest": null
+      },
+      "overallResult": "merged",
+      "ciRunUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33655075542"
+    },
+    {
+      "runId": "33647222525",
+      "timestamp": "2026-09-02T15:16:26.807Z",
+      "commit": "23d2aeb6ceb3e523767e4c06ed26441761e4cde3",
+      "branch": "main",
+      "scanners": {
+        "trivy": {
+          "result": "pass"
+        },
+        "osv": {
+          "result": "fail"
+        }
+      },
+      "sbom": {
+        "generated": true,
+        "format": "cyclonedx-json",
+        "artifactUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33647222525#artifacts",
+        "artifactName": "sbom-cyclonedx-repository"
+      },
+      "signing": {
+        "signed": false,
+        "imageDigest": null
+      },
+      "overallResult": "blocked",
+      "ciRunUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33647222525"
+    },
+    {
+      "runId": "33641658845",
+      "timestamp": "2026-09-02T14:25:30.473Z",
+      "commit": "1583099fc34e5bbebe35aac40a105db6c49d97a6",
+      "branch": "main",
+      "scanners": {
+        "trivy": {
+          "result": "pass"
+        },
+        "osv": {
+          "result": "pass"
+        }
+      },
+      "sbom": {
+        "generated": true,
+        "format": "cyclonedx-json",
+        "artifactUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33641658845#artifacts",
+        "artifactName": "sbom-cyclonedx-repository"
+      },
+      "signing": {
+        "signed": false,
+        "imageDigest": null
+      },
+      "overallResult": "merged",
+      "ciRunUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33641658845"
+    },
+    {
+      "runId": "33637577124",
+      "timestamp": "2026-09-02T13:46:52.140Z",
+      "commit": "3839136c6447e36f82ae6dc90dd6c144874e81ca",
+      "branch": "main",
+      "scanners": {
+        "trivy": {
+          "result": "pass"
+        },
+        "osv": {
+          "result": "pass"
+        }
+      },
+      "sbom": {
+        "generated": true,
+        "format": "cyclonedx-json",
+        "artifactUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33637577124#artifacts",
+        "artifactName": "sbom-cyclonedx-repository"
+      },
+      "signing": {
+        "signed": false,
+        "imageDigest": null
+      },
+      "overallResult": "merged",
+      "ciRunUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33637577124"
+    },
+    {
+      "runId": "33599988916",
+      "timestamp": "2026-09-02T06:44:17.119Z",
+      "commit": "6ca00b0d5c1a5ec5039054325fdddc28b77cd357",
+      "branch": "main",
+      "scanners": {
+        "trivy": {
+          "result": "pass"
+        },
+        "osv": {
+          "result": "pass"
+        }
+      },
+      "sbom": {
+        "generated": true,
+        "format": "cyclonedx-json",
+        "artifactUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33599988916#artifacts",
+        "artifactName": "sbom-cyclonedx-repository"
+      },
+      "signing": {
+        "signed": false,
+        "imageDigest": null
+      },
+      "overallResult": "merged",
+      "ciRunUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33599988916"
+    },
+    {
+      "runId": "33598565345",
+      "timestamp": "2026-09-02T06:24:38.433Z",
+      "commit": "1ef8288d1cf9a04adb1fbbaef14af5d8fb752aa1",
+      "branch": "main",
+      "scanners": {
+        "trivy": {
+          "result": "pass"
+        },
+        "osv": {
+          "result": "pass"
+        }
+      },
+      "sbom": {
+        "generated": true,
+        "format": "cyclonedx-json",
+        "artifactUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33598565345#artifacts",
+        "artifactName": "sbom-cyclonedx-repository"
+      },
+      "signing": {
+        "signed": false,
+        "imageDigest": null
+      },
+      "overallResult": "merged",
+      "ciRunUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33598565345"
+    },
+    {
+      "runId": "33594887327",
+      "timestamp": "2026-09-02T05:32:16.051Z",
+      "commit": "9b29c55ce1f0e7c6381e850801a14d33a2fc5e3d",
+      "branch": "main",
+      "scanners": {
+        "trivy": {
+          "result": "pass"
+        },
+        "osv": {
+          "result": "pass"
+        }
+      },
+      "sbom": {
+        "generated": true,
+        "format": "cyclonedx-json",
+        "artifactUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33594887327#artifacts",
+        "artifactName": "sbom-cyclonedx-repository"
+      },
+      "signing": {
+        "signed": false,
+        "imageDigest": null
+      },
+      "overallResult": "merged",
+      "ciRunUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33594887327"
+    },
+    {
+      "runId": "33593503982",
+      "timestamp": "2026-09-02T05:10:49.993Z",
+      "commit": "28a2961fccacb019f6561a2dac486acfb831e6a9",
+      "branch": "main",
+      "scanners": {
+        "trivy": {
+          "result": "pass"
+        },
+        "osv": {
+          "result": "pass"
+        }
+      },
+      "sbom": {
+        "generated": true,
+        "format": "cyclonedx-json",
+        "artifactUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33593503982#artifacts",
+        "artifactName": "sbom-cyclonedx-repository"
+      },
+      "signing": {
+        "signed": false,
+        "imageDigest": null
+      },
+      "overallResult": "merged",
+      "ciRunUrl": "https://github.com/danielsmithdevelopment/ClawQL/actions/runs/33593503982"
+    }
+  ]
 }

--- a/website/scripts/generate-llms-txt.mjs
+++ b/website/scripts/generate-llms-txt.mjs
@@ -114,6 +114,11 @@ const SECTIONS = [
     heading: 'Deployment & security',
     links: [
       ['Deployment', '/deployment', 'Docker, Kubernetes, and operations'],
+      [
+        'Security status',
+        '/security/status',
+        'Append-only Trivy/OSV scan history, SBOM, Cosign verify',
+      ],
       ['Defense in depth', '/security/defense-in-depth', 'Layered MCP security model'],
       [
         'Security best practices',

--- a/website/src/app/security/status/page.tsx
+++ b/website/src/app/security/status/page.tsx
@@ -43,10 +43,11 @@ export default function SecurityStatusPage() {
         Security status
       </h1>
       <p className="mt-4 max-w-3xl text-lg text-zinc-600 dark:text-zinc-400">
-        This page shows raw, independently checkable supply-chain evidence —
-        scan pass/fail history (including caught failures), SBOM artifact links,
-        and signature verification commands. It is fed by CI exports and an
-        append-only publish job, not hand-edited summaries. Spec:{' '}
+        This page proves ClawQL&apos;s security process runs and holds. Every
+        element is either raw, independently verifiable data (an SBOM, a
+        signature command, a CI log) or a real history of scan outcomes —
+        including failures that were caught and fixed — never a badge claiming a
+        snapshot state. Spec:{' '}
         <a
           href="https://github.com/danielsmithdevelopment/ClawQL/blob/main/docs/design/security-status-page-spec.md"
           className="font-medium text-claw-graph underline decoration-claw-graph/40 underline-offset-2 dark:text-claw-cyan"
@@ -56,6 +57,11 @@ export default function SecurityStatusPage() {
         </a>
         .
       </p>
+      <p className="mt-3 max-w-3xl text-sm text-zinc-600 dark:text-zinc-400">
+        This is not a live vulnerability dashboard. It never lists currently
+        open, unpatched findings on unmerged branches — only historical gate
+        outcomes after CI has already recorded them.
+      </p>
 
       <p className="not-prose mt-4 text-sm text-zinc-600 dark:text-zinc-400">
         <Link
@@ -64,14 +70,6 @@ export default function SecurityStatusPage() {
         >
           ← Security overview
         </Link>
-        {' · '}
-        <a
-          href="https://github.com/danielsmithdevelopment/ClawQL/blob/main/SECURITY.md"
-          className="font-medium underline-offset-2 hover:underline"
-          rel="noopener noreferrer"
-        >
-          SECURITY.md (disclosure)
-        </a>
       </p>
 
       <section className="not-prose mt-10 border-t border-zinc-900/10 pt-10 dark:border-white/10">
@@ -92,20 +90,58 @@ export default function SecurityStatusPage() {
           {rel.commit ? (
             <div className="flex flex-wrap gap-x-2">
               <dt className="text-zinc-500 dark:text-zinc-400">Commit</dt>
-              <dd>{rel.commit.slice(0, 8)}</dd>
+              <dd>
+                <a
+                  href={`https://github.com/danielsmithdevelopment/ClawQL/commit/${rel.commit}`}
+                  className="font-medium text-claw-graph underline-offset-2 hover:underline dark:text-claw-cyan"
+                  rel="noopener noreferrer"
+                >
+                  {rel.commit.slice(0, 8)}
+                </a>
+              </dd>
             </div>
           ) : null}
           <div>
             <dt className="text-zinc-500 dark:text-zinc-400">SBOM (Syft)</dt>
             <dd className="mt-1">
-              CycloneDX JSON via CI artifact{' '}
-              <code className="rounded bg-zinc-100 px-1 dark:bg-white/10">
-                {rel.sbomArtifactName}
-              </code>{' '}
-              on each green supply-chain run — download from the linked CI run
-              artifacts.
+              {rel.sbomArtifactUrl ? (
+                <>
+                  <a
+                    href={rel.sbomArtifactUrl}
+                    className="font-medium text-claw-graph underline decoration-claw-graph/40 underline-offset-2 dark:text-claw-cyan"
+                    rel="noopener noreferrer"
+                  >
+                    Download SBOM — {rel.sbomFormat}
+                  </a>
+                  <span className="text-zinc-500 dark:text-zinc-400">
+                    {' '}
+                    (CI artifact{' '}
+                    <code className="rounded bg-zinc-100 px-1 dark:bg-white/10">
+                      {rel.sbomArtifactName}
+                    </code>
+                    )
+                  </span>
+                </>
+              ) : (
+                <>
+                  CycloneDX JSON via CI artifact{' '}
+                  <code className="rounded bg-zinc-100 px-1 dark:bg-white/10">
+                    {rel.sbomArtifactName}
+                  </code>{' '}
+                  on each green supply-chain run — download from the linked CI
+                  run artifacts once history is published.
+                </>
+              )}
             </dd>
           </div>
+          {rel.image.digest ? (
+            <div className="flex flex-wrap gap-x-2">
+              <dt className="text-zinc-500 dark:text-zinc-400">
+                Signed image digest
+              </dt>
+              <dd className="break-all">{rel.image.digest}</dd>
+            </div>
+          ) : null}
           <div>
             <dt className="text-zinc-500 dark:text-zinc-400">
               Verify signature
@@ -114,6 +150,16 @@ export default function SecurityStatusPage() {
               <pre className="overflow-x-auto rounded-lg bg-zinc-100 p-3 text-xs dark:bg-white/10">
                 {rel.image.cosignVerifyCommand}
               </pre>
+              {!rel.image.digest ? (
+                <p className="mt-2 font-sans text-xs text-zinc-500 dark:text-zinc-400">
+                  Digest fills in when a signed image record is published from
+                  the container release pipeline. Until then, substitute the{' '}
+                  <code className="rounded bg-zinc-100 px-1 dark:bg-white/10">
+                    sha256:&lt;digest&gt;
+                  </code>{' '}
+                  from the GHCR package page.
+                </p>
+              ) : null}
             </dd>
           </div>
         </dl>
@@ -125,8 +171,9 @@ export default function SecurityStatusPage() {
         </h2>
         <p className="mt-2 max-w-3xl text-sm text-zinc-600 dark:text-zinc-400">
           Last {data.runs.length || 0} published main-branch CI supply-chain
-          runs. Failed rows are never removed — a fail-then-fix pair is evidence
-          the gate blocked a merge.
+          runs (capped at 30). Failed rows are never removed — a fail-then-fix
+          pair is evidence the gate blocked a merge. Sourced from CI export
+          artifacts, not hand-curated.
         </p>
         {data.runs.length === 0 ? (
           <p className="mt-4 text-sm text-zinc-600 dark:text-zinc-400">
@@ -134,7 +181,7 @@ export default function SecurityStatusPage() {
             <code className="rounded bg-zinc-100 px-1 dark:bg-white/10">
               security-status-publish
             </code>{' '}
-            workflow will append records after CI exports land on{' '}
+            workflow appends records after CI exports land on{' '}
             <code className="font-mono">main</code>.
           </p>
         ) : (
@@ -195,13 +242,66 @@ export default function SecurityStatusPage() {
 
       <section className="not-prose mt-10 border-t border-zinc-900/10 pt-10 dark:border-white/10">
         <h2 className="text-2xl font-semibold text-zinc-900 dark:text-white">
+          Security policy
+        </h2>
+        <p className="mt-2 max-w-3xl text-sm text-zinc-600 dark:text-zinc-400">
+          Disclosure process and response-time commitments live in{' '}
+          <a
+            href="https://github.com/danielsmithdevelopment/ClawQL/blob/main/SECURITY.md"
+            className="font-medium text-claw-graph underline decoration-claw-graph/40 underline-offset-2 dark:text-claw-cyan"
+            rel="noopener noreferrer"
+          >
+            SECURITY.md
+          </a>
+          . Report vulnerabilities to{' '}
+          <a
+            href="mailto:daniel@clawql.com"
+            className="font-medium underline-offset-2 hover:underline"
+          >
+            daniel@clawql.com
+          </a>
+          — do not open public issues for undisclosed findings.
+        </p>
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full max-w-md border-collapse text-left text-sm">
+            <thead>
+              <tr className="border-b border-zinc-200 dark:border-white/10">
+                <th className="py-2 pr-4 font-medium text-zinc-500">
+                  Severity
+                </th>
+                <th className="py-2 font-medium text-zinc-500">
+                  Target first response
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-b border-zinc-100 dark:border-white/5">
+                <td className="py-2 pr-4">Critical</td>
+                <td className="py-2">48 hours</td>
+              </tr>
+              <tr className="border-b border-zinc-100 dark:border-white/5">
+                <td className="py-2 pr-4">High</td>
+                <td className="py-2">5 business days</td>
+              </tr>
+              <tr className="border-b border-zinc-100 dark:border-white/5">
+                <td className="py-2 pr-4">Other</td>
+                <td className="py-2">10 business days</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="not-prose mt-10 border-t border-zinc-900/10 pt-10 dark:border-white/10">
+        <h2 className="text-2xl font-semibold text-zinc-900 dark:text-white">
           Independent verification
         </h2>
         <p className="mt-2 max-w-3xl text-sm text-zinc-600 dark:text-zinc-400">
           Third-party, vendor-neutral security benchmarks (for example
           MCPSEC-style formal properties) will be linked here when ClawQL
           completes a reproducible external evaluation — same
-          independent-evidence principle as Harvey LAB and ExtractBench.
+          independent-evidence principle as Harvey LAB and ExtractBench. This
+          page does not make comparative &quot;most secure gateway&quot; claims.
         </p>
       </section>
     </article>

--- a/website/src/lib/security-scan-history.types.ts
+++ b/website/src/lib/security-scan-history.types.ts
@@ -44,6 +44,8 @@ export type SecurityStatusHistory = {
     commit: string | null
     sbomFormat: string
     sbomArtifactName: string
+    /** Direct CI artifacts anchor for the newest published run's SBOM zip. */
+    sbomArtifactUrl?: string | null
     image: {
       repository: string
       digest: string | null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Security Status page (`/security/status`) already existed per `docs/design/security-status-page-spec.md`, but the scheduled **security-status-publish** job was failing every run — so the live page stayed empty.

### Root cause
`scripts/ci/publish-security-scan-history.mjs` called `https://github.com/repos/...` (from `GITHUB_SERVER_URL`) instead of the GitHub **API** (`api.github.com`). That 404’d before any artifacts could be merged.

### Changes
1. **Fix publisher** — API requests use `GITHUB_API_URL` / `https://api.github.com`; HTML links still use `GITHUB_SERVER_URL`.
2. **Backfill** `website/public/security-scan-history.json` with 11 main-branch CI records (including one **blocked** OSV fail that stays visible).
3. **Page alignment** — dedicated Security policy section (`SECURITY.md` + SLAs), SBOM download link from latest run, clearer “not a live vuln dashboard” framing.
4. **Discoverability** — `/security/status` added to `llms.txt` generator output.
5. Spec note: CI emits CycloneDX + keyless Cosign (not SPDX / static `cosign.pub`).
6. **Supply-chain fix** — npm override `@toon-format/toon@2.3.1` for CVE-2026-82404 / GHSA-p95v-992w-h6c3 (blocked PR CI).

### Verify
```bash
GITHUB_TOKEN=$(gh auth token) node scripts/ci/publish-security-scan-history.mjs
# idempotent; history under website/public/security-scan-history.json
```

After merge, the next cron/`workflow_dispatch` of `security-status-publish` should succeed and keep appending.

Will merge after CI is green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8f57-601a-7ec1-bff0-d35011fef4ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8f57-601a-7ec1-bff0-d35011fef4ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

