### PR TITLE
feat(clawql-audit): CBOR WORM hash dialect + ChainMetadata migration

### DIFF
--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -2,9 +2,10 @@
 
 Two different things share the word “audit”:
 
-| Surface                                                  | What it is                                                                                                                                              |
-| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| MCP **`audit`** (`clawql-core`)                          | **Shipped.** In-process **hash-chained** ring buffer. Droppable, clearable, RAM-only. `verify` checks the retained window. Not a compliance WORM trail. |
-| [`clawql-audit-spec-v0.1.md`](clawql-audit-spec-v0.1.md) | **Canonical v0.1.** `clawql-merkle` + `clawql-audit` Effect trail. Local durability is **sql.js SQLite** + dual-ack outbox. S3/HTTP/QR/TEE still spec.  |
+| Surface                                                                              | What it is                                                                                                                                              |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MCP **`audit`** (`clawql-core`)                                                      | **Shipped.** In-process **hash-chained** ring buffer. Droppable, clearable, RAM-only. `verify` checks the retained window. Not a compliance WORM trail. |
+| [`clawql-audit-spec-v0.1.md`](clawql-audit-spec-v0.1.md)                             | **Canonical v0.1.** `clawql-merkle` + `clawql-audit` Effect trail. Local durability is **sql.js SQLite** + dual-ack outbox. S3/HTTP/QR/TEE still spec.  |
+| [`clawql-audit-cbor-serialization-v0.1.md`](clawql-audit-cbor-serialization-v0.1.md) | **Addition.** CBOR (RFC 8949) hash dialect for WORM entries; chain mechanics unchanged; `ChainMetadata` for JSON→CBOR migration.                        |
 
 **Related:** [MCP `audit` tool](../mcp/mcp-tools.md) · [Enterprise MCP tools](../mcp/enterprise-mcp-tools.md) · [TEE air-gap QR](../streams/clawql-tee-airgap-audit.md) · [celld LTX WORM](../streams/clawql-celld.md) · [clawql-agents spec](../agents/clawql-agents-spec-v0.1.md)

--- a/docs/audit/clawql-audit-cbor-serialization-v0.1.md
+++ b/docs/audit/clawql-audit-cbor-serialization-v0.1.md
@@ -1,0 +1,123 @@
+---
+title: "clawql-audit — CBOR Serialization Addition"
+status: "September 2026"
+version: "0.1"
+package: "packages/clawql-audit/"
+---
+
+# clawql-audit — CBOR WORM Serialization
+
+**Addition to the existing clawql-audit specification. Hash-chain mechanics unchanged.**
+
+---
+
+## 1. What changes and what doesn't
+
+**Changes:** the byte encoding of a WORM entry, before it's hashed and appended to the chain.
+
+**Does not change:** the hash chain algorithm (SHA-256 over sealed content that already includes `prevHash` + `chainIndex`), the `HashChain`/`MerkleBatchLayer` split, `DualAckReplicator`, tip-loading on startup, or any entry's field structure. Every WORM entry type keeps its exact field shape. Only the serialization format underneath changes.
+
+Storage backends may still persist entries as JSON for query convenience; that persistence encoding is **not** the hash dialect.
+
+---
+
+## 2. Why CBOR, specifically for this structure
+
+WORM entries are the single highest-volume, most write-frequent structure in the whole system — every hook firing, every tool call, every org provisioning event produces one. CBOR (RFC 8949) is self-describing like JSON (no `.proto` schema-compilation step needed — existing JSON-shaped entry types map over directly) but binary, producing smaller payloads and faster parse/hash cycles than JSON at this volume.
+
+This is not the same class of change as adopting gRPC/protobuf elsewhere — no schema design, no code generation, no transport change. It's a drop-in serialization swap underneath an unchanged data model.
+
+**Implementation note:** hashing uses the existing `cbor` dependency (already required for QR air-gap export) with **canonical** encoding (`encodeCanonical`), not a second CBOR library. The public API matches `serializeWormEntry` / `deserializeWormEntry` as Effect programs.
+
+---
+
+## 3. Where CBOR is used and where it explicitly is not
+
+**Used:**
+
+- WORM entry serialization, before hashing (`HashChain` / `sealHashChainRecord`)
+- Skill index entries (plugin architecture — lightweight metadata tier; out of scope for this package)
+
+**Not used, and this boundary is deliberate:**
+
+- Skill/document _content_ (SKILL.md bodies, vault entries) — stays human-readable Markdown/text
+- Anything returned directly into a model's context (`execute` responses, tool results) — the consumer is the LLM, not a machine-to-machine wire; JSON/text stays here
+- `mcp-api-adapter`'s gRPC surface — already protobuf, no reason to add a second binary format alongside it
+- QR chunk wrappers remain a separate pipeline (CBOR of entry arrays for air-gap export) — not the per-entry hash dialect
+
+---
+
+## 4. Implementation
+
+```typescript
+// packages/clawql-audit/src/serialization.ts — Effect primary API
+
+import { encodeCanonical, decode } from "cbor"; // package: cbor (canonical)
+
+export type WORMEntryPayload = Omit<WORMEntry, "hash" | "backendAcks" | "teeSignature">;
+
+export const serializeWormEntry = (
+  entry: WORMEntryPayload,
+  version: "json" | "cbor" = "cbor"
+): Effect.Effect<Uint8Array> =>
+  Effect.sync(() =>
+    version === "cbor"
+      ? new Uint8Array(encodeCanonical(entry))
+      : new TextEncoder().encode(canonicalJSONSync(entry))
+  );
+
+export const deserializeWormEntry = (
+  bytes: Uint8Array,
+  version: "json" | "cbor" = "cbor"
+): Effect.Effect<WORMEntryPayload> =>
+  Effect.sync(() =>
+    version === "cbor"
+      ? (decode(bytes) as WORMEntryPayload)
+      : (JSON.parse(new TextDecoder().decode(bytes)) as WORMEntryPayload)
+  );
+```
+
+```typescript
+// packages/clawql-audit/src/seal.ts — unchanged link fields; serialization swap only
+
+export const sealHashChainRecord = (input: {
+  prev: SealPrev;
+  body: SealBody;
+  serializationVersion?: WormSerializationVersion;
+}): Effect.Effect<Omit<WORMEntry, "backendAcks">> =>
+  Effect.gen(function* () {
+    const chainIndex = input.prev ? input.prev.seq + 1 : 0;
+    const prevHash = input.prev ? input.prev.hash : WORM_GENESIS_PREV_HASH;
+    const content = { ...input.body, prevHash, chainIndex };
+    const version = input.serializationVersion ?? "cbor";
+    const serialized = yield* serializeWormEntry(content, version);
+    const hash = yield* sha256HexBytes(serialized);
+    return { ...content, hash };
+  });
+```
+
+No other function in the dual-ack replicator or Merkle batch layer changes. They operate on the resulting hash and stored entry identically regardless of what format produced the hash bytes.
+
+---
+
+## 5. Migration
+
+Existing JSON-serialized entries in an already-running chain are not re-encoded retroactively — the hash chain's integrity depends on entries being hashed exactly as they were originally serialized. New entries after this change use CBOR; a chain verifier needs to know which serialization format was in effect at a given point in the chain (a version marker on the chain itself, not per-entry, since the switch happens once).
+
+```typescript
+interface ChainMetadata {
+  serializationVersion: "json" | "cbor";
+  versionChangedAtIndex: number | null;
+}
+```
+
+**Resolution defaults** (`WORMAuditTrailConfig.chainMetadata`):
+
+- Explicit `chainMetadata` always wins.
+- When omitted → `{ serializationVersion: "cbor", versionChangedAtIndex: null }` (greenfield default).
+- Legacy JSON-only chains must pass `{ serializationVersion: "json", versionChangedAtIndex: null }` (or `LEGACY_JSON_CHAIN_METADATA`).
+- One-time switch to CBOR: set `serializationVersion: "cbor"` and `versionChangedAtIndex` to the first CBOR entry's `chainIndex`. Indices below that recompute with JSON; at/after use CBOR.
+
+---
+
+_clawql-audit CBOR Serialization Addition · v0.1 · September 2026_

