### PR TITLE
docs: customer provisioning core + hybrid billing specs

### DIFF
--- a/docs/payments/clawql-payments.md
+++ b/docs/payments/clawql-payments.md
@@ -876,11 +876,11 @@ See also: [`packages/clawql-inference/README.md`](../../packages/clawql-inferenc
 
 ## Follow-up work
 
-| Item                         | Tracking     |
-| ---------------------------- | ------------ |
-| Hosted webhook HTTP endpoint | not CLI-only |
+| Item                                                  | Tracking                                                                                                |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Hosted webhook HTTP endpoint                          | not CLI-only                                                                                            |
 | Customer provisioning core (`provisionOrg`, org-of-1) | [specs/billing/customer-provisioning-core-v0.1.md](../specs/billing/customer-provisioning-core-v0.1.md) |
-| Hybrid subscription + prepaid credits | [specs/billing/hybrid-billing-v0.1.md](../specs/billing/hybrid-billing-v0.1.md) |
+| Hybrid subscription + prepaid credits                 | [specs/billing/hybrid-billing-v0.1.md](../specs/billing/hybrid-billing-v0.1.md)                         |
 
 ## Related
 

--- a/docs/payments/clawql-payments.md
+++ b/docs/payments/clawql-payments.md
@@ -879,10 +879,14 @@ See also: [`packages/clawql-inference/README.md`](../../packages/clawql-inferenc
 | Item                         | Tracking     |
 | ---------------------------- | ------------ |
 | Hosted webhook HTTP endpoint | not CLI-only |
+| Customer provisioning core (`provisionOrg`, org-of-1) | [specs/billing/customer-provisioning-core-v0.1.md](../specs/billing/customer-provisioning-core-v0.1.md) |
+| Hybrid subscription + prepaid credits | [specs/billing/hybrid-billing-v0.1.md](../specs/billing/hybrid-billing-v0.1.md) |
 
 ## Related
 
 - Accounting & tax: [`docs/payments/accounting-and-tax.md`](./accounting-and-tax.md)
+- Org credits: [`docs/payments/org-credits.md`](./org-credits.md)
+- Billing specs: [`docs/specs/billing/README.md`](../specs/billing/README.md)
 - Package README: [`packages/clawql-payments/README.md`](../../packages/clawql-payments/README.md)
 - Inference doc: [`docs/inference/clawql-inference.md`](../inference/clawql-inference.md)
 - x402 protocol: [x402.org](https://www.x402.org/)

--- a/docs/payments/org-credits.md
+++ b/docs/payments/org-credits.md
@@ -77,4 +77,3 @@ Flags:
 - [`p2p-consumer-roadmap.md`](./p2p-consumer-roadmap.md) — cross-tenant P2P (self-hosted only)
 - [`../specs/billing/customer-provisioning-core-v0.1.md`](../specs/billing/customer-provisioning-core-v0.1.md) — org-of-1 provisioning + dual triggers
 - [`../specs/billing/hybrid-billing-v0.1.md`](../specs/billing/hybrid-billing-v0.1.md) — subscription + prepaid credits coexistence
-

--- a/docs/payments/org-credits.md
+++ b/docs/payments/org-credits.md
@@ -75,3 +75,6 @@ Flags:
 - [`deduction-service.md`](./deduction-service.md) — spend path
 - [`../enterprise/control-plane.md`](../enterprise/control-plane.md) — SSO domains, user admin, unified spend
 - [`p2p-consumer-roadmap.md`](./p2p-consumer-roadmap.md) — cross-tenant P2P (self-hosted only)
+- [`../specs/billing/customer-provisioning-core-v0.1.md`](../specs/billing/customer-provisioning-core-v0.1.md) — org-of-1 provisioning + dual triggers
+- [`../specs/billing/hybrid-billing-v0.1.md`](../specs/billing/hybrid-billing-v0.1.md) — subscription + prepaid credits coexistence
+

--- a/docs/specs/billing/README.md
+++ b/docs/specs/billing/README.md
@@ -1,8 +1,8 @@
 # Billing specs
 
-| Spec | Package / home | Notes |
-| ---- | -------------- | ----- |
-| [customer-provisioning-core-v0.1.md](./customer-provisioning-core-v0.1.md) | `clawql-payments` + thin `clawql-auth` key issue | One org model; `provisionOrg`; dual triggers |
-| [hybrid-billing-v0.1.md](./hybrid-billing-v0.1.md) | `clawql-payments` Stripe + credits ledger | Subscription tiers + prepaid credits + hybrid |
+| Spec                                                                       | Package / home                                   | Notes                                         |
+| -------------------------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------- |
+| [customer-provisioning-core-v0.1.md](./customer-provisioning-core-v0.1.md) | `clawql-payments` + thin `clawql-auth` key issue | One org model; `provisionOrg`; dual triggers  |
+| [hybrid-billing-v0.1.md](./hybrid-billing-v0.1.md)                         | `clawql-payments` Stripe + credits ledger        | Subscription tiers + prepaid credits + hybrid |
 
 **Related:** [org-credits](../../payments/org-credits.md) · [clawql-payments](../../payments/clawql-payments.md) · [spend-governance (outbound only)](../spend/spend-governance-v0.1.md) · [control-plane](../../enterprise/control-plane.md)

--- a/docs/specs/billing/README.md
+++ b/docs/specs/billing/README.md
@@ -1,0 +1,8 @@
+# Billing specs
+
+| Spec | Package / home | Notes |
+| ---- | -------------- | ----- |
+| [customer-provisioning-core-v0.1.md](./customer-provisioning-core-v0.1.md) | `clawql-payments` + thin `clawql-auth` key issue | One org model; `provisionOrg`; dual triggers |
+| [hybrid-billing-v0.1.md](./hybrid-billing-v0.1.md) | `clawql-payments` Stripe + credits ledger | Subscription tiers + prepaid credits + hybrid |
+
+**Related:** [org-credits](../../payments/org-credits.md) · [clawql-payments](../../payments/clawql-payments.md) · [spend-governance (outbound only)](../spend/spend-governance-v0.1.md) · [control-plane](../../enterprise/control-plane.md)

--- a/docs/specs/billing/customer-provisioning-core-v0.1.md
+++ b/docs/specs/billing/customer-provisioning-core-v0.1.md
@@ -20,15 +20,15 @@ Org-of-1 and org-of-1000 share one data shape.
 
 ## 2. Locked decisions (hardened against the repo)
 
-| Topic | Decision |
-| ----- | -------- |
-| **Org store** | Extend existing `$CLAWQL_HOME/Payments/org-credits.json` (`OrgRecord` / `OrgMembership`) — **do not** invent a second Org table in Postgres or auth |
-| **Roles** | Keep shipped `OrgMemberRole`: `billing_admin` \| `manager` \| `member`. Solo owner = sole member with `billing_admin` (can do everything; no second approver). Do **not** invent a parallel `SpendRole` / `spend_admin` for CPC — that name is reserved if spend-governance later grows RBAC |
-| **Plan / tier id** | Use existing `ClawqlPlanId` (`free` \| `pro` \| `team` \| `enterprise`) from `clawql-payments` plans — map to Stripe Products/Prices and gateway tiers explicitly |
-| **API keys** | Reuse `IssuedApiKeyStore.issue` with `subjectId` + optional `orgId` metadata. No `ownerType: 'org'` field today — org ownership is `orgId` on a subject-issued default key (or a dedicated service subject). Spec forbids inventing a second issuer |
-| **Credits ledger** | Reuse `CreditsLedgerService` / `CreditLedgerEntry` / `DeductionService` — **not** a new bare `CreditLedger` type |
-| **Stripe Checkout provision today** | Cloudflare gateway already handles `checkout.session.completed` → D1 tenant. Node CPC must **converge** on the same `provisionOrg` Effect (gateway calls shared logic or posts into payments), not fork a second provisioner |
-| **Effect** | `provisionOrg` / stores / Stripe wrappers are Effect `Context.Tag` + `Layer`; Express/MCP/webhook hosts stay thin Promise façades |
+| Topic                               | Decision                                                                                                                                                                                                                                                                                     |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Org store**                       | Extend existing `$CLAWQL_HOME/Payments/org-credits.json` (`OrgRecord` / `OrgMembership`) — **do not** invent a second Org table in Postgres or auth                                                                                                                                          |
+| **Roles**                           | Keep shipped `OrgMemberRole`: `billing_admin` \| `manager` \| `member`. Solo owner = sole member with `billing_admin` (can do everything; no second approver). Do **not** invent a parallel `SpendRole` / `spend_admin` for CPC — that name is reserved if spend-governance later grows RBAC |
+| **Plan / tier id**                  | Use existing `ClawqlPlanId` (`free` \| `pro` \| `team` \| `enterprise`) from `clawql-payments` plans — map to Stripe Products/Prices and gateway tiers explicitly                                                                                                                            |
+| **API keys**                        | Reuse `IssuedApiKeyStore.issue` with `subjectId` + optional `orgId` metadata. No `ownerType: 'org'` field today — org ownership is `orgId` on a subject-issued default key (or a dedicated service subject). Spec forbids inventing a second issuer                                          |
+| **Credits ledger**                  | Reuse `CreditsLedgerService` / `CreditLedgerEntry` / `DeductionService` — **not** a new bare `CreditLedger` type                                                                                                                                                                             |
+| **Stripe Checkout provision today** | Cloudflare gateway already handles `checkout.session.completed` → D1 tenant. Node CPC must **converge** on the same `provisionOrg` Effect (gateway calls shared logic or posts into payments), not fork a second provisioner                                                                 |
+| **Effect**                          | `provisionOrg` / stores / Stripe wrappers are Effect `Context.Tag` + `Layer`; Express/MCP/webhook hosts stay thin Promise façades                                                                                                                                                            |
 
 Spend-governance v0.1 remains **outbound USDC only**. CPC does not fold into that spec.
 
@@ -108,11 +108,11 @@ type ProvisionOrgResult = {
 
 **Two triggers call the same function:**
 
-| Trigger | Who | Typical `billingMode` |
-| ------- | --- | --------------------- |
-| Self-serve | Stripe `checkout.session.completed` (gateway today → must call shared `provisionOrg`) | `stripe_checkout` or `hybrid` |
-| Enterprise | Internal admin tool after deal close | `stripe_invoice` or `hybrid` |
-| Credits-only SKU | Checkout one-time top-up product without subscription | `credits_only` |
+| Trigger          | Who                                                                                   | Typical `billingMode`         |
+| ---------------- | ------------------------------------------------------------------------------------- | ----------------------------- |
+| Self-serve       | Stripe `checkout.session.completed` (gateway today → must call shared `provisionOrg`) | `stripe_checkout` or `hybrid` |
+| Enterprise       | Internal admin tool after deal close                                                  | `stripe_invoice` or `hybrid`  |
+| Credits-only SKU | Checkout one-time top-up product without subscription                                 | `credits_only`                |
 
 Nothing else forks provision logic.
 
@@ -136,10 +136,7 @@ reportUsageToStripe(orgId: string, period: DateRange): Effect<…>
 
 ```typescript
 type ProvisioningWORMEntryType =
-  | "ORG_PROVISIONED"
-  | "ORG_MEMBER_ADDED"
-  | "ORG_PLAN_CHANGED"
-  | "USAGE_REPORTED_TO_BILLING";
+  "ORG_PROVISIONED" | "ORG_MEMBER_ADDED" | "ORG_PLAN_CHANGED" | "USAGE_REPORTED_TO_BILLING";
 ```
 
 Same payments / clawql-audit trail. No separate billing audit schema.
@@ -150,15 +147,15 @@ Same payments / clawql-audit trail. No separate billing audit schema.
 
 **Stripe account / product setup is a live-billing blocker, not a schema blocker.** Spec + `Org` fields + `provisionOrg` Effect can land before Products exist; Checkout and meter reporting cannot go live without § Stripe setup in [hybrid-billing-v0.1](./hybrid-billing-v0.1.md).
 
-| # | Piece | New vs reuse |
-| - | ----- | ------------ |
-| 0 | Stripe Products / Prices / metered overage / credit top-up Prices | **Ops** (dashboard) — see hybrid-billing |
-| 1 | Org billing fields on `OrgRecord` + membership (already mostly shipped) | Extend store |
-| 2 | `provisionOrg` Effect Tag + Layer | **New** orchestration |
-| 3 | Stripe webhook → `provisionOrg` (converge CF gateway + Node) | **New** wiring |
-| 4 | Internal admin tool (enterprise trigger) | **New** CLI/MCP/UI |
-| 5 | `reportUsageToStripe` | **New** thin wrapper |
-| 6 | Self-serve dashboard (keys, usage, upgrade / top-up) | **New** UI surface |
+| #   | Piece                                                                   | New vs reuse                             |
+| --- | ----------------------------------------------------------------------- | ---------------------------------------- |
+| 0   | Stripe Products / Prices / metered overage / credit top-up Prices       | **Ops** (dashboard) — see hybrid-billing |
+| 1   | Org billing fields on `OrgRecord` + membership (already mostly shipped) | Extend store                             |
+| 2   | `provisionOrg` Effect Tag + Layer                                       | **New** orchestration                    |
+| 3   | Stripe webhook → `provisionOrg` (converge CF gateway + Node)            | **New** wiring                           |
+| 4   | Internal admin tool (enterprise trigger)                                | **New** CLI/MCP/UI                       |
+| 5   | `reportUsageToStripe`                                                   | **New** thin wrapper                     |
+| 6   | Self-serve dashboard (keys, usage, upgrade / top-up)                    | **New** UI surface                       |
 
 **Credit ledger + debit-on-inference:** already shipped (`CreditsLedgerService`, `DeductionService`). Spec requires CPC to **wire** them, not reinvent — details in hybrid-billing § Prepaid.
 

--- a/docs/specs/billing/customer-provisioning-core-v0.1.md
+++ b/docs/specs/billing/customer-provisioning-core-v0.1.md
@@ -1,0 +1,202 @@
+# Customer Provisioning Core
+
+**Status:** Spec v0.1 (design — not fully shipped)  
+**Primary package:** `clawql-payments` (org store, billing, ledger)  
+**Auth edge:** `clawql-auth` API-key issue only (`IssuedApiKeyStore`)  
+**Optional path note:** A thin `packages/clawql-auth/src/provisioning/` façade may re-export `provisionOrg` for hosts that already compose auth first — **storage and Stripe stay in payments**.  
+**Related:** [hybrid billing](./hybrid-billing-v0.1.md) · [org-credits](../../payments/org-credits.md) · [spend-governance](../spend/spend-governance-v0.1.md) (outbound USDC only — do not conflate)
+
+## Specification v0.1
+
+---
+
+## 1. Core principle
+
+**Every customer is an org.** Self-serve signup creates an org with one member. Enterprise sales creates an org with N members up front. There is **no** separate “individual account” table and **no** later migration when a solo org grows — it already is an org, just small.
+
+Org-of-1 and org-of-1000 share one data shape.
+
+---
+
+## 2. Locked decisions (hardened against the repo)
+
+| Topic | Decision |
+| ----- | -------- |
+| **Org store** | Extend existing `$CLAWQL_HOME/Payments/org-credits.json` (`OrgRecord` / `OrgMembership`) — **do not** invent a second Org table in Postgres or auth |
+| **Roles** | Keep shipped `OrgMemberRole`: `billing_admin` \| `manager` \| `member`. Solo owner = sole member with `billing_admin` (can do everything; no second approver). Do **not** invent a parallel `SpendRole` / `spend_admin` for CPC — that name is reserved if spend-governance later grows RBAC |
+| **Plan / tier id** | Use existing `ClawqlPlanId` (`free` \| `pro` \| `team` \| `enterprise`) from `clawql-payments` plans — map to Stripe Products/Prices and gateway tiers explicitly |
+| **API keys** | Reuse `IssuedApiKeyStore.issue` with `subjectId` + optional `orgId` metadata. No `ownerType: 'org'` field today — org ownership is `orgId` on a subject-issued default key (or a dedicated service subject). Spec forbids inventing a second issuer |
+| **Credits ledger** | Reuse `CreditsLedgerService` / `CreditLedgerEntry` / `DeductionService` — **not** a new bare `CreditLedger` type |
+| **Stripe Checkout provision today** | Cloudflare gateway already handles `checkout.session.completed` → D1 tenant. Node CPC must **converge** on the same `provisionOrg` Effect (gateway calls shared logic or posts into payments), not fork a second provisioner |
+| **Effect** | `provisionOrg` / stores / Stripe wrappers are Effect `Context.Tag` + `Layer`; Express/MCP/webhook hosts stay thin Promise façades |
+
+Spend-governance v0.1 remains **outbound USDC only**. CPC does not fold into that spec.
+
+---
+
+## 3. Data model (logical)
+
+Build on shipped shapes; additive fields for CPC:
+
+```typescript
+/** Extends OrgRecord — same file/store. */
+type OrgBillingFields = {
+  createdVia: "self_serve" | "enterprise_sales";
+  /**
+   * How money settles with Stripe.
+   * - stripe_checkout: self-serve Billing subscription (Checkout → Subscription)
+   * - stripe_invoice: enterprise NET terms / manual invoice
+   * - hybrid: subscription included quota + prepaid credits beyond / beside it
+   * - credits_only: no recurring subscription; prepaid top-ups only
+   */
+  billingMode: "stripe_checkout" | "stripe_invoice" | "hybrid" | "credits_only";
+  planId: ClawqlPlanId; // was optional on OrgRecord — required after provision
+  stripeCustomerId?: string;
+  stripeSubscriptionId?: string;
+};
+
+/**
+ * Membership continues as OrgMembership.
+ * Solo: one member, orgRole: "billing_admin".
+ */
+type OrgMemberView = {
+  orgId: string;
+  memberTenantId: string; // existing ledger tenant id
+  orgRole: "billing_admin" | "manager" | "member";
+  joinedAt: string;
+};
+```
+
+No new role system. Allocation roles (`intern` / `employee` / …) stay as **budget families** inside the org pool (see org-credits).
+
+---
+
+## 4. The provisioning core — one Effect, two triggers
+
+```typescript
+type ProvisionOrgInput = {
+  orgName: string;
+  ownerEmail: string;
+  planId: ClawqlPlanId;
+  createdVia: "self_serve" | "enterprise_sales";
+  billingMode: OrgBillingFields["billingMode"];
+  /** Optional Stripe ids when webhook already created customer/subscription. */
+  stripeCustomerId?: string;
+  stripeSubscriptionId?: string;
+  /** Enterprise: additional seats to invite at provision time. */
+  additionalMemberEmails?: readonly string[];
+};
+
+type ProvisionOrgResult = {
+  orgId: string;
+  poolTenantId: string;
+  ownerMemberTenantId: string;
+  /** Raw default API key — shown once. */
+  apiKey: string;
+};
+```
+
+**Behavior (normative):**
+
+1. Create / upsert `OrgRecord` with billing fields + `planId`.
+2. Ensure pool tenant `org:{orgId}:pool` and owner member tenant exist on the credits ledger.
+3. `addOrgMember` owner with `orgRole: "billing_admin"`.
+4. For each `additionalMemberEmails` (enterprise), add members as `member` (or invite-pending — implementation may stage invites).
+5. Issue default API key via `IssuedApiKeyStore.issue` with `orgId` set; scopes derived from `ClawqlPlanId` (tier → allowed tools / rate hints — product mapping in hybrid-billing).
+6. Append WORM `ORG_PROVISIONED`.
+7. Return `{ orgId, apiKey, … }` — raw key never written to WORM.
+
+**Two triggers call the same function:**
+
+| Trigger | Who | Typical `billingMode` |
+| ------- | --- | --------------------- |
+| Self-serve | Stripe `checkout.session.completed` (gateway today → must call shared `provisionOrg`) | `stripe_checkout` or `hybrid` |
+| Enterprise | Internal admin tool after deal close | `stripe_invoice` or `hybrid` |
+| Credits-only SKU | Checkout one-time top-up product without subscription | `credits_only` |
+
+Nothing else forks provision logic.
+
+---
+
+## 5. Metering — read existing spend, don’t duplicate
+
+```typescript
+/** Thin Stripe-facing wrapper — aggregation stays in payments. */
+reportUsageToStripe(orgId: string, period: DateRange): Effect<…>
+```
+
+- Prefer existing `getOrgUnifiedSpendSummary` / payment audit spend report — **not** a fictional `computeCurrentSpend` name unless aliased.
+- Split by [`hybrid-billing-v0.1`](./hybrid-billing-v0.1.md):
+  - Subscription-included / overage → Stripe Billing meter events on the metered Price.
+  - Prepaid credit usage → **ledger debit only** (`DeductionService`) — never Stripe meter API.
+
+---
+
+## 6. WORM entries
+
+```typescript
+type ProvisioningWORMEntryType =
+  | "ORG_PROVISIONED"
+  | "ORG_MEMBER_ADDED"
+  | "ORG_PLAN_CHANGED"
+  | "USAGE_REPORTED_TO_BILLING";
+```
+
+Same payments / clawql-audit trail. No separate billing audit schema.
+
+---
+
+## 7. Six build pieces (plus Stripe dashboard prep)
+
+**Stripe account / product setup is a live-billing blocker, not a schema blocker.** Spec + `Org` fields + `provisionOrg` Effect can land before Products exist; Checkout and meter reporting cannot go live without § Stripe setup in [hybrid-billing-v0.1](./hybrid-billing-v0.1.md).
+
+| # | Piece | New vs reuse |
+| - | ----- | ------------ |
+| 0 | Stripe Products / Prices / metered overage / credit top-up Prices | **Ops** (dashboard) — see hybrid-billing |
+| 1 | Org billing fields on `OrgRecord` + membership (already mostly shipped) | Extend store |
+| 2 | `provisionOrg` Effect Tag + Layer | **New** orchestration |
+| 3 | Stripe webhook → `provisionOrg` (converge CF gateway + Node) | **New** wiring |
+| 4 | Internal admin tool (enterprise trigger) | **New** CLI/MCP/UI |
+| 5 | `reportUsageToStripe` | **New** thin wrapper |
+| 6 | Self-serve dashboard (keys, usage, upgrade / top-up) | **New** UI surface |
+
+**Credit ledger + debit-on-inference:** already shipped (`CreditsLedgerService`, `DeductionService`). Spec requires CPC to **wire** them, not reinvent — details in hybrid-billing § Prepaid.
+
+---
+
+## 8. Build order (answer)
+
+1. **Stripe dashboard Products/Prices (ops)** — required before live Checkout / meters; not required to land schema + `provisionOrg` unit tests with dry-run Stripe.
+2. Org billing fields + `provisionOrg` (dry-run / fake Stripe ids).
+3. Webhook convergence (self-serve).
+4. Enterprise admin trigger.
+5. `reportUsageToStripe` + meter env.
+6. Dashboard UI.
+
+---
+
+## 9. What this deliberately does not add
+
+- A second Org/OrgMember database beside `org-credits.json`
+- `SpendRole` / `spend_admin` as a parallel enum to `OrgMemberRole`
+- A second credit ledger type named `CreditLedger`
+- Folding outbound USDC spend-governance into customer billing
+- ACP “checkout” confused with Stripe Checkout
+
+---
+
+## Concrete implementation slice
+
+1. Additive `OrgBillingFields` on org-credits store + loader tests.
+2. `ProvisionOrgService` Effect Tag; unit test: org-of-1 → one `billing_admin` member + key metadata `orgId`.
+3. Map CF gateway `checkout.session.completed` onto `provisionOrg` (or documented handoff).
+4. WORM `ORG_PROVISIONED` / `ORG_MEMBER_ADDED`.
+5. Cross-link hybrid-billing for subscription vs credits vs hybrid.
+
+## Related
+
+- [Hybrid billing v0.1](./hybrid-billing-v0.1.md)
+- [org-credits](../../payments/org-credits.md)
+- [clawql-payments](../../payments/clawql-payments.md)
+- [deduction-service](../../payments/deduction-service.md)
+- [spend-governance v0.1](../spend/spend-governance-v0.1.md) — outbound only

--- a/docs/specs/billing/hybrid-billing-v0.1.md
+++ b/docs/specs/billing/hybrid-billing-v0.1.md
@@ -29,11 +29,11 @@ Competitors ship **recurring subscription tiers** alongside **prepaid credits**.
 
 ### Coexistence (`hybrid`)
 
-| Usage | Where it settles |
-| ----- | ---------------- |
-| Within subscription included quota | Count against plan entitlements; no credit debit (or soft-count only) |
-| Beyond included quota (overage) | Stripe metered Price on the subscription **or** debit prepaid credits — product picks one waterfall; default recommendation: **credits first, then metered overage** if credits empty |
-| Credits-only SKUs / extra pack | Ledger only |
+| Usage                              | Where it settles                                                                                                                                                                      |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Within subscription included quota | Count against plan entitlements; no credit debit (or soft-count only)                                                                                                                 |
+| Beyond included quota (overage)    | Stripe metered Price on the subscription **or** debit prepaid credits — product picks one waterfall; default recommendation: **credits first, then metered overage** if credits empty |
+| Credits-only SKUs / extra pack     | Ledger only                                                                                                                                                                           |
 
 `reportUsageToStripe` only emits meter events for the overage rail. Credit debits never call Stripe metering.
 
@@ -46,8 +46,8 @@ Do this **before** enabling live self-serve Checkout / meters:
 1. **Products + recurring Prices:** `Pro`, `Team` (and optional annual). Map Price ids → env (`STRIPE_PRO_PRICE_ID`, `STRIPE_TEAM_PRICE_ID`).
 2. **Metered overage Price:** one metered Price (or per-tier); attach as add-on to subscription items. Configure Billing Meter + `STRIPE_METER_EVENT_NAME`.
 3. **Credit top-up Prices:** one-time Prices for denominations (e.g. $20 / $100 / $500) — Checkout `mode=payment` with metadata `clawql_credit_topup` / amount cents (align with existing PI top-up metadata).
-4. **Webhook endpoints:**  
-   - Gateway (or converged Node): `checkout.session.completed`, `customer.subscription.*`, `invoice.paid` → `provisionOrg` / plan sync.  
+4. **Webhook endpoints:**
+   - Gateway (or converged Node): `checkout.session.completed`, `customer.subscription.*`, `invoice.paid` → `provisionOrg` / plan sync.
    - Payments: existing top-up settle (`payment_intent.succeeded` + credit metadata).
 5. **Customer Portal** for upgrade / cancel (already wrapped by `StripeBillingService` patterns).
 
@@ -59,12 +59,12 @@ Ledger truth remains `$CLAWQL_HOME/Payments/credits-ledger.json` (or configured 
 
 **Yes — include ledger + debit-on-inference in the provisioning story**, as **reuse**:
 
-| Concern | Existing surface |
-| ------- | ---------------- |
+| Concern                   | Existing surface                                                |
+| ------------------------- | --------------------------------------------------------------- |
 | Ledger entries / accounts | `CreditsLedgerService`, `CreditLedgerEntry`, `CreditLedgerKind` |
-| Debit path | `DeductionService` hold / capture / release |
-| Org pool | `org:{orgId}:pool` + allocate to members |
-| Funding | Stripe top-up / ACH → settle into ledger |
+| Debit path                | `DeductionService` hold / capture / release                     |
+| Org pool                  | `org:{orgId}:pool` + allocate to members                        |
+| Funding                   | Stripe top-up / ACH → settle into ledger                        |
 
 **Do not** introduce a parallel type named `CreditLedger`. Specs and APIs say `CreditsLedgerService` / credits ledger.
 
@@ -74,12 +74,12 @@ Debit-on-inference is already the entitlement path when credits enforcement is o
 
 ## 4. `billingMode` matrix
 
-| Mode | Subscription | Prepaid credits | Meter overage |
-| ---- | ------------ | --------------- | ------------- |
-| `stripe_checkout` | Required | Optional packs | Yes |
-| `stripe_invoice` | Enterprise invoice / custom | Optional | Optional |
-| `hybrid` | Required | Required for overage-or-packs | Yes if credits exhausted (configurable) |
-| `credits_only` | None | Required | No |
+| Mode              | Subscription                | Prepaid credits               | Meter overage                           |
+| ----------------- | --------------------------- | ----------------------------- | --------------------------------------- |
+| `stripe_checkout` | Required                    | Optional packs                | Yes                                     |
+| `stripe_invoice`  | Enterprise invoice / custom | Optional                      | Optional                                |
+| `hybrid`          | Required                    | Required for overage-or-packs | Yes if credits exhausted (configurable) |
+| `credits_only`    | None                        | Required                      | No                                      |
 
 ---
 

--- a/docs/specs/billing/hybrid-billing-v0.1.md
+++ b/docs/specs/billing/hybrid-billing-v0.1.md
@@ -1,0 +1,115 @@
+# Hybrid billing — subscription tiers + prepaid credits
+
+**Status:** Spec v0.1 (design)  
+**Package:** `clawql-payments`  
+**Related:** [customer-provisioning-core](./customer-provisioning-core-v0.1.md) · [org-credits](../../payments/org-credits.md) · [credits-ach](../../payments/credits-ach.md) · [plans/tiers](../../../packages/clawql-payments/src/plans/tiers.ts)
+
+## Specification v0.1
+
+Competitors ship **recurring subscription tiers** alongside **prepaid credits**. Those are structurally different Stripe primitives — configure both, then combine with `billingMode: "hybrid"`.
+
+---
+
+## 1. Two Stripe products (not one Price with two flags)
+
+### Model A — Subscription tiers (Stripe Billing, recurring)
+
+- Create **Stripe Products** with **recurring Prices** (monthly / annual).
+- One Product per plan mapped to `ClawqlPlanId`: at minimum `Pro` and `Team` (env `STRIPE_PRO_PRICE_ID` / `STRIPE_TEAM_PRICE_ID` already referenced). `Free` has no Price. `Enterprise` typically uses invoice / negotiated Price, not public Checkout.
+- Subscription object handles renewal — prefer **Billing Subscriptions** (started via Checkout `mode=subscription` or Customer Portal), not one-time Checkout as the long-term source of truth.
+- Tier grants a **fixed included quota** (inference calls, seats, etc. from `CLAWQL_PLANS`) — not per-call Stripe metering for the included amount.
+- **Overage:** attach a **metered Price** as a subscription add-on; usage beyond included quota reports via Stripe Billing meter events (`StripeMeterService` / `STRIPE_METER_EVENT_NAME`).
+
+### Model B — Prepaid credit balance (debits as used)
+
+- **Not** a subscription. Stripe’s role is narrow: **process the top-up charge** (Checkout `mode=payment` or PaymentIntent / ACH — see credits-ach).
+- After payment succeeds, **credit your ledger** (`CreditsLedgerService` top-up / grant to org pool or member) — your DB is source of truth.
+- Every inference / paid ClawQL call **debits** via existing `DeductionService` (hold → capture). Do **not** use Stripe Customer Balance for high-frequency per-call debits.
+- Low-balance: threshold webhook / job → notify and optionally open a new Checkout top-up (auto-reload) or wait for manual top-up.
+
+### Coexistence (`hybrid`)
+
+| Usage | Where it settles |
+| ----- | ---------------- |
+| Within subscription included quota | Count against plan entitlements; no credit debit (or soft-count only) |
+| Beyond included quota (overage) | Stripe metered Price on the subscription **or** debit prepaid credits — product picks one waterfall; default recommendation: **credits first, then metered overage** if credits empty |
+| Credits-only SKUs / extra pack | Ledger only |
+
+`reportUsageToStripe` only emits meter events for the overage rail. Credit debits never call Stripe metering.
+
+---
+
+## 2. Stripe dashboard setup (ops order)
+
+Do this **before** enabling live self-serve Checkout / meters:
+
+1. **Products + recurring Prices:** `Pro`, `Team` (and optional annual). Map Price ids → env (`STRIPE_PRO_PRICE_ID`, `STRIPE_TEAM_PRICE_ID`).
+2. **Metered overage Price:** one metered Price (or per-tier); attach as add-on to subscription items. Configure Billing Meter + `STRIPE_METER_EVENT_NAME`.
+3. **Credit top-up Prices:** one-time Prices for denominations (e.g. $20 / $100 / $500) — Checkout `mode=payment` with metadata `clawql_credit_topup` / amount cents (align with existing PI top-up metadata).
+4. **Webhook endpoints:**  
+   - Gateway (or converged Node): `checkout.session.completed`, `customer.subscription.*`, `invoice.paid` → `provisionOrg` / plan sync.  
+   - Payments: existing top-up settle (`payment_intent.succeeded` + credit metadata).
+5. **Customer Portal** for upgrade / cancel (already wrapped by `StripeBillingService` patterns).
+
+Ledger truth remains `$CLAWQL_HOME/Payments/credits-ledger.json` (or configured path) — Stripe is not the credit balance store.
+
+---
+
+## 3. Credit ledger (included in CPC — reuse, don’t rename)
+
+**Yes — include ledger + debit-on-inference in the provisioning story**, as **reuse**:
+
+| Concern | Existing surface |
+| ------- | ---------------- |
+| Ledger entries / accounts | `CreditsLedgerService`, `CreditLedgerEntry`, `CreditLedgerKind` |
+| Debit path | `DeductionService` hold / capture / release |
+| Org pool | `org:{orgId}:pool` + allocate to members |
+| Funding | Stripe top-up / ACH → settle into ledger |
+
+**Do not** introduce a parallel type named `CreditLedger`. Specs and APIs say `CreditsLedgerService` / credits ledger.
+
+Debit-on-inference is already the entitlement path when credits enforcement is on; CPC requires provisioned orgs to land members on that path with clear `billingMode` waterfall (hybrid-billing §1).
+
+---
+
+## 4. `billingMode` matrix
+
+| Mode | Subscription | Prepaid credits | Meter overage |
+| ---- | ------------ | --------------- | ------------- |
+| `stripe_checkout` | Required | Optional packs | Yes |
+| `stripe_invoice` | Enterprise invoice / custom | Optional | Optional |
+| `hybrid` | Required | Required for overage-or-packs | Yes if credits exhausted (configurable) |
+| `credits_only` | None | Required | No |
+
+---
+
+## 5. Plan id vs gateway tier
+
+`ClawqlPlanId` (`free|pro|team|enterprise`) and Cloudflare `GatewayTier` are **not** the same enum. Provisioning must map explicitly (e.g. `pro` → hosted gateway `teams` / `developer` — product table in implementation). Spec forbids silent string equality.
+
+---
+
+## 6. WORM (billing-facing)
+
+Reuse CPC types plus existing payment audit categories for top-ups and meter reports:
+
+- `ORG_PROVISIONED` / `ORG_PLAN_CHANGED`
+- `USAGE_REPORTED_TO_BILLING`
+- Existing credit top-up / debit audit rows
+
+---
+
+## 7. Concrete implementation slice
+
+1. Document Stripe Product/Price/meter checklist (this §2) in runbook or ops doc link from CPC.
+2. `billingMode` + `planId` required on provision; hybrid waterfall unit tests (credits first vs meter).
+3. Wire `reportUsageToStripe` to `StripeMeterService` for overage-only.
+4. Keep `DeductionService` as sole per-call debit; tests that credit path never calls meter API.
+5. Dashboard: show plan, subscription status, credit balance, top-up CTA, upgrade via Portal.
+
+## Related
+
+- [Customer provisioning core](./customer-provisioning-core-v0.1.md)
+- [org-credits](../../payments/org-credits.md)
+- [deduction-service](../../payments/deduction-service.md)
+- [credits-ACH](../../payments/credits-ach.md)

--- a/docs/specs/spend/README.md
+++ b/docs/specs/spend/README.md
@@ -5,4 +5,3 @@
 | [spend-governance-v0.1.md](./spend-governance-v0.1.md) | `clawql-core` + `clawql-payments` | `spend-cap-enforce`; outbound payment allowlist/caps/HITL |
 
 **Related:** [execute batching](../execute/execute-batching-v0.1.md) · [clawql-network (tailcat)](../network/clawql-network-v0.1.md) · [clawql-payments](../../payments/clawql-payments.md) · [customer provisioning / hybrid billing](../billing/README.md) (inbound customer billing — not this outbound USDC hook)
-

--- a/docs/specs/spend/README.md
+++ b/docs/specs/spend/README.md
@@ -4,4 +4,5 @@
 | ------------------------------------------------------ | --------------------------------- | --------------------------------------------------------- |
 | [spend-governance-v0.1.md](./spend-governance-v0.1.md) | `clawql-core` + `clawql-payments` | `spend-cap-enforce`; outbound payment allowlist/caps/HITL |
 
-**Related:** [execute batching](../execute/execute-batching-v0.1.md) · [clawql-network (tailcat)](../network/clawql-network-v0.1.md) · [clawql-payments](../../payments/clawql-payments.md)
+**Related:** [execute batching](../execute/execute-batching-v0.1.md) · [clawql-network (tailcat)](../network/clawql-network-v0.1.md) · [clawql-payments](../../payments/clawql-payments.md) · [customer provisioning / hybrid billing](../billing/README.md) (inbound customer billing — not this outbound USDC hook)
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Specs for **Customer Provisioning Core** (org-of-1 = org) and **hybrid billing** (subscription tiers + prepaid credits), grounded in shipped `org-credits` / `CreditsLedgerService` / `ClawqlPlanId` — not parallel invent-new systems.

## Docs

| Path | Content |
| ---- | ------- |
| `docs/specs/billing/customer-provisioning-core-v0.1.md` | One org model, `provisionOrg`, dual triggers, WORM, six build pieces + Stripe ops order |
| `docs/specs/billing/hybrid-billing-v0.1.md` | Model A recurring vs Model B prepaid, `hybrid` waterfall, Stripe dashboard checklist, ledger reuse |
| `docs/specs/billing/README.md` | Index |

Cross-links from org-credits, spend README, clawql-payments follow-ups.

## Locked hardenings

- Reuse `OrgMemberRole` (`billing_admin` for solo) — no fictional `SpendRole`
- Reuse `CreditsLedgerService` + `DeductionService` — no new `CreditLedger` type
- Converge CF gateway `checkout.session.completed` onto shared `provisionOrg`
- `billingMode`: `stripe_checkout` \| `stripe_invoice` \| `hybrid` \| `credits_only`

## Answer embedded in spec

**Stripe product setup** is a live-billing blocker; schema + `provisionOrg` unit tests can land first. **Credit ledger + debit-on-inference** are included as **reuse** of existing ledger/deduction, not a greenfield table.

## Not in this PR

Implementation of the six build pieces.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55ab-f511-7e4b-b0af-83621ea0611b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55ab-f511-7e4b-b0af-83621ea0611b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