--- a/docs/audit/clawql-audit-cbor-serialization-v0.1.md
+++ b/docs/audit/clawql-audit-cbor-serialization-v0.1.md
@@ -17,7 +17,7 @@ package: "packages/clawql-audit/"
 
 **Does not change:** the hash chain algorithm (SHA-256 over sealed content that already includes `prevHash` + `chainIndex`), the `HashChain`/`MerkleBatchLayer` split, `DualAckReplicator`, tip-loading on startup, or any entry's field structure. Every WORM entry type keeps its exact field shape. Only the serialization format underneath changes.
 
-Storage backends may still persist entries as JSON for query convenience; that persistence encoding is **not** the hash dialect.
+Storage backends may still persist entries as JSON for query convenience; that persistence encoding is **not** the hash dialect. Before hashing, entries are normalized by dropping `undefined` fields so CBOR bytes match a JSON persistence round-trip (`JSON.stringify` also omits `undefined`).
 
 ---
 

--- a/packages/clawql-audit/README.md
+++ b/packages/clawql-audit/README.md
@@ -6,7 +6,8 @@ Tamper-evident **WORM** audit trail for AI agent deployments. Standalone — no 
 
 ## Capabilities
 
-- Hash-chained append (`sealHashChainRecord`)
+- Hash-chained append (`sealHashChainRecord`) — **CBOR** hash dialect by default (RFC 8949 canonical); legacy JSON via `chainMetadata`
+- Spec addition: [`docs/audit/clawql-audit-cbor-serialization-v0.1.md`](../../docs/audit/clawql-audit-cbor-serialization-v0.1.md)
 - Dual-ack local + remote (SQLite/`node:sqlite`, Postgres, or memory + S3/R2)
 - Outbox drain on startup + optional background reconciler
 - Periodic Merkle batch roots (handoff for multi-chain anchoring)

--- a/packages/clawql-audit/src/chain.ts
+++ b/packages/clawql-audit/src/chain.ts
@@ -3,11 +3,13 @@ import type { ChainVerifyResult, WORMEntry } from "./entry.js";
 import { WORM_GENESIS_PREV_HASH } from "./entry.js";
 import { AuditError } from "./errors.js";
 import { recomputeEntryHash } from "./seal.js";
+import { DEFAULT_CBOR_CHAIN_METADATA, formatAtIndex, type ChainMetadata } from "./serialization.js";
 import type { LocalStorageBackend } from "./storage/types.js";
 
 export class HashChain extends Context.Tag("clawql-audit/HashChain")<
   HashChain,
   {
+    readonly metadata: () => Effect.Effect<ChainMetadata>;
     readonly loadTip: (local: LocalStorageBackend) => Effect.Effect<void, AuditError>;
     readonly latest: () => Effect.Effect<WORMEntry | null>;
     readonly update: (entry: WORMEntry) => Effect.Effect<void, AuditError>;
@@ -15,69 +17,77 @@ export class HashChain extends Context.Tag("clawql-audit/HashChain")<
   }
 >() {}
 
-export const HashChainLive = Layer.sync(HashChain, () => {
-  let latest_: WORMEntry | null = null;
+export const makeHashChainLayer = (
+  metadata: ChainMetadata = DEFAULT_CBOR_CHAIN_METADATA
+): Layer.Layer<HashChain> =>
+  Layer.sync(HashChain, () => {
+    let latest_: WORMEntry | null = null;
 
-  return HashChain.of({
-    loadTip: (local) =>
-      Effect.gen(function* () {
-        latest_ = yield* local.latestEntry();
-      }),
-    latest: () => Effect.succeed(latest_),
-    update: (entry) =>
-      Effect.gen(function* () {
-        if (latest_ && entry.chainIndex !== latest_.chainIndex + 1) {
-          return yield* Effect.fail(
-            new AuditError({
-              reason: `Chain gap: expected ${latest_.chainIndex + 1}, got ${entry.chainIndex}`,
-            })
-          );
-        }
-        latest_ = entry;
-      }),
-    verify: (entries) =>
-      Effect.gen(function* () {
-        const sorted = [...entries].sort((a, b) => a.chainIndex - b.chainIndex);
-        for (let i = 0; i < sorted.length; i++) {
-          const entry = sorted[i]!;
-          if (i === 0) {
-            if (entry.prevHash !== WORM_GENESIS_PREV_HASH && entry.chainIndex !== 0) {
-              // First in a partial slice may not be genesis — only enforce when chainIndex===0
+    return HashChain.of({
+      metadata: () => Effect.succeed(metadata),
+      loadTip: (local) =>
+        Effect.gen(function* () {
+          latest_ = yield* local.latestEntry();
+        }),
+      latest: () => Effect.succeed(latest_),
+      update: (entry) =>
+        Effect.gen(function* () {
+          if (latest_ && entry.chainIndex !== latest_.chainIndex + 1) {
+            return yield* Effect.fail(
+              new AuditError({
+                reason: `Chain gap: expected ${latest_.chainIndex + 1}, got ${entry.chainIndex}`,
+              })
+            );
+          }
+          latest_ = entry;
+        }),
+      verify: (entries) =>
+        Effect.gen(function* () {
+          const sorted = [...entries].sort((a, b) => a.chainIndex - b.chainIndex);
+          for (let i = 0; i < sorted.length; i++) {
+            const entry = sorted[i]!;
+            if (i === 0) {
+              if (entry.prevHash !== WORM_GENESIS_PREV_HASH && entry.chainIndex !== 0) {
+                // First in a partial slice may not be genesis — only enforce when chainIndex===0
+              }
+              if (entry.chainIndex === 0 && entry.prevHash !== WORM_GENESIS_PREV_HASH) {
+                return {
+                  valid: false,
+                  invalidAt: entry.chainIndex,
+                  reason: `Genesis prevHash mismatch at index 0`,
+                };
+              }
+            } else {
+              const prev = sorted[i - 1]!;
+              if (entry.chainIndex !== prev.chainIndex + 1) {
+                return {
+                  valid: false,
+                  invalidAt: entry.chainIndex,
+                  reason: `Gap in chain: expected ${prev.chainIndex + 1}, found ${entry.chainIndex}`,
+                };
+              }
+              if (entry.prevHash !== prev.hash) {
+                return {
+                  valid: false,
+                  invalidAt: entry.chainIndex,
+                  reason: `prevHash mismatch at index ${entry.chainIndex}`,
+                };
+              }
             }
-            if (entry.chainIndex === 0 && entry.prevHash !== WORM_GENESIS_PREV_HASH) {
+            const version = formatAtIndex(metadata, entry.chainIndex);
+            const recomputed = yield* recomputeEntryHash(entry, version);
+            if (recomputed !== entry.hash) {
               return {
                 valid: false,
                 invalidAt: entry.chainIndex,
-                reason: `Genesis prevHash mismatch at index 0`,
-              };
-            }
-          } else {
-            const prev = sorted[i - 1]!;
-            if (entry.chainIndex !== prev.chainIndex + 1) {
-              return {
-                valid: false,
-                invalidAt: entry.chainIndex,
-                reason: `Gap in chain: expected ${prev.chainIndex + 1}, found ${entry.chainIndex}`,
-              };
-            }
-            if (entry.prevHash !== prev.hash) {
-              return {
-                valid: false,
-                invalidAt: entry.chainIndex,
-                reason: `prevHash mismatch at index ${entry.chainIndex}`,
+                reason: `Hash mismatch at index ${entry.chainIndex}: stored ${entry.hash}, computed ${recomputed}`,
               };
             }
           }
-          const recomputed = yield* recomputeEntryHash(entry);
-          if (recomputed !== entry.hash) {
-            return {
-              valid: false,
-              invalidAt: entry.chainIndex,
-              reason: `Hash mismatch at index ${entry.chainIndex}: stored ${entry.hash}, computed ${recomputed}`,
-            };
-          }
-        }
-        return { valid: true };
-      }),
+          return { valid: true };
+        }),
+    });
   });
-});
+
+/** @deprecated Prefer {@link makeHashChainLayer} with explicit {@link ChainMetadata}. */
+export const HashChainLive = makeHashChainLayer(DEFAULT_CBOR_CHAIN_METADATA);

--- a/packages/clawql-audit/src/index.ts
+++ b/packages/clawql-audit/src/index.ts
@@ -27,6 +27,7 @@ export {
   serializeWormEntry,
   sha256HexBytes,
   sortKeysDeep,
+  stripUndefinedDeep,
   type ChainMetadata,
   type WORMEntryPayload,
   type WormSerializationVersion,

--- a/packages/clawql-audit/src/index.ts
+++ b/packages/clawql-audit/src/index.ts
@@ -14,7 +14,23 @@ export {
   sealHashChainRecord,
   sha256Hex,
 } from "./seal.js";
-export { HashChain, HashChainLive } from "./chain.js";
+export { HashChain, HashChainLive, makeHashChainLayer } from "./chain.js";
+export {
+  DEFAULT_CBOR_CHAIN_METADATA,
+  LEGACY_JSON_CHAIN_METADATA,
+  WormSerialization,
+  canonicalJSONSync,
+  deserializeWormEntry,
+  formatAtIndex,
+  makeWormSerializationLayer,
+  resolveChainMetadata,
+  serializeWormEntry,
+  sha256HexBytes,
+  sortKeysDeep,
+  type ChainMetadata,
+  type WORMEntryPayload,
+  type WormSerializationVersion,
+} from "./serialization.js";
 export { MerkleBatchLayer, type MerkleInclusionProof, type MerkleRoot } from "./merkle.js";
 export { DualAckReplicator } from "./replication/dual-ack.js";
 export { defaultRetryConfig, withRetry, type RetryConfig } from "./replication/retry.js";

--- a/packages/clawql-audit/src/seal.ts
+++ b/packages/clawql-audit/src/seal.ts
@@ -1,6 +1,12 @@
 import { createHash, randomBytes } from "node:crypto";
 import { Effect } from "effect";
 import { WORM_GENESIS_PREV_HASH, type WORMEntry } from "./entry.js";
+import {
+  serializeWormEntry,
+  sha256HexBytes,
+  sortKeysDeep,
+  type WormSerializationVersion,
+} from "./serialization.js";
 
 /** UUID v7 (time-ordered). Primary API is Effect; sync helper for seal path. */
 export const generateUUIDv7 = (): Effect.Effect<string> =>
@@ -22,20 +28,9 @@ export const generateUUIDv7 = (): Effect.Effect<string> =>
     return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
   });
 
-function sortKeys(value: unknown): unknown {
-  if (value === null || typeof value !== "object") return value;
-  if (Array.isArray(value)) return value.map(sortKeys);
-  const obj = value as Record<string, unknown>;
-  const out: Record<string, unknown> = {};
-  for (const key of Object.keys(obj).sort()) {
-    out[key] = sortKeys(obj[key]);
-  }
-  return out;
-}
-
-/** Canonical JSON bytes for hashing (deterministic key order). */
+/** Canonical JSON bytes for hashing (deterministic key order). Legacy dialect. */
 export const canonicalJSON = (value: unknown): Effect.Effect<string> =>
-  Effect.sync(() => JSON.stringify(sortKeys(value)));
+  Effect.sync(() => JSON.stringify(sortKeysDeep(value)));
 
 export const sha256Hex = (input: string): Effect.Effect<string> =>
   Effect.sync(() => createHash("sha256").update(input, "utf8").digest("hex"));
@@ -47,10 +42,12 @@ export type SealBody = Omit<WORMEntry, "hash" | "prevHash" | "chainIndex" | "bac
 /**
  * Canonical hash-chain seal — one dialect for all callers.
  * Do not reimplement prevHash / chainIndex / hash elsewhere.
+ * Default serialization is CBOR; pass `serializationVersion: "json"` for legacy chains.
  */
 export const sealHashChainRecord = (input: {
   prev: SealPrev;
   body: SealBody;
+  serializationVersion?: WormSerializationVersion;
 }): Effect.Effect<Omit<WORMEntry, "backendAcks">> =>
   Effect.gen(function* () {
     const chainIndex = input.prev ? input.prev.seq + 1 : 0;
@@ -60,15 +57,22 @@ export const sealHashChainRecord = (input: {
       prevHash,
       chainIndex,
     };
-    const json = yield* canonicalJSON(content);
-    const hash = yield* sha256Hex(json);
+    const version = input.serializationVersion ?? "cbor";
+    const serialized = yield* serializeWormEntry(content, version);
+    const hash = yield* sha256HexBytes(serialized);
     return { ...content, hash };
   });
 
-/** Recompute content hash for verify (excludes hash, backendAcks; teeSignature excluded from hash body). */
-export const recomputeEntryHash = (entry: WORMEntry): Effect.Effect<string> =>
+/**
+ * Recompute content hash for verify (excludes hash, backendAcks, teeSignature).
+ * Must use the same serialization version that sealed the entry.
+ */
+export const recomputeEntryHash = (
+  entry: WORMEntry,
+  serializationVersion: WormSerializationVersion = "cbor"
+): Effect.Effect<string> =>
   Effect.gen(function* () {
     const { hash: _h, backendAcks: _a, teeSignature: _t, ...content } = entry;
-    const json = yield* canonicalJSON(content);
-    return yield* sha256Hex(json);
+    const serialized = yield* serializeWormEntry(content, serializationVersion);
+    return yield* sha256HexBytes(serialized);
   });

--- a/packages/clawql-audit/src/serialization.test.ts
+++ b/packages/clawql-audit/src/serialization.test.ts
@@ -148,4 +148,28 @@ describe("WormSerialization", () => {
     expect(await Effect.runPromise(recomputeEntryHash(rows[2]!, "cbor"))).toBe(rows[2]!.hash);
     await migrated.stop();
   });
+
+  it("CBOR hash matches after JSON persistence strips undefined fields", async () => {
+    const sealed = await Effect.runPromise(
+      sealHashChainRecord({
+        prev: null,
+        body: {
+          id: "00000000-0000-7000-8000-000000000099",
+          writtenAt: "2026-01-01T00:00:00.000Z",
+          type: "PANGUARD_DENY",
+          timestamp: "2026-01-01T00:00:00.000Z",
+          sessionId: "s-undef",
+          agentName: "cline",
+          virtualKeyId: undefined,
+          cellId: undefined,
+          metadata: { toolName: "sandbox_exec", extra: undefined },
+        },
+        serializationVersion: "cbor",
+      })
+    );
+    const persisted = JSON.parse(
+      JSON.stringify({ ...sealed, backendAcks: [] })
+    ) as typeof sealed & { backendAcks: string[] };
+    expect(await Effect.runPromise(recomputeEntryHash(persisted, "cbor"))).toBe(sealed.hash);
+  });
 });

--- a/packages/clawql-audit/src/serialization.test.ts
+++ b/packages/clawql-audit/src/serialization.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import { Effect } from "effect";
+import {
+  DEFAULT_CBOR_CHAIN_METADATA,
+  LEGACY_JSON_CHAIN_METADATA,
+  MemoryBackend,
+  WORMAuditTrail,
+  deserializeWormEntry,
+  formatAtIndex,
+  recomputeEntryHash,
+  resolveChainMetadata,
+  sealHashChainRecord,
+  serializeWormEntry,
+  WORM_GENESIS_PREV_HASH,
+} from "./index.js";
+
+const trailDefaults = {
+  retryMaxAttempts: 2,
+  retryBackoffMs: 1,
+  reconcileIntervalMs: 0,
+  merkleBatchSize: 0,
+} as const;
+
+describe("WormSerialization", () => {
+  it("round-trips CBOR payload with stable key order", async () => {
+    const payload = {
+      id: "00000000-0000-7000-8000-000000000001",
+      prevHash: WORM_GENESIS_PREV_HASH,
+      chainIndex: 0,
+      writtenAt: "2026-01-01T00:00:00.000Z",
+      type: "SESSION_START" as const,
+      timestamp: "2026-01-01T00:00:00.000Z",
+      sessionId: "s1",
+      metadata: { z: 1, a: 2 },
+    };
+    const a = await Effect.runPromise(serializeWormEntry(payload, "cbor"));
+    const b = await Effect.runPromise(
+      serializeWormEntry(
+        {
+          ...payload,
+          metadata: { a: 2, z: 1 },
+        },
+        "cbor"
+      )
+    );
+    expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true);
+    const back = await Effect.runPromise(deserializeWormEntry(a, "cbor"));
+    expect(back.sessionId).toBe("s1");
+    expect(back.metadata).toEqual({ a: 2, z: 1 });
+  });
+
+  it("CBOR and JSON dialects produce different hashes for the same content", async () => {
+    const sealedCbor = await Effect.runPromise(
+      sealHashChainRecord({
+        prev: null,
+        body: {
+          id: "00000000-0000-7000-8000-000000000001",
+          writtenAt: "2026-01-01T00:00:00.000Z",
+          type: "SESSION_START",
+          timestamp: "2026-01-01T00:00:00.000Z",
+          sessionId: "s1",
+        },
+        serializationVersion: "cbor",
+      })
+    );
+    const sealedJson = await Effect.runPromise(
+      sealHashChainRecord({
+        prev: null,
+        body: {
+          id: "00000000-0000-7000-8000-000000000001",
+          writtenAt: "2026-01-01T00:00:00.000Z",
+          type: "SESSION_START",
+          timestamp: "2026-01-01T00:00:00.000Z",
+          sessionId: "s1",
+        },
+        serializationVersion: "json",
+      })
+    );
+    expect(sealedCbor.hash).not.toBe(sealedJson.hash);
+    expect(
+      await Effect.runPromise(recomputeEntryHash({ ...sealedCbor, backendAcks: [] }, "cbor"))
+    ).toBe(sealedCbor.hash);
+    expect(
+      await Effect.runPromise(recomputeEntryHash({ ...sealedJson, backendAcks: [] }, "json"))
+    ).toBe(sealedJson.hash);
+  });
+
+  it("formatAtIndex honors one-time switch", () => {
+    const meta = {
+      serializationVersion: "cbor" as const,
+      versionChangedAtIndex: 2,
+    };
+    expect(formatAtIndex(meta, 0)).toBe("json");
+    expect(formatAtIndex(meta, 1)).toBe("json");
+    expect(formatAtIndex(meta, 2)).toBe("cbor");
+    expect(formatAtIndex(DEFAULT_CBOR_CHAIN_METADATA, 99)).toBe("cbor");
+    expect(formatAtIndex(LEGACY_JSON_CHAIN_METADATA, 0)).toBe("json");
+  });
+
+  it("resolveChainMetadata defaults to CBOR", () => {
+    expect(resolveChainMetadata(undefined, null)).toEqual(DEFAULT_CBOR_CHAIN_METADATA);
+    expect(resolveChainMetadata(LEGACY_JSON_CHAIN_METADATA, null)).toEqual(
+      LEGACY_JSON_CHAIN_METADATA
+    );
+  });
+
+  it("verifies a mixed JSON→CBOR chain via versionChangedAtIndex", async () => {
+    const local = new MemoryBackend();
+    const remote = new MemoryBackend();
+
+    const legacy = await WORMAuditTrail.create({
+      local,
+      remote,
+      ...trailDefaults,
+      chainMetadata: LEGACY_JSON_CHAIN_METADATA,
+    });
+    await legacy.append({
+      type: "SESSION_START",
+      timestamp: "2026-09-01T00:00:00.000Z",
+      sessionId: "mix",
+    });
+    await legacy.append({
+      type: "TOOL_CALL_ATTEMPT",
+      timestamp: "2026-09-01T00:00:01.000Z",
+      sessionId: "mix",
+    });
+    await legacy.stop();
+
+    const migrated = await WORMAuditTrail.create({
+      local,
+      remote,
+      ...trailDefaults,
+      chainMetadata: {
+        serializationVersion: "cbor",
+        versionChangedAtIndex: 2,
+      },
+    });
+    await migrated.append({
+      type: "TOOL_CALL_RESULT",
+      timestamp: "2026-09-01T00:00:02.000Z",
+      sessionId: "mix",
+    });
+    const verification = await migrated.verify();
+    expect(verification).toEqual({ valid: true });
+    const rows = await migrated.query({ sessionId: "mix" });
+    expect(rows).toHaveLength(3);
+    expect(await Effect.runPromise(recomputeEntryHash(rows[0]!, "json"))).toBe(rows[0]!.hash);
+    expect(await Effect.runPromise(recomputeEntryHash(rows[2]!, "cbor"))).toBe(rows[2]!.hash);
+    await migrated.stop();
+  });
+});

--- a/packages/clawql-audit/src/serialization.ts
+++ b/packages/clawql-audit/src/serialization.ts
@@ -1,0 +1,139 @@
+/**
+ * WORM entry byte encoding for the hash dialect (RFC 8949 CBOR or legacy JSON).
+ * Persistence backends may still store JSON; that is not this path.
+ */
+
+import { createHash } from "node:crypto";
+import cbor from "cbor";
+import { Context, Effect, Layer } from "effect";
+import type { WORMEntry } from "./entry.js";
+
+/** Sealed content that participates in the hash (excludes hash / acks / tee). */
+export type WORMEntryPayload = Omit<WORMEntry, "hash" | "backendAcks" | "teeSignature">;
+
+export type WormSerializationVersion = "json" | "cbor";
+
+/**
+ * Chain-level serialization marker (one switch, not per-entry).
+ * @see docs/audit/clawql-audit-cbor-serialization-v0.1.md §5
+ */
+export type ChainMetadata = {
+  serializationVersion: WormSerializationVersion;
+  /** First index using `serializationVersion` after a one-time switch; null = whole chain. */
+  versionChangedAtIndex: number | null;
+};
+
+export const DEFAULT_CBOR_CHAIN_METADATA: ChainMetadata = {
+  serializationVersion: "cbor",
+  versionChangedAtIndex: null,
+};
+
+export const LEGACY_JSON_CHAIN_METADATA: ChainMetadata = {
+  serializationVersion: "json",
+  versionChangedAtIndex: null,
+};
+
+/** Deep key-sort for deterministic JSON hashing (legacy dialect). */
+export const sortKeysDeep = (value: unknown): unknown => {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  const obj = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(obj).sort()) {
+    out[key] = sortKeysDeep(obj[key]);
+  }
+  return out;
+};
+
+export const canonicalJSONSync = (value: unknown): string => JSON.stringify(sortKeysDeep(value));
+
+/**
+ * Format in effect at `chainIndex` given one switch point.
+ * Indices strictly before `versionChangedAtIndex` use the previous dialect.
+ */
+export const formatAtIndex = (
+  meta: ChainMetadata,
+  chainIndex: number
+): WormSerializationVersion => {
+  if (meta.versionChangedAtIndex === null) {
+    return meta.serializationVersion;
+  }
+  const after = meta.serializationVersion;
+  const before: WormSerializationVersion = after === "cbor" ? "json" : "cbor";
+  return chainIndex < meta.versionChangedAtIndex ? before : after;
+};
+
+/**
+ * Greenfield / unspecified → CBOR. Legacy JSON chains must pass explicit metadata.
+ */
+export const resolveChainMetadata = (
+  explicit: ChainMetadata | undefined,
+  _tip: WORMEntry | null = null
+): ChainMetadata => {
+  if (explicit) return explicit;
+  return DEFAULT_CBOR_CHAIN_METADATA;
+};
+
+export const serializeWormEntry = (
+  entry: WORMEntryPayload,
+  version: WormSerializationVersion = "cbor"
+): Effect.Effect<Uint8Array> =>
+  Effect.sync(() => {
+    if (version === "cbor") {
+      return new Uint8Array(cbor.encodeCanonical(entry));
+    }
+    return new TextEncoder().encode(canonicalJSONSync(entry));
+  });
+
+export const deserializeWormEntry = (
+  bytes: Uint8Array,
+  version: WormSerializationVersion = "cbor"
+): Effect.Effect<WORMEntryPayload> =>
+  Effect.sync(() => {
+    if (version === "cbor") {
+      return cbor.decodeFirstSync(Buffer.from(bytes)) as WORMEntryPayload;
+    }
+    return JSON.parse(new TextDecoder().decode(bytes)) as WORMEntryPayload;
+  });
+
+export const sha256HexBytes = (input: Uint8Array): Effect.Effect<string> =>
+  Effect.sync(() => createHash("sha256").update(input).digest("hex"));
+
+export class WormSerialization extends Context.Tag("clawql-audit/WormSerialization")<
+  WormSerialization,
+  {
+    readonly metadata: ChainMetadata;
+    readonly formatAt: (chainIndex: number) => WormSerializationVersion;
+    readonly serialize: (
+      entry: WORMEntryPayload,
+      version?: WormSerializationVersion
+    ) => Effect.Effect<Uint8Array>;
+    readonly deserialize: (
+      bytes: Uint8Array,
+      version?: WormSerializationVersion
+    ) => Effect.Effect<WORMEntryPayload>;
+    readonly hashPayload: (
+      entry: WORMEntryPayload,
+      version: WormSerializationVersion
+    ) => Effect.Effect<string>;
+  }
+>() {}
+
+export const makeWormSerializationLayer = (
+  metadata: ChainMetadata
+): Layer.Layer<WormSerialization> =>
+  Layer.sync(WormSerialization, () =>
+    WormSerialization.of({
+      metadata,
+      formatAt: (chainIndex) => formatAtIndex(metadata, chainIndex),
+      serialize: (entry, version = metadata.serializationVersion) =>
+        serializeWormEntry(entry, version),
+      deserialize: (bytes, version = metadata.serializationVersion) =>
+        deserializeWormEntry(bytes, version),
+      hashPayload: (entry, version) =>
+        Effect.gen(function* () {
+          const bytes = yield* serializeWormEntry(entry, version);
+          return yield* sha256HexBytes(bytes);
+        }),
+    })
+  );

--- a/packages/clawql-audit/src/serialization.ts
+++ b/packages/clawql-audit/src/serialization.ts
@@ -45,7 +45,30 @@ export const sortKeysDeep = (value: unknown): unknown => {
   return out;
 };
 
-export const canonicalJSONSync = (value: unknown): string => JSON.stringify(sortKeysDeep(value));
+/**
+ * Drop `undefined` so the hash dialect matches `JSON.stringify` persistence
+ * round-trips (SQLite/Postgres/S3). CBOR otherwise encodes JS `undefined` as 0xf7.
+ */
+export const stripUndefinedDeep = (value: unknown): unknown => {
+  if (value === undefined) return undefined;
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) {
+    return value.map((item) => {
+      const next = stripUndefinedDeep(item);
+      return next === undefined ? null : next;
+    });
+  }
+  const obj = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(obj)) {
+    const next = stripUndefinedDeep(obj[key]);
+    if (next !== undefined) out[key] = next;
+  }
+  return out;
+};
+
+export const canonicalJSONSync = (value: unknown): string =>
+  JSON.stringify(sortKeysDeep(stripUndefinedDeep(value)));
 
 /**
  * Format in effect at `chainIndex` given one switch point.
@@ -79,10 +102,11 @@ export const serializeWormEntry = (
   version: WormSerializationVersion = "cbor"
 ): Effect.Effect<Uint8Array> =>
   Effect.sync(() => {
+    const normalized = stripUndefinedDeep(entry) as WORMEntryPayload;
     if (version === "cbor") {
-      return new Uint8Array(cbor.encodeCanonical(entry));
+      return new Uint8Array(cbor.encodeCanonical(normalized));
     }
-    return new TextEncoder().encode(canonicalJSONSync(entry));
+    return new TextEncoder().encode(canonicalJSONSync(normalized));
   });
 
 export const deserializeWormEntry = (

--- a/packages/clawql-audit/src/trail.ts
+++ b/packages/clawql-audit/src/trail.ts
@@ -1,5 +1,5 @@
 import { Context, Effect, Layer } from "effect";
-import { HashChain, HashChainLive } from "./chain.js";
+import { HashChain, makeHashChainLayer } from "./chain.js";
 import type { ChainVerifyResult, WORMAppendInput, WORMEntry, WORMFilter } from "./entry.js";
 import { AuditError } from "./errors.js";
 import { startAuditHttpServer, type AuditHttpServerHandle } from "./http/server.js";
@@ -14,6 +14,12 @@ import { DualAckReplicator } from "./replication/dual-ack.js";
 import { startOutboxReconciler, type ReconcilerHandle } from "./replication/reconciler.js";
 import { defaultRetryConfig, type RetryConfig } from "./replication/retry.js";
 import { generateUUIDv7, sealHashChainRecord } from "./seal.js";
+import {
+  formatAtIndex,
+  makeWormSerializationLayer,
+  resolveChainMetadata,
+  type ChainMetadata,
+} from "./serialization.js";
 import type { LocalStorageBackend, StorageBackend } from "./storage/types.js";
 import type { TEESigner } from "./tee/signer.js";
 
@@ -32,6 +38,12 @@ export type WORMAuditTrailConfig = {
   reconcileIntervalMs?: number;
   /** Seal + store a Merkle root every N appends (default 100). 0 disables. */
   merkleBatchSize?: number;
+  /**
+   * Hash-dialect marker (JSON vs CBOR). Default: CBOR for the whole chain.
+   * Legacy JSON chains must pass `LEGACY_JSON_CHAIN_METADATA`. See
+   * clawql-audit-cbor-serialization-v0.1.
+   */
+  chainMetadata?: ChainMetadata;
 };
 
 export class WORMAuditTrailService extends Context.Tag("clawql-audit/WORMAuditTrail")<
@@ -73,6 +85,21 @@ function retryFromConfig(config: WORMAuditTrailConfig): RetryConfig {
 export const makeWORMAuditTrailLayer = (
   config: WORMAuditTrailConfig
 ): Layer.Layer<WORMAuditTrailService, AuditError> =>
+  Layer.unwrapEffect(
+    Effect.gen(function* () {
+      const tip = yield* config.local.latestEntry();
+      const meta = resolveChainMetadata(config.chainMetadata, tip);
+      return makeWORMAuditTrailLayerWithMeta(config, meta).pipe(
+        Layer.provide(makeHashChainLayer(meta)),
+        Layer.provide(makeWormSerializationLayer(meta))
+      );
+    })
+  );
+
+const makeWORMAuditTrailLayerWithMeta = (
+  config: WORMAuditTrailConfig,
+  meta: ChainMetadata
+): Layer.Layer<WORMAuditTrailService, AuditError, HashChain> =>
   Layer.effect(
     WORMAuditTrailService,
     Effect.gen(function* () {
@@ -128,6 +155,8 @@ export const makeWORMAuditTrailLayer = (
         append: (input) =>
           Effect.gen(function* () {
             const prev = yield* chain.latest();
+            const nextIndex = prev ? prev.chainIndex + 1 : 0;
+            const serializationVersion = formatAtIndex(meta, nextIndex);
             const id = yield* generateUUIDv7();
             const writtenAt = new Date().toISOString();
             const sealed = yield* sealHashChainRecord({
@@ -137,6 +166,7 @@ export const makeWORMAuditTrailLayer = (
                 writtenAt,
                 ...input,
               },
+              serializationVersion,
             });
             let signed: Omit<WORMEntry, "backendAcks"> = sealed;
             if (tee) {
@@ -189,7 +219,7 @@ export const makeWORMAuditTrailLayer = (
 
       return service;
     })
-  ).pipe(Layer.provide(HashChainLive));
+  );
 
 /** Effect program that constructs the trail service (loads tip + drains outbox). */
 export const createWORMAuditTrailEffect = (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the **clawql-audit CBOR Serialization Addition** (v0.1): WORM entry hashing switches from canonical JSON to RFC 8949 **canonical CBOR** by default. Hash-chain link fields (`prevHash` / `chainIndex`), DualAck, Merkle, and tip-load are unchanged.

**Note:** Replaces [#1075](https://github.com/danielsmithdevelopment/ClawQL/pull/1075), whose branch lost shared history with `main` (unrelated histories / conflicted). Supply-chain bumps for `next` / `js-yaml` / `sharp` already landed on `main` separately.

## Changes

- Spec: `docs/audit/clawql-audit-cbor-serialization-v0.1.md` (+ index link)
- `packages/clawql-audit/src/serialization.ts` — Effect `serializeWormEntry` / `deserializeWormEntry`, `ChainMetadata`, `WormSerialization` Tag/Layer
- `seal.ts` / `chain.ts` / `trail.ts` — seal + verify honor serialization version; `WORMAuditTrailConfig.chainMetadata`
- Uses existing `cbor` dep (`encodeCanonical`) — no second CBOR library

## Tests

`npm test` in `packages/clawql-audit` — 27 passed (CBOR round-trip, dialect divergence, mixed JSON→CBOR verify).

## Migration

Default for new trails is CBOR. Existing JSON-only chains must set `LEGACY_JSON_CHAIN_METADATA`. Do not re-encode historical entries.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8f57-601a-7ec1-bff0-d35011fef4ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8f57-601a-7ec1-bff0-d35011fef4ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

